### PR TITLE
ci(bench): schedule e2e ClickHouse runs per preset

### DIFF
--- a/.github/scripts/bench-e2e-scheduled-refs.sh
+++ b/.github/scripts/bench-e2e-scheduled-refs.sh
@@ -6,8 +6,9 @@
 # the last commit that completed this scheduled e2e workflow successfully.
 # Release tag runs compare the pushed v*.*.* tag against the previous v*.*.* tag.
 #
-# Usage: bench-e2e-scheduled-refs.sh <force>
+# Usage: bench-e2e-scheduled-refs.sh <force> [preset]
 #   force - "true" to run even if no new nightly commit is available
+#   preset - txgen preset name used to scope persisted nightly state
 #
 # Outputs (via GITHUB_OUTPUT):
 #   baseline-ref
@@ -20,16 +21,26 @@
 #   is-stale
 #   stale-age-hours
 #   nightly-created
+#   state-file
 set -euo pipefail
 
 FORCE="${1:-false}"
+PRESET="${2:-${BENCH_E2E_PRESET:-tip20}}"
 REPO="${GITHUB_REPOSITORY:-tempoxyz/tempo}"
 STATE_REPO="${BENCH_E2E_STATE_REPO:-decofe/tempo-bench-charts}"
-STATE_FILE="${BENCH_E2E_STATE_FILE:-state/e2e-nightly-last-feature-ref}"
 STALE_THRESHOLD_HOURS="${BENCH_E2E_STALE_THRESHOLD_HOURS:-24}"
 
+if [[ ! "$PRESET" =~ ^[A-Za-z0-9_-]+$ ]]; then
+  echo "::error::Invalid preset name: $PRESET"
+  exit 1
+fi
+
+STATE_FILE="${BENCH_E2E_STATE_FILE:-state/e2e-nightly-${PRESET}-last-feature-ref}"
+
 echo "Force: $FORCE"
+echo "Preset: $PRESET"
 echo "Repository: $REPO"
+echo "State file: $STATE_FILE"
 
 short_sha() {
   printf "%.8s" "$1"
@@ -47,6 +58,8 @@ write_outputs() {
     echo "is-stale=$IS_STALE"
     echo "stale-age-hours=$AGE_HOURS"
     echo "nightly-created=$CREATED_AT"
+    echo "preset=$PRESET"
+    echo "state-file=$STATE_FILE"
   } >> "$GITHUB_OUTPUT"
 }
 
@@ -154,9 +167,9 @@ LAST_FEATURE_REF=""
 STATE_URL="https://raw.githubusercontent.com/${STATE_REPO}/state/${STATE_FILE}"
 if RAW="$(curl -sfL -H "Authorization: token ${DEREK_TOKEN:-}" "$STATE_URL")"; then
   LAST_FEATURE_REF="$(echo "$RAW" | tr -d '[:space:]')"
-  echo "Previous e2e feature ref: $LAST_FEATURE_REF"
+  echo "Previous e2e feature ref for $PRESET: $LAST_FEATURE_REF"
 else
-  echo "No persisted e2e state found"
+  echo "No persisted e2e state found for $PRESET"
 fi
 echo "::endgroup::"
 

--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -1,8 +1,9 @@
 # Scheduled e2e regression benchmarks.
 #
-# Runs nightly at 02:00 UTC and on v*.*.* tag pushes.
+# Runs nightly at 02:00 UTC and on v*.*.* tag pushes for the mix and tip20 presets.
 # Nightly runs compare the latest successful nightly Docker commit against the
-# last commit that completed this scheduled e2e workflow successfully.
+# last commit that completed this scheduled e2e workflow successfully for the
+# same preset.
 # Tag runs compare the pushed release tag against the previous release tag.
 
 name: bench-e2e-scheduled
@@ -31,16 +32,10 @@ jobs:
       actions: read
       contents: read
     outputs:
-      baseline-ref: ${{ steps.refs.outputs.baseline-ref }}
-      baseline-name: ${{ steps.refs.outputs.baseline-name }}
-      feature-ref: ${{ steps.refs.outputs.feature-ref }}
-      feature-name: ${{ steps.refs.outputs.feature-name }}
-      should-skip: ${{ steps.refs.outputs.should-skip }}
-      run-type: ${{ steps.refs.outputs.run-type }}
-      actor: ${{ steps.refs.outputs.actor }}
-      is-stale: ${{ steps.refs.outputs.is-stale }}
-      stale-age-hours: ${{ steps.refs.outputs.stale-age-hours }}
-      nightly-created: ${{ steps.refs.outputs.nightly-created }}
+      bench-matrix: ${{ steps.refs.outputs.bench-matrix }}
+      save-matrix: ${{ steps.refs.outputs.save-matrix }}
+      has-benchmarks: ${{ steps.refs.outputs.has-benchmarks }}
+      has-nightly-benchmarks: ${{ steps.refs.outputs.has-nightly-benchmarks }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -56,31 +51,104 @@ jobs:
           DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           INPUT_FORCE: ${{ inputs.force || 'false' }}
-        run: bash .github/scripts/bench-e2e-scheduled-refs.sh "$INPUT_FORCE"
-
-      - name: Fail on stale nightly
-        if: steps.refs.outputs.is-stale == 'true'
         run: |
-          echo "::error::Nightly Docker build is stale (>24h old). Aborting e2e benchmark."
-          exit 1
+          presets=(tip20 mix)
+          bench_entries=()
+          save_entries=()
+          stale_presets=()
+
+          get_output() {
+            local file="$1"
+            local key="$2"
+            grep -E "^${key}=" "$file" | tail -1 | sed "s/^${key}=//"
+          }
+
+          for preset in "${presets[@]}"; do
+            out="$(mktemp)"
+            GITHUB_OUTPUT="$out" bash .github/scripts/bench-e2e-scheduled-refs.sh "$INPUT_FORCE" "$preset"
+
+            baseline_ref="$(get_output "$out" baseline-ref)"
+            baseline_name="$(get_output "$out" baseline-name)"
+            feature_ref="$(get_output "$out" feature-ref)"
+            feature_name="$(get_output "$out" feature-name)"
+            should_skip="$(get_output "$out" should-skip)"
+            run_type="$(get_output "$out" run-type)"
+            actor="$(get_output "$out" actor)"
+            is_stale="$(get_output "$out" is-stale)"
+            state_file="$(get_output "$out" state-file)"
+
+            if [ "$is_stale" = "true" ]; then
+              stale_presets+=("$preset")
+            fi
+
+            if [ "$should_skip" != "true" ] && [ "$is_stale" != "true" ]; then
+              entry="$(jq -cn \
+                --arg preset "$preset" \
+                --arg actor "$actor" \
+                --arg baseline_ref "$baseline_ref" \
+                --arg feature_ref "$feature_ref" \
+                --arg baseline_name "$baseline_name" \
+                --arg feature_name "$feature_name" \
+                --arg run_type "$run_type" \
+                --arg state_file "$state_file" \
+                '{preset:$preset, actor:$actor, baseline_ref:$baseline_ref, feature_ref:$feature_ref, baseline_name:$baseline_name, feature_name:$feature_name, run_type:$run_type, state_file:$state_file}')"
+              bench_entries+=("$entry")
+              if [ "$run_type" = "nightly" ]; then
+                save_entries+=("$entry")
+              fi
+            fi
+
+            rm -f "$out"
+          done
+
+          if [ "${#stale_presets[@]}" -gt 0 ]; then
+            echo "::error::Nightly Docker build is stale (>24h old). Aborting e2e benchmark for preset(s): ${stale_presets[*]}."
+            exit 1
+          fi
+
+          if [ "${#bench_entries[@]}" -gt 0 ]; then
+            bench_matrix="$(printf '%s\n' "${bench_entries[@]}" | jq -cs '{include:.}')"
+            has_benchmarks="true"
+          else
+            bench_matrix='{"include":[]}'
+            has_benchmarks="false"
+          fi
+
+          if [ "${#save_entries[@]}" -gt 0 ]; then
+            save_matrix="$(printf '%s\n' "${save_entries[@]}" | jq -cs '{include:.}')"
+            has_nightly_benchmarks="true"
+          else
+            save_matrix='{"include":[]}'
+            has_nightly_benchmarks="false"
+          fi
+
+          {
+            echo "bench-matrix=$bench_matrix"
+            echo "save-matrix=$save_matrix"
+            echo "has-benchmarks=$has_benchmarks"
+            echo "has-nightly-benchmarks=$has_nightly_benchmarks"
+          } >> "$GITHUB_OUTPUT"
 
   bench-e2e:
     needs: resolve-refs
-    if: |
-      needs.resolve-refs.outputs.should-skip != 'true' &&
-      needs.resolve-refs.outputs.is-stale != 'true'
-    name: bench-e2e (${{ needs.resolve-refs.outputs.feature-name }})
+    if: needs.resolve-refs.outputs.has-benchmarks == 'true'
+    name: bench-e2e (${{ matrix.preset }}, ${{ matrix.feature_name }})
     uses: ./.github/workflows/bench-e2e.yml
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.resolve-refs.outputs.bench-matrix) }}
     permissions:
       contents: read
       pull-requests: write
     with:
-      actor: ${{ needs.resolve-refs.outputs.actor }}
-      baseline: ${{ needs.resolve-refs.outputs.baseline-ref }}
-      feature: ${{ needs.resolve-refs.outputs.feature-ref }}
-      baseline-name: ${{ needs.resolve-refs.outputs.baseline-name }}
-      feature-name: ${{ needs.resolve-refs.outputs.feature-name }}
-      run-type: ${{ needs.resolve-refs.outputs.run-type }}
+      actor: ${{ matrix.actor }}
+      baseline: ${{ matrix.baseline_ref }}
+      feature: ${{ matrix.feature_ref }}
+      baseline-name: ${{ matrix.baseline_name }}
+      feature-name: ${{ matrix.feature_name }}
+      preset: ${{ matrix.preset }}
+      tps: "20000"
+      run-type: ${{ matrix.run_type }}
       disable-abba: "true"
       clickhouse-run: feature-1
     secrets:
@@ -96,14 +164,17 @@ jobs:
 
   save-state:
     needs: [resolve-refs, bench-e2e]
-    if: success() && needs.resolve-refs.outputs.run-type == 'nightly'
+    if: |
+      always() &&
+      needs.resolve-refs.outputs.has-nightly-benchmarks == 'true' &&
+      needs.bench-e2e.result == 'success'
     name: save-state
     runs-on: ubuntu-latest
     steps:
       - name: Push state to charts repo
         env:
           DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
-          FEATURE_REF: ${{ needs.resolve-refs.outputs.feature-ref }}
+          SAVE_MATRIX: ${{ needs.resolve-refs.outputs.save-matrix }}
         run: |
           CHARTS_REPO="https://x-access-token:${DEREK_TOKEN}@github.com/decofe/tempo-bench-charts.git"
           TMP_DIR=$(mktemp -d)
@@ -115,11 +186,16 @@ jobs:
             git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
           fi
 
-          mkdir -p "${TMP_DIR}/state"
-          echo "${FEATURE_REF}" > "${TMP_DIR}/state/e2e-nightly-last-feature-ref"
-          git -C "${TMP_DIR}" add state/
+          echo "$SAVE_MATRIX" | jq -c '.include[]' | while read -r entry; do
+            state_file="$(echo "$entry" | jq -r '.state_file')"
+            feature_ref="$(echo "$entry" | jq -r '.feature_ref')"
+            mkdir -p "$(dirname "${TMP_DIR}/${state_file}")"
+            echo "${feature_ref}" > "${TMP_DIR}/${state_file}"
+            git -C "${TMP_DIR}" add "${state_file}"
+          done
+
           git -C "${TMP_DIR}" diff --cached --quiet && echo "No state change" && exit 0
           git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
-            commit -m "bench: update e2e nightly state to ${FEATURE_REF}"
+            commit -m "bench: update e2e nightly state"
           git -C "${TMP_DIR}" push origin HEAD:state
           rm -rf "${TMP_DIR}"

--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -81,6 +81,8 @@ jobs:
       baseline-name: ${{ needs.resolve-refs.outputs.baseline-name }}
       feature-name: ${{ needs.resolve-refs.outputs.feature-name }}
       run-type: ${{ needs.resolve-refs.outputs.run-type }}
+      disable-abba: "true"
+      clickhouse-run: feature-1
     secrets:
       DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -653,6 +653,8 @@ jobs:
           [ -n "$BENCH_BASELINE_ENV" ] && cmd+=(--baseline-env="$BENCH_BASELINE_ENV")
           [ -n "$BENCH_FEATURE_ENV" ] && cmd+=(--feature-env="$BENCH_FEATURE_ENV")
           [ -n "$BENCH_VICTORIAMETRICS_URL" ] && cmd+=(--victoriametrics-url "$BENCH_VICTORIAMETRICS_URL")
+          [ -n "$CLICKHOUSE_URL" ] && cmd+=(--clickhouse-url "$CLICKHOUSE_URL")
+          [ -n "$BENCH_RUN_TYPE" ] && cmd+=(--run-type "$BENCH_RUN_TYPE")
           "${cmd[@]}"
 
       - name: Find results directory

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -1,7 +1,7 @@
 # E2E benchmark job.
 #
 # Called by bench.yml when mode=e2e. Runs `nu bench-e2e.nu e2e`
-# for an interleaved baseline-feature-feature-baseline comparison using two local validators.
+# for a baseline/feature comparison using two local validators.
 
 name: bench-e2e
 
@@ -154,6 +154,16 @@ on:
         type: string
         required: false
         default: ""
+      disable-abba:
+        description: Run only baseline-1 and feature-1 instead of the full baseline-feature-feature-baseline sequence.
+        type: boolean
+        required: true
+        default: false
+      clickhouse-run:
+        description: Benchmark phase that may use the direct ClickHouse reporter.
+        type: string
+        required: false
+        default: "feature-1"
   workflow_call:
     inputs:
       pr:
@@ -282,6 +292,14 @@ on:
         type: string
         required: false
         default: ""
+      disable-abba:
+        type: string
+        required: false
+        default: "false"
+      clickhouse-run:
+        type: string
+        required: false
+        default: "feature-1"
       comment-id:
         type: string
         required: false
@@ -359,6 +377,8 @@ jobs:
       BENCH_BENCH_ENV: ${{ inputs.bench-env }}
       BENCH_BASELINE_ENV: ${{ inputs.baseline-env }}
       BENCH_FEATURE_ENV: ${{ inputs.feature-env }}
+      BENCH_DISABLE_ABBA: ${{ (inputs.disable-abba == true || inputs.disable-abba == 'true' || inputs.run-type == 'nightly') && 'true' || 'false' }}
+      BENCH_CLICKHOUSE_RUN: ${{ inputs.clickhouse-run || 'feature-1' }}
       BENCH_COMMENT_ID: ${{ inputs.comment-id }}
       BENCH_PR_HEAD_SHA: ${{ inputs.pr-head-sha }}
       BENCH_PR_HEAD_REF: ${{ inputs.pr-head-ref }}
@@ -655,6 +675,8 @@ jobs:
           [ -n "$BENCH_VICTORIAMETRICS_URL" ] && cmd+=(--victoriametrics-url "$BENCH_VICTORIAMETRICS_URL")
           [ -n "$CLICKHOUSE_URL" ] && cmd+=(--clickhouse-url "$CLICKHOUSE_URL")
           [ -n "$BENCH_RUN_TYPE" ] && cmd+=(--run-type "$BENCH_RUN_TYPE")
+          [ "$BENCH_DISABLE_ABBA" = "true" ] && cmd+=(--disable-abba)
+          [ -n "$BENCH_CLICKHOUSE_RUN" ] && cmd+=(--clickhouse-run "$BENCH_CLICKHOUSE_RUN")
           "${cmd[@]}"
 
       - name: Find results directory
@@ -675,16 +697,6 @@ jobs:
         with:
           name: tempo-bench-results
           path: bench-results/
-
-      - name: Upload results to ClickHouse
-        if: success()
-        env:
-          BENCH_BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
-          BENCH_FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
-          BENCH_RUN_TYPE: ${{ env.BENCH_RUN_TYPE }}
-          BENCH_JOB_URL: ${{ env.BENCH_JOB_URL }}
-          BENCH_RESULTS_DIR: ${{ steps.results-dir.outputs.path }}
-        run: bash contrib/bench/upload-clickhouse-txgen.sh "$BENCH_RESULTS_DIR"
 
       - name: Post results to PR
         if: success()
@@ -755,7 +767,8 @@ jobs:
               }
             } catch (e) {}
 
-            const runs = ['baseline-1', 'feature-1', 'feature-2', 'baseline-2'];
+            const runs = ['baseline-1', 'feature-1', 'feature-2', 'baseline-2']
+              .filter(run => fs.existsSync(`${resultsDir}/report-${run}.json`));
 
             // Samply profile links (URLs produced by tempo.nu upload-samply-profile)
             let samplySection = '';

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -744,6 +744,11 @@ def run-local-e2e-phase [run: record, ctx: record] {
 
     let tps_k = ($ctx.tps // 1000)
     let scenario = $"($ctx.preset)-($tps_k)k"
+    let phase_clickhouse_url = if $ctx.clickhouse_url != "" and ($ctx.clickhouse_run == "" or $ctx.clickhouse_run == $phase) {
+        $ctx.clickhouse_url
+    } else {
+        ""
+    }
 
     if $phase_exit == 0 {
         let sender_exit = (try {
@@ -771,7 +776,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --platform "tempo"
                 --scenario $scenario
                 --victoriametrics-url $ctx.victoriametrics_url
-                --clickhouse-url $ctx.clickhouse_url
+                --clickhouse-url $phase_clickhouse_url
                 --skip-funding=($ctx.bloat > 0))
             if not $bench_result.ok {
                 $bench_result.exit_code
@@ -803,7 +808,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
     return 0
 }
 
-# Run the baseline-feature-feature-baseline e2e sequence on one runner.
+# Run the e2e sequence on one runner.
 def "main e2e" [
     --baseline: string                                  # Baseline git SHA/ref
     --feature: string                                   # Feature git SHA/ref
@@ -828,6 +833,8 @@ def "main e2e" [
     --tracing-otlp: string = ""                         # OTLP endpoint for tracing (auto-derived from GRAFANA_TEMPO/TEMPO_TELEMETRY_URL)
     --victoriametrics-url: string = ""                  # VictoriaMetrics base URL for txgen metric sample import
     --clickhouse-url: string = ""                       # ClickHouse HTTP endpoint for txgen result upload
+    --clickhouse-run: string = "feature-1"              # Run label allowed to use the ClickHouse reporter; empty = every run
+    --disable-abba                                      # Run only baseline-1 and feature-1
     --run-type: string = ""                             # Run type label (dispatch, nightly, release)
     --baseline-args: string = ""                        # Additional node args for baseline phases
     --feature-args: string = ""                         # Additional node args for feature phases
@@ -847,6 +854,11 @@ def "main e2e" [
     txgen-validate-bench-args $bench_args
     if $tracy not-in ["off" "on" "full"] {
         print $"Error: --tracy must be one of: off, on, full \(got '($tracy)'\)"
+        exit 1
+    }
+    let valid_run_labels = ["baseline-1" "feature-1" "feature-2" "baseline-2"]
+    if $clickhouse_run != "" and $clickhouse_run not-in $valid_run_labels {
+        print $"Error: --clickhouse-run must be one of: ($valid_run_labels | str join ', ') \(got '($clickhouse_run)'\)"
         exit 1
     }
     let bloat_mib = (e2e-bloat-gib-to-mib $bloat)
@@ -1085,6 +1097,7 @@ def "main e2e" [
         bench_env: $bench_env
         victoriametrics_url: $victoriametrics_url
         clickhouse_url: $clickhouse_url
+        clickhouse_run: $clickhouse_run
         run_type: $run_type
         benchmark_id: $benchmark_id
         reference_epoch: $reference_epoch
@@ -1096,12 +1109,17 @@ def "main e2e" [
     let baseline_base_label = if $baseline_name != "" { $baseline_name } else { $baseline }
     let feature_base_label = if $feature_name != "" { $feature_name } else { $feature }
 
-    let runs = [
+    let abba_runs = [
         { phase: "baseline-1", ref: $baseline, ref_label: $baseline_base_label, tempo: $baseline_tempo, genesis: $baseline_genesis_path, hardfork: $baseline_hardfork_name }
         { phase: "feature-1", ref: $feature, ref_label: $feature_base_label, tempo: $feature_tempo, genesis: $feature_genesis_path, hardfork: $feature_hardfork_name }
         { phase: "feature-2", ref: $feature, ref_label: $feature_base_label, tempo: $feature_tempo, genesis: $feature_genesis_path, hardfork: $feature_hardfork_name }
         { phase: "baseline-2", ref: $baseline, ref_label: $baseline_base_label, tempo: $baseline_tempo, genesis: $baseline_genesis_path, hardfork: $baseline_hardfork_name }
     ]
+    let runs = if $disable_abba {
+        $abba_runs | where { |run| $run.phase in ["baseline-1" "feature-1"] }
+    } else {
+        $abba_runs
+    }
     let num_phases = ($runs | length)
     mut e2e_exit = 0
     for idx in 0..<$num_phases {

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -742,6 +742,9 @@ def run-local-e2e-phase [run: record, ctx: record] {
         $tracy_capture_started = true
     }
 
+    let tps_k = ($ctx.tps / 1000)
+    let scenario = $"($ctx.preset)-($tps_k)k"
+
     if $phase_exit == 0 {
         let sender_exit = (try {
             let bench_result = (txgen-run-preset-pipeline
@@ -758,13 +761,17 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --max-concurrent-requests $ctx.max_concurrent_requests
                 --bench-env $ctx.bench_env
                 --git-ref $run.ref
+                --git-ref-label ($run | get -o ref_label | default $run.ref)
                 --build-profile $ctx.profile
                 --benchmark-mode "e2e"
                 --benchmark-id $ctx.benchmark_id
                 --benchmark-run $phase
-                --run-type $run_type
+                --run-type $ctx.run_type
                 --benchmark-start $ctx.reference_epoch
+                --platform "tempo"
+                --scenario $scenario
                 --victoriametrics-url $ctx.victoriametrics_url
+                --clickhouse-url $ctx.clickhouse_url
                 --skip-funding=($ctx.bloat > 0))
             if not $bench_result.ok {
                 $bench_result.exit_code
@@ -820,6 +827,8 @@ def "main e2e" [
     --tracy-offset: int = 120                           # Seconds to wait before starting tracy capture
     --tracing-otlp: string = ""                         # OTLP endpoint for tracing (auto-derived from GRAFANA_TEMPO/TEMPO_TELEMETRY_URL)
     --victoriametrics-url: string = ""                  # VictoriaMetrics base URL for txgen metric sample import
+    --clickhouse-url: string = ""                       # ClickHouse HTTP endpoint for txgen result upload
+    --run-type: string = ""                             # Run type label (dispatch, nightly, release)
     --baseline-args: string = ""                        # Additional node args for baseline phases
     --feature-args: string = ""                         # Additional node args for feature phases
     --bench-args: string = ""                           # Additional txgen bench args
@@ -1075,6 +1084,8 @@ def "main e2e" [
         feature_env: $feature_env
         bench_env: $bench_env
         victoriametrics_url: $victoriametrics_url
+        clickhouse_url: $clickhouse_url
+        run_type: $run_type
         benchmark_id: $benchmark_id
         reference_epoch: $reference_epoch
         tune: $tune
@@ -1082,11 +1093,14 @@ def "main e2e" [
         gas_limit: $gas_limit
     }
 
+    let baseline_base_label = if $baseline_name != "" { $baseline_name } else { $baseline }
+    let feature_base_label = if $feature_name != "" { $feature_name } else { $feature }
+
     let runs = [
-        { phase: "baseline-1", ref: $baseline, tempo: $baseline_tempo, genesis: $baseline_genesis_path, hardfork: $baseline_hardfork_name }
-        { phase: "feature-1", ref: $feature, tempo: $feature_tempo, genesis: $feature_genesis_path, hardfork: $feature_hardfork_name }
-        { phase: "feature-2", ref: $feature, tempo: $feature_tempo, genesis: $feature_genesis_path, hardfork: $feature_hardfork_name }
-        { phase: "baseline-2", ref: $baseline, tempo: $baseline_tempo, genesis: $baseline_genesis_path, hardfork: $baseline_hardfork_name }
+        { phase: "baseline-1", ref: $baseline, ref_label: $baseline_base_label, tempo: $baseline_tempo, genesis: $baseline_genesis_path, hardfork: $baseline_hardfork_name }
+        { phase: "feature-1", ref: $feature, ref_label: $feature_base_label, tempo: $feature_tempo, genesis: $feature_genesis_path, hardfork: $feature_hardfork_name }
+        { phase: "feature-2", ref: $feature, ref_label: $feature_base_label, tempo: $feature_tempo, genesis: $feature_genesis_path, hardfork: $feature_hardfork_name }
+        { phase: "baseline-2", ref: $baseline, ref_label: $baseline_base_label, tempo: $baseline_tempo, genesis: $baseline_genesis_path, hardfork: $baseline_hardfork_name }
     ]
     let num_phases = ($runs | length)
     mut e2e_exit = 0
@@ -1124,8 +1138,6 @@ def "main e2e" [
         }
     }
 
-    let baseline_base_label = if $baseline_name != "" { $baseline_name } else { $baseline }
-    let feature_base_label = if $feature_name != "" { $feature_name } else { $feature }
     let baseline_label = if $hardfork_mode { $"($baseline_base_label) \(($baseline_hardfork_name)\)" } else { $baseline_base_label }
     let feature_label = if $hardfork_mode { $"($feature_base_label) \(($feature_hardfork_name)\)" } else { $feature_base_label }
     if $e2e_exit == 0 {

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -742,7 +742,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
         $tracy_capture_started = true
     }
 
-    let tps_k = ($ctx.tps / 1000)
+    let tps_k = ($ctx.tps // 1000)
     let scenario = $"($ctx.preset)-($tps_k)k"
 
     if $phase_exit == 0 {

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -271,7 +271,7 @@ def "main run" [
     let resolved_scenario = if $scenario != "" {
         $scenario
     } else {
-        let tps_k = ($tps / 1000)
+        let tps_k = ($tps // 1000)
         $"($preset)-($tps_k)k"
     }
     txgen-validate-bench-args $bench_args

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -199,6 +199,7 @@ def txgen-run-preset-pipeline [
     --platform: string = ""
     --scenario: string = ""
     --victoriametrics-url: string = ""
+    --clickhouse-url: string = ""
     --skip-funding                                   # Skip faucet funding (accounts already funded at genesis via state bloat)
 ] {
     let chain_id = (txgen-fetch-chain-id $generate_rpc_url)
@@ -235,6 +236,7 @@ def txgen-run-preset-pipeline [
         | append (if $victoriametrics_url != "" and $benchmark_start > 0 { ["--metrics-align" $"($benchmark_start)"] } else { [] })
     let report_args = ["--report" $"json:($report_path)"]
         | append (if $victoriametrics_url != "" { ["--report" $"victoriametrics:($victoriametrics_url)"] } else { [] })
+        | append (if $clickhouse_url != "" { ["--report" $"clickhouse:($clickhouse_url)"] } else { [] })
     let metadata_args = [
         "-m" "job=github-tempo-bench-e2e"
         "-m" $"chain_id=($chain_id)"

--- a/tempo.nu
+++ b/tempo.nu
@@ -800,7 +800,8 @@ def percentile [sorted_vals: list<any>, pct: int] {
 
 
 def generate-summary [results_dir: string, baseline_ref: string, feature_ref: string, bloat: int, preset: string, tps: int, duration: int, --benchmark-id: string = "", --reference-epoch: int = 0] {
-    let run_labels = ["baseline-1" "feature-1" "feature-2" "baseline-2"]
+    let candidate_run_labels = ["baseline-1" "feature-1" "feature-2" "baseline-2"]
+    let run_labels = ($candidate_run_labels | where { |label| ($"($results_dir)/report-($label).json" | path exists) })
     mut run_data = []
     mut baseline_blocks = []
     mut feature_blocks = []


### PR DESCRIPTION
Routes e2e ClickHouse writes through txgen native reporter and removes the legacy post-run uploader. ClickHouse reporting is gated by benchmark phase, with scheduled runs reporting only `feature-1` so each scheduled benchmark produces one feature row.

Scheduled e2e now builds a dynamic matrix for `tip20` and `mix` at 20k TPS. Nightly state is resolved and saved per preset under `state/e2e-nightly-<preset>-last-feature-ref`.

Manual and reusable runs can still choose the ABBA mode and ClickHouse reporting phase with workflow inputs.