### PR TITLE
ci(bench): run replay on dual schelk runners

### DIFF
--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -146,7 +146,7 @@ permissions:
 jobs:
   bench-replay:
     name: bench-replay
-    runs-on: [self-hosted, Linux, X64, bare-metal]
+    runs-on: [self-hosted, Linux, X64, bare-metal-dual-schelk]
     timeout-minutes: 300
     env:
       BENCH_CHAIN: ${{ inputs.chain || 'mainnet' }}

--- a/bench-schelk.nu
+++ b/bench-schelk.nu
@@ -33,14 +33,11 @@ def cmd-detect [] {
         return
     }
 
-    if ("/var/lib/schelk/state.json" | path exists) {
-        print "SCHELK_STATE_PATH=/var/lib/schelk/state.json"
-        print "SCHELK_MOUNT=/reth-bench"
-    } else if ("/var/lib/schelk/a.json" | path exists) {
+    if ("/var/lib/schelk/a.json" | path exists) {
         print "SCHELK_STATE_PATH=/var/lib/schelk/a.json"
         print "SCHELK_MOUNT=/reth-bench-a"
     } else {
-        print "::error::No supported schelk state file found"
+        print "::error::No dual-schelk state file found"
         exit 1
     }
 }


### PR DESCRIPTION
Routes replay benchmark jobs to the `bare-metal-dual-schelk` runner pool and removes the legacy schelk autodetect path from the shared bench helper. Replay now requires `/var/lib/schelk/a.json` and uses `/reth-bench-a`, matching the dual-schelk runner layout instead of falling back to `/var/lib/schelk/state.json` and `/reth-bench`.