### PR TITLE
reduce expiring nonce max expiry from 30s to 10s

### DIFF
--- a/crates/precompiles/src/nonce/mod.rs
+++ b/crates/precompiles/src/nonce/mod.rs
@@ -16,12 +16,12 @@ use crate::{
 };
 use alloy::primitives::{Address, B256, U256};
 
-/// Capacity of the expiring nonce seen set (supports 10k TPS for 30 seconds).
+/// Capacity of the expiring nonce seen set (supports 30k TPS for 10 seconds).
 pub const EXPIRING_NONCE_SET_CAPACITY: u32 = 300_000;
 
-/// Maximum allowed skew for expiring nonce transactions (30 seconds).
+/// Maximum allowed skew for expiring nonce transactions (10 seconds).
 /// Transactions must have valid_before in (now, now + MAX_EXPIRY_SECS].
-pub const EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 30;
+pub const EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 10;
 
 /// NonceManager contract for managing 2D nonces as per the AA spec
 ///
@@ -306,7 +306,7 @@ mod tests {
             let mut mgr = NonceManager::new();
 
             let tx_hash = B256::repeat_byte(0x11);
-            let valid_before = now + 20; // 20s in future, within 30s window
+            let valid_before = now + 5; // 5s in future, within 10s window
 
             // First tx should succeed
             mgr.check_and_mark_expiring_nonce(tx_hash, valid_before)?;
@@ -346,15 +346,15 @@ mod tests {
                 TempoPrecompileError::NonceError(NonceError::invalid_expiring_nonce_expiry())
             );
 
-            // valid_before too far in future should fail (uses EXPIRING_NONCE_MAX_EXPIRY_SECS = 30)
-            let result = mgr.check_and_mark_expiring_nonce(tx_hash, now + 31);
+            // valid_before too far in future should fail (uses EXPIRING_NONCE_MAX_EXPIRY_SECS = 10)
+            let result = mgr.check_and_mark_expiring_nonce(tx_hash, now + 11);
             assert_eq!(
                 result.unwrap_err(),
                 TempoPrecompileError::NonceError(NonceError::invalid_expiring_nonce_expiry())
             );
 
             // valid_before at exactly EXPIRING_NONCE_MAX_EXPIRY_SECS should succeed
-            mgr.check_and_mark_expiring_nonce(tx_hash, now + 30)?;
+            mgr.check_and_mark_expiring_nonce(tx_hash, now + 10)?;
 
             Ok(())
         })
@@ -364,7 +364,7 @@ mod tests {
     fn test_expiring_nonce_expired_entry_eviction() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         let now = 1000u64;
-        let valid_before = now + 20;
+        let valid_before = now + 5;
         storage.set_timestamp(U256::from(now));
         StorageCtx::enter(&mut storage, || {
             let mut mgr = NonceManager::new();
@@ -385,7 +385,7 @@ mod tests {
 
         // Insert second tx after first has expired - should evict first
         let new_now = valid_before + 1;
-        let new_valid_before = new_now + 20;
+        let new_valid_before = new_now + 5;
         storage.set_timestamp(U256::from(new_now));
         StorageCtx::enter(&mut storage, || {
             let mut mgr = NonceManager::new();
@@ -415,7 +415,7 @@ mod tests {
 
             // Insert a tx - pointer should wrap to 0
             let tx_hash = B256::repeat_byte(0x77);
-            let valid_before = now + 20;
+            let valid_before = now + 5;
             mgr.check_and_mark_expiring_nonce(tx_hash, valid_before)?;
 
             // Pointer should now be 0 (wrapped at capacity)

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -28,8 +28,8 @@ pub const MAX_WEBAUTHN_SIGNATURE_LENGTH: usize = 2048; // 2KB max
 /// Nonce key marking an expiring nonce transaction (uses tx hash for replay protection).
 pub const TEMPO_EXPIRING_NONCE_KEY: U256 = U256::MAX;
 
-/// Maximum allowed expiry window for expiring nonce transactions (30 seconds).
-pub const TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 30;
+/// Maximum allowed expiry window for expiring nonce transactions (10 seconds).
+pub const TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 10;
 
 /// Signature type enumeration
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
With `EXPIRING_NONCE_SET_CAPACITY` at 300k, a 30s window only supports ~10k TPS before `ExpiringNonceSetFull` errors. Reducing to 10s allows 30k TPS within the same buffer capacity (300k / 10s = 30k TPS).

**Changes:**
- `EXPIRING_NONCE_MAX_EXPIRY_SECS`: 30 → 10 (precompiles)
- `TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS`: 30 → 10 (primitives)
- Updated hardcoded test values to use 5s/10s/11s instead of 20s/30s/31s