### PR TITLE
docs(tip-1034): add per-payer channel accounting for storage gas optimization

### DIFF
--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -106,6 +106,28 @@ high 32 bits MUST remain zero.
 
 Closed channels MUST not retain any packed `ChannelState` slot at all.
 
+### Per-Payer Channel Accounting
+
+Implementations MUST maintain a per-payer accounting slot, keyed by `payer` address, packed into a
+single 32-byte storage slot:
+
+```text
+bits   0..63   currentCount   uint64   number of currently-open channels for this payer
+bits  64..127  maxCount       uint64   highest value currentCount has ever reached for this payer
+bits 128..255  reserved       zero
+```
+
+`open` MUST increment `currentCount` by 1 before persisting the channel state. If the new
+`currentCount` exceeds `maxCount`, implementations MUST update `maxCount` to match.
+
+Terminal `close` and `withdraw` MUST decrement `currentCount` by 1 after deleting the channel
+state. Implementations MUST NOT zero the accounting slot when `currentCount` reaches 0;
+`maxCount` MUST be preserved.
+
+The accounting slot is never deleted. When a returning payer opens their first channel after
+having previously closed all channels, the slot is already nonzero (because `maxCount > 0`), so
+the storage write is a nonzero-to-nonzero update rather than a zero-to-nonzero initialization.
+
 `channelId` MUST use the following deterministic domain-separated construction:
 
 ```solidity
@@ -207,7 +229,7 @@ behalf, but all settlement and close-capture payouts still transfer to `payee`.
 Execution semantics are:
 
 1. `open` MUST reject zero deposit, invalid token address, and invalid payee address.
-2. `open` MUST derive `expiringNonceHash` from the enclosing transaction's replay-protected context hash, persist only the packed `ChannelState` slot, and MUST emit the full immutable descriptor in `ChannelOpened`.
+2. `open` MUST derive `expiringNonceHash` from the enclosing transaction's replay-protected context hash, update the payer's per-payer channel accounting slot, persist the packed `ChannelState` slot, and MUST emit the full immutable descriptor in `ChannelOpened`.
 3. Post-open methods (`settle`, `topUp`, `close`, `requestClose`, `withdraw`, and descriptor-based views) MUST recompute `channelId` from the supplied descriptor and use that derived id for storage lookup.
 4. If `closeRequestedAt != 0`, a successful `topUp` MUST clear it back to `0` and emit `CloseRequestCancelled`.
 5. `requestClose` MUST set `closeRequestedAt = uint32(block.timestamp)` on the first successful call and leave it unchanged on later successful calls.
@@ -219,7 +241,7 @@ Execution semantics are:
 11. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
 12. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
 13. `withdraw` MUST be allowed only when the close grace period has elapsed from `closeRequestedAt`.
-14. Terminal `close` and `withdraw` MUST delete the stored slot entirely. Reopening the same logical channel in a later transaction MUST produce a different `channelId` because the replay-protected context hash changes.
+14. Terminal `close` and `withdraw` MUST delete the stored slot entirely, and MUST decrement the payer's per-payer channel accounting `currentCount`. Reopening the same logical channel in a later transaction MUST produce a different `channelId` because the replay-protected context hash changes.
 15. Within one top-level transaction, `open` MUST reject any `channelId` that was already opened earlier in that same transaction, even if the channel was terminally closed or withdrawn before the later `open` call.
 
 The `cumulativeAmount > deposit` allowance is specific to `close`, because `close` has a separate
@@ -319,6 +341,8 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 15. `open` and `topUp` MUST not require a prior user `approve` transaction.
 16. `withdraw` MUST require an active close request whose grace period has elapsed.
 17. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`, and `captureAmount <= deposit`.
+18. `currentCount <= maxCount` MUST hold in all reachable states.
+19. The per-payer accounting slot MUST NOT be zeroed when `currentCount` reaches 0.
 
 ## References
 

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -128,6 +128,17 @@ The accounting slot is never deleted. When a returning payer opens their first c
 having previously closed all channels, the slot is already nonzero (because `maxCount > 0`), so
 the storage write is a nonzero-to-nonzero update rather than a zero-to-nonzero initialization.
 
+### Channel Slot Initialization Cost
+
+When `open` increments `currentCount` and the new value does not exceed `maxCount`, the payer has
+previously had at least this many concurrent channels and later closed one. Implementations MUST
+treat the new channel's `ChannelState` slot write as a non-zero-to-non-zero SSTORE for gas
+accounting purposes, skipping the storage initialization cost (TIP-1016: 230,000 state gas +
+22,200 execution gas for zero-to-non-zero) and charging only the hot SSTORE cost (2,900 gas).
+
+When the new `currentCount` exceeds `maxCount`, the channel slot MUST be charged the full
+zero-to-non-zero SSTORE cost.
+
 `channelId` MUST use the following deterministic domain-separated construction:
 
 ```solidity


### PR DESCRIPTION
## Summary

Adds a per-payer `(currentCount, maxCount)` accounting slot to TIP-1034. The slot is never zeroed — when a returning payer opens their first channel after having closed all previous ones, the accounting slot is already nonzero (`maxCount > 0`), making the write a nonzero→nonzero SSTORE (~5k gas) instead of a zero→nonzero initialization (~20k gas).

## Changes (spec-only)

- New **Per-Payer Channel Accounting** section defining the packed slot layout (`uint64 currentCount`, `uint64 maxCount`)
- `open` increments `currentCount` and updates `maxCount` if exceeded
- Terminal `close`/`withdraw` decrement `currentCount` but never zero the slot
- Two new invariants: `currentCount <= maxCount` always holds; accounting slot is never deleted

No implementation or interface changes.