### PR TITLE
fix(p2p): report proxy request and item counts

### DIFF
--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -148,10 +148,12 @@ struct NetConfig {
     head: Head,
 }
 
-/// Shared request counters for periodic stats logging.
+/// Shared counters for periodic proxy stats logging.
 struct RequestStats {
-    headers: AtomicU64,
-    bodies: AtomicU64,
+    header_requests_received: AtomicU64,
+    body_requests_received: AtomicU64,
+    headers_served: AtomicU64,
+    bodies_served: AtomicU64,
 }
 
 /// Messages from the request handler to the single block-fetcher service.
@@ -348,10 +350,12 @@ async fn run_p2p_network(
     // Spawn the network
     tokio::spawn(network);
 
-    // Request stats for periodic logging
+    // Proxy stats for periodic logging
     let stats = Arc::new(RequestStats {
-        headers: AtomicU64::new(0),
-        bodies: AtomicU64::new(0),
+        header_requests_received: AtomicU64::new(0),
+        body_requests_received: AtomicU64::new(0),
+        headers_served: AtomicU64::new(0),
+        bodies_served: AtomicU64::new(0),
     });
 
     // Periodic stats logging
@@ -362,10 +366,20 @@ async fn run_p2p_network(
         interval.tick().await; // skip immediate first tick
         loop {
             interval.tick().await;
-            let h = stats_log.headers.load(Ordering::Relaxed);
-            let b = stats_log.bodies.load(Ordering::Relaxed);
+            let header_requests_received =
+                stats_log.header_requests_received.load(Ordering::Relaxed);
+            let body_requests_received = stats_log.body_requests_received.load(Ordering::Relaxed);
+            let headers_served = stats_log.headers_served.load(Ordering::Relaxed);
+            let bodies_served = stats_log.bodies_served.load(Ordering::Relaxed);
             let peers = stats_handle.num_connected_peers();
-            info!(peers, headers_served = h, bodies_served = b, "proxy stats");
+            info!(
+                peers,
+                header_requests_received,
+                body_requests_received,
+                headers_served,
+                bodies_served,
+                "proxy stats"
+            );
         }
     });
 
@@ -378,8 +392,11 @@ async fn run_p2p_network(
                 response,
             } => {
                 debug!(%peer_id, ?request, "received GetBlockHeaders");
-                stats.headers.fetch_add(1, Ordering::Relaxed);
+                stats
+                    .header_requests_received
+                    .fetch_add(1, Ordering::Relaxed);
                 let fetch_tx = fetch_tx.clone();
+                let stats = Arc::clone(&stats);
                 tokio::spawn(async move {
                     let headers = async {
                         let (tx, rx) = oneshot::channel();
@@ -394,7 +411,12 @@ async fn run_p2p_network(
                     }
                     .await
                     .unwrap_or_default();
-                    let _ = response.send(Ok(headers.into()));
+                    let headers_served = headers.len() as u64;
+                    if response.send(Ok(headers.into())).is_ok() {
+                        stats
+                            .headers_served
+                            .fetch_add(headers_served, Ordering::Relaxed);
+                    }
                 });
             }
             IncomingEthRequest::GetBlockBodies {
@@ -403,8 +425,9 @@ async fn run_p2p_network(
                 response,
             } => {
                 debug!(%peer_id, ?request, "received GetBlockBodies");
-                stats.bodies.fetch_add(1, Ordering::Relaxed);
+                stats.body_requests_received.fetch_add(1, Ordering::Relaxed);
                 let fetch_tx = fetch_tx.clone();
+                let stats = Arc::clone(&stats);
                 tokio::spawn(async move {
                     let bodies = async {
                         let (tx, rx) = oneshot::channel();
@@ -419,7 +442,12 @@ async fn run_p2p_network(
                     }
                     .await
                     .unwrap_or_default();
-                    let _ = response.send(Ok(bodies.into()));
+                    let bodies_served = bodies.len() as u64;
+                    if response.send(Ok(bodies.into())).is_ok() {
+                        stats
+                            .bodies_served
+                            .fetch_add(bodies_served, Ordering::Relaxed);
+                    }
                 });
             }
             // All other requests get empty responses


### PR DESCRIPTION
Splits proxy stats into received request counters and served response item counters. Header/body request counters now increment when P2P requests arrive, while header/body served counters increment only after a response is accepted, so the periodic stats log reflects both demand and delivered results.