### PR TITLE
ci(bench): remove faucet funding from txgen-run-preset-pipeline

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -764,7 +764,8 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --benchmark-run $phase
                 --run-type $run_type
                 --benchmark-start $ctx.reference_epoch
-                --victoriametrics-url $ctx.victoriametrics_url)
+                --victoriametrics-url $ctx.victoriametrics_url
+                --skip-funding=($ctx.bloat > 0))
             if not $bench_result.ok {
                 $bench_result.exit_code
             } else {

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -153,7 +153,8 @@ def run-txgen-bench-single [
         --benchmark-mode $benchmark_mode
         --git-ref-label $git_ref_label
         --platform $platform
-        --scenario $scenario)
+        --scenario $scenario
+        --skip-funding=($bloat > 0))
     if not $bench_result.ok {
         error make { msg: $"txgen benchmark run ($run_label) failed with exit code ($bench_result.exit_code)" }
     }

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -199,6 +199,7 @@ def txgen-run-preset-pipeline [
     --platform: string = ""
     --scenario: string = ""
     --victoriametrics-url: string = ""
+    --skip-funding                                   # Skip faucet funding (accounts already funded at genesis via state bloat)
 ] {
     let chain_id = (txgen-fetch-chain-id $generate_rpc_url)
     $env.TXGEN_ACCOUNTS = ($accounts | into string)
@@ -206,7 +207,9 @@ def txgen-run-preset-pipeline [
     if not ($spec_path | path exists) {
         error make { msg: $"txgen preset file not found: ($spec_path)" }
     }
-    txgen-fund-accounts $txgen_tempo_bin $spec_path $generate_rpc_url
+    if not $skip_funding {
+        txgen-fund-accounts $txgen_tempo_bin $spec_path $generate_rpc_url
+    }
 
     let tx_count = [($tps * $duration) 1] | math max
     let txgen_duration = $"($duration)s"

--- a/tempo.nu
+++ b/tempo.nu
@@ -648,7 +648,8 @@ def run-bench-single [
             --bench-env $bench_env
             --git-ref $git_ref
             --build-profile $build_profile
-            --benchmark-mode $benchmark_mode)
+            --benchmark-mode $benchmark_mode
+            --skip-funding=($bloat > 0))
         if not $result.ok {
             print $"  Benchmark run ($run_label) failed with exit code ($result.exit_code)"
         }
@@ -2317,7 +2318,8 @@ def "main bench" [
             --bench-env $bench_env
             --git-ref $current_sha
             --build-profile $profile
-            --benchmark-mode $mode)
+            --benchmark-mode $mode
+            --skip-funding=($bloat > 0))
         $result
     } catch { |e|
         print $"Benchmark interrupted or failed: ($e.msg)"


### PR DESCRIPTION
Txgen accounts (derived from the `test test test...` mnemonic) are already pre-funded with TIP-20 balances at genesis via `generate-localnet` / `generate_genesis()`. The `tempo_fundAddress` faucet call in `txgen-run-preset-pipeline` was redundant and added unnecessary latency to every benchmark run.

### Removed
- `txgen-fund-accounts` function and its call from `txgen-run-preset-pipeline`
- `txgen-wait-for-txpool-drain` helper (only used by funding)
- `TXGEN_HELPER_FUND_DRAIN_TIMEOUT_SECS` constant