### PR TITLE
ci(bench): add e2e hardfork selection

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -143,6 +143,11 @@ on:
         type: boolean
         required: true
         default: false
+      no-slack:
+        description: Skip Slack notification.
+        type: boolean
+        required: true
+        default: true
       bench-args:
         description: Extra bench args.
         type: string
@@ -333,7 +338,7 @@ jobs:
       BENCH_RUN_TYPE: ${{ inputs.run-type || 'dispatch' }}
       BENCH_FORCE_BLOAT: ${{ inputs.force-bloat }}
       BENCH_NO_CACHE: ${{ inputs.no-cache || 'false' }}
-      BENCH_NO_SLACK: ${{ inputs.no-slack || 'true' }}
+      BENCH_NO_SLACK: ${{ inputs.no-slack }}
       BENCH_BENCH_ARGS: ${{ inputs.bench-args }}
       BENCH_BENCH_ENV: ${{ inputs.bench-env }}
       BENCH_BASELINE_ENV: ${{ inputs.baseline-env }}

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -89,30 +89,16 @@ on:
         type: string
         required: false
         default: ""
-      samply:
-        description: Capture samply profiles.
-        type: boolean
-        required: true
-        default: false
-      tracy:
-        description: Tracy mode.
+      profiling:
+        description: Profiling.
         type: choice
         required: true
-        default: "off"
+        default: "Off"
         options:
-          - "off"
-          - "on"
-          - full
-      tracy-seconds:
-        description: Tracy capture duration in seconds.
-        type: string
-        required: true
-        default: "30"
-      tracy-offset:
-        description: Tracy capture start offset in seconds.
-        type: string
-        required: true
-        default: "120"
+          - "Off"
+          - Samply
+          - Tracy
+          - Both
       otlp:
         description: Export OTLP traces and logs.
         type: boolean
@@ -326,10 +312,10 @@ jobs:
       BENCH_BASELINE_HARDFORK: ${{ inputs.baseline-hardfork }}
       BENCH_FEATURE_HARDFORK: ${{ inputs.feature-hardfork }}
       BENCH_TXGEN_REF: ${{ inputs.txgen-ref }}
-      BENCH_SAMPLY: ${{ inputs.samply }}
-      BENCH_TRACY: ${{ inputs.tracy }}
-      BENCH_TRACY_SECONDS: ${{ inputs.tracy-seconds }}
-      BENCH_TRACY_OFFSET: ${{ inputs.tracy-offset }}
+      BENCH_SAMPLY: ${{ inputs.profiling == 'Samply' || inputs.profiling == 'Both' || inputs.samply == true || inputs.samply == 'true' }}
+      BENCH_TRACY: ${{ (inputs.profiling == 'Tracy' || inputs.profiling == 'Both') && 'on' || ((inputs.profiling == 'Off' || inputs.profiling == 'Samply') && 'off' || inputs.tracy) }}
+      BENCH_TRACY_SECONDS: ${{ inputs.tracy-seconds || '30' }}
+      BENCH_TRACY_OFFSET: ${{ inputs.tracy-offset || '120' }}
       BENCH_OTLP: ${{ inputs.otlp == true || inputs.otlp == 'true' }}
       BENCH_FEATURES: ${{ (inputs.otlp == true || inputs.otlp == 'true') && 'jemalloc,asm-keccak,keccak-cache-global,otlp' || 'jemalloc,asm-keccak,keccak-cache-global' }}
       BENCH_BASELINE_ARGS: ${{ inputs.baseline-args }}

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -18,6 +18,38 @@ on:
         type: string
         required: false
         default: ""
+      baseline-hardfork:
+        description: Latest active hardfork for the baseline run.
+        type: choice
+        required: true
+        default: T6
+        options:
+          - T0
+          - T1
+          - T1A
+          - T1B
+          - T1C
+          - T2
+          - T3
+          - T4
+          - T5
+          - T6
+      feature-hardfork:
+        description: Latest active hardfork for the feature run.
+        type: choice
+        required: true
+        default: T6
+        options:
+          - T0
+          - T1
+          - T1A
+          - T1B
+          - T1C
+          - T2
+          - T3
+          - T4
+          - T5
+          - T6
       preset:
         description: Benchmark preset.
         type: string
@@ -171,6 +203,14 @@ on:
       feature:
         type: string
         required: true
+      baseline-hardfork:
+        type: string
+        required: false
+        default: ""
+      feature-hardfork:
+        type: string
+        required: false
+        default: ""
       txgen-ref:
         type: string
         required: false
@@ -283,6 +323,8 @@ jobs:
       BENCH_TPS: ${{ inputs.tps }}
       BENCH_ACCOUNTS: ${{ inputs.accounts || '1000' }}
       BENCH_MAX_CONCURRENT_REQUESTS: ${{ inputs.max-concurrent-requests || '100' }}
+      BENCH_BASELINE_HARDFORK: ${{ inputs.baseline-hardfork }}
+      BENCH_FEATURE_HARDFORK: ${{ inputs.feature-hardfork }}
       BENCH_TXGEN_REF: ${{ inputs.txgen-ref }}
       BENCH_SAMPLY: ${{ inputs.samply }}
       BENCH_TRACY: ${{ inputs.tracy }}
@@ -390,6 +432,8 @@ jobs:
             const tps = process.env.BENCH_TPS;
             const accounts = process.env.BENCH_ACCOUNTS;
             const maxConcurrentRequests = process.env.BENCH_MAX_CONCURRENT_REQUESTS;
+            const baselineHardfork = process.env.BENCH_BASELINE_HARDFORK || '';
+            const featureHardfork = process.env.BENCH_FEATURE_HARDFORK || '';
             const baseline = process.env.INPUT_BASELINE_NAME;
             const feature = process.env.INPUT_FEATURE_NAME;
             const txgenRef = process.env.BENCH_TXGEN_REF || 'default';
@@ -402,7 +446,8 @@ jobs:
             const noCache = process.env.BENCH_NO_CACHE === 'true';
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const gasLimit = process.env.BENCH_GAS_LIMIT;
-            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${samplyNote}${tracyNote}${otlpNote}${noCacheNote}`);
+            const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
+            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${samplyNote}${tracyNote}${otlpNote}${noCacheNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -577,6 +622,8 @@ jobs:
           [ "$BENCH_NO_CACHE" = "true" ] && cmd+=(--no-cache)
           [ "$BENCH_SAMPLY" = "true" ] && cmd+=(--samply)
           [ "$BENCH_TRACY" != "off" ] && cmd+=(--tracy "$BENCH_TRACY" --tracy-seconds "$BENCH_TRACY_SECONDS" --tracy-offset "$BENCH_TRACY_OFFSET")
+          [ -n "$BENCH_BASELINE_HARDFORK" ] && cmd+=(--baseline-hardfork="$BENCH_BASELINE_HARDFORK")
+          [ -n "$BENCH_FEATURE_HARDFORK" ] && cmd+=(--feature-hardfork="$BENCH_FEATURE_HARDFORK")
           [ -n "$BENCH_BASELINE_ARGS" ] && cmd+=(--baseline-args="$BENCH_BASELINE_ARGS")
           [ -n "$BENCH_FEATURE_ARGS" ] && cmd+=(--feature-args="$BENCH_FEATURE_ARGS")
           [ -n "$BENCH_BENCH_ARGS" ] && cmd+=(--bench-args="$BENCH_BENCH_ARGS")

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -143,11 +143,6 @@ on:
         type: boolean
         required: true
         default: false
-      no-slack:
-        description: Skip Slack notification.
-        type: boolean
-        required: true
-        default: true
       bench-args:
         description: Extra bench args.
         type: string
@@ -338,7 +333,7 @@ jobs:
       BENCH_RUN_TYPE: ${{ inputs.run-type || 'dispatch' }}
       BENCH_FORCE_BLOAT: ${{ inputs.force-bloat }}
       BENCH_NO_CACHE: ${{ inputs.no-cache || 'false' }}
-      BENCH_NO_SLACK: ${{ inputs.no-slack }}
+      BENCH_NO_SLACK: ${{ inputs.no-slack || 'true' }}
       BENCH_BENCH_ARGS: ${{ inputs.bench-args }}
       BENCH_BENCH_ENV: ${{ inputs.bench-env }}
       BENCH_BASELINE_ENV: ${{ inputs.baseline-env }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,6 +36,8 @@ jobs:
       max-concurrent-requests: ${{ steps.args.outputs.max-concurrent-requests }}
       baseline: ${{ steps.args.outputs.baseline }}
       feature: ${{ steps.args.outputs.feature }}
+      baseline-hardfork: ${{ steps.args.outputs.baseline-hardfork }}
+      feature-hardfork: ${{ steps.args.outputs.feature-hardfork }}
       txgen-ref: ${{ steps.args.outputs.txgen-ref }}
       baseline-name: ${{ steps.args.outputs.baseline-name }}
       feature-name: ${{ steps.args.outputs.feature-name }}
@@ -102,7 +104,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
-            let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup;
+            let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup;
             let explicitWarmup = false;
 
             pr = String(context.issue.number);
@@ -111,10 +113,11 @@ jobs:
             const body = context.payload.comment.body.trim();
             const intArgs = new Set(['duration', 'bloat', 'tps', 'accounts', 'max-concurrent-requests', 'gas-limit', 'tracy-seconds', 'tracy-offset', 'blocks', 'warmup']);
             const refArgs = new Set(['baseline', 'feature', 'txgen-ref']);
-            const stringArgs = new Set(['mode', 'preset', 'tracy', 'baseline-args', 'feature-args', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain']);
+            const stringArgs = new Set(['mode', 'preset', 'tracy', 'baseline-args', 'feature-args', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain', 'baseline-hardfork', 'feature-hardfork']);
             const boolArgs = new Set(['samply', 'force-bloat', 'no-cache', 'no-slack', 'no-existing-recipients', 'otlp']);
             const bloatValues = new Set(['1', '10', '100']);
-            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '10000', accounts: '1000', 'max-concurrent-requests': '100', baseline: '', feature: '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet' };
+            const hardforkValues = new Set(['T0', 'T1', 'T1A', 'T1B', 'T1C', 'T2', 'T3', 'T4', 'T5', 'T6']);
+            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '10000', accounts: '1000', 'max-concurrent-requests': '100', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet' };
             const unknown = [];
             const invalid = [];
             const defaultWarmup = (blockCount) => String(Math.floor(Number(blockCount) / 4));
@@ -187,7 +190,7 @@ jobs:
             if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
             if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
             if (errors.length) {
-              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [txgen-ref=REF] [samply] [otlp] [force-bloat] [no-cache] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
+              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [txgen-ref=REF] [samply] [otlp] [force-bloat] [no-cache] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -206,6 +209,8 @@ jobs:
             maxConcurrentRequests = defaults['max-concurrent-requests'];
             baseline = defaults.baseline;
             feature = defaults.feature;
+            baselineHardfork = defaults['baseline-hardfork'];
+            featureHardfork = defaults['feature-hardfork'];
             txgenRef = defaults['txgen-ref'];
             samply = defaults.samply;
             tracy = defaults.tracy;
@@ -234,7 +239,7 @@ jobs:
             const erFlag = `--existing-recipients=${existingRecipients}`;
             benchArgs = benchArgs ? `${benchArgs} ${erFlag}` : erFlag;
 
-            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [txgen-ref=REF] [samply] [otlp] [force-bloat] [no-cache] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
+            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [txgen-ref=REF] [samply] [otlp] [force-bloat] [no-cache] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 
             // Validate chain value
             if (!['mainnet', 'testnet'].includes(chain)) {
@@ -260,6 +265,45 @@ jobs:
               });
               core.setFailed(msg);
               return;
+            }
+
+            if ((baselineHardfork || featureHardfork) && mode !== 'e2e') {
+              const msg = `❌ **Invalid bench command**\n\n\`baseline-hardfork\` and \`feature-hardfork\` are only supported with \`mode=e2e\`.\n\n${usageStr}`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: msg,
+              });
+              core.setFailed(msg);
+              return;
+            }
+            if ((baselineHardfork || featureHardfork) && !(baselineHardfork && featureHardfork)) {
+              const msg = `❌ **Invalid bench command**\n\n\`baseline-hardfork\` and \`feature-hardfork\` must be provided together.\n\n${usageStr}`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: msg,
+              });
+              core.setFailed(msg);
+              return;
+            }
+            if (baselineHardfork || featureHardfork) {
+              baselineHardfork = baselineHardfork.toUpperCase();
+              featureHardfork = featureHardfork.toUpperCase();
+              const badHardforks = [baselineHardfork, featureHardfork].filter(value => !hardforkValues.has(value));
+              if (badHardforks.length) {
+                const msg = `❌ **Invalid bench command**\n\nUnknown hardfork(s): \`${badHardforks.join('`, `')}\`. Must be one of: \`${Array.from(hardforkValues).join('`, `')}\`.\n\n${usageStr}`;
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: msg,
+                });
+                core.setFailed(msg);
+                return;
+              }
             }
 
             // Validate tracy value
@@ -321,6 +365,8 @@ jobs:
             core.setOutput('max-concurrent-requests', maxConcurrentRequests);
             core.setOutput('baseline', baseline);
             core.setOutput('feature', feature);
+            core.setOutput('baseline-hardfork', baselineHardfork || '');
+            core.setOutput('feature-hardfork', featureHardfork || '');
             core.setOutput('txgen-ref', txgenRef || '');
             core.setOutput('baseline-name', baselineName);
             core.setOutput('feature-name', featureName);
@@ -359,6 +405,8 @@ jobs:
           ACK_MAX_CONCURRENT_REQUESTS: ${{ steps.args.outputs.max-concurrent-requests }}
           ACK_BASELINE_NAME: ${{ steps.args.outputs.baseline-name }}
           ACK_FEATURE_NAME: ${{ steps.args.outputs.feature-name }}
+          ACK_BASELINE_HARDFORK: ${{ steps.args.outputs.baseline-hardfork }}
+          ACK_FEATURE_HARDFORK: ${{ steps.args.outputs.feature-hardfork }}
           ACK_TXGEN_REF: ${{ steps.args.outputs.txgen-ref }}
           ACK_SAMPLY: ${{ steps.args.outputs.samply }}
           ACK_TRACY: ${{ steps.args.outputs.tracy }}
@@ -394,6 +442,8 @@ jobs:
             const maxConcurrentRequests = process.env.ACK_MAX_CONCURRENT_REQUESTS;
             const baseline = process.env.ACK_BASELINE_NAME;
             const feature = process.env.ACK_FEATURE_NAME;
+            const baselineHardfork = process.env.ACK_BASELINE_HARDFORK || '';
+            const featureHardfork = process.env.ACK_FEATURE_HARDFORK || '';
             const txgenRef = process.env.ACK_TXGEN_REF || 'default';
             const samply = process.env.ACK_SAMPLY === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
@@ -407,7 +457,8 @@ jobs:
             const gasLimit = process.env.ACK_GAS_LIMIT;
             const noCache = process.env.ACK_NO_CACHE === 'true';
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
-            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${samplyNote}${tracyNote}${otlpNote}${naNote}${noCacheNote}`;
+            const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
+            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${samplyNote}${tracyNote}${otlpNote}${naNote}${noCacheNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -433,6 +484,8 @@ jobs:
       max-concurrent-requests: ${{ needs.tempo-bench-ack.outputs.max-concurrent-requests }}
       baseline: ${{ needs.tempo-bench-ack.outputs.baseline }}
       feature: ${{ needs.tempo-bench-ack.outputs.feature }}
+      baseline-hardfork: ${{ needs.tempo-bench-ack.outputs.baseline-hardfork }}
+      feature-hardfork: ${{ needs.tempo-bench-ack.outputs.feature-hardfork }}
       txgen-ref: ${{ needs.tempo-bench-ack.outputs.txgen-ref }}
       baseline-name: ${{ needs.tempo-bench-ack.outputs.baseline-name }}
       feature-name: ${{ needs.tempo-bench-ack.outputs.feature-name }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -319,19 +319,6 @@ jobs:
               return;
             }
 
-            // Mutual exclusivity: samply and tracy cannot be used together
-            if (samply === 'true' && tracy !== 'off') {
-              const msg = '❌ **Invalid bench command**\n\n`samply` and `tracy` are mutually exclusive. Choose one.';
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: msg,
-              });
-              core.setFailed(msg);
-              return;
-            }
-
             if (!['manual', 'nightly'].includes(runType)) {
               const msg = `❌ **Invalid benchmark type**\n\n\`run-type=${runType}\` is not valid. Must be \`manual\` or \`nightly\`.`;
               core.setFailed(msg);

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -334,6 +334,56 @@ def e2e-snapshots-ready [a_db: string, b_db: string] {
     (e2e-snapshot-ready $a_db) and (e2e-snapshot-ready $b_db)
 }
 
+def e2e-snapshot-state-hardfork [datadir: string] {
+    let marker = (read-bench-marker $datadir)
+    if $marker == null {
+        return (latest-tempo-hardfork)
+    }
+    let state_hardfork = ($marker | get -o state_hardfork | default "")
+    if $state_hardfork == "" {
+        return (latest-tempo-hardfork)
+    }
+    normalize-hardfork $state_hardfork
+}
+
+def ensure-e2e-snapshot-supports-hardfork [datadir: string, requested_hardfork: string] {
+    let state_hardfork = (e2e-snapshot-state-hardfork $datadir)
+    let requested = (normalize-hardfork $requested_hardfork)
+    if (hardfork-index $state_hardfork) < (hardfork-index $requested) {
+        print $"Error: local e2e snapshot at ($datadir) was initialized with state_hardfork=($state_hardfork), but requested ($requested)."
+        print "Re-run with --force-bloat to regenerate the local benchmark snapshot for the requested hardfork."
+        exit 1
+    }
+}
+
+def e2e-synthesize-hardfork-genesis [source_genesis: string, target_genesis: string, hardfork: string] {
+    let fork = (normalize-hardfork $hardfork)
+    mut config = (open $source_genesis | get config)
+    for field in (hardfork-genesis-config-fields $fork) {
+        $config = ($config | upsert $field.name $field.value)
+    }
+    let genesis = (
+        open $source_genesis
+        | upsert config $config
+        | upsert baseFeePerGas (hardfork-base-fee-per-gas $fork)
+    )
+    let target_dir = ($target_genesis | path dirname)
+    mkdir $target_dir
+    $genesis | to json | save -f $target_genesis
+    print $"Synthesized ($fork) genesis at ($target_genesis)"
+}
+
+def e2e-regenesis [tempo_bin: string, genesis: string, datadir: string] {
+    print $"Running tempo regenesis for ($datadir) with ($genesis)..."
+    let result = (run-external $tempo_bin "regenesis" "--chain" $genesis "--datadir" $datadir | complete)
+    if $result.stdout != "" { print $result.stdout }
+    if $result.stderr != "" { print $result.stderr }
+    if $result.exit_code != 0 {
+        print $"Error: tempo regenesis failed for ($datadir) with exit code ($result.exit_code)"
+        exit $result.exit_code
+    }
+}
+
 def derive-tracing-otlp [tracing_otlp: string] {
     if $tracing_otlp == "" and ($env.GRAFANA_TEMPO? | default "" | str length) > 0 {
         let base = ($env.GRAFANA_TEMPO | str trim --right --char '/')
@@ -678,6 +728,8 @@ def run-local-e2e-phase [run: record, ctx: record] {
     let phase = $run.phase
     print $"=== Starting local e2e phase: ($phase) ==="
     let run_type = if ($phase | str starts-with "baseline") { "baseline" } else { "feature" }
+    let genesis = ($run | get -o genesis | default $ctx.genesis)
+    let regenesis = ($run | get -o regenesis | default false)
     let side_args = if $run_type == "baseline" { $ctx.baseline_args } else { $ctx.feature_args }
     let side_env = if $run_type == "baseline" { $ctx.baseline_env } else { $ctx.feature_env }
     let extra_args = if $side_args == "" { [] } else { $side_args | split row " " }
@@ -686,11 +738,15 @@ def run-local-e2e-phase [run: record, ctx: record] {
     bench-restore-at $ctx.a.state_path $ctx.a.mount $ctx.a.datadir
     bench-restore-at $ctx.b.state_path $ctx.b.mount $ctx.b.datadir
 
-    for path in [$ctx.genesis $ctx.a.node_dir $ctx.b.node_dir] {
+    for path in [$genesis $ctx.a.node_dir $ctx.b.node_dir] {
         if not ($path | path exists) {
             print $"Error: required e2e path does not exist after snapshot recovery: ($path)"
             exit 1
         }
+    }
+    if $regenesis {
+        e2e-regenesis $run.tempo $genesis $ctx.a.datadir
+        e2e-regenesis $run.tempo $genesis $ctx.b.datadir
     }
     for role_info in [
         { role: "a", node_dir: $ctx.a.node_dir }
@@ -727,13 +783,13 @@ def run-local-e2e-phase [run: record, ctx: record] {
 
     let a_rpc = "http://127.0.0.1:8545"
     let b_rpc = "http://127.0.0.1:8645"
-    let a_base_args = (build-base-args $ctx.genesis $ctx.a.datadir $a_log_dir "0.0.0.0" 8545 9001)
+    let a_base_args = (build-base-args $genesis $ctx.a.datadir $a_log_dir "0.0.0.0" 8545 9001)
         | append (build-e2e-consensus-args $ctx.a.node_dir $ctx.trusted_peers $ctx.a.consensus_port $ctx.a.ip)
         | append $E2E_LOCAL_RETH_ARGS
         | append (log-filter-args $ctx.loud)
         | append (if $ctx.gas_limit != "" { ["--builder.gaslimit" $ctx.gas_limit] } else { [] })
         | append (if $ctx.tracy != "off" { ["--log.tracy" "--log.tracy.filter" $ctx.tracy_filter] } else { [] })
-    let b_base_args = (build-base-args $ctx.genesis $ctx.b.datadir $b_log_dir "0.0.0.0" 8645 9101)
+    let b_base_args = (build-base-args $genesis $ctx.b.datadir $b_log_dir "0.0.0.0" 8645 9101)
         | append (build-e2e-consensus-args $ctx.b.node_dir $ctx.trusted_peers $ctx.b.consensus_port $ctx.b.ip)
         | append $E2E_LOCAL_RETH_ARGS
         | append (log-filter-args $ctx.loud)
@@ -901,6 +957,8 @@ def "main e2e" [
     --bench-env: string = ""                            # Environment vars for the sender process
     --baseline-name: string = ""                         # Baseline display name for summary
     --feature-name: string = ""                          # Feature display name for summary
+    --baseline-hardfork: string = ""                     # Latest active hardfork for baseline phases
+    --feature-hardfork: string = ""                      # Latest active hardfork for feature phases
     --tune                                              # Apply system tuning
     --loud                                              # Show node debug logs
     --no-cache                                           # Skip binary cache
@@ -934,6 +992,19 @@ def "main e2e" [
         print "Error: tracy-capture not found. Install tracy and ensure tracy-capture is in PATH."
         exit 1
     }
+    let hardfork_mode = $baseline_hardfork != "" or $feature_hardfork != ""
+    if $hardfork_mode and ($baseline_hardfork == "" or $feature_hardfork == "") {
+        print "Error: --baseline-hardfork and --feature-hardfork must both be provided"
+        exit 1
+    }
+    let baseline_hardfork_name = if $hardfork_mode { normalize-hardfork $baseline_hardfork } else { "" }
+    let feature_hardfork_name = if $hardfork_mode { normalize-hardfork $feature_hardfork } else { "" }
+    let snapshot_state_hardfork = if $hardfork_mode {
+        highest-hardfork [$baseline_hardfork_name $feature_hardfork_name]
+    } else {
+        latest-tempo-hardfork
+    }
+    let snapshot_hardfork_args = (hardfork-to-genesis-args $snapshot_state_hardfork)
 
     let validator_list = (
         $E2E_VALIDATORS
@@ -1002,7 +1073,7 @@ def "main e2e" [
         let tempo_bin = if $profile == "dev" { "./target/debug/tempo" } else { $"./target/($profile)/tempo" }
         let genesis_accounts = ([$accounts 3] | math max) + 1
         print $"Generating local e2e localnet config for validators: ($E2E_VALIDATORS)"
-        cargo run -p tempo-xtask --profile $profile -- generate-localnet -o $init_dir --accounts $genesis_accounts --validators $E2E_VALIDATORS --seed $E2E_SEED --force ...$gas_limit_args
+        cargo run -p tempo-xtask --profile $profile -- generate-localnet -o $init_dir --accounts $genesis_accounts --validators $E2E_VALIDATORS --seed $E2E_SEED --force ...$gas_limit_args ...$snapshot_hardfork_args
 
         let trusted_peers = (trusted-peers-from-localnet $init_dir)
         if $trusted_peers == "" {
@@ -1025,6 +1096,7 @@ def "main e2e" [
             gas_limit: $gas_limit
             dkg_in_genesis: true
             topology: "single-runner"
+            state_hardfork: $snapshot_state_hardfork
         }
         init-local-e2e-side a $E2E_A_STATE_PATH $E2E_A_MOUNT $a_db $a_identity $"($init_dir)/($a_validator)" $generated_genesis $trusted_peers $bloat_mib $bloat_file $tempo_bin ($marker | insert bench_datadir $a_db | insert node_dir $a_identity | insert validator_addr $a_validator)
         init-local-e2e-side b $E2E_B_STATE_PATH $E2E_B_MOUNT $b_db $b_identity $"($init_dir)/($b_validator)" $generated_genesis $trusted_peers $bloat_mib $bloat_file $tempo_bin ($marker | insert bench_datadir $b_db | insert node_dir $b_identity | insert validator_addr $b_validator)
@@ -1040,6 +1112,17 @@ def "main e2e" [
     if $init_only {
         cleanup-local-e2e-processes
         return
+    }
+    let hardfork_genesis_dir = $"($LOCALNET_DIR)/e2e-hardfork-genesis"
+    let baseline_genesis_path = if $hardfork_mode { $"($hardfork_genesis_dir)/genesis-baseline.json" } else { $genesis_path }
+    let feature_genesis_path = if $hardfork_mode { $"($hardfork_genesis_dir)/genesis-feature.json" } else { $genesis_path }
+    if $hardfork_mode {
+        ensure-e2e-snapshot-supports-hardfork $a_db $snapshot_state_hardfork
+        ensure-e2e-snapshot-supports-hardfork $b_db $snapshot_state_hardfork
+        if ($hardfork_genesis_dir | path exists) { rm -rf $hardfork_genesis_dir }
+        mkdir $hardfork_genesis_dir
+        e2e-synthesize-hardfork-genesis $genesis_path $baseline_genesis_path $baseline_hardfork_name
+        e2e-synthesize-hardfork-genesis $genesis_path $feature_genesis_path $feature_hardfork_name
     }
     let trusted_peers = if ($a_trusted_peers_path | path exists) {
         open $a_trusted_peers_path | str trim
@@ -1137,10 +1220,10 @@ def "main e2e" [
     }
 
     let runs = [
-        { phase: "baseline-1", ref: $baseline, tempo: $baseline_tempo }
-        { phase: "feature-1", ref: $feature, tempo: $feature_tempo }
-        { phase: "feature-2", ref: $feature, tempo: $feature_tempo }
-        { phase: "baseline-2", ref: $baseline, tempo: $baseline_tempo }
+        { phase: "baseline-1", ref: $baseline, tempo: $baseline_tempo, genesis: $baseline_genesis_path, regenesis: $hardfork_mode }
+        { phase: "feature-1", ref: $feature, tempo: $feature_tempo, genesis: $feature_genesis_path, regenesis: $hardfork_mode }
+        { phase: "feature-2", ref: $feature, tempo: $feature_tempo, genesis: $feature_genesis_path, regenesis: $hardfork_mode }
+        { phase: "baseline-2", ref: $baseline, tempo: $baseline_tempo, genesis: $baseline_genesis_path, regenesis: $hardfork_mode }
     ]
     mut e2e_exit = 0
     for run in $runs {
@@ -1175,8 +1258,10 @@ def "main e2e" [
         }
     }
 
-    let baseline_label = if $baseline_name != "" { $baseline_name } else { $baseline }
-    let feature_label = if $feature_name != "" { $feature_name } else { $feature }
+    let baseline_base_label = if $baseline_name != "" { $baseline_name } else { $baseline }
+    let feature_base_label = if $feature_name != "" { $feature_name } else { $feature }
+    let baseline_label = if $hardfork_mode { $"($baseline_base_label) \(($baseline_hardfork_name)\)" } else { $baseline_base_label }
+    let feature_label = if $hardfork_mode { $"($feature_base_label) \(($feature_hardfork_name)\)" } else { $feature_base_label }
     if $e2e_exit == 0 {
         generate-summary $results_dir $baseline_label $feature_label $bloat_mib $preset $tps $duration --benchmark-id $benchmark_id --reference-epoch $reference_epoch
     }

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -732,7 +732,6 @@ def run-local-e2e-phase [run: record, ctx: record] {
     print $"=== Starting local e2e phase: ($phase) ==="
     let run_type = if ($phase | str starts-with "baseline") { "baseline" } else { "feature" }
     let genesis = ($run | get -o genesis | default $ctx.genesis)
-    let regenesis = ($run | get -o regenesis | default false)
     let hardfork = ($run | get -o hardfork | default "")
     let side_args = if $run_type == "baseline" { $ctx.baseline_args } else { $ctx.feature_args }
     let side_env = if $run_type == "baseline" { $ctx.baseline_env } else { $ctx.feature_env }
@@ -748,7 +747,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
             exit 1
         }
     }
-    if $regenesis {
+    if $hardfork != "" {
         e2e-regenesis $run.tempo $genesis $ctx.a.datadir $hardfork
         e2e-regenesis $run.tempo $genesis $ctx.b.datadir $hardfork
     }
@@ -1222,10 +1221,10 @@ def "main e2e" [
     }
 
     let runs = [
-        { phase: "baseline-1", ref: $baseline, tempo: $baseline_tempo, genesis: $baseline_genesis_path, regenesis: $hardfork_mode, hardfork: $baseline_hardfork_name }
-        { phase: "feature-1", ref: $feature, tempo: $feature_tempo, genesis: $feature_genesis_path, regenesis: $hardfork_mode, hardfork: $feature_hardfork_name }
-        { phase: "feature-2", ref: $feature, tempo: $feature_tempo, genesis: $feature_genesis_path, regenesis: $hardfork_mode, hardfork: $feature_hardfork_name }
-        { phase: "baseline-2", ref: $baseline, tempo: $baseline_tempo, genesis: $baseline_genesis_path, regenesis: $hardfork_mode, hardfork: $baseline_hardfork_name }
+        { phase: "baseline-1", ref: $baseline, tempo: $baseline_tempo, genesis: $baseline_genesis_path, hardfork: $baseline_hardfork_name }
+        { phase: "feature-1", ref: $feature, tempo: $feature_tempo, genesis: $feature_genesis_path, hardfork: $feature_hardfork_name }
+        { phase: "feature-2", ref: $feature, tempo: $feature_tempo, genesis: $feature_genesis_path, hardfork: $feature_hardfork_name }
+        { phase: "baseline-2", ref: $baseline, tempo: $baseline_tempo, genesis: $baseline_genesis_path, hardfork: $baseline_hardfork_name }
     ]
     mut e2e_exit = 0
     for run in $runs {

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -346,14 +346,11 @@ def e2e-snapshot-state-hardfork [datadir: string] {
     normalize-hardfork $state_hardfork
 }
 
-def ensure-e2e-snapshot-supports-hardfork [datadir: string, requested_hardfork: string] {
-    let state_hardfork = (e2e-snapshot-state-hardfork $datadir)
-    let requested = (normalize-hardfork $requested_hardfork)
-    if (hardfork-index $state_hardfork) < (hardfork-index $requested) {
-        print $"Error: local e2e snapshot at ($datadir) was initialized with state_hardfork=($state_hardfork), but requested ($requested)."
-        print "Re-run with --force-bloat to regenerate the local benchmark snapshot for the requested hardfork."
-        exit 1
-    }
+def e2e-update-snapshot-hardfork-marker [datadir: string, hardfork: string] {
+    let fork = (normalize-hardfork $hardfork)
+    let marker_path = $"($datadir)/($BENCH_META_SUBDIR)/marker.json"
+    let marker = (open $marker_path)
+    $marker | upsert state_hardfork $fork | to json | save -f $marker_path
 }
 
 def e2e-synthesize-hardfork-genesis [source_genesis: string, target_genesis: string, hardfork: string] {
@@ -370,22 +367,15 @@ def e2e-synthesize-hardfork-genesis [source_genesis: string, target_genesis: str
     print $"Synthesized ($fork) genesis at ($target_genesis)"
 }
 
-def e2e-hardfork-config-matches [genesis: string, hardfork: string] {
-    let fork = (normalize-hardfork $hardfork)
-    let config = (open $genesis | get config)
-    hardfork-genesis-config-fields $fork | all { |field|
-        ($config | get -o $field.name) == $field.value
-    }
-}
-
 def e2e-regenesis [tempo_bin: string, genesis: string, datadir: string, hardfork: string] {
-    let current_genesis = $"($datadir)/($BENCH_META_SUBDIR)/genesis.json"
-    if (e2e-hardfork-config-matches $current_genesis $hardfork) {
-        print $"Skipping tempo regenesis for ($datadir); hardfork config already matches ($hardfork)"
+    let fork = (normalize-hardfork $hardfork)
+    let current_hardfork = (e2e-snapshot-state-hardfork $datadir)
+    if $current_hardfork == $fork {
+        print $"Skipping tempo regenesis for ($datadir); marker state_hardfork already matches ($fork)"
         return
     }
 
-    print $"Running tempo regenesis for ($datadir) with ($genesis)..."
+    print $"Running tempo regenesis for ($datadir): state_hardfork=($current_hardfork) -> ($fork) with ($genesis)..."
     let result = (run-external $tempo_bin "regenesis" "--chain" $genesis "--datadir" $datadir | complete)
     if $result.stdout != "" { print $result.stdout }
     if $result.stderr != "" { print $result.stderr }
@@ -393,6 +383,8 @@ def e2e-regenesis [tempo_bin: string, genesis: string, datadir: string, hardfork
         print $"Error: tempo regenesis failed for ($datadir) with exit code ($result.exit_code)"
         exit $result.exit_code
     }
+    e2e-synthesize-hardfork-genesis $"($datadir)/($BENCH_META_SUBDIR)/genesis.json" $"($datadir)/($BENCH_META_SUBDIR)/genesis.json" $fork
+    e2e-update-snapshot-hardfork-marker $datadir $fork
 }
 
 def derive-tracing-otlp [tracing_otlp: string] {
@@ -1129,8 +1121,6 @@ def "main e2e" [
     let baseline_genesis_path = if $hardfork_mode { $"($hardfork_genesis_dir)/genesis-baseline.json" } else { $genesis_path }
     let feature_genesis_path = if $hardfork_mode { $"($hardfork_genesis_dir)/genesis-feature.json" } else { $genesis_path }
     if $hardfork_mode {
-        ensure-e2e-snapshot-supports-hardfork $a_db $snapshot_state_hardfork
-        ensure-e2e-snapshot-supports-hardfork $b_db $snapshot_state_hardfork
         if ($hardfork_genesis_dir | path exists) { rm -rf $hardfork_genesis_dir }
         mkdir $hardfork_genesis_dir
         e2e-synthesize-hardfork-genesis $genesis_path $baseline_genesis_path $baseline_hardfork_name

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -358,22 +358,33 @@ def ensure-e2e-snapshot-supports-hardfork [datadir: string, requested_hardfork: 
 
 def e2e-synthesize-hardfork-genesis [source_genesis: string, target_genesis: string, hardfork: string] {
     let fork = (normalize-hardfork $hardfork)
-    mut config = (open $source_genesis | get config)
+    let source = (open $source_genesis)
+    mut config = ($source | get config)
     for field in (hardfork-genesis-config-fields $fork) {
         $config = ($config | upsert $field.name $field.value)
     }
-    let genesis = (
-        open $source_genesis
-        | upsert config $config
-        | upsert baseFeePerGas (hardfork-base-fee-per-gas $fork)
-    )
+    let genesis = ($source | upsert config $config)
     let target_dir = ($target_genesis | path dirname)
     mkdir $target_dir
     $genesis | to json | save -f $target_genesis
     print $"Synthesized ($fork) genesis at ($target_genesis)"
 }
 
-def e2e-regenesis [tempo_bin: string, genesis: string, datadir: string] {
+def e2e-hardfork-config-matches [genesis: string, hardfork: string] {
+    let fork = (normalize-hardfork $hardfork)
+    let config = (open $genesis | get config)
+    hardfork-genesis-config-fields $fork | all { |field|
+        ($config | get -o $field.name) == $field.value
+    }
+}
+
+def e2e-regenesis [tempo_bin: string, genesis: string, datadir: string, hardfork: string] {
+    let current_genesis = $"($datadir)/($BENCH_META_SUBDIR)/genesis.json"
+    if (e2e-hardfork-config-matches $current_genesis $hardfork) {
+        print $"Skipping tempo regenesis for ($datadir); hardfork config already matches ($hardfork)"
+        return
+    }
+
     print $"Running tempo regenesis for ($datadir) with ($genesis)..."
     let result = (run-external $tempo_bin "regenesis" "--chain" $genesis "--datadir" $datadir | complete)
     if $result.stdout != "" { print $result.stdout }
@@ -730,6 +741,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
     let run_type = if ($phase | str starts-with "baseline") { "baseline" } else { "feature" }
     let genesis = ($run | get -o genesis | default $ctx.genesis)
     let regenesis = ($run | get -o regenesis | default false)
+    let hardfork = ($run | get -o hardfork | default "")
     let side_args = if $run_type == "baseline" { $ctx.baseline_args } else { $ctx.feature_args }
     let side_env = if $run_type == "baseline" { $ctx.baseline_env } else { $ctx.feature_env }
     let extra_args = if $side_args == "" { [] } else { $side_args | split row " " }
@@ -745,8 +757,8 @@ def run-local-e2e-phase [run: record, ctx: record] {
         }
     }
     if $regenesis {
-        e2e-regenesis $run.tempo $genesis $ctx.a.datadir
-        e2e-regenesis $run.tempo $genesis $ctx.b.datadir
+        e2e-regenesis $run.tempo $genesis $ctx.a.datadir $hardfork
+        e2e-regenesis $run.tempo $genesis $ctx.b.datadir $hardfork
     }
     for role_info in [
         { role: "a", node_dir: $ctx.a.node_dir }
@@ -1220,10 +1232,10 @@ def "main e2e" [
     }
 
     let runs = [
-        { phase: "baseline-1", ref: $baseline, tempo: $baseline_tempo, genesis: $baseline_genesis_path, regenesis: $hardfork_mode }
-        { phase: "feature-1", ref: $feature, tempo: $feature_tempo, genesis: $feature_genesis_path, regenesis: $hardfork_mode }
-        { phase: "feature-2", ref: $feature, tempo: $feature_tempo, genesis: $feature_genesis_path, regenesis: $hardfork_mode }
-        { phase: "baseline-2", ref: $baseline, tempo: $baseline_tempo, genesis: $baseline_genesis_path, regenesis: $hardfork_mode }
+        { phase: "baseline-1", ref: $baseline, tempo: $baseline_tempo, genesis: $baseline_genesis_path, regenesis: $hardfork_mode, hardfork: $baseline_hardfork_name }
+        { phase: "feature-1", ref: $feature, tempo: $feature_tempo, genesis: $feature_genesis_path, regenesis: $hardfork_mode, hardfork: $feature_hardfork_name }
+        { phase: "feature-2", ref: $feature, tempo: $feature_tempo, genesis: $feature_genesis_path, regenesis: $hardfork_mode, hardfork: $feature_hardfork_name }
+        { phase: "baseline-2", ref: $baseline, tempo: $baseline_tempo, genesis: $baseline_genesis_path, regenesis: $hardfork_mode, hardfork: $baseline_hardfork_name }
     ]
     mut e2e_exit = 0
     for run in $runs {

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -863,7 +863,6 @@ def run-local-e2e-phase [run: record, ctx: record] {
 
             let report_path = $"($ctx.results_dir)/report-($phase).json"
             let tx_count = [($ctx.tps * $ctx.duration) 1] | math max
-            let bench_duration = $"($ctx.duration)sec"
             let txgen_cmd = [
                 $ctx.txgen.txgen_tempo_bin
                 "generate"
@@ -881,7 +880,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 "--metrics-url" "http://127.0.0.1:9001/metrics"
                 "--scrape-interval-ms" $TXGEN_SCRAPE_INTERVAL_MS
                 "--drain-timeout" $TXGEN_DRAIN_TIMEOUT_SECS
-                "--duration" $bench_duration
+                "--duration" $ctx.duration
                 "--report" $"json:($report_path)"
                 "-m" $"chain_id=($chain_id)"
                 "-m" $"target_tps=($ctx.tps)"

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -982,10 +982,6 @@ def "main e2e" [
         print $"Error: --tracy must be one of: off, on, full \(got '($tracy)'\)"
         exit 1
     }
-    if $samply and $tracy != "off" {
-        print "Error: --samply and --tracy are mutually exclusive. Choose one."
-        exit 1
-    }
     let bloat_mib = (e2e-bloat-gib-to-mib $bloat)
     if $init_only and not $force_bloat {
         print "Error: --init-only requires --force-bloat"

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -863,6 +863,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
 
             let report_path = $"($ctx.results_dir)/report-($phase).json"
             let tx_count = [($ctx.tps * $ctx.duration) 1] | math max
+            let bench_duration = $"($ctx.duration)sec"
             let txgen_cmd = [
                 $ctx.txgen.txgen_tempo_bin
                 "generate"
@@ -880,7 +881,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 "--metrics-url" "http://127.0.0.1:9001/metrics"
                 "--scrape-interval-ms" $TXGEN_SCRAPE_INTERVAL_MS
                 "--drain-timeout" $TXGEN_DRAIN_TIMEOUT_SECS
-                "--duration" $ctx.duration
+                "--duration" $bench_duration
                 "--report" $"json:($report_path)"
                 "-m" $"chain_id=($chain_id)"
                 "-m" $"target_tps=($ctx.tps)"

--- a/tempo.nu
+++ b/tempo.nu
@@ -289,8 +289,6 @@ def read-bench-marker [datadir: string] {
 # Ordered list of all Tempo hardforks (must match TempoHardfork enum in crates/chainspec)
 const TEMPO_HARDFORKS = ["T0" "T1" "T1A" "T1B" "T1C" "T2" "T3" "T4" "T5" "T6"]
 const TEMPO_DISABLED_HARDFORK_TIME = 9223372036854775807
-const TEMPO_T0_BASE_FEE_PER_GAS = "0x2540be400"
-const TEMPO_T1_BASE_FEE_PER_GAS = "0x4a817c800"
 
 def normalize-hardfork [fork: string] {
     let fork_upper = ($fork | str upcase)
@@ -323,14 +321,6 @@ def highest-hardfork [forks: list<string>] {
         }
     }
     $highest
-}
-
-def hardfork-base-fee-per-gas [fork: string] {
-    if (hardfork-index $fork) >= (hardfork-index "T1") {
-        $TEMPO_T1_BASE_FEE_PER_GAS
-    } else {
-        $TEMPO_T0_BASE_FEE_PER_GAS
-    }
 }
 
 def hardfork-genesis-config-fields [fork: string] {

--- a/tempo.nu
+++ b/tempo.nu
@@ -287,23 +287,71 @@ def read-bench-marker [datadir: string] {
 # ============================================================================
 
 # Ordered list of all Tempo hardforks (must match TempoHardfork enum in crates/chainspec)
-const TEMPO_HARDFORKS = ["T0" "T1" "T1A" "T1B" "T1C" "T2" "T3" "T4"]
+const TEMPO_HARDFORKS = ["T0" "T1" "T1A" "T1B" "T1C" "T2" "T3" "T4" "T5" "T6"]
+const TEMPO_DISABLED_HARDFORK_TIME = 9223372036854775807
+const TEMPO_T0_BASE_FEE_PER_GAS = "0x2540be400"
+const TEMPO_T1_BASE_FEE_PER_GAS = "0x4a817c800"
 
-# Map a hardfork name to generate-genesis CLI args.
-# Forks up to and including the given fork are active at genesis (time=0).
-# Forks after are disabled (time=max u64).
-# Returns a list of CLI flag strings, e.g. ["--t0-time" "0" "--t1-time" "0" "--t1a-time" "9223372036854775807" ...]
-def hardfork-to-genesis-args [fork: string] {
+def normalize-hardfork [fork: string] {
     let fork_upper = ($fork | str upcase)
     let idx = ($TEMPO_HARDFORKS | enumerate | where item == $fork_upper)
     if ($idx | length) == 0 {
         print $"Error: unknown hardfork '($fork)'. Valid: ($TEMPO_HARDFORKS | str join ', ')"
         exit 1
     }
-    let cutoff = ($idx | get 0.index)
+    $fork_upper
+}
+
+def hardfork-index [fork: string] {
+    let fork_upper = (normalize-hardfork $fork)
+    ($TEMPO_HARDFORKS | enumerate | where item == $fork_upper | get 0.index)
+}
+
+def latest-tempo-hardfork [] {
+    $TEMPO_HARDFORKS | last
+}
+
+def highest-hardfork [forks: list<string>] {
+    if ($forks | length) == 0 {
+        return (latest-tempo-hardfork)
+    }
+    mut highest = (normalize-hardfork ($forks | first))
+    for fork in ($forks | skip 1) {
+        let current = (normalize-hardfork $fork)
+        if (hardfork-index $current) > (hardfork-index $highest) {
+            $highest = $current
+        }
+    }
+    $highest
+}
+
+def hardfork-base-fee-per-gas [fork: string] {
+    if (hardfork-index $fork) >= (hardfork-index "T1") {
+        $TEMPO_T1_BASE_FEE_PER_GAS
+    } else {
+        $TEMPO_T0_BASE_FEE_PER_GAS
+    }
+}
+
+def hardfork-genesis-config-fields [fork: string] {
+    let cutoff = (hardfork-index $fork)
     $TEMPO_HARDFORKS | enumerate | each { |it|
-        let flag = $"--($it.item | str downcase)-time"
-        let time = if $it.index <= $cutoff { "0" } else { "9223372036854775807" }
+        {
+            fork: $it.item
+            name: $"($it.item | str downcase)Time"
+            value: (if $it.index <= $cutoff { 0 } else { $TEMPO_DISABLED_HARDFORK_TIME })
+        }
+    }
+}
+
+# Map a hardfork name to generate-genesis CLI args.
+# Forks up to and including the given fork are active at genesis (time=0).
+# Forks after are disabled (time=max u64).
+# Returns a list of CLI flag strings, e.g. ["--t0-time" "0" "--t1-time" "0" "--t1a-time" "9223372036854775807" ...]
+def hardfork-to-genesis-args [fork: string] {
+    hardfork-genesis-config-fields $fork | each { |it|
+        let flag = $"--($it.fork | str downcase)-time"
+        let time = ($it.value | into string)
         [$flag $time]
     } | flatten
 }


### PR DESCRIPTION
Adds `baseline-hardfork` and `feature-hardfork` inputs to e2e bench workflows and forwards them through manual and comment-triggered runs.

When a restored snapshot marker does not match the requested hardfork, the harness synthesizes a genesis with only Tempo `config.t*Time` fields changed and runs `tempo regenesis`. Matching markers reuse the snapshot without regenerating or reimporting bloat.