### PR TITLE
ci(bench): build baseline and feature binaries in parallel

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1006,13 +1006,19 @@ def "main e2e" [
     let effective_features = $tbc.features
     let effective_extra_rustflags = $tbc.extra_rustflags
     let effective_no_cache = $no_cache or ($tracy != "off")
-    if $effective_no_cache {
-        build-in-worktree --no-cache --no-default-features=$no_default_features --extra-rustflags $effective_extra_rustflags --bench-features $features $baseline_wt $baseline $profile $effective_features $baseline
-        build-in-worktree --no-cache --no-default-features=$no_default_features --extra-rustflags $effective_extra_rustflags --bench-features $features $feature_wt $feature $profile $effective_features $feature
-    } else {
-        build-in-worktree --no-default-features=$no_default_features $baseline_wt $baseline $profile $effective_features $baseline
-        build-in-worktree --no-default-features=$no_default_features $feature_wt $feature $profile $effective_features $feature
-    }
+    # Build baseline and feature in parallel — they use separate worktrees
+    # with independent target/ directories, so cargo invocations don't collide.
+    let builds = [
+        { wt: $baseline_wt, ref_name: $baseline, sha: $baseline, label: "baseline" }
+        { wt: $feature_wt, ref_name: $feature, sha: $feature, label: "feature" }
+    ]
+    $builds | par-each { |b|
+        if $effective_no_cache {
+            build-in-worktree --no-cache --no-default-features=$no_default_features --extra-rustflags $effective_extra_rustflags --bench-features $features $b.wt $b.ref_name $profile $effective_features $b.sha
+        } else {
+            build-in-worktree --no-default-features=$no_default_features $b.wt $b.ref_name $profile $effective_features $b.sha
+        }
+    } | ignore
     let baseline_tempo = (worktree-bin $baseline_wt $profile "tempo")
     let feature_tempo = (worktree-bin $feature_wt $profile "tempo")
     let txgen = txgen-resolve-binaries


### PR DESCRIPTION
## Summary

Build baseline and feature tempo binaries concurrently using `par-each` instead of sequentially.

## Motivation

In [run 25789620069](https://github.com/tempoxyz/tempo/actions/runs/25789620069/job/75751514252), both binary cache lookups missed, causing two serial `cargo build --profile profiling` invocations:
- Baseline build: **3m 06s** (09:10:13 → 09:13:19)
- Feature build: **3m 00s** (09:13:20 → 09:16:20)

The feature build didn't start until the baseline finished. Since they use separate worktrees with independent `target/` directories, they can safely run in parallel.

## Changes

Replace sequential `build-in-worktree` calls with a `par-each` block over both builds.

## Expected impact

~3 min saved on cache-miss runs (wall-clock build time drops from ~6 min to ~3 min). Cache-hit runs are unaffected (downloads are fast either way).