### PR TITLE
test(primitives): add unit tests for address, ed25519, header, and gas spending

### DIFF
--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -93,3 +93,77 @@ impl TempoAddressExt for Address {
         Self::from(bytes)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::address;
+
+    #[test]
+    fn is_tip20_prefix_variations() {
+        // address with exact TIP20 prefix
+        let mut bytes = [0u8; 20];
+        bytes[..12].copy_from_slice(&TIP20_TOKEN_PREFIX);
+        let tip20_addr = Address::from(bytes);
+        assert!(is_tip20_prefix(tip20_addr));
+        assert!(tip20_addr.is_tip20());
+
+        // zero address is not TIP20
+        assert!(!Address::ZERO.is_tip20());
+
+        // random address is not TIP20
+        assert!(!address!("0x1111111111111111111111111111111111111111").is_tip20());
+
+        // differs at byte index 1 (0xC0 → 0x00) — not TIP20
+        let mut wrong = [0u8; 20];
+        wrong[0] = TIP20_TOKEN_PREFIX[0];
+        // skip byte 1 (leave as 0 instead of 0xC0)
+        assert!(!is_tip20_prefix(Address::from(wrong)));
+    }
+
+    #[test]
+    fn virtual_address_variations() {
+        let master_id = MasterId::from([0xAA, 0xBB, 0xCC, 0xDD]);
+        let user_tag = UserTag::from([1, 2, 3, 4, 5, 6]);
+
+        // construct → decode roundtrip
+        let vaddr = Address::new_virtual(master_id, user_tag);
+        assert!(vaddr.is_virtual());
+        let (decoded_master, decoded_tag) = vaddr.decode_virtual().unwrap();
+        assert_eq!(decoded_master, master_id);
+        assert_eq!(decoded_tag, user_tag);
+
+        // non-virtual address returns None
+        assert!(Address::ZERO.decode_virtual().is_none());
+        assert!(!Address::ZERO.is_virtual());
+
+        // zero master_id + zero user_tag
+        let zero_vaddr = Address::new_virtual(MasterId::ZERO, UserTag::ZERO);
+        assert!(zero_vaddr.is_virtual());
+        let (m, t) = zero_vaddr.decode_virtual().unwrap();
+        assert_eq!(m, MasterId::ZERO);
+        assert_eq!(t, UserTag::ZERO);
+    }
+
+    #[test]
+    fn is_valid_master_variations() {
+        // regular address is valid master
+        let regular = address!("0x1111111111111111111111111111111111111111");
+        assert!(regular.is_valid_master());
+
+        // zero address is not valid master
+        assert!(!Address::ZERO.is_valid_master());
+
+        // virtual address is not valid master
+        let vaddr = Address::new_virtual(
+            MasterId::from([1, 2, 3, 4]),
+            UserTag::from([5, 6, 7, 8, 9, 10]),
+        );
+        assert!(!vaddr.is_valid_master());
+
+        // TIP20 address is not valid master
+        let mut tip20_bytes = [0u8; 20];
+        tip20_bytes[..12].copy_from_slice(&TIP20_TOKEN_PREFIX);
+        assert!(!Address::from(tip20_bytes).is_valid_master());
+    }
+}

--- a/crates/primitives/src/ed25519.rs
+++ b/crates/primitives/src/ed25519.rs
@@ -84,3 +84,43 @@ impl<'a> arbitrary::Arbitrary<'a> for PublicKey {
         Ok(Self::from_seed(u.arbitrary()?))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_rlp::{Decodable, Encodable};
+
+    #[test]
+    fn public_key_conversions_and_rlp() {
+        let pk = PublicKey::from_seed([0xab; 32]);
+        let pk2 = PublicKey::from_seed([0xcd; 32]);
+
+        // different seeds produce different keys
+        assert_ne!(pk, pk2);
+
+        // PublicKey → B256 roundtrip (ref and owned)
+        let b256: B256 = B256::from(&pk);
+        let b256_owned: B256 = B256::from(pk);
+        assert_eq!(b256, b256_owned);
+        let recovered = PublicKey::try_from(b256).unwrap();
+        assert_eq!(pk, recovered);
+
+        // get() returns the inner key
+        let _ = pk.get();
+
+        // RLP encode → decode roundtrip
+        let mut buf = Vec::new();
+        pk.encode(&mut buf);
+        assert_eq!(buf.len(), pk.length());
+        let decoded = PublicKey::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(pk, decoded);
+
+        // truncated RLP fails
+        let short_buf = &buf[..buf.len() - 1];
+        assert!(PublicKey::decode(&mut &short_buf[..]).is_err());
+
+        // Hash + Eq: same seed → same key
+        let pk_dup = PublicKey::from_seed([0xab; 32]);
+        assert_eq!(pk, pk_dup);
+    }
+}

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -192,4 +192,131 @@ mod tests {
         let decoded = TempoConsensusContext::decode(&mut encoded.as_slice()).unwrap();
         assert_eq!(ctx, decoded);
     }
+
+    #[test]
+    fn timestamp_millis_variations() {
+        // basic: 100s + 500ms = 100_500
+        let header = TempoHeader {
+            timestamp_millis_part: 500,
+            inner: Header {
+                timestamp: 100,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(header.timestamp_millis(), 100_500);
+
+        // zero timestamp
+        let header = TempoHeader::default();
+        assert_eq!(header.timestamp_millis(), 0);
+
+        // millis part only (timestamp=0)
+        let header = TempoHeader {
+            timestamp_millis_part: 999,
+            ..Default::default()
+        };
+        assert_eq!(header.timestamp_millis(), 999);
+
+        // large timestamp saturating_mul safety
+        let header = TempoHeader {
+            timestamp_millis_part: 999,
+            inner: Header {
+                timestamp: u64::MAX / 1000,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let result = header.timestamp_millis();
+        assert!(result > 0);
+    }
+
+    #[test]
+    fn header_block_header_delegation() {
+        let inner = Header {
+            number: 42,
+            gas_limit: 30_000_000,
+            gas_used: 21_000,
+            timestamp: 1_700_000_000,
+            base_fee_per_gas: Some(1_000_000_000),
+            ..Default::default()
+        };
+        let header = TempoHeader {
+            inner: inner.clone(),
+            ..Default::default()
+        };
+
+        assert_eq!(BlockHeader::number(&header), 42);
+        assert_eq!(BlockHeader::gas_limit(&header), 30_000_000);
+        assert_eq!(BlockHeader::gas_used(&header), 21_000);
+        assert_eq!(BlockHeader::timestamp(&header), 1_700_000_000);
+        assert_eq!(BlockHeader::base_fee_per_gas(&header), Some(1_000_000_000));
+        assert_eq!(BlockHeader::parent_hash(&header), inner.parent_hash());
+        assert_eq!(BlockHeader::state_root(&header), inner.state_root());
+        assert_eq!(BlockHeader::difficulty(&header), inner.difficulty());
+    }
+
+    #[test]
+    fn header_rlp_roundtrip() {
+        let header = TempoHeader {
+            general_gas_limit: 15_000_000,
+            shared_gas_limit: 5_000_000,
+            timestamp_millis_part: 123,
+            inner: Header {
+                number: 1,
+                timestamp: 100,
+                ..Default::default()
+            },
+            consensus_context: Some(TempoConsensusContext {
+                epoch: 1,
+                view: 2,
+                parent_view: 1,
+                proposer: PublicKey::from_seed([0x01; 32]),
+            }),
+        };
+
+        let encoded = alloy_rlp::encode(&header);
+        let decoded = TempoHeader::decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(header, decoded);
+
+        // without consensus_context
+        let header_no_ctx = TempoHeader {
+            general_gas_limit: 10_000_000,
+            shared_gas_limit: 3_000_000,
+            timestamp_millis_part: 0,
+            inner: Header::default(),
+            consensus_context: None,
+        };
+        let encoded = alloy_rlp::encode(&header_no_ctx);
+        let decoded = TempoHeader::decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(header_no_ctx, decoded);
+    }
+
+    #[test]
+    fn header_sealable_hash() {
+        let header = TempoHeader {
+            general_gas_limit: 1,
+            inner: Header {
+                number: 42,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // deterministic
+        let h1 = header.hash_slow();
+        let h2 = header.hash_slow();
+        assert_eq!(h1, h2);
+        assert_ne!(h1, B256::ZERO);
+
+        // different header → different hash
+        let header2 = TempoHeader {
+            general_gas_limit: 2,
+            inner: Header {
+                number: 42,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_ne!(header.hash_slow(), header2.hash_slow());
+    }
 }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -61,3 +61,40 @@ pub fn calc_gas_balance_spending(gas_limit: u64, gas_price: u128) -> U256 {
         .saturating_mul(U256::from(gas_price))
         .div_ceil(TEMPO_GAS_PRICE_SCALING_FACTOR)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calc_gas_balance_spending_variations() {
+        // zero gas → zero spending
+        assert_eq!(calc_gas_balance_spending(0, 1_000_000_000), U256::ZERO);
+
+        // zero price → zero spending
+        assert_eq!(calc_gas_balance_spending(21000, 0), U256::ZERO);
+
+        // both zero
+        assert_eq!(calc_gas_balance_spending(0, 0), U256::ZERO);
+
+        // exact division: 1 gas * 10^12 attodollars = 1 microdollar
+        assert_eq!(
+            calc_gas_balance_spending(1, 1_000_000_000_000),
+            U256::from(1)
+        );
+
+        // rounds up via div_ceil: 1 gas * 1 attodollar → ceil(1 / 10^12) = 1
+        assert_eq!(calc_gas_balance_spending(1, 1), U256::from(1));
+
+        // typical tx: 21000 gas * 1 gwei (10^9 attodollars)
+        // = 21000 * 10^9 / 10^12 = 21000 / 1000 = 21
+        assert_eq!(
+            calc_gas_balance_spending(21000, 1_000_000_000),
+            U256::from(21)
+        );
+
+        // large values don't overflow (saturating_mul)
+        let result = calc_gas_balance_spending(u64::MAX, u128::MAX);
+        assert!(result > U256::ZERO);
+    }
+}


### PR DESCRIPTION
Add edge-case unit tests for previously untested primitives functions: TIP20/virtual address classification and roundtrips, ed25519 PublicKey conversions and RLP, TempoHeader timestamp_millis/BlockHeader delegation/RLP/Sealable, and calc_gas_balance_spending arithmetic boundaries.