### PR TITLE
use consensus context label for follower stack

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -498,7 +498,7 @@ fn main() -> eyre::Result<()> {
                 };
 
                 Either::Left(run_follow_stack(
-                    ctx.with_label("follow"),
+                    ctx.with_label("consensus"),
                     args.consensus,
                     follow_url,
                     Arc::new(node),


### PR DESCRIPTION
Both the consensus and follower stacks now use the same `consensus` context label for the commonware runtime, aligning metrics and tracing spans between the two modes.