### PR TITLE
feat(bench): add mixed txgen preset

### DIFF
--- a/contrib/bench/txgen/presets/mix.yml
+++ b/contrib/bench/txgen/presets/mix.yml
@@ -29,7 +29,7 @@ setup:
         artifact: MPPChannel
         gas_limit: 20000000
         constructor_args: []
-    - id: dex_approve
+    - id: dex_approve_quote
       tx:
         type: eip1559
         from:
@@ -42,7 +42,21 @@ setup:
           function: approve
           args:
             - "0xdec0000000000000000000000000000000000000"
-            - 100000000000
+            - "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+    - id: dex_approve_base
+      tx:
+        type: eip1559
+        from:
+          pool: users
+          select: { index: 0 }
+        gas_limit: 300000
+        call:
+          to: "0x20c0000000000000000000000000000000000001"
+          abi: ERC20
+          function: approve
+          args:
+            - "0xdec0000000000000000000000000000000000000"
+            - "115792089237316195423570985008687907853269984665640564039457584007913129639935"
     - id: dex_seed_bid
       tx:
         type: eip1559
@@ -53,12 +67,13 @@ setup:
         call:
           to: "0xdec0000000000000000000000000000000000000"
           abi: StablecoinDEX
-          function: place
+          function: placeFlip
           args:
             - "0x20c0000000000000000000000000000000000001"
-            - 100000000000
+            - 1000000000000
             - true
-            - 0
+            - -10
+            - 10
 
 templates:
   tip20_transfer:
@@ -71,7 +86,7 @@ templates:
     max_priority_fee_per_gas: 100000000000
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
-    valid_for_secs: 10
+    valid_for_secs: 25
     call:
       to: "0x20c0000000000000000000000000000000000000"
       abi: ERC20
@@ -107,7 +122,7 @@ templates:
     max_priority_fee_per_gas: 100000000000
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
-    valid_for_secs: 10
+    valid_for_secs: 25
 
   dex_swap:
     type: tempo
@@ -119,7 +134,7 @@ templates:
     max_priority_fee_per_gas: 100000000000
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
-    valid_for_secs: 10
+    valid_for_secs: 25
     calls:
       - to: "0x20c0000000000000000000000000000000000001"
         abi: ERC20

--- a/contrib/bench/txgen/presets/mix.yml
+++ b/contrib/bench/txgen/presets/mix.yml
@@ -49,17 +49,16 @@ setup:
         from:
           pool: users
           select: { index: 0 }
-        gas_limit: 2000000
+        gas_limit: 8000000
         call:
           to: "0xdec0000000000000000000000000000000000000"
           abi: StablecoinDEX
-          function: placeFlip
+          function: place
           args:
             - "0x20c0000000000000000000000000000000000001"
             - 100000000000
             - true
             - 0
-            - 10
 
 templates:
   tip20_transfer:
@@ -115,7 +114,7 @@ templates:
     from:
       pool: users
       select: random
-    gas_limit: 3000000
+    gas_limit: 5000000
     max_fee_per_gas: 100000000000
     max_priority_fee_per_gas: 100000000000
     fee_token: "0x20c0000000000000000000000000000000000000"

--- a/contrib/bench/txgen/presets/mix.yml
+++ b/contrib/bench/txgen/presets/mix.yml
@@ -1,0 +1,212 @@
+chain_id: 1337
+
+gas:
+  max_fee_per_gas: 100000000000
+  max_priority_fee_per_gas: 100000000000
+
+accounts:
+  users:
+    mnemonic: "test test test test test test test test test test test junk"
+    range:
+      - 0
+      - ${TXGEN_ACCOUNTS}
+
+artifacts:
+  ERC20: ../erc20.abi.json
+  MPPChannel:
+    abi: ../mpp-channel.json
+    bytecode: ../mpp-channel.json
+  StablecoinDEX: ../stablecoin-dex.abi.json
+
+setup:
+  steps:
+    - id: channel
+      deploy:
+        type: eip1559
+        from:
+          pool: users
+          select: { index: 0 }
+        artifact: MPPChannel
+        gas_limit: 20000000
+        constructor_args: []
+    - id: dex_approve
+      tx:
+        type: eip1559
+        from:
+          pool: users
+          select: { index: 0 }
+        gas_limit: 300000
+        call:
+          to: "0x20c0000000000000000000000000000000000000"
+          abi: ERC20
+          function: approve
+          args:
+            - "0xdec0000000000000000000000000000000000000"
+            - 100000000000
+    - id: dex_seed_bid
+      tx:
+        type: eip1559
+        from:
+          pool: users
+          select: { index: 0 }
+        gas_limit: 2000000
+        call:
+          to: "0xdec0000000000000000000000000000000000000"
+          abi: StablecoinDEX
+          function: placeFlip
+          args:
+            - "0x20c0000000000000000000000000000000000001"
+            - 100000000000
+            - true
+            - 0
+            - 10
+
+templates:
+  tip20_transfer:
+    type: tempo
+    from:
+      pool: users
+      select: random
+    gas_limit: 300000
+    max_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 100000000000
+    fee_token: "0x20c0000000000000000000000000000000000000"
+    expiring_nonce: true
+    valid_for_secs: 10
+    call:
+      to: "0x20c0000000000000000000000000000000000000"
+      abi: ERC20
+      function: transfer
+      args:
+        - pool:
+            pool: users
+            select: random
+        - 1
+
+  erc20_transfer:
+    type: eip1559
+    from:
+      pool: users
+      select: random
+    gas_limit: 300000
+    max_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 100000000000
+    call:
+      to: "0x20c0000000000000000000000000000000000000"
+      abi: ERC20
+      function: transfer
+      args:
+        - pool:
+            pool: users
+            select: random
+        - 1
+
+  mpp_channel:
+    type: tempo
+    gas_limit: 8000000
+    max_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 100000000000
+    fee_token: "0x20c0000000000000000000000000000000000000"
+    expiring_nonce: true
+    valid_for_secs: 10
+
+  dex_swap:
+    type: tempo
+    from:
+      pool: users
+      select: random
+    gas_limit: 3000000
+    max_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 100000000000
+    fee_token: "0x20c0000000000000000000000000000000000000"
+    expiring_nonce: true
+    valid_for_secs: 10
+    calls:
+      - to: "0x20c0000000000000000000000000000000000001"
+        abi: ERC20
+        function: approve
+        args:
+          - "0xdec0000000000000000000000000000000000000"
+          - 1
+      - to: "0xdec0000000000000000000000000000000000000"
+        abi: StablecoinDEX
+        function: swapExactAmountIn
+        args:
+          - "0x20c0000000000000000000000000000000000001"
+          - "0x20c0000000000000000000000000000000000000"
+          - 1
+          - 0
+
+sequences:
+  mpp_open_close:
+    bindings:
+      payer:
+        account:
+          pool: users
+          select: random
+      token:
+        address:
+          const: "0x20c0000000000000000000000000000000000001"
+      authorized_signer:
+        address:
+          const: "0x0000000000000000000000000000000000000000"
+      salt:
+        bytes32:
+          random_bytes: 32
+      channel_id:
+        abi_hash:
+          types: [address, address, address, bytes32, address, address, uint256]
+          values:
+            - { var: payer.address }
+            - { var: payer.address }
+            - { var: token }
+            - { var: salt }
+            - { var: authorized_signer }
+            - { var: setup.channel.address }
+            - { var: chain_id }
+      channel_key:
+        abi_encode_packed:
+          types: [bytes32, address, address, bytes32]
+          values:
+            - { var: channel_id }
+            - { var: token }
+            - { var: authorized_signer }
+            - { var: salt }
+    steps:
+      - name: open_close
+        template: mpp_channel
+        with:
+          from: { var: payer.ref }
+          calls:
+            - to: { var: token }
+              abi: ERC20
+              function: approve
+              args:
+                - { var: setup.channel.address }
+                - 1
+            - to: { var: setup.channel.address }
+              abi: MPPChannel
+              function: open
+              args:
+                - { var: payer.address }
+                - { var: token }
+                - 1
+                - { var: salt }
+                - { var: authorized_signer }
+            - to: { var: setup.channel.address }
+              abi: MPPChannel
+              function: close
+              args:
+                - { var: channel_key }
+                - 0
+                - "0x"
+
+mix:
+  - template: tip20_transfer
+    weight: 70
+  - template: erc20_transfer
+    weight: 10
+  - sequence: mpp_open_close
+    weight: 10
+  - template: dex_swap
+    weight: 10

--- a/contrib/bench/txgen/stablecoin-dex.abi.json
+++ b/contrib/bench/txgen/stablecoin-dex.abi.json
@@ -1,0 +1,75 @@
+[
+  {
+    "type": "function",
+    "name": "placeFlip",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "name": "isBid",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "tick",
+        "type": "int16",
+        "internalType": "int16"
+      },
+      {
+        "name": "flipTick",
+        "type": "int16",
+        "internalType": "int16"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "orderId",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "swapExactAmountIn",
+    "inputs": [
+      {
+        "name": "tokenIn",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenOut",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "name": "minAmountOut",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  }
+]

--- a/contrib/bench/txgen/stablecoin-dex.abi.json
+++ b/contrib/bench/txgen/stablecoin-dex.abi.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "function",
-    "name": "placeFlip",
+    "name": "place",
     "inputs": [
       {
         "name": "token",
@@ -20,11 +20,6 @@
       },
       {
         "name": "tick",
-        "type": "int16",
-        "internalType": "int16"
-      },
-      {
-        "name": "flipTick",
         "type": "int16",
         "internalType": "int16"
       }

--- a/contrib/bench/txgen/stablecoin-dex.abi.json
+++ b/contrib/bench/txgen/stablecoin-dex.abi.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "function",
-    "name": "place",
+    "name": "placeFlip",
     "inputs": [
       {
         "name": "token",
@@ -20,6 +20,11 @@
       },
       {
         "name": "tick",
+        "type": "int16",
+        "internalType": "int16"
+      },
+      {
+        "name": "flipTick",
         "type": "int16",
         "internalType": "int16"
       }


### PR DESCRIPTION
## Summary
- Adds a new `mix` txgen preset with a 70/10/10/10 split across TIP-20 transfers, ERC-20 transfers, MPP channel flows, and DEX swaps.
- Adds the StablecoinDEX ABI needed for the DEX setup and swap calls.
- Seeds a DEX bid in setup so the swap workload has liquidity to hit.

## Testing
- Ran `txgen-tempo generate` against `mix.yml` to confirm the preset parses and emits workload transactions.
- Verified a 1000-transaction sample matches the requested mix closely: 709 TIP-20, 96 ERC-20, 95 MPP, 100 DEX.