### PR TITLE
ci: full-crate Codecov coverage with PR delta comments

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -182,22 +182,40 @@ jobs:
           workspaces: foundry
 
       - name: Install llvm-tools
+        if: github.event_name != 'merge_group'
         run: rustup component add llvm-tools-preview
 
       - name: Patch foundry to use checked-out tempo crates
         run: tempo/scripts/foundry-patch.sh "$GITHUB_WORKSPACE/tempo" "$GITHUB_WORKSPACE/foundry"
 
+      # Build and run WITH coverage (pull_request and main push)
       - name: Build foundry forge with coverage instrumentation
+        if: github.event_name != 'merge_group'
         working-directory: foundry
         run: RUSTFLAGS="-C instrument-coverage" cargo build -p forge --profile release --no-default-features
 
       - name: Run Forge tests with Rust precompiles (with coverage)
+        if: github.event_name != 'merge_group'
         working-directory: tempo/tips/verify
         run: |
           echo "Running forge test with Rust precompiles"
           LLVM_PROFILE_FILE="$(pwd)/forge-coverage-%p.profraw" ../../../foundry/target/release/forge test -vvv
 
+      # Build and run WITHOUT coverage (merge_group)
+      - name: Build foundry forge
+        if: github.event_name == 'merge_group'
+        working-directory: foundry
+        run: cargo build -p forge --profile release --no-default-features
+
+      - name: Run Forge tests with Rust precompiles
+        if: github.event_name == 'merge_group'
+        working-directory: tempo/tips/verify
+        run: |
+          echo "Running forge test with Rust precompiles"
+          ../../../foundry/target/release/forge test -vvv
+
       - name: Generate coverage data
+        if: github.event_name != 'merge_group'
         run: |
           LLVM_BIN="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | grep host | cut -d' ' -f2)/bin"
           mkdir -p coverage

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -182,45 +182,48 @@ jobs:
           workspaces: foundry
 
       - name: Install llvm-tools
-        if: needs.check-precompiles.outputs.coverage == 'true'
         run: rustup component add llvm-tools-preview
 
       - name: Patch foundry to use checked-out tempo crates
         run: tempo/scripts/foundry-patch.sh "$GITHUB_WORKSPACE/tempo" "$GITHUB_WORKSPACE/foundry"
 
-      # Build and run WITH coverage (only on PR when precompiles changed)
       - name: Build foundry forge with coverage instrumentation
-        if: needs.check-precompiles.outputs.coverage == 'true'
         working-directory: foundry
         run: RUSTFLAGS="-C instrument-coverage" cargo build -p forge --profile release --no-default-features
 
       - name: Run Forge tests with Rust precompiles (with coverage)
-        if: needs.check-precompiles.outputs.coverage == 'true'
         working-directory: tempo/tips/verify
         run: |
           echo "Running forge test with Rust precompiles"
           LLVM_PROFILE_FILE="$(pwd)/forge-coverage-%p.profraw" ../../../foundry/target/release/forge test -vvv
 
-      # Build and run WITHOUT coverage (main/merge_group or no precompiles changes)
-      - name: Build foundry forge
-        if: needs.check-precompiles.outputs.coverage != 'true'
-        working-directory: foundry
-        run: cargo build -p forge --profile release --no-default-features
-
-      - name: Run Forge tests with Rust precompiles
-        if: needs.check-precompiles.outputs.coverage != 'true'
-        working-directory: tempo/tips/verify
-        run: |
-          echo "Running forge test with Rust precompiles"
-          ../../../foundry/target/release/forge test -vvv
-
-      - name: Generate coverage profdata
-        if: needs.check-precompiles.outputs.coverage == 'true'
+      - name: Generate coverage data
         run: |
           LLVM_BIN="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | grep host | cut -d' ' -f2)/bin"
           mkdir -p coverage
           "$LLVM_BIN/llvm-profdata" merge -sparse tempo/tips/verify/*.profraw -o coverage/forge-test.profdata
 
+          # Generate lcov for Codecov
+          chmod +x foundry/target/release/forge
+          "$LLVM_BIN/llvm-cov" export \
+            --format=lcov \
+            --instr-profile=coverage/forge-test.profdata \
+            --object=foundry/target/release/forge \
+            --ignore-filename-regex='/rustc/' \
+            --ignore-filename-regex='\.cargo/' \
+            --ignore-filename-regex='\.rustup/' \
+            --ignore-filename-regex='foundry/' \
+            > coverage/forge-lcov.info 2>/dev/null || true
+
+      - name: Upload coverage to Codecov
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+        uses: codecov/codecov-action@3f20e214133d0983f9a10f3d63b0faf9241a3daa # v6.0.0
+        with:
+          files: coverage/forge-lcov.info
+          flags: forge-test
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload forge coverage artifacts
         if: needs.check-precompiles.outputs.coverage == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -182,40 +182,40 @@ jobs:
           workspaces: foundry
 
       - name: Install llvm-tools
-        if: github.event_name != 'merge_group'
+        if: needs.check-precompiles.outputs.coverage == 'true'
         run: rustup component add llvm-tools-preview
 
       - name: Patch foundry to use checked-out tempo crates
         run: tempo/scripts/foundry-patch.sh "$GITHUB_WORKSPACE/tempo" "$GITHUB_WORKSPACE/foundry"
 
-      # Build and run WITH coverage (pull_request and main push)
+      # Build and run WITH coverage (only on PR when precompiles changed)
       - name: Build foundry forge with coverage instrumentation
-        if: github.event_name != 'merge_group'
+        if: needs.check-precompiles.outputs.coverage == 'true'
         working-directory: foundry
         run: RUSTFLAGS="-C instrument-coverage" cargo build -p forge --profile release --no-default-features
 
       - name: Run Forge tests with Rust precompiles (with coverage)
-        if: github.event_name != 'merge_group'
+        if: needs.check-precompiles.outputs.coverage == 'true'
         working-directory: tempo/tips/verify
         run: |
           echo "Running forge test with Rust precompiles"
           LLVM_PROFILE_FILE="$(pwd)/forge-coverage-%p.profraw" ../../../foundry/target/release/forge test -vvv
 
-      # Build and run WITHOUT coverage (merge_group)
+      # Build and run WITHOUT coverage (main/merge_group or no precompiles changes)
       - name: Build foundry forge
-        if: github.event_name == 'merge_group'
+        if: needs.check-precompiles.outputs.coverage != 'true'
         working-directory: foundry
         run: cargo build -p forge --profile release --no-default-features
 
       - name: Run Forge tests with Rust precompiles
-        if: github.event_name == 'merge_group'
+        if: needs.check-precompiles.outputs.coverage != 'true'
         working-directory: tempo/tips/verify
         run: |
           echo "Running forge test with Rust precompiles"
           ../../../foundry/target/release/forge test -vvv
 
       - name: Generate coverage data
-        if: github.event_name != 'merge_group'
+        if: needs.check-precompiles.outputs.coverage == 'true'
         run: |
           LLVM_BIN="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | grep host | cut -d' ' -f2)/bin"
           mkdir -p coverage
@@ -234,7 +234,7 @@ jobs:
             > coverage/forge-lcov.info 2>/dev/null || true
 
       - name: Upload coverage to Codecov
-        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+        if: needs.check-precompiles.outputs.coverage == 'true'
         uses: codecov/codecov-action@3f20e214133d0983f9a10f3d63b0faf9241a3daa # v6.0.0
         with:
           files: coverage/forge-lcov.info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,42 +99,68 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: ${{ needs.check-precompiles.outputs.coverage == 'true' && 'llvm-tools-preview' || '' }}
+          components: ${{ github.event_name != 'merge_group' && 'llvm-tools-preview' || '' }}
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
         with:
           tool: nextest@0.9.124
-      # Build and run tests WITH coverage (only when precompiles changed)
+      # Build and run WITH coverage (pull_request and main push)
       - name: Build and compile tests with coverage
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: github.event_name != 'merge_group'
         run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2 --no-run
         env:
           RUSTFLAGS: -C instrument-coverage
       - name: Run tests with coverage
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: github.event_name != 'merge_group'
         run: |
           mkdir -p coverage
           cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2
         env:
           RUSTFLAGS: -C instrument-coverage
           LLVM_PROFILE_FILE: ${{ github.workspace }}/coverage/cargo-%p-%m.profraw
-      # Build and run tests WITHOUT coverage (when precompiles not changed)
+      # Build and run WITHOUT coverage (merge_group)
       - name: Build and compile tests
-        if: needs.check-precompiles.outputs.coverage != 'true'
+        if: github.event_name == 'merge_group'
         run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2 --no-run
       - name: Run tests
-        if: needs.check-precompiles.outputs.coverage != 'true'
+        if: github.event_name == 'merge_group'
         run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2
-      - name: Generate precompiles coverage profdata
-        if: needs.check-precompiles.outputs.coverage == 'true'
+      - name: Generate coverage data
+        if: github.event_name != 'merge_group'
         run: |
           LLVM_BIN="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | grep host | cut -d' ' -f2)/bin"
           "$LLVM_BIN/llvm-profdata" merge -sparse coverage/*.profraw -o coverage/cargo-test.profdata
+
+          # Collect all test binaries for full-crate coverage
+          OBJECT_FLAGS=""
+          for bin in $(find target/debug/deps -type f -executable ! -name '*.d' ! -name '*.so'); do
+            OBJECT_FLAGS="$OBJECT_FLAGS --object=$bin"
+          done
+
+          # Generate lcov for all crates (Codecov upload)
+          "$LLVM_BIN/llvm-cov" export \
+            --format=lcov \
+            --instr-profile=coverage/cargo-test.profdata \
+            $OBJECT_FLAGS \
+            --ignore-filename-regex='/rustc/' \
+            --ignore-filename-regex='\.cargo/' \
+            --ignore-filename-regex='\.rustup/' \
+            > coverage/lcov.info 2>/dev/null || true
+
+          # Copy precompiles/contracts binaries for the detailed HTML report
           mkdir -p coverage/precompiles-bin
-          # Copy precompiles and contracts test binaries
           find target/debug/deps -name 'tempo_precompiles-*' -type f -executable ! -name '*.d' -exec cp {} coverage/precompiles-bin/ \;
           find target/debug/deps -name 'tempo_contracts-*' -type f -executable ! -name '*.d' -exec cp {} coverage/precompiles-bin/ \;
+      - name: Upload coverage to Codecov
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+        uses: codecov/codecov-action@3f20e214133d0983f9a10f3d63b0faf9241a3daa # v6.0.0
+        with:
+          files: coverage/lcov.info
+          flags: cargo-test-${{ matrix.partition }}
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload precompiles coverage artifacts
         if: needs.check-precompiles.outputs.coverage == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,42 +99,57 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: ${{ needs.check-precompiles.outputs.coverage == 'true' && 'llvm-tools-preview' || '' }}
+          components: llvm-tools-preview
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
         with:
           tool: nextest@0.9.124
-      # Build and run tests WITH coverage (only when precompiles changed)
       - name: Build and compile tests with coverage
-        if: needs.check-precompiles.outputs.coverage == 'true'
         run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2 --no-run
         env:
           RUSTFLAGS: -C instrument-coverage
       - name: Run tests with coverage
-        if: needs.check-precompiles.outputs.coverage == 'true'
         run: |
           mkdir -p coverage
           cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2
         env:
           RUSTFLAGS: -C instrument-coverage
           LLVM_PROFILE_FILE: ${{ github.workspace }}/coverage/cargo-%p-%m.profraw
-      # Build and run tests WITHOUT coverage (when precompiles not changed)
-      - name: Build and compile tests
-        if: needs.check-precompiles.outputs.coverage != 'true'
-        run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2 --no-run
-      - name: Run tests
-        if: needs.check-precompiles.outputs.coverage != 'true'
-        run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2
-      - name: Generate precompiles coverage profdata
-        if: needs.check-precompiles.outputs.coverage == 'true'
+      - name: Generate coverage data
         run: |
           LLVM_BIN="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | grep host | cut -d' ' -f2)/bin"
           "$LLVM_BIN/llvm-profdata" merge -sparse coverage/*.profraw -o coverage/cargo-test.profdata
+
+          # Collect all test binaries for full-crate coverage
+          OBJECT_FLAGS=""
+          for bin in $(find target/debug/deps -type f -executable ! -name '*.d' ! -name '*.so'); do
+            OBJECT_FLAGS="$OBJECT_FLAGS --object=$bin"
+          done
+
+          # Generate lcov for all crates (Codecov upload)
+          "$LLVM_BIN/llvm-cov" export \
+            --format=lcov \
+            --instr-profile=coverage/cargo-test.profdata \
+            $OBJECT_FLAGS \
+            --ignore-filename-regex='/rustc/' \
+            --ignore-filename-regex='\.cargo/' \
+            --ignore-filename-regex='\.rustup/' \
+            > coverage/lcov.info 2>/dev/null || true
+
+          # Copy precompiles/contracts binaries for the detailed HTML report
           mkdir -p coverage/precompiles-bin
-          # Copy precompiles and contracts test binaries
           find target/debug/deps -name 'tempo_precompiles-*' -type f -executable ! -name '*.d' -exec cp {} coverage/precompiles-bin/ \;
           find target/debug/deps -name 'tempo_contracts-*' -type f -executable ! -name '*.d' -exec cp {} coverage/precompiles-bin/ \;
+      - name: Upload coverage to Codecov
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+        uses: codecov/codecov-action@3f20e214133d0983f9a10f3d63b0faf9241a3daa # v6.0.0
+        with:
+          files: coverage/lcov.info
+          flags: cargo-test-${{ matrix.partition }}
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload precompiles coverage artifacts
         if: needs.check-precompiles.outputs.coverage == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,68 +99,42 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: ${{ github.event_name != 'merge_group' && 'llvm-tools-preview' || '' }}
+          components: ${{ needs.check-precompiles.outputs.coverage == 'true' && 'llvm-tools-preview' || '' }}
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
         with:
           tool: nextest@0.9.124
-      # Build and run WITH coverage (pull_request and main push)
+      # Build and run tests WITH coverage (only when precompiles changed)
       - name: Build and compile tests with coverage
-        if: github.event_name != 'merge_group'
+        if: needs.check-precompiles.outputs.coverage == 'true'
         run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2 --no-run
         env:
           RUSTFLAGS: -C instrument-coverage
       - name: Run tests with coverage
-        if: github.event_name != 'merge_group'
+        if: needs.check-precompiles.outputs.coverage == 'true'
         run: |
           mkdir -p coverage
           cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2
         env:
           RUSTFLAGS: -C instrument-coverage
           LLVM_PROFILE_FILE: ${{ github.workspace }}/coverage/cargo-%p-%m.profraw
-      # Build and run WITHOUT coverage (merge_group)
+      # Build and run tests WITHOUT coverage (when precompiles not changed)
       - name: Build and compile tests
-        if: github.event_name == 'merge_group'
+        if: needs.check-precompiles.outputs.coverage != 'true'
         run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2 --no-run
       - name: Run tests
-        if: github.event_name == 'merge_group'
+        if: needs.check-precompiles.outputs.coverage != 'true'
         run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2
-      - name: Generate coverage data
-        if: github.event_name != 'merge_group'
+      - name: Generate precompiles coverage profdata
+        if: needs.check-precompiles.outputs.coverage == 'true'
         run: |
           LLVM_BIN="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | grep host | cut -d' ' -f2)/bin"
           "$LLVM_BIN/llvm-profdata" merge -sparse coverage/*.profraw -o coverage/cargo-test.profdata
-
-          # Collect all test binaries for full-crate coverage
-          OBJECT_FLAGS=""
-          for bin in $(find target/debug/deps -type f -executable ! -name '*.d' ! -name '*.so'); do
-            OBJECT_FLAGS="$OBJECT_FLAGS --object=$bin"
-          done
-
-          # Generate lcov for all crates (Codecov upload)
-          "$LLVM_BIN/llvm-cov" export \
-            --format=lcov \
-            --instr-profile=coverage/cargo-test.profdata \
-            $OBJECT_FLAGS \
-            --ignore-filename-regex='/rustc/' \
-            --ignore-filename-regex='\.cargo/' \
-            --ignore-filename-regex='\.rustup/' \
-            > coverage/lcov.info 2>/dev/null || true
-
-          # Copy precompiles/contracts binaries for the detailed HTML report
           mkdir -p coverage/precompiles-bin
+          # Copy precompiles and contracts test binaries
           find target/debug/deps -name 'tempo_precompiles-*' -type f -executable ! -name '*.d' -exec cp {} coverage/precompiles-bin/ \;
           find target/debug/deps -name 'tempo_contracts-*' -type f -executable ! -name '*.d' -exec cp {} coverage/precompiles-bin/ \;
-      - name: Upload coverage to Codecov
-        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
-        uses: codecov/codecov-action@3f20e214133d0983f9a10f3d63b0faf9241a3daa # v6.0.0
-        with:
-          files: coverage/lcov.info
-          flags: cargo-test-${{ matrix.partition }}
-          fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload precompiles coverage artifacts
         if: needs.check-precompiles.outputs.coverage == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,24 +99,35 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: llvm-tools-preview
+          components: ${{ github.event_name != 'merge_group' && 'llvm-tools-preview' || '' }}
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
         with:
           tool: nextest@0.9.124
+      # Build and run WITH coverage (pull_request and main push)
       - name: Build and compile tests with coverage
+        if: github.event_name != 'merge_group'
         run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2 --no-run
         env:
           RUSTFLAGS: -C instrument-coverage
       - name: Run tests with coverage
+        if: github.event_name != 'merge_group'
         run: |
           mkdir -p coverage
           cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2
         env:
           RUSTFLAGS: -C instrument-coverage
           LLVM_PROFILE_FILE: ${{ github.workspace }}/coverage/cargo-%p-%m.profraw
+      # Build and run WITHOUT coverage (merge_group)
+      - name: Build and compile tests
+        if: github.event_name == 'merge_group'
+        run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2 --no-run
+      - name: Run tests
+        if: github.event_name == 'merge_group'
+        run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2
       - name: Generate coverage data
+        if: github.event_name != 'merge_group'
         run: |
           LLVM_BIN="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | grep host | cut -d' ' -f2)/bin"
           "$LLVM_BIN/llvm-profdata" merge -sparse coverage/*.profraw -o coverage/cargo-test.profdata

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,43 @@
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  precision: 2
+  round: down
+  range: "0...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 50%
+        threshold: 5%
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true
+  require_base: false
+  require_head: true
+
+ignore:
+  - "tips/verify/lib/**"
+  - "tips/verify/script/**"
+  - "**/tests/**"
+  - "**/test/**"
+  - "**/benches/**"
+  - "crates/xtask/**"
+  - "bin/tempo/src/main.rs"
+
+flags:
+  cargo-test-1:
+    carryforward: true
+  cargo-test-2:
+    carryforward: true
+  forge-test:
+    carryforward: true


### PR DESCRIPTION
Adds Codecov integration for full-crate coverage reporting with PR delta comments.

## Changes

- **Always instrument coverage** on PRs and main pushes — no longer gated on precompiles-only changes
- **Generate lcov for all crates** (not just `precompiles`/`contracts`) and upload to Codecov from both `cargo test` partitions and `forge test`
- **`codecov.yml` config** — PR comment shows coverage diff, patch coverage, per-flag breakdown; project/patch status checks are informational (won't block merge)
- **Existing precompiles HTML report** is unchanged — still triggers on precompiles changes for the detailed drill-down

## Setup required

Add `CODECOV_TOKEN` as a repository secret (get it from [codecov.io](https://app.codecov.io) after enabling the repo).

## How it works

Each CI run uploads lcov data with flags (`cargo-test-1`, `cargo-test-2`, `forge-test`). Codecov merges them, compares against the base branch baseline, and posts a PR comment showing:
- Overall project coverage change
- Patch coverage (lines added in this PR)
- Per-file breakdown of changed coverage

Flags use `carryforward: true` so partial runs (e.g. forge skipped) don't zero out prior data.