### PR TITLE
ci(bench): schedule docker-gated e2e runs

### DIFF
--- a/.github/scripts/bench-e2e-scheduled-refs.sh
+++ b/.github/scripts/bench-e2e-scheduled-refs.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# Resolves baseline and feature refs for scheduled e2e benchmark runs.
+#
+# Nightly runs compare the latest successful scheduled docker.yml build against
+# the last commit that completed this scheduled e2e workflow successfully.
+# Release tag runs compare the pushed v*.*.* tag against the previous v*.*.* tag.
+#
+# Usage: bench-e2e-scheduled-refs.sh <force>
+#   force - "true" to run even if no new nightly commit is available
+#
+# Outputs (via GITHUB_OUTPUT):
+#   baseline-ref
+#   baseline-name
+#   feature-ref
+#   feature-name
+#   should-skip
+#   run-type
+#   actor
+#   is-stale
+#   stale-age-hours
+#   nightly-created
+set -euo pipefail
+
+FORCE="${1:-false}"
+REPO="${GITHUB_REPOSITORY:-tempoxyz/tempo}"
+STATE_REPO="${BENCH_E2E_STATE_REPO:-decofe/tempo-bench-charts}"
+STATE_FILE="${BENCH_E2E_STATE_FILE:-state/e2e-nightly-last-feature-ref}"
+STALE_THRESHOLD_HOURS="${BENCH_E2E_STALE_THRESHOLD_HOURS:-24}"
+
+echo "Force: $FORCE"
+echo "Repository: $REPO"
+
+short_sha() {
+  printf "%.8s" "$1"
+}
+
+write_outputs() {
+  {
+    echo "baseline-ref=$BASELINE_REF"
+    echo "baseline-name=$BASELINE_NAME"
+    echo "feature-ref=$FEATURE_REF"
+    echo "feature-name=$FEATURE_NAME"
+    echo "should-skip=$SHOULD_SKIP"
+    echo "run-type=$RUN_TYPE"
+    echo "actor=$ACTOR"
+    echo "is-stale=$IS_STALE"
+    echo "stale-age-hours=$AGE_HOURS"
+    echo "nightly-created=$CREATED_AT"
+  } >> "$GITHUB_OUTPUT"
+}
+
+SHOULD_SKIP="false"
+IS_STALE="false"
+AGE_HOURS="0"
+CREATED_AT=""
+
+if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+  RUN_TYPE="release"
+  ACTOR="e2e-release"
+  CURRENT_TAG="${GITHUB_REF_NAME:-}"
+
+  if [ -z "$CURRENT_TAG" ]; then
+    echo "::error::GITHUB_REF_NAME is not set for tag run"
+    exit 1
+  fi
+
+  echo "::group::Resolving release tags"
+  git fetch --tags --force --quiet --no-recurse-submodules origin
+
+  mapfile -t TAGS < <(git tag --list "v*.*.*" --sort=-v:refname)
+  FOUND="false"
+  PREVIOUS_TAG=""
+  for tag in "${TAGS[@]}"; do
+    if [ "$FOUND" = "true" ] && [ "$tag" != "$CURRENT_TAG" ]; then
+      PREVIOUS_TAG="$tag"
+      break
+    fi
+    if [ "$tag" = "$CURRENT_TAG" ]; then
+      FOUND="true"
+    fi
+  done
+
+  if [ "$FOUND" != "true" ]; then
+    echo "::error::Current tag $CURRENT_TAG was not found in fetched v*.*.* tags"
+    exit 1
+  fi
+
+  FEATURE_REF="$(git rev-list -n 1 "$CURRENT_TAG")"
+  FEATURE_NAME="$CURRENT_TAG"
+
+  if [ -n "$PREVIOUS_TAG" ]; then
+    BASELINE_REF="$(git rev-list -n 1 "$PREVIOUS_TAG")"
+    BASELINE_NAME="$PREVIOUS_TAG"
+  else
+    BASELINE_REF="$FEATURE_REF"
+    BASELINE_NAME="$CURRENT_TAG"
+    echo "No previous release tag found before $CURRENT_TAG; benchmarking release against itself"
+  fi
+
+  echo "Baseline: $BASELINE_NAME ($BASELINE_REF)"
+  echo "Feature:  $FEATURE_NAME ($FEATURE_REF)"
+  echo "::endgroup::"
+
+  write_outputs
+  exit 0
+fi
+
+RUN_TYPE="nightly"
+ACTOR="e2e-nightly"
+
+echo "::group::Querying latest nightly docker build"
+RUNS_JSON="$(gh run list \
+  -R "$REPO" \
+  --workflow=docker.yml \
+  --event=schedule \
+  --status=completed \
+  --limit 10 \
+  --json headSha,createdAt,conclusion)"
+
+LATEST="$(echo "$RUNS_JSON" | jq -r '[.[] | select(.conclusion == "success")] | first // empty')"
+if [ -z "$LATEST" ]; then
+  echo "::error::No successful scheduled docker.yml run found in the last 10 runs"
+  echo "Runs found: $RUNS_JSON"
+  exit 1
+fi
+
+FEATURE_REF="$(echo "$LATEST" | jq -r '.headSha')"
+CREATED_AT="$(echo "$LATEST" | jq -r '.createdAt')"
+echo "Latest nightly commit: $FEATURE_REF"
+echo "Built at: $CREATED_AT"
+echo "::endgroup::"
+
+echo "::group::Checking nightly staleness"
+NOW_EPOCH="$(date +%s)"
+CREATED_EPOCH="$(date -d "$CREATED_AT" +%s 2>/dev/null || \
+  date -j -f "%Y-%m-%dT%H:%M:%SZ" "$CREATED_AT" +%s 2>/dev/null || \
+  date -j -f "%Y-%m-%dT%T%z" "$CREATED_AT" +%s 2>/dev/null || \
+  { echo "::error::Cannot parse date: $CREATED_AT"; exit 1; })"
+
+AGE_SECONDS=$(( NOW_EPOCH - CREATED_EPOCH ))
+AGE_HOURS=$(( AGE_SECONDS / 3600 ))
+
+if [ "$AGE_HOURS" -gt "$STALE_THRESHOLD_HOURS" ]; then
+  IS_STALE="true"
+  echo "::warning::Stale nightly Docker build: ${AGE_HOURS}h old (threshold: ${STALE_THRESHOLD_HOURS}h)"
+else
+  echo "Nightly Docker build age: ${AGE_HOURS}h"
+fi
+echo "::endgroup::"
+
+echo "::group::Reading persisted e2e state"
+LAST_FEATURE_REF=""
+STATE_URL="https://raw.githubusercontent.com/${STATE_REPO}/state/${STATE_FILE}"
+if RAW="$(curl -sfL -H "Authorization: token ${DEREK_TOKEN:-}" "$STATE_URL")"; then
+  LAST_FEATURE_REF="$(echo "$RAW" | tr -d '[:space:]')"
+  echo "Previous e2e feature ref: $LAST_FEATURE_REF"
+else
+  echo "No persisted e2e state found"
+fi
+echo "::endgroup::"
+
+echo "::group::Resolving refs"
+BASELINE_REF="$FEATURE_REF"
+
+if [ "$IS_STALE" = "true" ]; then
+  BASELINE_REF="${LAST_FEATURE_REF:-$FEATURE_REF}"
+  echo "Stale nightly detected; workflow will fail before benchmarking"
+elif [ -z "$LAST_FEATURE_REF" ]; then
+  BASELINE_REF="$FEATURE_REF"
+  echo "First run; benchmarking nightly against itself to establish e2e state"
+elif [ "$LAST_FEATURE_REF" = "$FEATURE_REF" ]; then
+  BASELINE_REF="$LAST_FEATURE_REF"
+  if [ "$FORCE" = "true" ] || [ "$FORCE" = "--force" ]; then
+    echo "No new nightly commit, but force=true; running anyway"
+  else
+    SHOULD_SKIP="true"
+    echo "No new nightly commit since last successful e2e run; skipping"
+  fi
+else
+  BASELINE_REF="$LAST_FEATURE_REF"
+  echo "New nightly commit detected"
+fi
+
+BASELINE_NAME="nightly-$(short_sha "$BASELINE_REF")"
+FEATURE_NAME="nightly-$(short_sha "$FEATURE_REF")"
+
+echo "Baseline: $BASELINE_REF"
+echo "Feature:  $FEATURE_REF"
+echo "Skip:     $SHOULD_SKIP"
+echo "Stale:    $IS_STALE"
+echo "::endgroup::"
+
+write_outputs

--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -1,0 +1,123 @@
+# Scheduled e2e regression benchmarks.
+#
+# Runs nightly at 02:00 UTC and on v*.*.* tag pushes.
+# Nightly runs compare the latest successful nightly Docker commit against the
+# last commit that completed this scheduled e2e workflow successfully.
+# Tag runs compare the pushed release tag against the previous release tag.
+
+name: bench-e2e-scheduled
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Force run even if no new nightly commit is available"
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  resolve-refs:
+    name: resolve-refs
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      baseline-ref: ${{ steps.refs.outputs.baseline-ref }}
+      baseline-name: ${{ steps.refs.outputs.baseline-name }}
+      feature-ref: ${{ steps.refs.outputs.feature-ref }}
+      feature-name: ${{ steps.refs.outputs.feature-name }}
+      should-skip: ${{ steps.refs.outputs.should-skip }}
+      run-type: ${{ steps.refs.outputs.run-type }}
+      actor: ${{ steps.refs.outputs.actor }}
+      is-stale: ${{ steps.refs.outputs.is-stale }}
+      stale-age-hours: ${{ steps.refs.outputs.stale-age-hours }}
+      nightly-created: ${{ steps.refs.outputs.nightly-created }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: true
+
+      - name: Resolve refs
+        id: refs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          INPUT_FORCE: ${{ inputs.force || 'false' }}
+        run: bash .github/scripts/bench-e2e-scheduled-refs.sh "$INPUT_FORCE"
+
+      - name: Fail on stale nightly
+        if: steps.refs.outputs.is-stale == 'true'
+        run: |
+          echo "::error::Nightly Docker build is stale (>24h old). Aborting e2e benchmark."
+          exit 1
+
+  bench-e2e:
+    needs: resolve-refs
+    if: |
+      needs.resolve-refs.outputs.should-skip != 'true' &&
+      needs.resolve-refs.outputs.is-stale != 'true'
+    name: bench-e2e (${{ needs.resolve-refs.outputs.feature-name }})
+    uses: ./.github/workflows/bench-e2e.yml
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      actor: ${{ needs.resolve-refs.outputs.actor }}
+      baseline: ${{ needs.resolve-refs.outputs.baseline-ref }}
+      feature: ${{ needs.resolve-refs.outputs.feature-ref }}
+      baseline-name: ${{ needs.resolve-refs.outputs.baseline-name }}
+      feature-name: ${{ needs.resolve-refs.outputs.feature-name }}
+      run-type: ${{ needs.resolve-refs.outputs.run-type }}
+    secrets:
+      DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
+      TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
+      GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}
+      CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+      CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
+      BENCH_VICTORIAMETRICS_URL: ${{ secrets.BENCH_VICTORIAMETRICS_URL }}
+      SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
+      SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
+
+  save-state:
+    needs: [resolve-refs, bench-e2e]
+    if: success() && needs.resolve-refs.outputs.run-type == 'nightly'
+    name: save-state
+    runs-on: ubuntu-latest
+    steps:
+      - name: Push state to charts repo
+        env:
+          DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
+          FEATURE_REF: ${{ needs.resolve-refs.outputs.feature-ref }}
+        run: |
+          CHARTS_REPO="https://x-access-token:${DEREK_TOKEN}@github.com/decofe/tempo-bench-charts.git"
+          TMP_DIR=$(mktemp -d)
+
+          if git clone --depth 1 --branch state "${CHARTS_REPO}" "${TMP_DIR}" 2>/dev/null; then
+            true
+          else
+            git init "${TMP_DIR}"
+            git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
+          fi
+
+          mkdir -p "${TMP_DIR}/state"
+          echo "${FEATURE_REF}" > "${TMP_DIR}/state/e2e-nightly-last-feature-ref"
+          git -C "${TMP_DIR}" add state/
+          git -C "${TMP_DIR}" diff --cached --quiet && echo "No state change" && exit 0
+          git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
+            commit -m "bench: update e2e nightly state to ${FEATURE_REF}"
+          git -C "${TMP_DIR}" push origin HEAD:state
+          rm -rf "${TMP_DIR}"

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -161,63 +161,79 @@ on:
         required: false
       actor:
         type: string
-        required: true
+        required: false
       mode:
         type: string
-        required: true
+        required: false
+        default: e2e
       preset:
         type: string
-        required: true
+        required: false
+        default: tip20
       duration:
         type: string
-        required: true
+        required: false
+        default: "300"
       bloat:
         type: string
-        required: true
+        required: false
+        default: "100"
       tps:
         type: string
-        required: true
+        required: false
+        default: "20000"
       accounts:
         type: string
-        required: true
+        required: false
+        default: "1000"
       max-concurrent-requests:
         type: string
-        required: true
+        required: false
+        default: "100"
       baseline:
         type: string
-        required: true
+        required: false
+        default: ""
       feature:
         type: string
-        required: true
+        required: false
+        default: ""
       baseline-hardfork:
         type: string
         required: false
-        default: ""
+        default: T6
       feature-hardfork:
         type: string
         required: false
-        default: ""
+        default: T6
       txgen-ref:
         type: string
         required: false
+        default: ""
       baseline-name:
         type: string
-        required: true
+        required: false
+        default: ""
       feature-name:
         type: string
-        required: true
+        required: false
+        default: ""
       samply:
         type: string
-        required: true
+        required: false
+        default: "false"
       tracy:
         type: string
-        required: true
+        required: false
+        default: "off"
       tracy-seconds:
         type: string
-        required: true
+        required: false
+        default: "30"
       tracy-offset:
         type: string
-        required: true
+        required: false
+        default: "120"
       otlp:
         type: string
         required: false
@@ -225,39 +241,51 @@ on:
       baseline-args:
         type: string
         required: false
+        default: ""
       feature-args:
         type: string
         required: false
+        default: ""
       gas-limit:
         type: string
-        required: true
+        required: false
+        default: "500000000"
       run-type:
         type: string
-        required: true
+        required: false
+        default: dispatch
       force-bloat:
         type: string
-        required: true
+        required: false
+        default: "false"
       no-cache:
         type: string
-        required: true
+        required: false
+        default: "false"
       no-slack:
         type: string
-        required: true
+        required: false
+        default: "true"
       bench-args:
         type: string
         required: false
+        default: ""
       bench-env:
         type: string
         required: false
+        default: ""
       baseline-env:
         type: string
         required: false
+        default: ""
       feature-env:
         type: string
         required: false
+        default: ""
       comment-id:
         type: string
         required: false
+        default: ""
       pr-head-sha:
         description: Pinned PR head SHA from the ack job.
         type: string


### PR DESCRIPTION
Adds `bench-e2e-scheduled.yml` to run e2e benchmarks nightly at 02:00 UTC and on `v*.*.*` tag pushes.

Nightly e2e mirrors replay by using the latest successful scheduled `docker.yml` build as the feature ref, failing stale Docker builds before occupying the benchmark runner, and comparing against the previous successful scheduled ref in the bench charts state branch. E2E tag runs compare the pushed release tag against the previous `v*.*.*` tag, and the scheduled caller relies on `bench-e2e.yml` workflow-call defaults.