### PR TITLE
deps: update reth from main (2026-05-12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8322,7 +8322,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8349,7 +8349,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8381,7 +8381,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8401,7 +8401,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8497,7 +8497,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8507,7 +8507,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8560,7 +8560,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8576,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8590,7 +8590,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8603,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8682,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8712,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8776,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8920,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8943,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9027,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9055,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9087,7 +9087,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9109,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9148,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9211,7 +9211,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "clap",
  "eyre",
@@ -9234,7 +9234,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9250,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9266,7 +9266,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9309,7 +9309,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9323,7 +9323,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9333,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9357,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9395,7 +9395,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9408,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9479,7 +9479,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "serde",
  "serde_json",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "bytes",
  "futures",
@@ -9537,7 +9537,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "bindgen",
  "cc",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "futures",
  "metrics",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9585,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9599,7 +9599,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9682,7 +9682,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9705,7 +9705,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9720,7 +9720,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9734,7 +9734,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9751,7 +9751,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9775,7 +9775,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9898,7 +9898,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9936,7 +9936,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9960,7 +9960,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9984,7 +9984,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "bytes",
  "eyre",
@@ -10013,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10025,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10049,7 +10049,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10061,7 +10061,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10127,7 +10127,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10175,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10204,7 +10204,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10220,7 +10220,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10235,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10312,7 +10312,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10342,7 +10342,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10385,7 +10385,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10405,7 +10405,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10482,7 +10482,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10530,7 +10530,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10544,7 +10544,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10575,7 +10575,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10627,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10655,7 +10655,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10704,7 +10704,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10729,7 +10729,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10747,7 +10747,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10768,7 +10768,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10784,7 +10784,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10794,7 +10794,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "clap",
  "eyre",
@@ -10813,7 +10813,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "clap",
  "eyre",
@@ -10831,7 +10831,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10876,7 +10876,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10902,7 +10902,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10929,7 +10929,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10949,7 +10949,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10978,7 +10978,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b5886ca#b5886caf30270bc24cf618f865115f46fdb0a767"
+source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,64 +140,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b5886ca", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`b5886ca...8248a24`](https://github.com/paradigmxyz/reth/compare/b5886ca...8248a24)

🔗 Amp thread: https://ampcode.com/threads/T-019e1c09-09ff-76a9-bebd-ac56d8039d0b
**Engine**
- Return BAL in payload bodies by hash v2 ([#24128](https://github.com/paradigmxyz/reth/pull/24128))
- Add test coverage for BAL executor error paths and gas tracker ([#24137](https://github.com/paradigmxyz/reth/pull/24137))

**Bench**
- Set OTLP `service.version` to baseline/feature label ([#24143](https://github.com/paradigmxyz/reth/pull/24143))
- Bump `BENCH_RUNNERS` from 2 to 4 ([#24146](https://github.com/paradigmxyz/reth/pull/24146))

**Observability**
- Add `DefaultTraceValues` for overridable OTLP service identity ([#24145](https://github.com/paradigmxyz/reth/pull/24145))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019e1c09-1981-7559-9551-05155f7b44dd
- Bumped all `reth-*` git dependencies in [Cargo.toml](file:///home/runner/work/tempo/tempo/Cargo.toml) from rev `b5886ca` to `8248a24` to track the latest upstream Reth SDK revision.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/25732441886)
