### PR TITLE
feat(p2p-proxy): expose prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6450,11 +6450,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
  "base64 0.22.1",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
  "indexmap 2.14.0",
+ "ipnet",
  "metrics",
  "metrics-util",
  "quanta",
+ "rustls",
  "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -12471,6 +12479,8 @@ dependencies = [
  "eyre",
  "futures",
  "jiff",
+ "metrics",
+ "metrics-exporter-prometheus",
  "opentelemetry-otlp",
  "pyroscope",
  "pyroscope_pprofrs",

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -79,6 +79,8 @@ reth-etl.workspace = true
 reth-ethereum = { workspace = true, features = ["full", "cli", "network"] }
 reth-ethereum-cli.workspace = true
 reth-metrics.workspace = true
+metrics.workspace = true
+metrics-exporter-prometheus = { version = "0.18.1", features = ["http-listener"] }
 reth-network-peers.workspace = true
 reth-node-builder.workspace = true
 reth-primitives-traits.workspace = true

--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -23,6 +23,7 @@ use reth_ethereum::{
 };
 use std::{
     collections::{BTreeMap, HashMap},
+    net::SocketAddr,
     path::PathBuf,
     sync::{
         Arc,
@@ -81,10 +82,24 @@ pub(crate) struct P2pProxyArgs {
     /// and saved. If omitted, an ephemeral key is generated on each start.
     #[arg(long)]
     p2p_secret_key: Option<PathBuf>,
+
+    /// Enable Prometheus metrics.
+    ///
+    /// The metrics will be served at the given interface and port.
+    #[arg(long, value_parser = reth_cli_util::parse_socket_address)]
+    metrics: Option<SocketAddr>,
 }
 
 impl P2pProxyArgs {
     pub(crate) async fn run(self) -> Result<()> {
+        if let Some(metrics_addr) = self.metrics {
+            metrics_exporter_prometheus::PrometheusBuilder::new()
+                .with_http_listener(metrics_addr)
+                .install()
+                .context("failed to start Prometheus metrics endpoint")?;
+            info!(listen_addr = %metrics_addr, "started Prometheus metrics endpoint");
+        }
+
         let chain_spec = chain_value_parser(&self.chain)?;
 
         // Fetch latest head from RPC for the network status handshake
@@ -362,6 +377,9 @@ async fn run_p2p_network(
             let h = stats_log.headers.load(Ordering::Relaxed);
             let b = stats_log.bodies.load(Ordering::Relaxed);
             let peers = stats_handle.num_connected_peers();
+            metrics::gauge!("p2p_proxy_connected_peers").set(peers as f64);
+            metrics::gauge!("p2p_proxy_headers_served").set(h as f64);
+            metrics::gauge!("p2p_proxy_bodies_served").set(b as f64);
             info!(peers, headers_served = h, bodies_served = b, "proxy stats");
         }
     });
@@ -376,6 +394,7 @@ async fn run_p2p_network(
             } => {
                 debug!(%peer_id, ?request, "received GetBlockHeaders");
                 stats.headers.fetch_add(1, Ordering::Relaxed);
+                metrics::counter!("p2p_proxy_requests_total", "request" => "headers").increment(1);
                 let fetch_tx = fetch_tx.clone();
                 tokio::spawn(async move {
                     let headers = async {
@@ -401,6 +420,7 @@ async fn run_p2p_network(
             } => {
                 debug!(%peer_id, ?request, "received GetBlockBodies");
                 stats.bodies.fetch_add(1, Ordering::Relaxed);
+                metrics::counter!("p2p_proxy_requests_total", "request" => "bodies").increment(1);
                 let fetch_tx = fetch_tx.clone();
                 tokio::spawn(async move {
                     let bodies = async {


### PR DESCRIPTION
## Summary
- add `--metrics <addr>` to `tempo p2p-proxy` using the same socket parser as reth metrics args
- start a Prometheus scrape endpoint when the flag is set
- expose p2p proxy request and peer gauges/counters

## Validation
- cargo check -p tempo --bin tempo
- cargo build -p tempo --bin tempo
- cargo fmt --check
- ./target/debug/tempo p2p-proxy --help shows `--metrics <METRICS>`
