### PR TITLE
ci(bench): clear manual warmup default

### DIFF
--- a/.github/workflows/bench-replay-scheduled.yml
+++ b/.github/workflows/bench-replay-scheduled.yml
@@ -43,7 +43,6 @@ on:
       warmup:
         description: "Number of warmup blocks (default: one-quarter of blocks)"
         required: false
-        default: ""
         type: string
       samply:
         description: "Enable samply profiling"

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -22,7 +22,6 @@ on:
       warmup:
         description: "Number of warmup blocks (default: one-quarter of blocks)"
         type: string
-        default: ""
       samply:
         description: "Enable samply profiling"
         type: string


### PR DESCRIPTION
Removes the explicit empty default from manual replay benchmark warmup inputs so GitHub Actions renders the field without a preset value. The existing workflow resolution still treats an omitted warmup as one-quarter of the requested block count.

Co-Authored-By: Brian Picciano <933154+mediocregopher@users.noreply.github.com>

Prompted by: mediocregopher