### PR TITLE
ci(bench): use DEREK_BENCH_ACK_TOKEN for org membership check

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -68,7 +68,7 @@ jobs:
         if: github.event_name == 'issue_comment'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.DEREK_BENCH_ACK_TOKEN }}
           script: |
             const org = 'tempoxyz';
             const checkMembership = async (username) => {


### PR DESCRIPTION
The default `GITHUB_TOKEN` cannot see concealed org members — `checkMembershipForUser` returns 302 for public members and 404 for concealed ones, so users with private membership fail the bench gate.

Switch to `DEREK_BENCH_ACK_TOKEN` which has `org:read` scope and returns 204 for all members regardless of visibility.