### PR TITLE
style: rename TIP1028BlockedTransfers to TIP1028Guard

### DIFF
--- a/crates/contracts/src/precompiles/tip1028_blocked_transfers.rs
+++ b/crates/contracts/src/precompiles/tip1028_blocked_transfers.rs
@@ -1,12 +1,12 @@
-pub use ITIP1028BlockedTransfers::{
-    ITIP1028BlockedTransfersErrors as BlockTransferError,
-    ITIP1028BlockedTransfersEvents as BlockTransferEvent,
+pub use ITIP1028Guard::{
+    ITIP1028GuardErrors as BlockTransferError,
+    ITIP1028GuardEvents as BlockTransferEvent,
 };
 
 crate::sol! {
     #[derive(Debug, PartialEq, Eq)]
     #[sol(abi)]
-    interface ITIP1028BlockedTransfers {
+    interface ITIP1028Guard {
         enum InboundKind {
             TRANSFER,
             MINT
@@ -39,26 +39,26 @@ crate::sol! {
 
 impl BlockTransferError {
     pub const fn unauthorized_claimer() -> Self {
-        Self::UnauthorizedClaimer(ITIP1028BlockedTransfers::UnauthorizedClaimer {})
+        Self::UnauthorizedClaimer(ITIP1028Guard::UnauthorizedClaimer {})
     }
 
     pub const fn invalid_proof() -> Self {
-        Self::InvalidProof(ITIP1028BlockedTransfers::InvalidProof {})
+        Self::InvalidProof(ITIP1028Guard::InvalidProof {})
     }
 
     pub const fn insufficient_balance() -> Self {
-        Self::InsufficientBalance(ITIP1028BlockedTransfers::InsufficientBalance {})
+        Self::InsufficientBalance(ITIP1028Guard::InsufficientBalance {})
     }
 
     pub const fn block_address_reserved() -> Self {
-        Self::BlockAddressReserved(ITIP1028BlockedTransfers::BlockAddressReserved {})
+        Self::BlockAddressReserved(ITIP1028Guard::BlockAddressReserved {})
     }
 
     pub const fn invalid_claim_address() -> Self {
-        Self::InvalidClaimAddress(ITIP1028BlockedTransfers::InvalidClaimAddress {})
+        Self::InvalidClaimAddress(ITIP1028Guard::InvalidClaimAddress {})
     }
 
     pub const fn invalid_token() -> Self {
-        Self::InvalidToken(ITIP1028BlockedTransfers::InvalidToken {})
+        Self::InvalidToken(ITIP1028Guard::InvalidToken {})
     }
 }

--- a/crates/e2e/src/tests/blocked_transfers.rs
+++ b/crates/e2e/src/tests/blocked_transfers.rs
@@ -23,7 +23,7 @@ use tempo_precompiles::{
     tip403_registry::{ALLOW_ALL_POLICY_ID, ITIP403Registry, REJECT_ALL_POLICY_ID},
     tip1028_blocked_transfers::{
         BLOCKED_PROOF_VERSION,
-        ITIP1028BlockedTransfers::{self, ITIP1028BlockedTransfersErrors as BlockTransferError},
+        ITIP1028Guard::{self, ITIP1028GuardErrors as BlockTransferError},
         InboundKind, RECOVERY_RECEIVER,
     },
 };
@@ -59,7 +59,7 @@ fn test_blocked_transfer_claim_no_recovery() {
             .wallet(other_wallet)
             .connect_http(http_url.clone());
         let other_tip1028 =
-            ITIP1028BlockedTransfers::new(BLOCKED_TRANSFERS_ADDRESS, other_provider);
+            ITIP1028Guard::new(BLOCKED_TRANSFERS_ADDRESS, other_provider);
         let Err(result) = other_tip1028
             .claim(
                 blocked.token,
@@ -90,7 +90,7 @@ fn test_blocked_transfer_claim_no_recovery() {
             .wallet(receiver_wallet)
             .connect_http(http_url.clone());
         let receiver_tip1028 =
-            ITIP1028BlockedTransfers::new(BLOCKED_TRANSFERS_ADDRESS, receiver_provider);
+            ITIP1028Guard::new(BLOCKED_TRANSFERS_ADDRESS, receiver_provider);
         let claim = receiver_tip1028
             .claim(
                 blocked.token,
@@ -138,7 +138,7 @@ fn test_tip1028_claim_with_recovery() {
             .wallet(wallet(22)?)
             .connect_http(http_url.clone());
         let recovery_tip1028 =
-            ITIP1028BlockedTransfers::new(BLOCKED_TRANSFERS_ADDRESS, recovery_provider);
+            ITIP1028Guard::new(BLOCKED_TRANSFERS_ADDRESS, recovery_provider);
         let claim = recovery_tip1028
             .claim(
                 blocked.token,
@@ -266,7 +266,7 @@ async fn create_blocked_transfer(
         ITIP403Registry::BlockedReason::RECEIVE_POLICY as u8
     );
 
-    let proof: Bytes = ITIP1028BlockedTransfers::ClaimProofV1 {
+    let proof: Bytes = ITIP1028Guard::ClaimProofV1 {
         originator: blocked.from,
         recipient: blocked.recipient,
         blockedAt: blocked.blockedAt,
@@ -278,7 +278,7 @@ async fn create_blocked_transfer(
     .abi_encode()
     .into();
 
-    let tip1028 = ITIP1028BlockedTransfers::new(
+    let tip1028 = ITIP1028Guard::new(
         BLOCKED_TRANSFERS_ADDRESS,
         ProviderBuilder::new().connect_http(http_url.clone()),
     );
@@ -361,11 +361,11 @@ fn token_view(http_url: Url, token: Address) -> ITIP20::ITIP20Instance<impl Clon
 
 fn transfer_blocked(
     receipt: &TransactionReceipt,
-) -> eyre::Result<ITIP1028BlockedTransfers::TransferBlocked> {
+) -> eyre::Result<ITIP1028Guard::TransferBlocked> {
     receipt
         .logs()
         .iter()
-        .filter_map(|log| ITIP1028BlockedTransfers::TransferBlocked::decode_log(&log.inner).ok())
+        .filter_map(|log| ITIP1028Guard::TransferBlocked::decode_log(&log.inner).ok())
         .map(|event| event.data)
         .next()
         .ok_or_eyre("TransferBlocked event missing")

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -31,7 +31,7 @@ use crate::{
     signature_verifier::SignatureVerifier, stablecoin_dex::StablecoinDEX, storage::StorageCtx,
     tip_fee_manager::TipFeeManager, tip20::TIP20Token, tip20_channel_escrow::TIP20ChannelEscrow,
     tip20_factory::TIP20Factory, tip403_registry::TIP403Registry,
-    tip1028_blocked_transfers::TIP1028BlockedTransfers, validator_config::ValidatorConfig,
+    tip1028_blocked_transfers::TIP1028Guard, validator_config::ValidatorConfig,
     validator_config_v2::ValidatorConfigV2,
 };
 use tempo_chainspec::hardfork::TempoHardfork;
@@ -145,7 +145,7 @@ pub fn extend_tempo_precompiles(precompiles: &mut PrecompilesMap, cfg: &CfgEnv<T
         } else if *address == SIGNATURE_VERIFIER_ADDRESS && cfg.spec.is_t3() {
             Some(SignatureVerifier::create_precompile(&cfg))
         } else if *address == BLOCKED_TRANSFERS_ADDRESS && cfg.spec.is_t6() {
-            Some(TIP1028BlockedTransfers::create_precompile(&cfg))
+            Some(TIP1028Guard::create_precompile(&cfg))
         } else {
             None
         }
@@ -272,10 +272,10 @@ impl TIP20ChannelEscrow {
     }
 }
 
-impl TIP1028BlockedTransfers {
+impl TIP1028Guard {
     /// Creates the EVM precompile for this type.
     pub fn create_precompile(cfg: &CfgEnv<TempoHardfork>) -> DynPrecompile {
-        tempo_precompile!("TIP1028BlockedTransfers", cfg, |input| { Self::new() })
+        tempo_precompile!("TIP1028Guard", cfg, |input| { Self::new() })
     }
 }
 

--- a/crates/precompiles/src/tip1028_blocked_transfers/dispatch.rs
+++ b/crates/precompiles/src/tip1028_blocked_transfers/dispatch.rs
@@ -1,14 +1,14 @@
-//! ABI dispatch for the [`TIP1028BlockedTransfers`] precompile.
+//! ABI dispatch for the [`TIP1028Guard`] precompile.
 
 use crate::{
     Precompile, charge_input_cost, dispatch_call, mutate_void,
-    tip1028_blocked_transfers::TIP1028BlockedTransfers, view,
+    tip1028_blocked_transfers::TIP1028Guard, view,
 };
 use alloy::{primitives::Address, sol_types::SolInterface};
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::ITIP1028BlockedTransfers::ITIP1028BlockedTransfersCalls;
+use tempo_contracts::precompiles::ITIP1028Guard::ITIP1028GuardCalls;
 
-impl Precompile for TIP1028BlockedTransfers {
+impl Precompile for TIP1028Guard {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
         if let Some(err) = charge_input_cost(&mut self.storage, calldata) {
             return err;
@@ -17,12 +17,12 @@ impl Precompile for TIP1028BlockedTransfers {
         dispatch_call(
             calldata,
             &[],
-            ITIP1028BlockedTransfersCalls::abi_decode,
+            ITIP1028GuardCalls::abi_decode,
             |call| match call {
-                ITIP1028BlockedTransfersCalls::balanceOf(call) => {
+                ITIP1028GuardCalls::balanceOf(call) => {
                     view(call, |c| self.balance_of(c))
                 }
-                ITIP1028BlockedTransfersCalls::claim(call) => {
+                ITIP1028GuardCalls::claim(call) => {
                     mutate_void(call, msg_sender, |s, c| self.claim(s, c))
                 }
             },

--- a/crates/precompiles/src/tip1028_blocked_transfers/mod.rs
+++ b/crates/precompiles/src/tip1028_blocked_transfers/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod dispatch;
 
-pub use tempo_contracts::precompiles::ITIP1028BlockedTransfers::{self, InboundKind};
+pub use tempo_contracts::precompiles::ITIP1028Guard::{self, InboundKind};
 use tempo_contracts::precompiles::{
     BlockTransferError, BlockTransferEvent,
     ITIP403Registry::{self, BlockedReason},
@@ -22,7 +22,7 @@ use alloy::{
 use tempo_precompiles_macros::contract;
 use tempo_primitives::TempoAddressExt;
 
-/// Version tag for the v1 [`ITIP1028BlockedTransfers::ClaimProofV1`] layout.
+/// Version tag for the v1 [`ITIP1028Guard::ClaimProofV1`] layout.
 pub const BLOCKED_PROOF_VERSION: u8 = 1;
 
 /// Recovery-authority sentinel: originator/sender is authorized to claim (`address(0)`).
@@ -33,19 +33,19 @@ pub const RECOVERY_RECEIVER: Address = Address::with_last_byte(1);
 
 /// TIP-1028 precompile holding blocked inbound transfers and mints until claimed.
 #[contract(addr = BLOCKED_TRANSFERS_ADDRESS)]
-pub struct TIP1028BlockedTransfers {
+pub struct TIP1028Guard {
     nonce: u64,
     balances: Mapping<B256, U256>,
 }
 
-impl TIP1028BlockedTransfers {
+impl TIP1028Guard {
     /// One-time storage initialization.
     pub fn initialize(&mut self) -> Result<()> {
         self.__initialize()
     }
 
     /// Returns the unclaimed amount for a proof, or zero if unknown or already claimed.
-    pub fn balance_of(&self, call: ITIP1028BlockedTransfers::balanceOfCall) -> Result<U256> {
+    pub fn balance_of(&self, call: ITIP1028Guard::balanceOfCall) -> Result<U256> {
         if !call.token.is_tip20() {
             return Err(BlockTransferError::invalid_token().into());
         }
@@ -81,7 +81,7 @@ impl TIP1028BlockedTransfers {
         if matches!(
             blocked_reason,
             ITIP403Registry::BlockedReason::NONE | ITIP403Registry::BlockedReason::__Invalid
-        ) || kind == ITIP1028BlockedTransfers::InboundKind::__Invalid
+        ) || kind == ITIP1028Guard::InboundKind::__Invalid
         {
             return Err(BlockTransferError::invalid_proof().into());
         }
@@ -91,7 +91,7 @@ impl TIP1028BlockedTransfers {
 
         let blocked_nonce = self.next_proof_nonce()?;
         let blocked_at = self.storage.timestamp().saturating_to::<u64>();
-        let proof = ITIP1028BlockedTransfers::ClaimProofV1 {
+        let proof = ITIP1028Guard::ClaimProofV1 {
             originator,
             recipient,
             blockedAt: blocked_at,
@@ -104,7 +104,7 @@ impl TIP1028BlockedTransfers {
         self.balances[key].write(amount)?;
 
         self.emit_event(BlockTransferEvent::TransferBlocked(
-            ITIP1028BlockedTransfers::TransferBlocked {
+            ITIP1028Guard::TransferBlocked {
                 token,
                 from: originator,
                 receiver,
@@ -126,7 +126,7 @@ impl TIP1028BlockedTransfers {
     pub fn claim(
         &mut self,
         msg_sender: Address,
-        call: ITIP1028BlockedTransfers::claimCall,
+        call: ITIP1028Guard::claimCall,
     ) -> Result<()> {
         if !call.token.is_tip20() {
             return Err(BlockTransferError::invalid_token().into());
@@ -172,7 +172,7 @@ impl TIP1028BlockedTransfers {
         )?;
 
         self.emit_event(BlockTransferEvent::ProofClaimed(
-            ITIP1028BlockedTransfers::ProofClaimed {
+            ITIP1028Guard::ProofClaimed {
                 token: call.token,
                 receiver,
                 proofVersion: call.proofVersion,
@@ -206,11 +206,11 @@ impl TIP1028BlockedTransfers {
     fn decode_v1(
         proof_version: u8,
         proof: &[u8],
-    ) -> Result<ITIP1028BlockedTransfers::ClaimProofV1> {
+    ) -> Result<ITIP1028Guard::ClaimProofV1> {
         if proof_version != BLOCKED_PROOF_VERSION {
             return Err(BlockTransferError::invalid_proof().into());
         }
-        ITIP1028BlockedTransfers::ClaimProofV1::abi_decode(proof)
+        ITIP1028Guard::ClaimProofV1::abi_decode(proof)
             .map_err(|_| BlockTransferError::invalid_proof().into())
     }
 
@@ -220,7 +220,7 @@ impl TIP1028BlockedTransfers {
         proof_version: u8,
         token: Address,
         recovery_address: Address,
-        proof: &ITIP1028BlockedTransfers::ClaimProofV1,
+        proof: &ITIP1028Guard::ClaimProofV1,
     ) -> Result<B256> {
         self.storage.keccak256(
             (
@@ -313,8 +313,8 @@ mod tests {
         blocked_reason: BlockedReason,
         kind: InboundKind,
         memo: B256,
-    ) -> ITIP1028BlockedTransfers::ClaimProofV1 {
-        ITIP1028BlockedTransfers::ClaimProofV1 {
+    ) -> ITIP1028Guard::ClaimProofV1 {
+        ITIP1028Guard::ClaimProofV1 {
             originator,
             recipient,
             blockedAt: blocked_at,
@@ -337,12 +337,12 @@ mod tests {
     }
 
     fn proof_balance(
-        precompile: &TIP1028BlockedTransfers,
+        precompile: &TIP1028Guard,
         token: Address,
         recovery_contract: Address,
-        proof: &ITIP1028BlockedTransfers::ClaimProofV1,
+        proof: &ITIP1028Guard::ClaimProofV1,
     ) -> Result<U256> {
-        precompile.balance_of(ITIP1028BlockedTransfers::balanceOfCall {
+        precompile.balance_of(ITIP1028Guard::balanceOfCall {
             token,
             recoveryAuthority: recovery_contract,
             proofVersion: BLOCKED_PROOF_VERSION,
@@ -353,10 +353,10 @@ mod tests {
     fn claim_call(
         token: Address,
         recovery_contract: Address,
-        proof: &ITIP1028BlockedTransfers::ClaimProofV1,
+        proof: &ITIP1028Guard::ClaimProofV1,
         to: Address,
-    ) -> ITIP1028BlockedTransfers::claimCall {
-        ITIP1028BlockedTransfers::claimCall {
+    ) -> ITIP1028Guard::claimCall {
+        ITIP1028Guard::claimCall {
             token,
             recoveryAuthority: recovery_contract,
             proofVersion: BLOCKED_PROOF_VERSION,
@@ -411,7 +411,7 @@ mod tests {
                     InboundKind::TRANSFER,
                     B256::ZERO,
                 );
-                let precompile = TIP1028BlockedTransfers::new();
+                let precompile = TIP1028Guard::new();
                 assert_eq!(
                     proof_balance(
                         &precompile,
@@ -449,7 +449,7 @@ mod tests {
                     amount
                 );
 
-                TIP1028BlockedTransfers::new().claim(
+                TIP1028Guard::new().claim(
                     recovery_auth.claimer(),
                     claim_call(
                         token.address(),
@@ -525,7 +525,7 @@ mod tests {
                 InboundKind::TRANSFER,
                 B256::ZERO,
             );
-            let mut precompile = TIP1028BlockedTransfers::new();
+            let mut precompile = TIP1028Guard::new();
             let result = precompile.claim(
                 receiver,
                 claim_call(token.address(), RECOVERY_RECEIVER, &proof, receiver),
@@ -629,7 +629,7 @@ mod tests {
                 B256::ZERO,
             );
 
-            let precompile = TIP1028BlockedTransfers::new();
+            let precompile = TIP1028Guard::new();
             assert_eq!(
                 token_a.balance_of(ITIP20::balanceOfCall {
                     account: BLOCKED_TRANSFERS_ADDRESS
@@ -644,7 +644,7 @@ mod tests {
                 proof_balance(&precompile, token_b.address(), RECOVERY_RECEIVER, &proof_c)?
             );
 
-            TIP1028BlockedTransfers::new().claim(
+            TIP1028Guard::new().claim(
                 receiver_a,
                 claim_call(token_a.address(), RECOVERY_RECEIVER, &proof_a, receiver_a),
             )?;
@@ -661,7 +661,7 @@ mod tests {
                 proof_balance(&precompile, token_b.address(), RECOVERY_RECEIVER, &proof_c)?
             );
 
-            TIP1028BlockedTransfers::new().claim(
+            TIP1028Guard::new().claim(
                 recovery,
                 claim_call(token_a.address(), recovery, &proof_b, receiver_b),
             )?;
@@ -689,7 +689,7 @@ mod tests {
 
         StorageCtx::enter(&mut storage, || {
             let token = TIP20Setup::create("T", "T", admin).apply()?;
-            let precompile = TIP1028BlockedTransfers::new();
+            let precompile = TIP1028Guard::new();
             let proof = proof_v1(
                 Address::random(),
                 Address::random(),
@@ -704,7 +704,7 @@ mod tests {
                 (BLOCKED_PROOF_VERSION + 1, proof.abi_encode().into()),
                 (BLOCKED_PROOF_VERSION, vec![0xde, 0xad, 0xbe, 0xef].into()),
             ] {
-                let result = precompile.balance_of(ITIP1028BlockedTransfers::balanceOfCall {
+                let result = precompile.balance_of(ITIP1028Guard::balanceOfCall {
                     token: token.address(),
                     recoveryAuthority: Address::ZERO,
                     proofVersion: proof_version,
@@ -733,7 +733,7 @@ mod tests {
                 (BlockedReason::__Invalid, InboundKind::TRANSFER),
                 (BlockedReason::RECEIVE_POLICY, InboundKind::__Invalid),
             ] {
-                let result = TIP1028BlockedTransfers::new().store_blocked(
+                let result = TIP1028Guard::new().store_blocked(
                     token.address(),
                     Address::random(),
                     &Recipient::direct(Address::random()),
@@ -770,7 +770,7 @@ mod tests {
         StorageCtx::enter(&mut storage, || {
             let token_a = TIP20Setup::create("A", "A", admin).apply()?;
             let token_b = TIP20Setup::create("B", "B", admin).apply()?;
-            let mut precompile = TIP1028BlockedTransfers::new();
+            let mut precompile = TIP1028Guard::new();
 
             let (nonce_a, blocked_at_a) = precompile.store_blocked(
                 token_a.address(),
@@ -931,7 +931,7 @@ mod tests {
                 .with_mint(originator, amount)
                 .apply()?;
 
-            assert_invalid_proof(TIP1028BlockedTransfers::new().claim(
+            assert_invalid_proof(TIP1028Guard::new().claim(
                 receiver,
                 claim_call(token.address(), RECOVERY_RECEIVER, &proof, receiver),
             ));
@@ -944,11 +944,11 @@ mod tests {
                     amount,
                 },
             )?;
-            TIP1028BlockedTransfers::new().claim(
+            TIP1028Guard::new().claim(
                 receiver,
                 claim_call(token.address(), RECOVERY_RECEIVER, &proof, receiver),
             )?;
-            assert_invalid_proof(TIP1028BlockedTransfers::new().claim(
+            assert_invalid_proof(TIP1028Guard::new().claim(
                 receiver,
                 claim_call(token.address(), RECOVERY_RECEIVER, &proof, receiver),
             ));
@@ -1012,12 +1012,12 @@ mod tests {
                 B256::ZERO,
             );
 
-            assert_unauthorized(TIP1028BlockedTransfers::new().claim(
+            assert_unauthorized(TIP1028Guard::new().claim(
                 stranger,
                 claim_call(token.address(), RECOVERY_RECEIVER, &self_proof, receiver),
             ));
             for caller in [recovery_receiver, stranger] {
-                assert_unauthorized(TIP1028BlockedTransfers::new().claim(
+                assert_unauthorized(TIP1028Guard::new().claim(
                     caller,
                     claim_call(
                         token.address(),
@@ -1030,7 +1030,7 @@ mod tests {
 
             assert_eq!(
                 proof_balance(
-                    &TIP1028BlockedTransfers::new(),
+                    &TIP1028Guard::new(),
                     token.address(),
                     RECOVERY_RECEIVER,
                     &self_proof
@@ -1039,7 +1039,7 @@ mod tests {
             );
             assert_eq!(
                 proof_balance(
-                    &TIP1028BlockedTransfers::new(),
+                    &TIP1028Guard::new(),
                     token.address(),
                     recovery,
                     &recovery_proof
@@ -1085,7 +1085,7 @@ mod tests {
                 B256::ZERO,
             );
 
-            let mut precompile = TIP1028BlockedTransfers::new();
+            let mut precompile = TIP1028Guard::new();
             precompile.clear_emitted_events();
             precompile.claim(
                 receiver,
@@ -1093,7 +1093,7 @@ mod tests {
             )?;
 
             precompile.assert_emitted_events(vec![BlockTransferEvent::ProofClaimed(
-                ITIP1028BlockedTransfers::ProofClaimed {
+                ITIP1028Guard::ProofClaimed {
                     token: token.address(),
                     receiver,
                     proofVersion: BLOCKED_PROOF_VERSION,
@@ -1161,7 +1161,7 @@ mod tests {
                 InboundKind::TRANSFER,
                 B256::ZERO,
             );
-            let mut precompile = TIP1028BlockedTransfers::new();
+            let mut precompile = TIP1028Guard::new();
             precompile.clear_emitted_events();
             precompile.claim(
                 recovery,
@@ -1169,7 +1169,7 @@ mod tests {
             )?;
 
             precompile.assert_emitted_events(vec![BlockTransferEvent::ProofClaimed(
-                ITIP1028BlockedTransfers::ProofClaimed {
+                ITIP1028Guard::ProofClaimed {
                     token: token.address(),
                     receiver,
                     proofVersion: BLOCKED_PROOF_VERSION,
@@ -1239,8 +1239,8 @@ mod tests {
                 InboundKind::TRANSFER,
                 B256::ZERO,
             );
-            let precompile = TIP1028BlockedTransfers::new();
-            let result = TIP1028BlockedTransfers::new().claim(
+            let precompile = TIP1028Guard::new();
+            let result = TIP1028Guard::new().claim(
                 receiver,
                 claim_call(token.address(), RECOVERY_RECEIVER, &proof, destination),
             );
@@ -1309,7 +1309,7 @@ mod tests {
                 InboundKind::TRANSFER,
                 B256::ZERO,
             );
-            let precompile = TIP1028BlockedTransfers::new();
+            let precompile = TIP1028Guard::new();
             assert_eq!(
                 proof_balance(&precompile, token.address(), recovery, &proof)?,
                 amount
@@ -1323,15 +1323,15 @@ mod tests {
                 U256::ZERO
             );
 
-            assert_unauthorized(TIP1028BlockedTransfers::new().claim(
+            assert_unauthorized(TIP1028Guard::new().claim(
                 receiver,
                 claim_call(token.address(), Address::ZERO, &proof, receiver),
             ));
-            assert_invalid_proof(TIP1028BlockedTransfers::new().claim(
+            assert_invalid_proof(TIP1028Guard::new().claim(
                 other_recovery,
                 claim_call(token.address(), other_recovery, &proof, receiver),
             ));
-            TIP1028BlockedTransfers::new().claim(
+            TIP1028Guard::new().claim(
                 recovery,
                 claim_call(token.address(), recovery, &proof, receiver),
             )?;
@@ -1377,7 +1377,7 @@ mod tests {
                 InboundKind::TRANSFER,
                 B256::ZERO,
             );
-            let mut precompile = TIP1028BlockedTransfers::new();
+            let mut precompile = TIP1028Guard::new();
             precompile.clear_emitted_events();
             precompile.claim(
                 VIRTUAL_MASTER,
@@ -1385,7 +1385,7 @@ mod tests {
             )?;
 
             precompile.assert_emitted_events(vec![BlockTransferEvent::ProofClaimed(
-                ITIP1028BlockedTransfers::ProofClaimed {
+                ITIP1028Guard::ProofClaimed {
                     token: token.address(),
                     receiver: VIRTUAL_MASTER,
                     proofVersion: BLOCKED_PROOF_VERSION,
@@ -1437,7 +1437,7 @@ mod tests {
                     .apply()?;
                 block_all_senders(receiver, recovery_auth.address())?;
 
-                let mut precompile = TIP1028BlockedTransfers::new();
+                let mut precompile = TIP1028Guard::new();
                 precompile.clear_emitted_events();
                 token.mint(
                     admin,
@@ -1447,7 +1447,7 @@ mod tests {
                     },
                 )?;
                 precompile.assert_emitted_events(vec![BlockTransferEvent::TransferBlocked(
-                    ITIP1028BlockedTransfers::TransferBlocked {
+                    ITIP1028Guard::TransferBlocked {
                         token: token.address(),
                         from: admin,
                         receiver,

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     tip20::{rewards::UserRewardInfo, roles::DEFAULT_ADMIN_ROLE},
     tip20_factory::TIP20Factory,
     tip403_registry::{AuthRole, ITIP403Registry, TIP403Registry},
-    tip1028_blocked_transfers::{InboundKind, TIP1028BlockedTransfers},
+    tip1028_blocked_transfers::{InboundKind, TIP1028Guard},
 };
 use alloy::{
     primitives::{Address, B256, U256, keccak256, uint},
@@ -1241,7 +1241,7 @@ impl TIP20Token {
                 return Err(BlockTransferError::invalid_proof().into());
             }
         }
-        TIP1028BlockedTransfers::new()
+        TIP1028Guard::new()
             .store_blocked(token, originator, to, recovery, amount, reason, kind, memo)?;
 
         Ok(true)
@@ -1621,7 +1621,7 @@ mod recipient_tests {
 pub(crate) mod tests {
     use alloy::primitives::{Address, FixedBytes, IntoLogData, U256, hex};
     use tempo_contracts::precompiles::{
-        BlockTransferEvent, ITIP1028BlockedTransfers, createTokenCall,
+        BlockTransferEvent, ITIP1028Guard, createTokenCall,
     };
 
     use super::*;
@@ -1634,7 +1634,7 @@ pub(crate) mod tests {
         error::TempoPrecompileError,
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{TIP20Setup, VIRTUAL_MASTER, register_virtual_master, setup_storage},
-        tip1028_blocked_transfers::TIP1028BlockedTransfers,
+        tip1028_blocked_transfers::TIP1028Guard,
     };
     use rand_08::{Rng, distributions::Alphanumeric, thread_rng};
     use tempo_chainspec::hardfork::TempoHardfork;
@@ -1731,8 +1731,8 @@ pub(crate) mod tests {
             blocked_reason: ITIP403Registry::BlockedReason,
             kind: InboundKind,
             memo: B256,
-        ) -> ITIP1028BlockedTransfers::ClaimProofV1 {
-            ITIP1028BlockedTransfers::ClaimProofV1 {
+        ) -> ITIP1028Guard::ClaimProofV1 {
+            ITIP1028Guard::ClaimProofV1 {
                 originator,
                 recipient,
                 blockedAt: BLOCKED_AT,
@@ -1746,9 +1746,9 @@ pub(crate) mod tests {
         fn proof_balance(
             token: Address,
             recovery_contract: Address,
-            proof: &ITIP1028BlockedTransfers::ClaimProofV1,
+            proof: &ITIP1028Guard::ClaimProofV1,
         ) -> Result<U256> {
-            TIP1028BlockedTransfers::new().balance_of(ITIP1028BlockedTransfers::balanceOfCall {
+            TIP1028Guard::new().balance_of(ITIP1028Guard::balanceOfCall {
                 token,
                 recoveryAuthority: recovery_contract,
                 proofVersion: BLOCKED_PROOF_VERSION,
@@ -1804,9 +1804,9 @@ pub(crate) mod tests {
                     B256::ZERO,
                 );
                 assert_eq!(proof_balance(token.address, Address::ZERO, &proof)?, amount);
-                TIP1028BlockedTransfers::new().assert_emitted_events(vec![
+                TIP1028Guard::new().assert_emitted_events(vec![
                     BlockTransferEvent::TransferBlocked(
-                        ITIP1028BlockedTransfers::TransferBlocked {
+                        ITIP1028Guard::TransferBlocked {
                             token: token.address,
                             from: sender,
                             receiver,
@@ -1864,9 +1864,9 @@ pub(crate) mod tests {
                     B256::ZERO,
                 );
                 assert_eq!(proof_balance(token.address, Address::ZERO, &proof)?, amount);
-                TIP1028BlockedTransfers::new().assert_emitted_events(vec![
+                TIP1028Guard::new().assert_emitted_events(vec![
                     BlockTransferEvent::TransferBlocked(
-                        ITIP1028BlockedTransfers::TransferBlocked {
+                        ITIP1028Guard::TransferBlocked {
                             token: token.address,
                             from: sender,
                             receiver,
@@ -2091,7 +2091,7 @@ pub(crate) mod tests {
                     Address::ZERO,
                 )?;
 
-                TIP1028BlockedTransfers::new().clear_emitted_events();
+                TIP1028Guard::new().clear_emitted_events();
                 token.mint(
                     admin,
                     ITIP20::mintCall {
@@ -2108,9 +2108,9 @@ pub(crate) mod tests {
                     to: BLOCKED_TRANSFERS_ADDRESS,
                     amount,
                 })]);
-                TIP1028BlockedTransfers::new().assert_emitted_events(vec![
+                TIP1028Guard::new().assert_emitted_events(vec![
                     BlockTransferEvent::TransferBlocked(
-                        ITIP1028BlockedTransfers::TransferBlocked {
+                        ITIP1028Guard::TransferBlocked {
                             token: token.address,
                             from: admin,
                             receiver,
@@ -3309,7 +3309,7 @@ pub(crate) mod tests {
             Ok::<_, TempoPrecompileError>(())
         })?;
 
-        // Pre-T6: TIP1028_BLOCKED_TRANSFERS_ADDRESS is not yet in PROTECTED, so burn_blocked
+        // Pre-T6: TIP1028_GUARD_ADDRESS is not yet in PROTECTED, so burn_blocked
         // actually burns from it (REJECT_ALL satisfies the sender-policy gate).
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T5);
         StorageCtx::enter(&mut storage, || {

--- a/xtask/src/check_abi.rs
+++ b/xtask/src/check_abi.rs
@@ -49,7 +49,7 @@ static INTERFACE_SPECS: &[InterfaceSpec] = &[
     interface_spec!(ITIP20Factory),
     interface_spec!(IRolesAuth).with_name("ITIP20RolesAuth"),
     interface_spec!(ITIP403Registry),
-    interface_spec!(ITIP1028BlockedTransfers),
+    interface_spec!(ITIP1028Guard),
     interface_spec!(ITIPFeeAMM).with_name("IFeeAMM"),
     interface_spec!(IFeeManager).inherits(&["IFeeAMM"]),
     interface_spec!(IStablecoinDEX),

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -59,7 +59,7 @@ use tempo_precompiles::{
     tip20::{ISSUER_ROLE, ITIP20, TIP20Token},
     tip20_factory::TIP20Factory,
     tip403_registry::TIP403Registry,
-    tip1028_blocked_transfers::TIP1028BlockedTransfers,
+    tip1028_blocked_transfers::TIP1028Guard,
     validator_config_v2::ValidatorConfigV2,
 };
 
@@ -943,7 +943,7 @@ fn initialize_tip1028_blocked_transfers(evm: &mut TempoEvm<CacheDB<EmptyDB>>) ->
         &ctx.block,
         &ctx.cfg,
         &ctx.tx,
-        || TIP1028BlockedTransfers::new().initialize(),
+        || TIP1028Guard::new().initialize(),
     )?;
 
     Ok(())


### PR DESCRIPTION
Renames `TIP1028BlockedTransfers` → `TIP1028Guard` across the codebase (struct, interface, associated types, and address constant). All crates compile clean.