### PR TITLE
docs(tip-1040): dynamic congestion-aware pricing for temporary storage

### DIFF
--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -1,7 +1,7 @@
 ---
 id: TIP-1040
 title: Epoch-Scoped Temporary Storage Precompile
-description: A precompile providing cheap temporary key-value storage that expires after a caller-chosen number of epochs, with tiered gas pricing.
+description: A precompile providing cheap temporary key-value storage that expires after a caller-chosen number of epochs, with dynamic congestion-aware gas pricing.
 authors: Dankrad
 status: Draft
 related: N/A
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP introduces a precompile that provides temporary key-value storage scoped to epochs. An epoch is 2^16 (65,536) blocks. The caller chooses how many epochs the data should live for (1 to `MAX_EXPIRY_EPOCHS`). Data written in epoch `E` with duration `N` epochs is readable from epoch `E` through epoch `E + N`, then automatically becomes inaccessible. Gas pricing scales with the requested lifetime — short-lived entries are cheap, while long-lived entries approach permanent storage cost.
+This TIP introduces a precompile that provides temporary key-value storage scoped to epochs. An epoch is 2^16 (65,536) blocks. The caller chooses how many epochs the data should live for (1 to `MAX_EXPIRY_EPOCHS`). Data written in epoch `E` with duration `N` epochs is readable from epoch `E` through epoch `E + N`, then automatically becomes inaccessible. Gas pricing is a function of two inputs: the requested **lifetime** (`numEpochs`) and the **current epoch congestion** (total new slots already created in the current epoch). Short-lived entries with low congestion are cheap; long-lived entries or entries created during congested epochs approach permanent storage cost.
 
 ## Motivation
 
@@ -50,6 +50,10 @@ The original single-epoch design (values live for 1–2 epochs) was too rigid fo
 | `TEMPORARY_LOAD_GAS_WARM` | 100 | Gas cost for `temporaryLoad` on a warm slot |
 | `TEMPORARY_STORE_GAS_EXISTING_COLD` | 5,000 | Gas cost for overwriting an existing slot (cold) |
 | `TEMPORARY_STORE_GAS_EXISTING_WARM` | 200 | Gas cost for overwriting an existing slot (warm) |
+| `MIN_TEMPORARY_STORE_GAS` | 20,000 | Minimum gas for a 1-epoch `temporaryStore` at zero congestion |
+| `MAX_TEMPORARY_STORE_GAS` | 250,000 | Maximum gas, matching TIP-1000 permanent storage cost |
+| `EPOCH_SLOT_TARGET` | 1,000,000 | Target number of new temporary slots per epoch before congestion surcharge begins |
+| `EPOCH_SLOT_HARD_CAP` | 10,000,000 | Hard cap — new slots above this are priced at `MAX_TEMPORARY_STORE_GAS` regardless of lifetime |
 
 ## Epoch Derivation
 
@@ -104,18 +108,53 @@ If the caller previously wrote to the same `(sender, key)` in an earlier epoch t
 
 **Gas**:
 
-Gas cost is determined by the requested `numEpochs` lifetime:
+Gas cost is determined by a **pricing function** that takes two inputs:
+- `numEpochs` — the requested storage lifetime.
+- `slots_created` — the total number of new temporary storage slots already created in the current epoch (tracked by the node as a per-epoch counter, incremented on each new-slot `temporaryStore`).
 
-| Lifetime (numEpochs) | Approximate Duration (1s blocks) | Gas |
+```
+temporary_store_gas(numEpochs, slots_created) =
+    min(MAX_TEMPORARY_STORE_GAS,
+        base_cost(numEpochs) + congestion_surcharge(slots_created))
+```
+
+**Base cost** — scales linearly with requested lifetime:
+
+```
+base_cost(numEpochs) =
+    MIN_TEMPORARY_STORE_GAS
+    + (MAX_TEMPORARY_STORE_GAS - MIN_TEMPORARY_STORE_GAS)
+      * (numEpochs - 1) / (MAX_EXPIRY_EPOCHS - 1)
+```
+
+This produces a smooth linear ramp from 20,000 gas (1 epoch, ~18h) to 250,000 gas (512 epochs, ~1 year). Example values at zero congestion:
+
+| numEpochs | ≈ Duration | Base Gas |
 |---|---|---|
 | 1 | ~18 hours | 20,000 |
-| 2–4 | ~1–3 days | 40,000 |
-| 5–10 | ~4–7 days | 80,000 |
-| 11–45 | ~1–4 weeks | 120,000 |
-| 46–180 | ~1–4 months | 200,000 |
-| 181–512 | ~4–12 months | 250,000 |
+| 4 | ~3 days | 21,346 |
+| 10 | ~7 days | 24,047 |
+| 45 | ~1 month | 39,843 |
+| 180 | ~4 months | 100,587 |
+| 512 | ~1 year | 250,000 |
 
-These tiers ensure short-lived storage is cheap while long-lived entries approach the [TIP-1000](./tip-1000.md) benchmark of 250,000 gas for permanent state.
+**Congestion surcharge** — adds a linear penalty once `slots_created` exceeds `EPOCH_SLOT_TARGET`:
+
+```
+congestion_surcharge(slots_created) =
+    if slots_created <= EPOCH_SLOT_TARGET:
+        0
+    else:
+        (MAX_TEMPORARY_STORE_GAS - MIN_TEMPORARY_STORE_GAS)
+        * min(slots_created - EPOCH_SLOT_TARGET, EPOCH_SLOT_HARD_CAP - EPOCH_SLOT_TARGET)
+        / (EPOCH_SLOT_HARD_CAP - EPOCH_SLOT_TARGET)
+```
+
+Below the target (1M slots), temporary storage is priced purely on lifetime. Above the target, the surcharge grows linearly until it reaches 230,000 additional gas at the hard cap (10M slots), at which point even a 1-epoch write costs 250,000 gas — the same as permanent storage.
+
+The congestion surcharge resets to 0 at every epoch boundary (every ~18 hours) as `slots_created` resets.
+
+**Design rationale**: This approach mirrors EIP-4844 blob gas pricing — a "target" level of usage is cheap, and usage above the target becomes progressively more expensive to discourage state bloat. The linear ramp (rather than exponential) was chosen because temporary storage bloat is recoverable (it expires), so a gentler curve is appropriate. The surcharge is not expected to activate under normal usage; it exists as a safety valve against viral-mint-style attacks (e.g., XEN-like tokens using XSTORE for all balance mappings at a discount).
 
 For **overwriting** an existing entry in the same epoch (current epoch value already nonzero):
 - Cold (first access): `COLD_SLOAD_COST` (2,100) + `TEMPORARY_STORE_GAS_EXISTING_COLD` (5,000) = 7,100 gas.
@@ -322,10 +361,11 @@ contract TemporaryStorageMock {
 4. **Zero default**: `temporaryLoad` for a key that has never been written (or has expired) MUST return `bytes32(0)`.
 5. **Shadow semantics**: A new `temporaryStore` for the same key in a later epoch shadows any earlier live entry. `temporaryLoad` MUST return the most recently written live value.
 6. **Epoch account pruning safety**: Deleting any epoch account `E` where `current_epoch > E + MAX_EXPIRY_EPOCHS` MUST NOT affect the result of any `temporaryLoad` call.
-7. **Tiered pricing**: `temporaryStore` gas MUST follow the lifetime bucket table. Short-lived entries MUST be cheaper than permanent storage. Entries at `MAX_EXPIRY_EPOCHS` MUST cost 250,000 gas, matching the TIP-1000 permanent storage benchmark.
+7. **Dynamic pricing**: `temporaryStore` gas MUST follow `temporary_store_gas(numEpochs, slots_created)`. At zero congestion, a 1-epoch write MUST cost `MIN_TEMPORARY_STORE_GAS` (20,000) and a `MAX_EXPIRY_EPOCHS`-epoch write MUST cost `MAX_TEMPORARY_STORE_GAS` (250,000). The congestion surcharge MUST activate only when `slots_created > EPOCH_SLOT_TARGET` and MUST cap at `MAX_TEMPORARY_STORE_GAS`.
 8. **Bounded numEpochs**: `temporaryStore` MUST revert if `numEpochs < 1` or `numEpochs > MAX_EXPIRY_EPOCHS`.
 9. **Overwrite semantics**: A second `temporaryStore(key, value2, N2)` in the same epoch overwrites both value and expiry. `temporaryLoad(key)` MUST return `value2`.
 10. **Deterministic gas for loads**: `temporaryLoad` gas cost MUST reflect the number of epoch accounts actually accessed during the backward scan, charged per cold/warm access rules.
+11. **Congestion counter reset**: `slots_created` MUST reset to 0 at every epoch boundary. The counter MUST only increment on new-slot writes (not overwrites of existing slots in the same epoch).
 
 ## Design Rationale: Epoch-Based vs. Timestamp-Based Expiry
 


### PR DESCRIPTION
## Summary

Replaces the static 6-tier gas table in TIP-1040 with a dynamic pricing function that takes **storage expiry** + **current epoch congestion** as inputs.

### Pricing function

```
temporary_store_gas(numEpochs, slots_created) =
    min(MAX, base_cost(numEpochs) + congestion_surcharge(slots_created))
```

**Base cost** — linear ramp from 20k gas (1 epoch / ~18h) to 250k gas (512 epochs / ~1yr):

```
base_cost = 20_000 + 230_000 * (numEpochs - 1) / 511
```

**Congestion surcharge** — kicks in above `EPOCH_SLOT_TARGET` (1M new slots in current epoch), grows linearly to cap at `EPOCH_SLOT_HARD_CAP` (10M slots):

```
surcharge = 230_000 * (slots_created - 1M) / 9M   (clamped to [0, 230_000])
```

At 10M+ slots, even a 1-epoch write costs 250k (same as permanent storage). Resets every epoch boundary.

### Motivation (from thread discussion)

- Small amounts of temporary storage relative to total state are negligible — price only the trie/DB commit overhead
- Large amounts of temporary storage create real state bloat (potentially 2x slower DB ops) — price in the bloat externally
- Mirrors EIP-4844 blob gas: target usage is cheap, excess gets progressively expensive
- Linear rather than exponential because temporary bloat is recoverable (it expires)
- Congestion surcharge is not expected to activate under normal usage — safety valve for XEN-like viral mint attacks

### New constants

| Name | Value |
|------|-------|
| `MIN_TEMPORARY_STORE_GAS` | 20,000 |
| `MAX_TEMPORARY_STORE_GAS` | 250,000 |
| `EPOCH_SLOT_TARGET` | 1,000,000 |
| `EPOCH_SLOT_HARD_CAP` | 10,000,000 |

### New invariant

`slots_created` counter resets to 0 at epoch boundaries. Only increments on new-slot writes (not overwrites).

---

Stacked on #3879. For discussion at the network upgrade call.

cc @klkvr @dankrad @tanishqsh