### PR TITLE
deps: update reth from main (2026-05-13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8260,7 +8260,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8319,7 +8319,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8339,7 +8339,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8352,7 +8352,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8435,7 +8435,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8445,7 +8445,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8498,7 +8498,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8514,7 +8514,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8528,7 +8528,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8541,7 +8541,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8566,7 +8566,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8595,7 +8595,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8621,7 +8621,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8666,7 +8666,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8691,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8715,7 +8715,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8739,7 +8739,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8774,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8831,7 +8831,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8859,7 +8859,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8882,7 +8882,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8907,7 +8907,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8966,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8996,7 +8996,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9012,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9028,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9050,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9061,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9089,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9111,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "clap",
  "eyre",
@@ -9175,7 +9175,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9191,7 +9191,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9250,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9264,7 +9264,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9274,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9298,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9318,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9368,7 +9368,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9420,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "serde",
  "serde_json",
@@ -9430,7 +9430,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9458,7 +9458,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "bytes",
  "futures",
@@ -9478,7 +9478,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9495,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "bindgen",
  "cc",
@@ -9504,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "futures",
  "metrics",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9526,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9540,7 +9540,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9598,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9623,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9646,7 +9646,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9661,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9692,7 +9692,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9716,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9784,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9839,7 +9839,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9877,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9901,7 +9901,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "bytes",
  "eyre",
@@ -9954,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9966,7 +9966,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10025,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10116,7 +10116,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10145,7 +10145,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10161,7 +10161,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10253,7 +10253,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10283,7 +10283,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10326,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10377,7 +10377,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10423,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10471,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10485,7 +10485,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10516,7 +10516,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10568,7 +10568,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10610,7 +10610,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10645,7 +10645,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10670,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10688,7 +10688,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10709,7 +10709,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10725,7 +10725,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10735,7 +10735,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "clap",
  "eyre",
@@ -10754,7 +10754,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "clap",
  "eyre",
@@ -10772,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10817,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10843,7 +10843,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10870,7 +10870,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10890,7 +10890,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10919,7 +10919,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
+source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8260,7 +8260,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8319,7 +8319,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8339,7 +8339,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8352,7 +8352,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8435,7 +8435,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8445,7 +8445,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8498,7 +8498,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8514,7 +8514,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8528,7 +8528,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8541,8 +8541,9 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -8565,7 +8566,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8594,7 +8595,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8620,7 +8621,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8650,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8665,7 +8666,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8690,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8714,7 +8715,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8738,7 +8739,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8773,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8830,7 +8831,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8858,7 +8859,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8881,7 +8882,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8906,7 +8907,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8965,9 +8966,11 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
+ "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "eyre",
  "futures",
@@ -8993,7 +8996,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9009,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9025,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9047,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9058,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9086,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9108,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9149,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "clap",
  "eyre",
@@ -9172,7 +9175,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9188,7 +9191,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9204,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9217,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9247,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9261,7 +9264,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9271,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9295,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9315,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9333,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9346,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9365,7 +9368,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9403,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9417,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "serde",
  "serde_json",
@@ -9427,7 +9430,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9455,7 +9458,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "bytes",
  "futures",
@@ -9475,7 +9478,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9492,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "bindgen",
  "cc",
@@ -9501,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "futures",
  "metrics",
@@ -9514,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9523,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9537,7 +9540,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9595,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9620,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9643,7 +9646,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9658,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9672,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9689,7 +9692,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9713,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9781,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9836,7 +9839,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9874,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9898,7 +9901,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9922,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "bytes",
  "eyre",
@@ -9951,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9963,7 +9966,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9987,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9999,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10022,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10065,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10113,7 +10116,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10142,7 +10145,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10158,7 +10161,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10173,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10250,7 +10253,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10280,7 +10283,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10323,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10343,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10374,7 +10377,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10420,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10468,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10482,7 +10485,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10513,7 +10516,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10565,7 +10568,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10593,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10607,7 +10610,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10627,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10642,7 +10645,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10667,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10685,7 +10688,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10706,7 +10709,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10722,7 +10725,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10732,7 +10735,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "clap",
  "eyre",
@@ -10751,7 +10754,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "clap",
  "eyre",
@@ -10769,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10814,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10840,7 +10843,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10867,7 +10870,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10887,7 +10890,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10916,7 +10919,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8248a24#8248a24288af0550137bc79b958cddd598c315b8"
+source = "git+https://github.com/paradigmxyz/reth?rev=bedf334#bedf3346b33705d2ddddb9d87219b735fab53591"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,64 +139,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,64 +139,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8248a24", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "bedf334", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -25,7 +25,7 @@ use reth_node_builder::{
     },
 };
 use reth_node_ethereum::EthereumNetworkBuilder;
-use reth_primitives_traits::{SealedBlock, SealedHeader};
+use reth_primitives_traits::SealedHeader;
 use reth_provider::{EthStorage, providers::ProviderFactoryBuilder};
 use reth_rpc_builder::{Identity, RethRpcModule};
 use reth_rpc_eth_api::{
@@ -34,12 +34,12 @@ use reth_rpc_eth_api::{
 };
 use reth_tracing::tracing::{debug, info};
 use reth_transaction_pool::{TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore};
-use std::{default::Default, sync::Arc};
+use std::default::Default;
 use tempo_chainspec::spec::TempoChainSpec;
 use tempo_consensus::TempoConsensus;
 use tempo_evm::TempoEvmConfig;
 use tempo_payload_builder::TempoPayloadBuilder;
-use tempo_payload_types::{TempoExecutionData, TempoPayloadAttributes};
+use tempo_payload_types::TempoPayloadAttributes;
 use tempo_primitives::{TempoHeader, TempoPrimitives, TempoTxEnvelope, TempoTxType};
 use tempo_transaction_pool::{
     AA2dPool, AA2dPoolConfig, TempoTransactionPool,
@@ -282,14 +282,10 @@ impl<N: FullNodeComponents<Types = Self>> DebugNode<N> for TempoNode {
     type RpcBlock =
         alloy_rpc_types_eth::Block<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>, TempoHeader>;
 
-    fn rpc_to_execution_data(rpc_block: Self::RpcBlock) -> TempoExecutionData {
-        let block = rpc_block
+    fn rpc_to_primitive_block(rpc_block: Self::RpcBlock) -> tempo_primitives::Block {
+        rpc_block
             .into_consensus_block()
-            .map_transactions(|tx| tx.into_inner());
-        TempoExecutionData {
-            block: Arc::new(SealedBlock::seal_slow(block)),
-            validator_set: None,
-        }
+            .map_transactions(|tx| tx.into_inner())
     }
 
     fn local_payload_attributes_builder(

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -147,7 +147,10 @@ impl PayloadTypes for TempoPayloadTypes {
     type BuiltPayload = TempoBuiltPayload;
     type PayloadAttributes = TempoPayloadAttributes;
 
-    fn block_to_payload(block: SealedBlock<Block>) -> Self::ExecutionData {
+    fn block_to_payload(
+        block: SealedBlock<Block>,
+        _bal: Option<alloy_primitives::Bytes>,
+    ) -> Self::ExecutionData {
         TempoExecutionData {
             block: Arc::new(block),
             validator_set: None,


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`8248a24...9b6a79f`](https://github.com/paradigmxyz/reth/compare/8248a24...9b6a79f)

🔗 Amp thread: https://ampcode.com/threads/T-019e21c8-ffc7-774d-99db-860d65b89610
**Engine**
- Support Block Access Lists (BAL) in `create_reorg_head` ([#24147](https://github.com/paradigmxyz/reth/pull/24147)) and return BALs in payload range v2 ([#24177](https://github.com/paradigmxyz/reth/pull/24177))
- Spawn full block validation ([#24160](https://github.com/paradigmxyz/reth/pull/24160))

**RPC**
- Support BAL with block RLP payloads ([#24153](https://github.com/paradigmxyz/reth/pull/24153))
- Reuse cached block access lists ([#24185](https://github.com/paradigmxyz/reth/pull/24185))
- Simplify blob bundle validation ([#24169](https://github.com/paradigmxyz/reth/pull/24169))

**Net**
- Model unavailable BALs explicitly ([#24157](https://github.com/paradigmxyz/reth/pull/24157))
- Bind discovery to net-if address ([#24178](https://github.com/paradigmxyz/reth/pull/24178))
- Retain announced port ([#24182](https://github.com/paradigmxyz/reth/pull/24182))

**Storage**
- Remove BAL range lookup ([#24180](https://github.com/paradigmxyz/reth/pull/24180))

**Perf**
- Buffer recent block hash requests in `reth-bench` ([#24176](https://github.com/paradigmxyz/reth/pull/24176))
- Preallocate receipt root encode buffer ([#24173](https://github.com/paradigmxyz/reth/pull/24173))
- Use `parking_lot` mutex in lazy task handle ([#24161](https://github.com/paradigmxyz/reth/pull/24161))

**Debug Client**
- Support block access list payload conversion ([#23989](https://github.com/paradigmxyz/reth/pull/23989))

**Bench**
- Extract txgen payloads once and reuse across runs ([#24144](https://github.com/paradigmxyz/reth/pull/24144))
- Reduce false positives with between-pairing CI and unified bootstrap ([#24179](https://github.com/paradigmxyz/reth/pull/24179))
- Show per-phase status in PR comment during benchmark runs ([#24158](https://github.com/paradigmxyz/reth/pull/24158))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019e21c9-2634-7669-b162-4fff9df56e77
- Bumped `reth` git dependency revision from `8248a24` to `9b6a79f` across all `reth-*` crates in `Cargo.toml`.
- Migrated `DebugNode::rpc_to_execution_data` → `rpc_to_primitive_block` in [crates/node/src/node.rs](file:///home/runner/work/tempo/tempo/crates/node/src/node.rs): now returns a `tempo_primitives::Block` instead of constructing a `TempoExecutionData` (sealing/wrapping moved upstream).
- Removed now-unused imports (`SealedBlock`, `Arc`, `TempoExecutionData`) from [crates/node/src/node.rs](file:///home/runner/work/tempo/tempo/crates/node/src/node.rs) following the signature change.
- Updated `PayloadTypes::block_to_payload` in [crates/payload/types/src/lib.rs](file:///home/runner/work/tempo/tempo/crates/payload/types/src/lib.rs) to accept a new second parameter `_bal: Option<alloy_primitives::Bytes>` (block access list), matching the upstream trait signature change.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/25805957659)
