### PR TITLE
bench: disable state root computation, keep prewarming only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8322,7 +8322,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8349,7 +8349,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8381,7 +8381,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8401,7 +8401,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8497,7 +8497,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8507,7 +8507,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8560,7 +8560,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8576,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8590,7 +8590,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8603,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8682,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8712,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8776,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8920,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8943,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9027,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9055,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9087,7 +9087,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9109,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9148,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9211,7 +9211,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "clap",
  "eyre",
@@ -9234,7 +9234,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9250,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9266,7 +9266,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9309,7 +9309,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9323,7 +9323,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9333,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9357,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9395,7 +9395,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9408,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9479,7 +9479,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "serde",
  "serde_json",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "bytes",
  "futures",
@@ -9537,7 +9537,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "bindgen",
  "cc",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "futures",
  "metrics",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9585,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9599,7 +9599,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9682,7 +9682,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9721,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9735,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9752,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9844,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9899,7 +9899,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9961,7 +9961,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "bytes",
  "eyre",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10026,7 +10026,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10050,7 +10050,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10062,7 +10062,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10128,7 +10128,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10205,7 +10205,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10236,7 +10236,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10313,7 +10313,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10343,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10386,7 +10386,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10406,7 +10406,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10437,7 +10437,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10483,7 +10483,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10531,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10545,7 +10545,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10628,7 +10628,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10656,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10670,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10705,7 +10705,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10730,7 +10730,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10748,7 +10748,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10769,7 +10769,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10785,7 +10785,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10795,7 +10795,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "clap",
  "eyre",
@@ -10814,7 +10814,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "clap",
  "eyre",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10877,7 +10877,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10903,7 +10903,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10930,7 +10930,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10950,7 +10950,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10979,7 +10979,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=47b18bc60#47b18bc6062a102107a1ae3a184f908cc4411c36"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,64 +140,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "7354172", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7354172", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "7354172", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "7354172", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "47b18bc60", features = [
   "std",
   "optional-checks",
 ] }

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -219,6 +219,9 @@ fn init_engine_defaults() {
         .with_always_process_payload_attributes_on_canonical_head(true)
         // Defer persistence I/O during active payload builds.
         .with_suppress_persistence_during_build(true)
+        // BENCH: Skip state root computation during validation — trust the proposer's state root.
+        // Only prewarming remains active. This isolates execution performance from trie overhead.
+        .with_skip_state_root(true)
         .try_init()
         .expect("failed to initialize engine defaults");
 }


### PR DESCRIPTION
## Summary

Disables state root computation during engine validation while keeping prewarming fully active. This isolates execution performance from trie computation overhead for benchmarking.

### How it works

Points reth to `paradigmxyz/reth@centaur/skip-state-root` ([`47b18bc60`](https://github.com/paradigmxyz/reth/commit/47b18bc6062a102107a1ae3a184f908cc4411c36)) which adds a `skip_state_root` flag to `TreeConfig`. When enabled:

- State root computation is skipped entirely (no sparse trie, parallel, or serial root)
- The proposer's state root from the block header is trusted
- Prewarming remains fully active via the `spawn_cache_exclusive` path
- The state root task is not even started (`Synchronous` strategy used)

The flag is enabled by default in `init_engine_defaults()` and can also be toggled via CLI: `--engine.skip-state-root`

### Changes

- **`Cargo.toml`**: Points all reth deps to the patched rev
- **`bin/tempo/src/defaults.rs`**: Enables `skip_state_root` in engine defaults

Prompted by: @shekhirin