### PR TITLE
docs(tip-1028): make originator the default claimer

### DIFF
--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -108,7 +108,7 @@ ReceivePolicy(account) = (
 )
 ```
 
-`recoveryAuthority` selects who can claim future blocked receipts: `address(0)` means the receiver, `address(1)` is a sentinel meaning the transfer originator (i.e., where the funds came from), and any other address names a third-party recovery authority.
+`recoveryAuthority` selects who can claim future blocked receipts: `address(0)` means the transfer originator (i.e., where the funds came from), `address(1)` is a sentinel meaning the receiver, and any other address names a third-party recovery authority. Since uninitialized storage defaults to zero, the originator is the default claimer when a receive policy is set without an explicit recovery authority.
 
 If no receive policy is set, all transfers and mints are allowed.
 
@@ -140,7 +140,7 @@ mapping(address => address) public addressRecoveryAuthority;
 
 When `hasReceivePolicy == 0`, the address has no receive policy and all transfers and mints are allowed. The cached type fields are valid because policy type and token filter type are immutable after creation.
 
-`addressRecoveryAuthority[account]` stores the encoded recovery authority for the address. `address(0)` selects receiver recovery, `address(1)` is reserved as an originator-recovery sentinel, and any other address selects that third-party address or contract.
+`addressRecoveryAuthority[account]` stores the encoded recovery authority for the address. `address(0)` selects originator recovery (the default for uninitialized storage), `address(1)` is reserved as a receiver-recovery sentinel, and any other address selects that third-party address or contract.
 
 `recoveryAuthority` is stored separately because a 160-bit address does not fit in the packed config slot.
 
@@ -273,7 +273,7 @@ where:
 - `token`: the TIP-20 token whose balance ledger holds the blocked amount at `ESCROW_ADDRESS`.
 - `originator`: `from` for transfers, `msg.sender` for mints.
 - `recipient`: the literal `to` supplied at the TIP-20 entrypoint. For non-virtual inbounds this is the receiver itself; for TIP-1022 inbounds this is the virtual alias. The canonical owner is derived at claim time as `tip1022.resolve(recipient)`, which is deterministic.
-- `recoveryAuthority`: the encoded recovery authority captured when the receipt was created: `address(0)` for receiver recovery, `address(1)` as an originator-recovery sentinel, or a third-party address.
+- `recoveryAuthority`: the encoded recovery authority captured when the receipt was created: `address(0)` for originator recovery (default), `address(1)` as a receiver-recovery sentinel, or a third-party address.
 - `blockedReason`: `TOKEN_FILTER` or `RECEIVE_POLICY`.
 - `kind`: `TRANSFER` or `MINT`.
 - `memo`: original memo for memo-bearing paths, `bytes32(0)` otherwise.
@@ -302,8 +302,8 @@ The receipt witness only tells the escrow which receipt to consume. It does not 
 
 Each receipt is governed by the `recoveryAuthority` captured for that receipt at block time:
 
-- if `recoveryAuthority == address(0)`, only `receiver` may call `claimBlocked(...)`;
-- if `recoveryAuthority == address(1)`, only `receipt.originator` may call `claimBlocked(...)`; and
+- if `recoveryAuthority == address(0)`, only `receipt.originator` may call `claimBlocked(...)`;
+- if `recoveryAuthority == address(1)`, only `receiver` may call `claimBlocked(...)`; and
 - otherwise, only `recoveryAuthority` may call `claimBlocked(...)`.
 
 For transfer-like receipts, `originator` is `from`, including for `transferFrom` where `from` may differ from `msg.sender`. For mint receipts, `originator` is the mint caller. An originator-authorized claim of a blocked mint is a reroute of minted supply, not a refund.
@@ -312,7 +312,7 @@ Changing `addressRecoveryAuthority[receiver]` affects future receipts only. Exis
 
 The destination `to` and the receipt's `recoveryAuthority` decide whether the claim **resumes** the original transfer back to the receiver or **reroutes** it to a new address.
 
-When `recoveryAuthority != address(1)` and `to == receiver`, the claim resumes a previously authorized inbound. It bypasses the receiver's receive policy, token-level recipient authorization for the receiver, and AccountKeychain spending-limit metering. This is intentional. A blocked mint, for example, has already passed the token's original mint-recipient check on the inbound path. Releasing escrow back to the same receiver is not a new transfer and MUST NOT be rechecked against the recipient's receive policy. A third-party recovery authority may use this resume path because the receiver selected that authority.
+When `recoveryAuthority != address(0)` and `to == receiver`, the claim resumes a previously authorized inbound. It bypasses the receiver's receive policy, token-level recipient authorization for the receiver, and AccountKeychain spending-limit metering. This is intentional. A blocked mint, for example, has already passed the token's original mint-recipient check on the inbound path. Releasing escrow back to the same receiver is not a new transfer and MUST NOT be rechecked against the recipient's receive policy. A third-party recovery authority may use this resume path because the receiver selected that authority.
 
 All other claims are reroutes. This includes every originator-authorized claim, even if `to == receiver`. A reroute MUST reject `to == ESCROW_ADDRESS`. If `to` is a TIP-1022 virtual address, it is resolved to its master address before destination checks and final credit; if resolution fails, the call MUST revert with `ClaimDestinationUnauthorized()`. The reroute enforces token-level transfer-recipient authorization and receive policy checks against the resolved destination, using the consumed receipt's `originator` for the receive policy check. If either destination check fails, the call MUST revert with `ClaimDestinationUnauthorized()`. The `BlockedReceiptClaimed` event preserves the literal `to` supplied by the caller for attribution. If a direct receiver-authorized reroute is initiated through an access key, the claim MUST meter the claimed amount against the receiver's AccountKeychain spending limit as an ordinary TIP-20 spend by the receiver. If an originator-authorized reroute is initiated through an access key, it MUST meter against the originator. If the receiver uses a third-party recovery authority, any equivalent delegation, timelock, multisig, or key-policy enforcement is the responsibility of that authority.
 


### PR DESCRIPTION
## Summary

Swap the recovery-authority sentinel assignments so that **`address(0)` selects originator recovery** and **`address(1)` selects receiver recovery**.

Because Solidity storage defaults to zero, this makes the **originator the default claimer** when a receive policy is set without an explicit recovery authority — a safer default since blocked funds can always be returned to the sender without requiring the receiver to act.

### Changes

All spec references in `tips/tip-1028.md` are updated:
- `address(0)` → originator recovery (was receiver)
- `address(1)` → receiver recovery sentinel (was originator)
- Resume-path condition updated accordingly (`recoveryAuthority != address(0)`)

### Context

Matches the implementation change in #3800 ([c6000c28](https://github.com/tempoxyz/tempo/pull/3800/commits/c6000c282ba6a6aeb396ee514b1fbe0dd1c87570)).

Depends on #3791.