### PR TITLE
ci(bench): bump default stdout log filter to info

### DIFF
--- a/tempo.nu
+++ b/tempo.nu
@@ -30,7 +30,7 @@ def port-to-node-index [port: int] {
 
 # Build log filter args based on --loud flag
 def log-filter-args [loud: bool] {
-    if $loud { [] } else { ["--log.stdout.filter" "warn"] }
+    if $loud { [] } else { ["--log.stdout.filter" "info"] }
 }
 
 # Wrap command with samply if enabled


### PR DESCRIPTION
Changes default `--log.stdout.filter` from `warn` to `info` so validator logs appear in CI output without needing `--loud`.