### PR TITLE
bench: show per-phase status in PR comment during benchmark runs

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -325,12 +325,38 @@ run_single() {
 }
 
 # ============================================================================
+# PR comment status helper
+# ============================================================================
+
+update_bench_status() {
+  local status="$1"
+  if [ -z "${BENCH_COMMENT_ID:-}" ] || [ -z "${BENCH_GH_TOKEN:-${DEREK_BENCH_TOKEN:-}}" ]; then
+    return 0
+  fi
+  local token="${BENCH_GH_TOKEN:-${DEREK_BENCH_TOKEN}}"
+  local body
+  body=$(printf 'cc @%s\n\n🚀 Benchmark started! [View job](%s)\n\n⏳ **Status:** %s\n\n%s' \
+    "${BENCH_ACTOR:-}" "${BENCH_JOB_URL:-}" "$status" "${BENCH_CONFIG:-}")
+  local payload
+  payload=$(jq -n --arg body "$body" '{body: $body}')
+  curl -sS -X PATCH \
+    "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/comments/${BENCH_COMMENT_ID}" \
+    -H "Authorization: token $token" \
+    -H "Accept: application/vnd.github+json" \
+    -d "$payload" > /dev/null || echo "Warning: failed to update PR comment status"
+}
+
+# ============================================================================
 # B-F-F-B interleaved runs
 # ============================================================================
 
+update_bench_status "Running replay phase baseline-1 (1/4)..."
 run_single baseline-1 "$BASELINE_BIN" "$BENCH_WORK_DIR/baseline-1"
+update_bench_status "Running replay phase feature-1 (2/4)..."
 run_single feature-1  "$FEATURE_BIN"  "$BENCH_WORK_DIR/feature-1"
+update_bench_status "Running replay phase feature-2 (3/4)..."
 run_single feature-2  "$FEATURE_BIN"  "$BENCH_WORK_DIR/feature-2"
+update_bench_status "Running replay phase baseline-2 (4/4)..."
 run_single baseline-2 "$BASELINE_BIN" "$BENCH_WORK_DIR/baseline-2"
 
 echo "All replay benchmark runs complete."

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -580,6 +580,7 @@ jobs:
         env:
           BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
+          BENCH_GH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
         run: |
           if [ "$BENCH_OTLP" != "true" ]; then
             unset TEMPO_TELEMETRY_URL

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -604,6 +604,26 @@ def init-local-e2e-side [
     bench-save-e2e-meta $datadir $meta_dir ($marker | insert validator_role $role) [[$generated_genesis "genesis.json"] [$generated_trusted_peers "trusted-peers.txt"]]
 }
 
+# Update the PR comment with current benchmark phase status.
+# Requires BENCH_GH_TOKEN, BENCH_COMMENT_ID, BENCH_ACTOR, BENCH_JOB_URL,
+# BENCH_CONFIG, and GITHUB_REPOSITORY environment variables.
+def bench-update-pr-status [status: string] {
+    let comment_id = ($env | get -o BENCH_COMMENT_ID | default "")
+    let token = ($env | get -o BENCH_GH_TOKEN | default "")
+    if $comment_id == "" or $token == "" { return }
+    let repo = $env.GITHUB_REPOSITORY
+    let actor = ($env | get -o BENCH_ACTOR | default "")
+    let job_url = ($env | get -o BENCH_JOB_URL | default "")
+    let config = ($env | get -o BENCH_CONFIG | default "")
+    let body = $"cc @($actor)\n\n🚀 Benchmark started! [View job]\(($job_url)\)\n\n⏳ **Status:** ($status)\n\n($config)"
+    let payload = { body: $body } | to json
+    try {
+        ^curl -sS -X PATCH $"https://api.github.com/repos/($repo)/issues/comments/($comment_id)" -H $"Authorization: token ($token)" -H "Accept: application/vnd.github+json" -d $payload | ignore
+    } catch {
+        print $"Warning: failed to update PR comment status"
+    }
+}
+
 def run-local-e2e-phase [run: record, ctx: record] {
     let phase = $run.phase
     print $"=== Starting local e2e phase: ($phase) ==="
@@ -1055,8 +1075,11 @@ def "main e2e" [
         { phase: "feature-2", ref: $feature, tempo: $feature_tempo, genesis: $feature_genesis_path, hardfork: $feature_hardfork_name }
         { phase: "baseline-2", ref: $baseline, tempo: $baseline_tempo, genesis: $baseline_genesis_path, hardfork: $baseline_hardfork_name }
     ]
+    let num_phases = ($runs | length)
     mut e2e_exit = 0
-    for run in $runs {
+    for idx in 0..<$num_phases {
+        let run = ($runs | get $idx)
+        bench-update-pr-status $"Running benchmark phase ($run.phase) \(($idx + 1)/($num_phases)\)..."
         let phase_exit = (run-local-e2e-phase $run $ctx)
         if $phase_exit != 0 {
             $e2e_exit = $phase_exit


### PR DESCRIPTION
Instead of a static **Running benchmark…** status, the PR comment now updates before each phase with the phase name and progress counter (e.g. `Running benchmark phase feature-1 (2/4)…`).

**Changes:**
- `bench-e2e.nu`: add `bench-update-pr-status` helper that calls the GitHub API via `curl`, invoked before each phase in the B-F-F-B loop
- `bench-e2e.yml`: pass `BENCH_GH_TOKEN` env var to the benchmark step
- `bench-tempo-replay.sh`: add `update_bench_status` helper with the same behavior for replay benchmarks