### PR TITLE
deps: update reth from main (2026-05-14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8260,7 +8260,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8319,7 +8319,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8339,7 +8339,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8352,7 +8352,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8435,7 +8435,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8445,7 +8445,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8498,7 +8498,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8514,7 +8514,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8528,7 +8528,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8541,7 +8541,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8566,7 +8566,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8595,7 +8595,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8621,7 +8621,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8666,7 +8666,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8691,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8715,7 +8715,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8739,7 +8739,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8774,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8831,7 +8831,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8859,7 +8859,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8882,7 +8882,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8907,7 +8907,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8966,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8996,7 +8996,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9012,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9028,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9050,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9061,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9089,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9111,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "clap",
  "eyre",
@@ -9175,7 +9175,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9191,7 +9191,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9250,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9264,7 +9264,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9274,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9298,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9318,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9368,7 +9368,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9420,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "serde",
  "serde_json",
@@ -9430,7 +9430,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9458,7 +9458,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "bytes",
  "futures",
@@ -9478,7 +9478,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9495,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "bindgen",
  "cc",
@@ -9504,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "futures",
  "metrics",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9526,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9540,7 +9540,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9598,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9623,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9646,7 +9646,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9661,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9692,7 +9692,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9716,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9784,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9839,7 +9839,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9877,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9901,7 +9901,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "bytes",
  "eyre",
@@ -9954,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9966,7 +9966,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10025,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10116,7 +10116,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10145,7 +10145,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10161,7 +10161,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10253,7 +10253,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10283,7 +10283,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10326,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10377,7 +10377,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10423,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10471,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10485,7 +10485,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10516,7 +10516,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10568,7 +10568,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10610,7 +10610,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10645,7 +10645,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10670,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10688,7 +10688,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10709,7 +10709,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10725,7 +10725,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10735,7 +10735,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "clap",
  "eyre",
@@ -10754,7 +10754,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "clap",
  "eyre",
@@ -10772,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10817,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10843,7 +10843,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10870,7 +10870,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10890,7 +10890,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10919,7 +10919,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8260,7 +8260,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8319,7 +8319,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8339,7 +8339,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8352,7 +8352,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8435,7 +8435,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8445,7 +8445,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8498,7 +8498,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8514,7 +8514,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8528,7 +8528,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8541,7 +8541,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8566,7 +8566,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8595,7 +8595,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8621,7 +8621,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8666,7 +8666,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8691,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8715,7 +8715,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8739,7 +8739,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8774,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8831,7 +8831,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8859,7 +8859,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8882,7 +8882,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8907,7 +8907,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8966,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8996,7 +8996,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9012,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9028,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9050,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9061,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9089,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9111,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "clap",
  "eyre",
@@ -9175,7 +9175,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9191,7 +9191,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9250,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9264,7 +9264,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9274,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9298,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9318,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9368,7 +9368,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9420,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "serde",
  "serde_json",
@@ -9430,7 +9430,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9458,7 +9458,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "bytes",
  "futures",
@@ -9478,7 +9478,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9495,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "bindgen",
  "cc",
@@ -9504,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "futures",
  "metrics",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9526,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9540,7 +9540,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9598,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9623,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9646,7 +9646,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9661,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9692,7 +9692,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9716,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9784,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9839,7 +9839,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9877,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9901,7 +9901,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "bytes",
  "eyre",
@@ -9954,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9966,7 +9966,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10025,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10116,7 +10116,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10145,7 +10145,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10161,7 +10161,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10253,7 +10253,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10283,7 +10283,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10326,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10377,7 +10377,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10423,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10471,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10485,7 +10485,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10516,7 +10516,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10568,7 +10568,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10610,7 +10610,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10645,7 +10645,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10670,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10688,7 +10688,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10709,7 +10709,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10725,7 +10725,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10735,7 +10735,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "clap",
  "eyre",
@@ -10754,7 +10754,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "clap",
  "eyre",
@@ -10772,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10817,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10843,7 +10843,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10870,7 +10870,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10890,7 +10890,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10919,7 +10919,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d2609bf#d2609bfb4ff69a0059882c02a5600e4466756659"
+source = "git+https://github.com/paradigmxyz/reth?rev=4206935#420693521fccd1437071a15a4a54a3a98b5492cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,64 +139,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,64 +139,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "4206935", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4206935", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "4206935", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "4206935" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "d2609bf", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "4206935", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`9b6a79f...4206935`](https://github.com/paradigmxyz/reth/compare/9b6a79f...4206935)

🔗 Amp thread: https://ampcode.com/threads/T-019e2762-5e1e-7627-8558-d18aa6373f05
**Engine**
- Reserve prewarm proof target sets for performance ([#24198](https://github.com/paradigmxyz/reth/pull/24198))

**CLI**
- Add `download --force` snapshot overwrite support ([#24229](https://github.com/paradigmxyz/reth/pull/24229))

**Examples**
- Add custom state root example ([#24135](https://github.com/paradigmxyz/reth/pull/24135))

**Migration**
- Properly handle dummy blocks in `migrate-v2` ([#24189](https://github.com/paradigmxyz/reth/pull/24189))

**Bench**
- Add benchmarkoor replay workflow ([#24172](https://github.com/paradigmxyz/reth/pull/24172))
- Add git-sha, git-ref, platform, and scenario metadata to txgen bench; use `DEREK_BENCH_ACK_TOKEN` for org membership check ([#24190](https://github.com/paradigmxyz/reth/pull/24190), [#24191](https://github.com/paradigmxyz/reth/pull/24191))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019e2762-730d-7364-8c00-0ff1da43811b
- Bumped all `reth-*` git dependencies in `Cargo.toml` from rev `9b6a79f` to rev `4206935` (Reth SDK upstream version bump); no API or code changes included in this diff.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/25872584315)
