### PR TITLE
ci(bench): add optional ClickHouse reporting to replay bench

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -324,12 +324,18 @@ run_single() {
   # Benchmark
   local bench_to=$(( from_block + BLOCKS - 1 ))
   echo "Running benchmark ($BLOCKS blocks: $from_block..$bench_to)..."
+  local clickhouse_report=()
+  if [ -n "${CLICKHOUSE_URL:-}" ]; then
+    clickhouse_report=(--report "clickhouse:$CLICKHOUSE_URL")
+  fi
+
   "$TXGEN_TEMPO_BIN" extract --rpc "$REPLAY_RPC_URL" --from "$from_block" --to "$bench_to" \
     | "$TXGEN_BENCH_BIN" send-blocks \
       --engine http://127.0.0.1:8551 \
       --jwt-secret "$DATADIR/jwt.hex" \
       --metrics-url http://localhost:9001 \
       --report "json:$output_dir/report.json" \
+      "${clickhouse_report[@]}" \
       -m "git-sha=$git_sha" \
       -m "git-ref=$git_ref" \
       -m "platform=tempo" \

--- a/.github/workflows/bench-replay-scheduled.yml
+++ b/.github/workflows/bench-replay-scheduled.yml
@@ -239,6 +239,9 @@ jobs:
       DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
       SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
       SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
+      CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+      CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
 
   save-state:
     needs: [resolve-refs, bench-replay]

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -134,6 +134,12 @@ on:
         required: false
       SLACK_BENCH_CHANNEL:
         required: false
+      CLICKHOUSE_URL:
+        required: false
+      CLICKHOUSE_USER:
+        required: false
+      CLICKHOUSE_PASSWORD:
+        required: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -393,6 +399,9 @@ jobs:
           BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
           DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
+          CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+          CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+          CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
         run: bash .github/scripts/bench-tempo-replay.sh
 
       - name: Parse results


### PR DESCRIPTION
Stacked on #3960.

Uses txgen's built-in ClickHouse reporter (`--report clickhouse:$CLICKHOUSE_URL`) to write replay bench results directly to `txgen_runs`/`txgen_blocks`/`txgen_metric_samples` tables — the same tables the perf site reads from.

**How it works:**
- When `CLICKHOUSE_URL` is set, the script adds `--report clickhouse:$CLICKHOUSE_URL` to the `bench send-blocks` call
- The reporter reads `CLICKHOUSE_USER`/`CLICKHOUSE_PASSWORD` from env
- Required metadata (`git-sha`, `git-ref`, `platform`, `scenario`) is already set by #3960

**Enabled for:** `bench-replay-scheduled.yml` (nightly) — secrets are threaded through `bench-replay.yml`. PR benches don't get the secrets so nothing changes for them.

**Requires:** `CLICKHOUSE_URL`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD` repo secrets to be configured.