### PR TITLE
ci(bench): change bench e2e defaults to 20k TPS and 500M gas limit

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -73,7 +73,7 @@ on:
         description: Target transactions per second.
         type: string
         required: true
-        default: "10000"
+        default: "20000"
       accounts:
         description: Number of benchmark accounts.
         type: string
@@ -118,7 +118,7 @@ on:
         description: Builder gas limit.
         type: string
         required: true
-        default: "1000000000000"
+        default: "500000000"
       force-bloat:
         description: Force regeneration of local benchmark state.
         type: boolean
@@ -322,7 +322,7 @@ jobs:
       BENCH_FEATURES: ${{ (inputs.otlp == true || inputs.otlp == 'true') && 'jemalloc,asm-keccak,keccak-cache-global,otlp' || 'jemalloc,asm-keccak,keccak-cache-global' }}
       BENCH_BASELINE_ARGS: ${{ inputs.baseline-args }}
       BENCH_FEATURE_ARGS: ${{ inputs.feature-args }}
-      BENCH_GAS_LIMIT: ${{ inputs.gas-limit || '1000000000000' }}
+      BENCH_GAS_LIMIT: ${{ inputs.gas-limit || '500000000' }}
       BENCH_RUN_TYPE: ${{ inputs.run-type || 'dispatch' }}
       BENCH_FORCE_BLOAT: ${{ inputs.force-bloat }}
       BENCH_NO_CACHE: ${{ inputs.no-cache || 'false' }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -117,7 +117,7 @@ jobs:
             const boolArgs = new Set(['samply', 'force-bloat', 'no-cache', 'no-slack', 'no-existing-recipients', 'otlp']);
             const bloatValues = new Set(['1', '10', '100']);
             const hardforkValues = new Set(['T0', 'T1', 'T1A', 'T1B', 'T1C', 'T2', 'T3', 'T4', 'T5', 'T6']);
-            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '10000', accounts: '1000', 'max-concurrent-requests': '100', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet' };
+            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '20000', accounts: '1000', 'max-concurrent-requests': '100', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '500000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet' };
             const unknown = [];
             const invalid = [];
             const defaultWarmup = (blockCount) => String(Math.floor(Number(blockCount) / 4));

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -16,7 +16,7 @@ const E2E_A_CPUS = "0-7,16-23"
 const E2E_B_CPUS = "8-15,24-31"
 const E2E_A_MEMORY = "60G"
 const E2E_B_MEMORY = "60G"
-const E2E_GAS_LIMIT = "1000000000000"
+const E2E_GAS_LIMIT = "500000000"
 const E2E_BLOAT_TMP_DIR = "/reth-bench-a/.bench-tmp/e2e-local-init"
 const E2E_BLOAT_FREE_MARGIN_MIB = 51200
 const E2E_DEFAULT_BLOAT = 100
@@ -800,7 +800,7 @@ def "main e2e" [
     --baseline: string                                  # Baseline git SHA/ref
     --feature: string                                   # Feature git SHA/ref
     --preset: string = ""                               # Txgen preset name
-    --tps: int = 10000                                  # Target TPS
+    --tps: int = 20000                                  # Target TPS
     --duration: int = 300                               # Duration in seconds
     --accounts: int = 1000                              # Number of accounts
     --max-concurrent-requests: int = 100                # Max concurrent requests


### PR DESCRIPTION
## Summary
- Raise the default e2e benchmark target to `20000` TPS.
- Lower the default builder gas limit to `500000000` across the reusable workflow, PR-comment workflow defaults, and local `bench-e2e.nu` entrypoint.
- Keep the existing `100` GiB bloat default unchanged.

## Testing
- `git diff --check`
- Parsed the updated workflow YAML files successfully with `python3` and PyYAML