### PR TITLE
ci(bench): add git_sha and git_ref metadata to replay bench reports

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -333,7 +333,7 @@ run_single() {
       -m "git-sha=$git_sha" \
       -m "git-ref=$git_ref" \
       -m "platform=tempo" \
-      -m "mode=replay" \
+      -m "scenario=replay" \
       -m "chain=$CHAIN_NAME" \
       -m "blocks=$BLOCKS" 2>&1 | sed -u "s/^/[bench] /"
 

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -287,6 +287,13 @@ run_single() {
 
   local from_block=$(( SNAPSHOT_BLOCK + 1 ))
 
+  # Resolve git ref for this run label
+  local git_ref=""
+  case "$label" in
+    baseline*) git_ref="${BASELINE_REF:-}" ;;
+    feature*)  git_ref="${FEATURE_REF:-}" ;;
+  esac
+
   # Warmup
   if [ "$WARMUP" -gt 0 ]; then
     local warmup_to=$(( from_block + WARMUP - 1 ))
@@ -306,7 +313,11 @@ run_single() {
       --engine http://127.0.0.1:8551 \
       --jwt-secret "$DATADIR/jwt.hex" \
       --metrics-url http://localhost:9001 \
-      --report "json:$output_dir/report.json" 2>&1 | sed -u "s/^/[bench] /"
+      --report "json:$output_dir/report.json" \
+      -m "git_sha=$git_ref" \
+      -m "git_ref=$git_ref" \
+      -m "chain=$CHAIN_NAME" \
+      -m "blocks=$BLOCKS" 2>&1 | sed -u "s/^/[bench] /"
 
   # Cleanup
   kill "$tail_pid" 2>/dev/null || true

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -333,7 +333,7 @@ run_single() {
       -m "git-sha=$git_sha" \
       -m "git-ref=$git_ref" \
       -m "platform=tempo" \
-      -m "scenario=replay" \
+      -m "mode=replay" \
       -m "chain=$CHAIN_NAME" \
       -m "blocks=$BLOCKS" 2>&1 | sed -u "s/^/[bench] /"
 

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -287,12 +287,28 @@ run_single() {
 
   local from_block=$(( SNAPSHOT_BLOCK + 1 ))
 
-  # Resolve git ref for this run label
-  local git_ref=""
+  # Resolve git SHA for this run label
+  local git_sha=""
   case "$label" in
-    baseline*) git_ref="${BASELINE_REF:-}" ;;
-    feature*)  git_ref="${FEATURE_REF:-}" ;;
+    baseline*) git_sha="${BASELINE_REF:-}" ;;
+    feature*)  git_sha="${FEATURE_REF:-}" ;;
   esac
+
+  # Resolve git_ref: tag if tagged, otherwise branch name, otherwise raw SHA
+  local git_ref="$git_sha"
+  if [ -n "$git_sha" ]; then
+    local tag_name
+    tag_name=$(git tag --points-at "$git_sha" 2>/dev/null | head -1)
+    if [ -n "$tag_name" ]; then
+      git_ref="$tag_name"
+    else
+      local branch_name
+      branch_name=$(git branch -r --points-at "$git_sha" 2>/dev/null | sed 's|^ *origin/||' | head -1)
+      if [ -n "$branch_name" ]; then
+        git_ref="$branch_name"
+      fi
+    fi
+  fi
 
   # Warmup
   if [ "$WARMUP" -gt 0 ]; then
@@ -314,8 +330,10 @@ run_single() {
       --jwt-secret "$DATADIR/jwt.hex" \
       --metrics-url http://localhost:9001 \
       --report "json:$output_dir/report.json" \
-      -m "git_sha=$git_ref" \
+      -m "git_sha=$git_sha" \
       -m "git_ref=$git_ref" \
+      -m "platform=tempo" \
+      -m "scenario=nightly" \
       -m "chain=$CHAIN_NAME" \
       -m "blocks=$BLOCKS" 2>&1 | sed -u "s/^/[bench] /"
 

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -324,12 +324,18 @@ run_single() {
   # Benchmark
   local bench_to=$(( from_block + BLOCKS - 1 ))
   echo "Running benchmark ($BLOCKS blocks: $from_block..$bench_to)..."
+  local clickhouse_report=()
+  if [ -n "${CLICKHOUSE_URL:-}" ]; then
+    clickhouse_report=(--report "clickhouse:$CLICKHOUSE_URL")
+  fi
+
   "$TXGEN_TEMPO_BIN" extract --rpc "$REPLAY_RPC_URL" --from "$from_block" --to "$bench_to" \
     | "$TXGEN_BENCH_BIN" send-blocks \
       --engine http://127.0.0.1:8551 \
       --jwt-secret "$DATADIR/jwt.hex" \
       --metrics-url http://localhost:9001 \
       --report "json:$output_dir/report.json" \
+      "${clickhouse_report[@]}" \
       -m "git-sha=$git_sha" \
       -m "git-ref=$git_ref" \
       -m "platform=tempo" \

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -330,10 +330,10 @@ run_single() {
       --jwt-secret "$DATADIR/jwt.hex" \
       --metrics-url http://localhost:9001 \
       --report "json:$output_dir/report.json" \
-      -m "git_sha=$git_sha" \
-      -m "git_ref=$git_ref" \
+      -m "git-sha=$git_sha" \
+      -m "git-ref=$git_ref" \
       -m "platform=tempo" \
-      -m "scenario=nightly" \
+      -m "scenario=replay" \
       -m "chain=$CHAIN_NAME" \
       -m "blocks=$BLOCKS" 2>&1 | sed -u "s/^/[bench] /"
 

--- a/.github/workflows/bench-replay-scheduled.yml
+++ b/.github/workflows/bench-replay-scheduled.yml
@@ -239,6 +239,9 @@ jobs:
       DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
       SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
       SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
+      CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+      CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
 
   save-state:
     needs: [resolve-refs, bench-replay]

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -134,6 +134,12 @@ on:
         required: false
       SLACK_BENCH_CHANNEL:
         required: false
+      CLICKHOUSE_URL:
+        required: false
+      CLICKHOUSE_USER:
+        required: false
+      CLICKHOUSE_PASSWORD:
+        required: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -393,6 +399,9 @@ jobs:
           BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
           DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
+          CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+          CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+          CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
         run: bash .github/scripts/bench-tempo-replay.sh
 
       - name: Parse results

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -49,7 +49,7 @@ def run-txgen-bench-single [
     --benchmark-mode: string = ""
     --benchmark-id: string = ""
     --platform: string = ""
-    --bench-mode: string = ""
+    --scenario: string = ""
     --reference-epoch: int = 0
     --samply
     --samply-args: list<string> = []
@@ -153,7 +153,7 @@ def run-txgen-bench-single [
         --benchmark-mode $benchmark_mode
         --git-ref-label $git_ref_label
         --platform $platform
-        --bench-mode $bench_mode)
+        --scenario $scenario)
     if not $bench_result.ok {
         error make { msg: $"txgen benchmark run ($run_label) failed with exit code ($bench_result.exit_code)" }
     }
@@ -260,17 +260,18 @@ def "main run" [
     --feature-hardfork: string = ""
     --gas-limit: string = ""
     --platform: string = "tempo"
-    --bench-mode: string = ""
+    --scenario: string = ""
 ] {
     let runtime_mode = (resolved-runtime-mode $mode)
     if $runtime_mode != "dev" {
         error make { msg: $"txgen benchmark path currently supports only dev/e2e mode \(got ($mode)\)" }
     }
     let preset_path = (txgen-preset-path $preset)
-    let resolved_mode = if $bench_mode != "" {
-        $bench_mode
+    let resolved_scenario = if $scenario != "" {
+        $scenario
     } else {
-        "e2e"
+        let tps_k = ($tps / 1000)
+        $"($preset)-($tps_k)k"
     }
     txgen-validate-bench-args $bench_args
     if ($baseline != "" and $feature == "") or ($baseline == "" and $feature != "") {
@@ -592,7 +593,7 @@ def "main run" [
             --tracy-offset $tracy_offset
             --tracing-otlp $tracing_otlp
             --platform $platform
-            --bench-mode $resolved_mode)
+            --scenario $resolved_scenario)
     }
 
     let summary_baseline = if $dual_hardfork { $"($baseline) \(($baseline_hardfork | str upcase)\)" } else { $baseline }

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -306,6 +306,11 @@ def "main run" [
 
     let baseline_sha = if $baseline == "local" { "local" } else { resolve-git-ref $baseline }
     let feature_sha = if $feature == "local" { "local" } else { resolve-git-ref $feature }
+
+    # Resolve git-ref label: tag > branch > original input
+    let baseline_ref_label = if $baseline == "local" { "local" } else { resolve-git-ref-label $baseline_sha $baseline }
+    let feature_ref_label = if $feature == "local" { "local" } else { resolve-git-ref-label $feature_sha $feature }
+
     let baseline_label = if $baseline == "local" { "local (working tree)" } else { $"($baseline) → ($baseline_sha)" }
     let feature_label = if $feature == "local" { "local (working tree)" } else { $"($feature) → ($feature_sha)" }
     print $"Baseline: ($baseline_label)"
@@ -539,17 +544,17 @@ def "main run" [
     let samply_args_list = if $samply_args == "" { [] } else { $samply_args | split row " " }
     let runs = if $dual_hardfork {
         [
-            { label: "baseline-1", tempo: $baseline_tempo, git_ref: $baseline_sha, git_ref_label: $baseline, genesis: $"($abs_localnet)/genesis-baseline.json", datadir: $"($datadir)/baseline-db" }
-            { label: "feature-1", tempo: $feature_tempo, git_ref: $feature_sha, git_ref_label: $feature, genesis: $"($abs_localnet)/genesis-feature.json", datadir: $"($datadir)/feature-db" }
-            { label: "feature-2", tempo: $feature_tempo, git_ref: $feature_sha, git_ref_label: $feature, genesis: $"($abs_localnet)/genesis-feature.json", datadir: $"($datadir)/feature-db" }
-            { label: "baseline-2", tempo: $baseline_tempo, git_ref: $baseline_sha, git_ref_label: $baseline, genesis: $"($abs_localnet)/genesis-baseline.json", datadir: $"($datadir)/baseline-db" }
+            { label: "baseline-1", tempo: $baseline_tempo, git_ref: $baseline_sha, git_ref_label: $baseline_ref_label, genesis: $"($abs_localnet)/genesis-baseline.json", datadir: $"($datadir)/baseline-db" }
+            { label: "feature-1", tempo: $feature_tempo, git_ref: $feature_sha, git_ref_label: $feature_ref_label, genesis: $"($abs_localnet)/genesis-feature.json", datadir: $"($datadir)/feature-db" }
+            { label: "feature-2", tempo: $feature_tempo, git_ref: $feature_sha, git_ref_label: $feature_ref_label, genesis: $"($abs_localnet)/genesis-feature.json", datadir: $"($datadir)/feature-db" }
+            { label: "baseline-2", tempo: $baseline_tempo, git_ref: $baseline_sha, git_ref_label: $baseline_ref_label, genesis: $"($abs_localnet)/genesis-baseline.json", datadir: $"($datadir)/baseline-db" }
         ]
     } else {
         [
-            { label: "baseline-1", tempo: $baseline_tempo, git_ref: $baseline_sha, git_ref_label: $baseline, genesis: $genesis_path, datadir: $datadir }
-            { label: "feature-1", tempo: $feature_tempo, git_ref: $feature_sha, git_ref_label: $feature, genesis: $genesis_path, datadir: $datadir }
-            { label: "feature-2", tempo: $feature_tempo, git_ref: $feature_sha, git_ref_label: $feature, genesis: $genesis_path, datadir: $datadir }
-            { label: "baseline-2", tempo: $baseline_tempo, git_ref: $baseline_sha, git_ref_label: $baseline, genesis: $genesis_path, datadir: $datadir }
+            { label: "baseline-1", tempo: $baseline_tempo, git_ref: $baseline_sha, git_ref_label: $baseline_ref_label, genesis: $genesis_path, datadir: $datadir }
+            { label: "feature-1", tempo: $feature_tempo, git_ref: $feature_sha, git_ref_label: $feature_ref_label, genesis: $genesis_path, datadir: $datadir }
+            { label: "feature-2", tempo: $feature_tempo, git_ref: $feature_sha, git_ref_label: $feature_ref_label, genesis: $genesis_path, datadir: $datadir }
+            { label: "baseline-2", tempo: $baseline_tempo, git_ref: $baseline_sha, git_ref_label: $baseline_ref_label, genesis: $genesis_path, datadir: $datadir }
         ]
     }
 

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -44,9 +44,12 @@ def run-txgen-bench-single [
     --bench-env: string = ""
     --bloat: int = 0
     --git-ref: string = ""
+    --git-ref-label: string = ""
     --build-profile: string = ""
     --benchmark-mode: string = ""
     --benchmark-id: string = ""
+    --platform: string = ""
+    --scenario: string = ""
     --reference-epoch: int = 0
     --samply
     --samply-args: list<string> = []
@@ -147,7 +150,10 @@ def run-txgen-bench-single [
         --bench-env $bench_env
         --git-ref $git_ref
         --build-profile $build_profile
-        --benchmark-mode $benchmark_mode)
+        --benchmark-mode $benchmark_mode
+        --git-ref-label $git_ref_label
+        --platform $platform
+        --scenario $scenario)
     if not $bench_result.ok {
         error make { msg: $"txgen benchmark run ($run_label) failed with exit code ($bench_result.exit_code)" }
     }
@@ -253,12 +259,20 @@ def "main run" [
     --baseline-hardfork: string = ""
     --feature-hardfork: string = ""
     --gas-limit: string = ""
+    --platform: string = "tempo"
+    --scenario: string = ""
 ] {
     let runtime_mode = (resolved-runtime-mode $mode)
     if $runtime_mode != "dev" {
         error make { msg: $"txgen benchmark path currently supports only dev/e2e mode \(got ($mode)\)" }
     }
     let preset_path = (txgen-preset-path $preset)
+    let resolved_scenario = if $scenario != "" {
+        $scenario
+    } else {
+        let tps_k = ($tps / 1000)
+        $"($preset)-($tps_k)k"
+    }
     txgen-validate-bench-args $bench_args
     if ($baseline != "" and $feature == "") or ($baseline == "" and $feature != "") {
         error make { msg: "--baseline and --feature must both be provided for txgen comparison mode" }
@@ -525,17 +539,17 @@ def "main run" [
     let samply_args_list = if $samply_args == "" { [] } else { $samply_args | split row " " }
     let runs = if $dual_hardfork {
         [
-            { label: "baseline-1", tempo: $baseline_tempo, git_ref: $baseline_sha, genesis: $"($abs_localnet)/genesis-baseline.json", datadir: $"($datadir)/baseline-db" }
-            { label: "feature-1", tempo: $feature_tempo, git_ref: $feature_sha, genesis: $"($abs_localnet)/genesis-feature.json", datadir: $"($datadir)/feature-db" }
-            { label: "feature-2", tempo: $feature_tempo, git_ref: $feature_sha, genesis: $"($abs_localnet)/genesis-feature.json", datadir: $"($datadir)/feature-db" }
-            { label: "baseline-2", tempo: $baseline_tempo, git_ref: $baseline_sha, genesis: $"($abs_localnet)/genesis-baseline.json", datadir: $"($datadir)/baseline-db" }
+            { label: "baseline-1", tempo: $baseline_tempo, git_ref: $baseline_sha, git_ref_label: $baseline, genesis: $"($abs_localnet)/genesis-baseline.json", datadir: $"($datadir)/baseline-db" }
+            { label: "feature-1", tempo: $feature_tempo, git_ref: $feature_sha, git_ref_label: $feature, genesis: $"($abs_localnet)/genesis-feature.json", datadir: $"($datadir)/feature-db" }
+            { label: "feature-2", tempo: $feature_tempo, git_ref: $feature_sha, git_ref_label: $feature, genesis: $"($abs_localnet)/genesis-feature.json", datadir: $"($datadir)/feature-db" }
+            { label: "baseline-2", tempo: $baseline_tempo, git_ref: $baseline_sha, git_ref_label: $baseline, genesis: $"($abs_localnet)/genesis-baseline.json", datadir: $"($datadir)/baseline-db" }
         ]
     } else {
         [
-            { label: "baseline-1", tempo: $baseline_tempo, git_ref: $baseline_sha, genesis: $genesis_path, datadir: $datadir }
-            { label: "feature-1", tempo: $feature_tempo, git_ref: $feature_sha, genesis: $genesis_path, datadir: $datadir }
-            { label: "feature-2", tempo: $feature_tempo, git_ref: $feature_sha, genesis: $genesis_path, datadir: $datadir }
-            { label: "baseline-2", tempo: $baseline_tempo, git_ref: $baseline_sha, genesis: $genesis_path, datadir: $datadir }
+            { label: "baseline-1", tempo: $baseline_tempo, git_ref: $baseline_sha, git_ref_label: $baseline, genesis: $genesis_path, datadir: $datadir }
+            { label: "feature-1", tempo: $feature_tempo, git_ref: $feature_sha, git_ref_label: $feature, genesis: $genesis_path, datadir: $datadir }
+            { label: "feature-2", tempo: $feature_tempo, git_ref: $feature_sha, git_ref_label: $feature, genesis: $genesis_path, datadir: $datadir }
+            { label: "baseline-2", tempo: $baseline_tempo, git_ref: $baseline_sha, git_ref_label: $baseline, genesis: $genesis_path, datadir: $datadir }
         ]
     }
 
@@ -566,6 +580,7 @@ def "main run" [
             --extra-env $side_env
             --bench-env $bench_env
             --git-ref $run.git_ref
+            --git-ref-label $run.git_ref_label
             --build-profile $profile
             --benchmark-mode $mode
             --benchmark-id $benchmark_id
@@ -576,7 +591,9 @@ def "main run" [
             --tracy-filter $tracy_filter
             --tracy-seconds $tracy_seconds
             --tracy-offset $tracy_offset
-            --tracing-otlp $tracing_otlp)
+            --tracing-otlp $tracing_otlp
+            --platform $platform
+            --scenario $resolved_scenario)
     }
 
     let summary_baseline = if $dual_hardfork { $"($baseline) \(($baseline_hardfork | str upcase)\)" } else { $baseline }

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -49,7 +49,7 @@ def run-txgen-bench-single [
     --benchmark-mode: string = ""
     --benchmark-id: string = ""
     --platform: string = ""
-    --scenario: string = ""
+    --bench-mode: string = ""
     --reference-epoch: int = 0
     --samply
     --samply-args: list<string> = []
@@ -153,7 +153,7 @@ def run-txgen-bench-single [
         --benchmark-mode $benchmark_mode
         --git-ref-label $git_ref_label
         --platform $platform
-        --scenario $scenario)
+        --bench-mode $bench_mode)
     if not $bench_result.ok {
         error make { msg: $"txgen benchmark run ($run_label) failed with exit code ($bench_result.exit_code)" }
     }
@@ -260,18 +260,17 @@ def "main run" [
     --feature-hardfork: string = ""
     --gas-limit: string = ""
     --platform: string = "tempo"
-    --scenario: string = ""
+    --bench-mode: string = ""
 ] {
     let runtime_mode = (resolved-runtime-mode $mode)
     if $runtime_mode != "dev" {
         error make { msg: $"txgen benchmark path currently supports only dev/e2e mode \(got ($mode)\)" }
     }
     let preset_path = (txgen-preset-path $preset)
-    let resolved_scenario = if $scenario != "" {
-        $scenario
+    let resolved_mode = if $bench_mode != "" {
+        $bench_mode
     } else {
-        let tps_k = ($tps / 1000)
-        $"($preset)-($tps_k)k"
+        "e2e"
     }
     txgen-validate-bench-args $bench_args
     if ($baseline != "" and $feature == "") or ($baseline == "" and $feature != "") {
@@ -593,7 +592,7 @@ def "main run" [
             --tracy-offset $tracy_offset
             --tracing-otlp $tracing_otlp
             --platform $platform
-            --scenario $resolved_scenario)
+            --bench-mode $resolved_mode)
     }
 
     let summary_baseline = if $dual_hardfork { $"($baseline) \(($baseline_hardfork | str upcase)\)" } else { $baseline }

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -197,7 +197,7 @@ def txgen-run-preset-pipeline [
     --run-type: string = ""
     --benchmark-start: int = 0
     --platform: string = ""
-    --scenario: string = ""
+    --bench-mode: string = ""
     --victoriametrics-url: string = ""
 ] {
     let chain_id = (txgen-fetch-chain-id $generate_rpc_url)
@@ -253,7 +253,7 @@ def txgen-run-preset-pipeline [
         | append (if $benchmark_run != "" { ["-m" $"benchmark_run=($benchmark_run)"] } else { [] })
         | append (if $run_type != "" { ["-m" $"run_type=($run_type)"] } else { [] })
         | append (if $platform != "" { ["-m" $"platform=($platform)"] } else { [] })
-        | append (if $scenario != "" { ["-m" $"scenario=($scenario)"] } else { [] })
+        | append (if $bench_mode != "" { ["-m" $"mode=($bench_mode)"] } else { [] })
     let bench_cmd = $bench_base_cmd | append $report_args | append $metadata_args
 
     let bench_env_export = if $bench_env != "" { $"export ($bench_env) && " } else { "" }

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -189,12 +189,15 @@ def txgen-run-preset-pipeline [
     --max-concurrent-requests: int
     --bench-env: string = ""
     --git-ref: string = ""
+    --git-ref-label: string = ""
     --build-profile: string = ""
     --benchmark-mode: string = ""
     --benchmark-id: string = ""
     --benchmark-run: string = ""
     --run-type: string = ""
     --benchmark-start: int = 0
+    --platform: string = ""
+    --scenario: string = ""
     --victoriametrics-url: string = ""
 ] {
     let chain_id = (txgen-fetch-chain-id $generate_rpc_url)
@@ -241,12 +244,16 @@ def txgen-run-preset-pipeline [
         "-m" "swap_weight=0.0"
         "-m" "erc20_weight=0.0"
         "-m" $"node_commit_sha=($git_ref)"
+        "-m" $"git-sha=($git_ref)"
+        "-m" $"git-ref=($git_ref_label)"
         "-m" $"build_profile=($build_profile)"
         "-m" $"mode=($benchmark_mode)"
     ]
         | append (if $benchmark_id != "" { ["-m" $"benchmark_id=($benchmark_id)"] } else { [] })
         | append (if $benchmark_run != "" { ["-m" $"benchmark_run=($benchmark_run)"] } else { [] })
         | append (if $run_type != "" { ["-m" $"run_type=($run_type)"] } else { [] })
+        | append (if $platform != "" { ["-m" $"platform=($platform)"] } else { [] })
+        | append (if $scenario != "" { ["-m" $"scenario=($scenario)"] } else { [] })
     let bench_cmd = $bench_base_cmd | append $report_args | append $metadata_args
 
     let bench_env_export = if $bench_env != "" { $"export ($bench_env) && " } else { "" }

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -197,7 +197,7 @@ def txgen-run-preset-pipeline [
     --run-type: string = ""
     --benchmark-start: int = 0
     --platform: string = ""
-    --bench-mode: string = ""
+    --scenario: string = ""
     --victoriametrics-url: string = ""
 ] {
     let chain_id = (txgen-fetch-chain-id $generate_rpc_url)
@@ -253,7 +253,7 @@ def txgen-run-preset-pipeline [
         | append (if $benchmark_run != "" { ["-m" $"benchmark_run=($benchmark_run)"] } else { [] })
         | append (if $run_type != "" { ["-m" $"run_type=($run_type)"] } else { [] })
         | append (if $platform != "" { ["-m" $"platform=($platform)"] } else { [] })
-        | append (if $bench_mode != "" { ["-m" $"mode=($bench_mode)"] } else { [] })
+        | append (if $scenario != "" { ["-m" $"scenario=($scenario)"] } else { [] })
     let bench_cmd = $bench_base_cmd | append $report_args | append $metadata_args
 
     let bench_env_export = if $bench_env != "" { $"export ($bench_env) && " } else { "" }

--- a/tempo.nu
+++ b/tempo.nu
@@ -342,6 +342,19 @@ def resolve-git-ref [ref: string] {
     git rev-parse $ref | str trim
 }
 
+# Resolve a SHA to a human-readable label: tag > branch > fallback.
+def resolve-git-ref-label [sha: string, fallback: string] {
+    let tag = (git tag --points-at $sha | lines | first | default "")
+    if $tag != "" {
+        return $tag
+    }
+    let branch = (git branch -r --points-at $sha | lines | first | default "" | str replace -r '^\s*origin/' '')
+    if $branch != "" {
+        return $branch
+    }
+    $fallback
+}
+
 def bench-cache-key [commit_sha: string, features: string, no_default_features: bool] {
     if not $no_default_features {
         return $commit_sha


### PR DESCRIPTION
Adds `-m git_sha=...`, `-m git_ref=...`, `-m chain=...`, and `-m blocks=...` metadata flags to the `bench send-blocks` call in the replay benchmark script.

The `send-blocks` CLI already supports `-m` metadata — we just weren't passing any. This ensures replay reports include commit attribution so downstream consumers (ClickHouse uploads, perf dashboard) can identify which commit produced each result.

Resolves the gap noted in [thread](https://tempoxyz.slack.com/archives/C0A87C21805/p1778681997731069).