### PR TITLE
ci(bench): reduce expiring nonce valid_for_secs from 25s to 10s

### DIFF
--- a/contrib/bench/txgen/presets/tip20.yml
+++ b/contrib/bench/txgen/presets/tip20.yml
@@ -25,7 +25,7 @@ templates:
     max_priority_fee_per_gas: 100000000000
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
-    valid_for_secs: 25
+    valid_for_secs: 10
     call:
       to: "0x20c0000000000000000000000000000000000000"
       abi: ERC20


### PR DESCRIPTION
At 30k TPS the 300k ring buffer fills in 10s, so `valid_for_secs` must be ≤10s to avoid `ExpiringNonceSetFull` errors.

Changes `tip20.yml` preset from 25s → 10s. `mpp.yml` doesn't use expiring nonces so no change needed there.