### PR TITLE
ci(bench): align VictoriaMetrics samples

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -764,6 +764,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --benchmark-id $ctx.benchmark_id
                 --benchmark-run $phase
                 --run-type $run_type
+                --benchmark-start $ctx.reference_epoch
                 --victoriametrics-url $ctx.victoriametrics_url)
             if not $bench_result.ok {
                 $bench_result.exit_code

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -194,6 +194,7 @@ def txgen-run-preset-pipeline [
     --benchmark-id: string = ""
     --benchmark-run: string = ""
     --run-type: string = ""
+    --benchmark-start: int = 0
     --victoriametrics-url: string = ""
 ] {
     let chain_id = (txgen-fetch-chain-id $generate_rpc_url)
@@ -225,6 +226,7 @@ def txgen-run-preset-pipeline [
         "--scrape-interval-ms" $TXGEN_HELPER_SCRAPE_INTERVAL_MS
         "--drain-timeout" $TXGEN_HELPER_DRAIN_TIMEOUT_SECS
     ]
+        | append (if $victoriametrics_url != "" and $benchmark_start > 0 { ["--metrics-align" $"($benchmark_start)"] } else { [] })
     let report_args = ["--report" $"json:($report_path)"]
         | append (if $victoriametrics_url != "" { ["--report" $"victoriametrics:($victoriametrics_url)"] } else { [] })
     let metadata_args = [


### PR DESCRIPTION
Adds `--metrics-align` to e2e txgen bench runs when VictoriaMetrics export is enabled, using the benchmark start timestamp from the workflow.