### PR TITLE
cli: mute tracing events for `tempo consensus` commands

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -407,6 +407,15 @@ fn main() -> eyre::Result<()> {
         telemetry_config.replace(config);
     }
 
+    // Mute tracing output for `tempo consensus` CLI commands so that only
+    // the command's own stdout (e.g. JSON) is emitted without interleaved log lines.
+    if matches!(
+        cli.command,
+        Commands::Ext(tempo_cmd::TempoSubcommand::Consensus(_))
+    ) {
+        cli.logs.log_stdout_filter = "off".to_string();
+    }
+
     let is_node = matches!(cli.command, Commands::Node(_));
 
     let (args_and_node_handle_tx, args_and_node_handle_rx) =


### PR DESCRIPTION
## Summary

Sets the stdout log filter to `"off"` when running any `tempo consensus` subcommand so that tracing output does not interleave with the command's own stdout (e.g. JSON responses from RPC queries).

## Changes

- **`bin/tempo/src/main.rs`**: Before the CLI runs, detect `Commands::Ext(TempoSubcommand::Consensus(_))` and override `cli.logs.log_stdout_filter` to `"off"`. This leverages reth's existing `LogArgs` filter mechanism — no new dependencies or plumbing required.