### PR TITLE
ci(bench): drop root privileges in replay benchmark

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -257,7 +257,7 @@ run_single() {
     samply_bin="$(which samply)"
     sudo systemd-run --quiet --scope --collect --unit="$TEMPO_SCOPE" \
       --uid="$run_uid" --gid="$run_gid" \
-      -p MemoryMax="$mem_limit" -p CPUWeight=100 \
+      -p MemoryMax="$mem_limit" \
       "${scope_env[@]}" \
       "$samply_bin" record --save-only --presymbolicate --rate 10000 \
       --output "$output_dir/samply-profile.json.gz" \
@@ -266,7 +266,7 @@ run_single() {
   else
     sudo systemd-run --quiet --scope --collect --unit="$TEMPO_SCOPE" \
       --uid="$run_uid" --gid="$run_gid" \
-      -p MemoryMax="$mem_limit" -p CPUWeight=100 \
+      -p MemoryMax="$mem_limit" \
       "${scope_env[@]}" "$binary" "${NODE_ARGS[@]}" \
       > "$log" 2>&1 &
   fi

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -247,21 +247,27 @@ run_single() {
     fi
   done
 
-  # Start tempo node
+  # Start tempo node (drop back to runner user, matching bench-e2e.nu)
+  local run_uid run_gid
+  run_uid="$(id -u)"
+  run_gid="$(id -g)"
+
   if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
     local samply_bin
     samply_bin="$(which samply)"
     sudo systemd-run --quiet --scope --collect --unit="$TEMPO_SCOPE" \
-      -p MemoryMax="$mem_limit" \
-      "${scope_env[@]}" nice -n -20 \
+      --uid="$run_uid" --gid="$run_gid" \
+      -p MemoryMax="$mem_limit" -p CPUWeight=100 \
+      "${scope_env[@]}" \
       "$samply_bin" record --save-only --presymbolicate --rate 10000 \
       --output "$output_dir/samply-profile.json.gz" \
       -- "$binary" "${NODE_ARGS[@]}" \
       > "$log" 2>&1 &
   else
     sudo systemd-run --quiet --scope --collect --unit="$TEMPO_SCOPE" \
-      -p MemoryMax="$mem_limit" \
-      "${scope_env[@]}" nice -n -20 "$binary" "${NODE_ARGS[@]}" \
+      --uid="$run_uid" --gid="$run_gid" \
+      -p MemoryMax="$mem_limit" -p CPUWeight=100 \
+      "${scope_env[@]}" "$binary" "${NODE_ARGS[@]}" \
       > "$log" 2>&1 &
   fi
   stdbuf -oL tail -f "$log" | sed -u "s/^/[$label] /" &

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -308,7 +308,6 @@ def systemd-scope-command [unit: string, cpus: string, memory: string, script: s
         "--uid" $uid
         "--gid" $gid
         ...$telemetry_env
-        "-p" "CPUWeight=100"
         ...$memory_args
         "bash"
         "-lc"


### PR DESCRIPTION
The replay benchmark script runs tempo as root via `sudo systemd-run` without dropping privileges, unlike `bench-e2e.nu` which passes `--uid`/`--gid` to run the process as the runner user.

This PR aligns the replay script with the e2e approach:
- Adds `--uid`/`--gid` to both `systemd-run` calls so tempo runs as the runner user
- Replaces `nice -n -20` (requires root inside the scope) with `CPUWeight=100` cgroup property (same as bench-e2e.nu)