### PR TITLE
fix(p2p): serve full header batches

### DIFF
--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -43,7 +43,10 @@ type TempoRpcBlock = <TempoNetwork as Network>::BlockResponse;
 
 /// 3 hrs of blocks at 500ms block time.
 const CACHE_CAPACITY: u64 = 60 * 60 * 6; // 21600
-const HEADER_BATCH_SIZE: usize = 512;
+/// Maximum number of headers to fetch per RPC batch request.
+const HEADER_RPC_BATCH_SIZE: usize = 128;
+/// Maximum number of block headers to serve in a `GetBlockHeaders` response.
+const MAX_HEADERS_SERVE: usize = 1024;
 /// Soft cap on the total encoded body size in a `GetBlockBodies` response.
 const SOFT_BODY_RESPONSE_SIZE_LIMIT: usize = 1024 * 1024; // 1 MiB
 
@@ -561,7 +564,7 @@ async fn fetch_and_cache_headers(
         .filter(|number| cache.get_by_number(*number).is_none())
         .collect();
 
-    for chunk in missing_numbers.chunks(HEADER_BATCH_SIZE) {
+    for chunk in missing_numbers.chunks(HEADER_RPC_BATCH_SIZE) {
         if fetch_and_cache_header_batch(provider, cache, chunk)
             .await
             .is_err()
@@ -596,7 +599,7 @@ fn requested_header_numbers(
     mut current: u64,
     request: &reth_eth_wire_types::GetBlockHeaders,
 ) -> Vec<u64> {
-    let limit = request.limit.min(HEADER_BATCH_SIZE as u64) as usize;
+    let limit = request.limit.min(MAX_HEADERS_SERVE as u64) as usize;
     let mut numbers = Vec::with_capacity(limit);
     let step = u64::from(request.skip) + 1;
 
@@ -706,7 +709,10 @@ async fn resolve_bodies(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::{consensus::BlockHeader, primitives::Sealable};
+    use alloy::{
+        consensus::{BlockHeader, Header},
+        primitives::Sealable,
+    };
     use reth_eth_wire_types::GetBlockHeaders;
 
     const MODERATO_RPC: &str = "https://rpc.moderato.tempo.xyz";
@@ -722,6 +728,77 @@ mod tests {
             body.ommers.push(TempoHeader::default());
         }
         body
+    }
+
+    fn numbered_hash(number: u64) -> B256 {
+        let mut hash = [0u8; 32];
+        hash[24..].copy_from_slice(&number.to_be_bytes());
+        B256::from(hash)
+    }
+
+    fn insert_test_header(cache: &mut BlockCache, number: u64) {
+        let header = TempoHeader {
+            inner: Header {
+                number,
+                parent_hash: number.checked_sub(1).map_or(B256::default(), numbered_hash),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        cache.insert_header(number, numbered_hash(number), header);
+    }
+
+    #[test]
+    fn requested_header_numbers_allows_reth_default_request_limit() {
+        let request = GetBlockHeaders {
+            start_block: BlockHashOrNumber::Number(10),
+            limit: 1_000,
+            skip: 0,
+            direction: HeadersDirection::Rising,
+        };
+
+        let numbers = requested_header_numbers(10, &request);
+
+        assert_eq!(numbers.len(), 1_000);
+        assert_eq!(numbers[0], 10);
+        assert_eq!(numbers[999], 1_009);
+    }
+
+    #[test]
+    fn requested_header_numbers_caps_at_protocol_header_limit() {
+        let request = GetBlockHeaders {
+            start_block: BlockHashOrNumber::Number(0),
+            limit: MAX_HEADERS_SERVE as u64 + 1,
+            skip: 0,
+            direction: HeadersDirection::Rising,
+        };
+
+        let numbers = requested_header_numbers(0, &request);
+
+        assert_eq!(numbers.len(), MAX_HEADERS_SERVE);
+        assert_eq!(numbers[MAX_HEADERS_SERVE - 1], MAX_HEADERS_SERVE as u64 - 1);
+    }
+
+    #[tokio::test]
+    async fn resolve_headers_serves_more_than_rpc_batch_size_when_cached() {
+        let provider = moderato_provider();
+        let mut cache = BlockCache::new(MAX_HEADERS_SERVE as u64);
+
+        for number in 1..=1_000 {
+            insert_test_header(&mut cache, number);
+        }
+
+        let request = GetBlockHeaders {
+            start_block: BlockHashOrNumber::Number(1),
+            limit: 1_000,
+            skip: 0,
+            direction: HeadersDirection::Rising,
+        };
+        let headers = resolve_headers(&provider, &mut cache, &request).await;
+
+        assert_eq!(headers.len(), 1_000);
+        assert_eq!(headers[0].number(), 1);
+        assert_eq!(headers[999].number(), 1_000);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Separates the P2P header response cap from the RPC batch size so `GetBlockHeaders` can serve Reth's 1000-header requests while still chunking RPC calls at 128.

The response builder now uses the 1024-header protocol cap instead of the smaller RPC batch chunk size.