### PR TITLE
chore: bump reth to 4d61762 (skip-state-root flag)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,7 +1162,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1173,7 +1173,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4157,7 +4157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4597,7 +4597,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -6714,7 +6714,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8260,7 +8260,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8319,7 +8319,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8339,7 +8339,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8352,7 +8352,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8435,7 +8435,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8445,7 +8445,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8498,7 +8498,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8514,7 +8514,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8528,7 +8528,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8541,7 +8541,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8566,7 +8566,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8595,7 +8595,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8621,7 +8621,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8666,7 +8666,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8691,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8715,7 +8715,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8739,7 +8739,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8774,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8831,7 +8831,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8859,7 +8859,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8882,7 +8882,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8907,7 +8907,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8966,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8996,7 +8996,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9012,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9028,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9050,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9061,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9089,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9111,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "clap",
  "eyre",
@@ -9175,7 +9175,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9191,7 +9191,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9250,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9264,7 +9264,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9274,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9298,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9318,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9368,7 +9368,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9420,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "serde",
  "serde_json",
@@ -9430,7 +9430,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9458,7 +9458,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "bytes",
  "futures",
@@ -9478,7 +9478,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9495,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "bindgen",
  "cc",
@@ -9504,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "futures",
  "metrics",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9526,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9540,7 +9540,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9598,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9623,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9646,7 +9646,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9661,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9692,7 +9692,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9716,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9784,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9839,7 +9839,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9877,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9901,7 +9901,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "bytes",
  "eyre",
@@ -9954,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9966,7 +9966,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10025,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10116,7 +10116,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10145,7 +10145,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10161,7 +10161,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10253,7 +10253,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10283,7 +10283,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10326,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10377,7 +10377,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10423,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10471,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10485,7 +10485,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10516,7 +10516,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10568,7 +10568,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10610,7 +10610,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10645,7 +10645,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10670,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10688,7 +10688,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10709,7 +10709,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10725,7 +10725,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10735,7 +10735,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "clap",
  "eyre",
@@ -10754,7 +10754,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "clap",
  "eyre",
@@ -10772,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10817,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10843,7 +10843,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10870,7 +10870,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10890,7 +10890,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10919,7 +10919,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9b6a79f#9b6a79ff9c72e467bebcde2369c574cb22927cc7"
+source = "git+https://github.com/paradigmxyz/reth?rev=4d6176201eccad05b481439c723be5b832bfe981#4d6176201eccad05b481439c723be5b832bfe981"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11410,7 +11410,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11469,7 +11469,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11490,7 +11490,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12107,7 +12107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12373,7 +12373,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14362,7 +14362,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,64 +139,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9b6a79f", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "4d6176201eccad05b481439c723be5b832bfe981", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
Bumps reth to [paradigmxyz/reth@4d61762](https://github.com/paradigmxyz/reth/commit/4d6176201eccad05b481439c723be5b832bfe981) from [PR #24139](https://github.com/paradigmxyz/reth/pull/24139) (centaur/skip-state-root branch).

This revision includes the `--engine.skip-state-root` flag for benchmarking execution performance in isolation from trie computation.