### PR TITLE
feat(storage): enable v2 (hot/cold) layout by default

### DIFF
--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -4,7 +4,7 @@ use jiff::SignedDuration;
 use reth_cli_commands::download::DownloadDefaults;
 use reth_ethereum::node::core::args::{
     DefaultDiscoveryArgs, DefaultEngineValues, DefaultNetworkArgs, DefaultPayloadBuilderValues,
-    DefaultStorageValues, DefaultTxPoolValues,
+    DefaultTxPoolValues,
 };
 use std::{borrow::Cow, str::FromStr, time::Duration};
 use tempo_chainspec::hardfork::TempoHardfork;
@@ -198,14 +198,6 @@ fn init_txpool_defaults() {
         .expect("failed to initialize txpool defaults");
 }
 
-fn init_storage_defaults() {
-    DefaultStorageValues::default()
-        // NOTE: when changing, don't forget to change in `e2e::launch_execution_node`
-        .with_v2(false)
-        .try_init()
-        .expect("failed to initialize storage defaults");
-}
-
 fn init_engine_defaults() {
     DefaultEngineValues::default()
         // In Commonware consensus, it might happen that a head is notarized (causing it to become a canonical tip for reth),
@@ -257,7 +249,6 @@ fn init_discovery_defaults() {
 }
 
 pub(crate) fn init_defaults() {
-    init_storage_defaults();
     init_download_urls();
     init_payload_builder_defaults();
     init_txpool_defaults();

--- a/crates/e2e/src/execution_runtime.rs
+++ b/crates/e2e/src/execution_runtime.rs
@@ -40,7 +40,7 @@ use reth_ethereum::{
 };
 use reth_node_builder::{NodeBuilder, NodeConfig};
 use reth_node_core::{
-    args::{DatadirArgs, PayloadBuilderArgs, RpcServerArgs, StorageArgs},
+    args::{DatadirArgs, PayloadBuilderArgs, RpcServerArgs},
     exit::NodeExitFuture,
 };
 use reth_rpc_builder::RpcModuleSelection;
@@ -893,7 +893,6 @@ pub async fn launch_execution_node<P: AsRef<Path>>(
             interval: Duration::from_millis(100),
             ..Default::default()
         })
-        .with_storage(StorageArgs { v2: false })
         .apply(|mut c| {
             c.network.discovery.disable_discovery = true;
             c.network = c.network.with_unused_ports();


### PR DESCRIPTION
Switches the default storage layout to v2 (hot/cold).

### Changes
- `defaults.rs`: `init_storage_defaults()` now sets `.with_v2(true)`
- `execution_runtime.rs`: Removed explicit `.with_storage(StorageArgs { v2: false })` — the e2e test launcher now inherits the global default
- Cleaned up unused `StorageArgs` import