### PR TITLE
docs(tips): add Compatibility section to TIP template

### DIFF
--- a/tips/tip_template.md
+++ b/tips/tip_template.md
@@ -35,13 +35,12 @@ For features that do not introduce a precompile, this section should define the 
 
 Where a feature involves multiple processes, state diagrams / flowcharts should be considered when helpful.
 
-# Invariants
-
-This section should describe invariants that must always hold, and outline the critical cases that the test suite must cover.
-
 # Compatibility
 
 Describe the impact of this TIP on external systems (indexers, market makers, analytics, wallets, tooling, etc.) and on existing on-chain state, events, or interfaces. Call out any breaking changes and the rules external systems must adopt to remain compatible.
 
 If this TIP has no external compatibility impact, write `N/A`.
 
+# Invariants
+
+This section should describe invariants that must always hold, and outline the critical cases that the test suite must cover.

--- a/tips/tip_template.md
+++ b/tips/tip_template.md
@@ -37,4 +37,11 @@ Where a feature involves multiple processes, state diagrams / flowcharts should 
 
 # Invariants
 
-This section should describe invariants that must always hold, and outline the critical cases that the test suite must cover. 
+This section should describe invariants that must always hold, and outline the critical cases that the test suite must cover.
+
+# Compatibility
+
+Describe the impact of this TIP on external systems (indexers, market makers, analytics, wallets, tooling, etc.) and on existing on-chain state, events, or interfaces. Call out any breaking changes and the rules external systems must adopt to remain compatible.
+
+If this TIP has no external compatibility impact, write `N/A`.
+


### PR DESCRIPTION
Adds a `Compatibility` section to the TIP template so authors always describe external-system impact (indexers, market makers, analytics, wallets, tooling, on-chain events/IDs) or explicitly write `N/A`.

Mirrors the section already used ad hoc in TIPs like [TIP-1056](https://tips.sh/1056#compatibility).