### PR TITLE
fix(tip-1033): surface tx `validator_fee` info to builder

### DIFF
--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -99,6 +99,11 @@ pub struct TempoTxResult {
     tx: Option<TempoTxEnvelope>,
     /// Block gas consumed by this transaction. The block `gas_used` field will be incremented by this value.
     block_gas_used: u64,
+    /// Validator-credited fee (in the validator's fee token) reported by `collectFeePostTx`.
+    ///
+    /// Used by the payload builder to score blocks by actual proposer revenue. The value is the
+    /// post-feeAMM amount, regardless of route shape — absorbs any number of pool haircuts.
+    validator_fee: U256,
 }
 
 impl TempoTxResult {
@@ -110,6 +115,11 @@ impl TempoTxResult {
     /// Returns the state gas consumed by this transaction.
     pub fn state_gas_used(&self) -> u64 {
         self.inner.result.result.gas().state_gas_spent()
+    }
+
+    /// Returns the validator-credited fee amount (post-feeAMM haircut) for this transaction.
+    pub fn validator_fee(&self) -> U256 {
+        self.validator_fee
     }
 }
 
@@ -538,6 +548,8 @@ where
         } else {
             self.validate_tx(recovered.tx(), block_gas_used)?
         };
+        // Snapshot the per-tx validator-credited fee set by the handler's `reimburse_caller`
+        let validator_fee = self.evm().validator_fee();
         Ok(TempoTxResult {
             inner,
             next_section,
@@ -545,6 +557,7 @@ where
             tx: matches!(next_section, BlockSection::SubBlock { .. })
                 .then(|| recovered.tx().clone()),
             block_gas_used,
+            validator_fee,
         })
     }
 
@@ -555,6 +568,7 @@ where
             is_payment,
             tx,
             block_gas_used,
+            validator_fee: _,
         } = output;
 
         let gas_output = self.inner.commit_transaction(inner);
@@ -1310,6 +1324,7 @@ mod tests {
             is_payment: false,
             tx: None,
             block_gas_used: 21000,
+            validator_fee: U256::ZERO,
         };
 
         let gas_output = executor.commit_transaction(output);
@@ -1392,6 +1407,7 @@ mod tests {
             is_payment: false,
             tx: None,
             block_gas_used: 21000,
+            validator_fee: U256::ZERO,
         };
 
         let gas_output = executor.commit_transaction(output);
@@ -1431,6 +1447,7 @@ mod tests {
             is_payment: false,
             tx: None,
             block_gas_used: 21000,
+            validator_fee: U256::ZERO,
         };
         executor.commit_transaction(output1);
 
@@ -1454,6 +1471,7 @@ mod tests {
             is_payment: false,
             tx: None,
             block_gas_used: 50000,
+            validator_fee: U256::ZERO,
         };
         executor.commit_transaction(output2);
 
@@ -1516,6 +1534,7 @@ mod tests {
             is_payment: false,
             tx: None,
             block_gas_used: 50000,
+            validator_fee: U256::ZERO,
         };
         executor.commit_transaction(output);
 
@@ -1561,6 +1580,7 @@ mod tests {
             is_payment: false,
             tx: None,
             block_gas_used: 200_000,
+            validator_fee: U256::ZERO,
         };
         executor.commit_transaction(output);
 
@@ -1609,6 +1629,7 @@ mod tests {
             is_payment: false,
             tx: None,
             block_gas_used: 200_000,
+            validator_fee: U256::ZERO,
         };
         executor.commit_transaction(output);
 

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -105,6 +105,12 @@ impl<DB: Database, I> TempoEvm<DB, I> {
         &mut self.inner
     }
 
+    /// Returns the validator-credited fee amount (post-feeAMM haircut) recorded by the most
+    /// recent `collectFeePostTx`. Reset per-tx in the handler's `validate_env`.
+    pub fn validator_fee(&self) -> alloy_primitives::U256 {
+        self.inner.validator_fee
+    }
+
     /// Sets the inspector for the EVM.
     pub fn with_inspector<OINSP>(self, inspector: OINSP) -> TempoEvm<DB, OINSP> {
         TempoEvm {

--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -616,17 +616,29 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
     let fee_beneficiary = Address::ZERO;
 
     // Create a two-hop fee route: user_fee_token -> hop_fee_token -> PATH_USD.
-    let hop_fee_token =
-        setup_token_manual(&mut setup.node, &user_provider, &user_signer, chain_id).await?;
+    // Track the next available nonce so CodeQL doesn't flag sequential test nonces as
+    // hard-coded cryptographic values.
+    let mut nonce = 0u64;
+    let hop_fee_token = setup_token_manual_with_quote_and_nonce(
+        &mut setup.node,
+        &user_provider,
+        &user_signer,
+        chain_id,
+        PATH_USD_ADDRESS,
+        nonce,
+    )
+    .await?;
+    nonce += 3; // setup_token_manual uses 3 txs (create, grantRole, mint)
     let user_fee_token = setup_token_manual_with_quote_and_nonce(
         &mut setup.node,
         &user_provider,
         &user_signer,
         chain_id,
         *hop_fee_token.address(),
-        3,
+        nonce,
     )
     .await?;
+    nonce += 3;
 
     let fee_amm = ITIPFeeAMM::new(TIP_FEE_MANAGER_ADDRESS, user_provider.clone());
     let fee_manager = IFeeManager::new(TIP_FEE_MANAGER_ADDRESS, user_provider.clone());
@@ -645,9 +657,10 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
                 user_address,
             )
             .into_transaction_request(),
-        6,
+        nonce,
     )
     .await?;
+    nonce += 1;
     setup.node.advance_block().await?;
     sign_and_inject(
         &mut setup.node,
@@ -661,9 +674,10 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
                 user_address,
             )
             .into_transaction_request(),
-        7,
+        nonce,
     )
     .await?;
+    nonce += 1;
     setup.node.advance_block().await?;
 
     // Set the user's fee token preference to the custom token
@@ -674,9 +688,10 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
         fee_manager
             .setUserToken(*user_fee_token.address())
             .into_transaction_request(),
-        8,
+        nonce,
     )
     .await?;
+    nonce += 1;
     setup.node.advance_block().await?;
 
     // Record collected fees before the attack block
@@ -693,7 +708,7 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
         ITIP20::new(PATH_USD_ADDRESS, user_provider.clone())
             .transfer(Address::random(), U256::from(1))
             .into_transaction_request(),
-        9,
+        nonce,
     )
     .await?;
 

--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -33,6 +33,28 @@ async fn setup_token_manual<P>(
 where
     P: Provider + Clone,
 {
+    setup_token_manual_with_quote_and_nonce(
+        node,
+        provider,
+        sender,
+        chain_id,
+        PATH_USD_ADDRESS,
+        0,
+    )
+    .await
+}
+
+async fn setup_token_manual_with_quote_and_nonce<P>(
+    node: &mut reth_e2e_test_utils::NodeHelperType<TempoNode>,
+    provider: &P,
+    sender: &alloy::signers::local::PrivateKeySigner,
+    chain_id: u64,
+    quote_token: Address,
+    nonce_start: u64,
+) -> eyre::Result<ITIP20::ITIP20Instance<P>>
+where
+    P: Provider + Clone,
+{
     let factory = ITIP20Factory::new(TIP20_FACTORY_ADDRESS, provider.clone());
     let sender_address = sender.address();
     let signer = EthereumWallet::from(sender.clone());
@@ -64,11 +86,11 @@ where
         "Test".to_string(),
         "TEST".to_string(),
         "USD".to_string(),
-        PATH_USD_ADDRESS,
+        quote_token,
         sender_address,
         salt,
     );
-    let create_bytes = sign_and_encode(create_tx.into_transaction_request(), 0).await?;
+    let create_bytes = sign_and_encode(create_tx.into_transaction_request(), nonce_start).await?;
     node.rpc.inject_tx(create_bytes).await?;
     node.advance_block().await?;
 
@@ -89,14 +111,14 @@ where
     // Grant issuer role
     let roles = IRolesAuth::new(token_addr, provider.clone());
     let grant_tx = roles.grantRole(*ISSUER_ROLE, sender_address);
-    let grant_bytes = sign_and_encode(grant_tx.into_transaction_request(), 1).await?;
+    let grant_bytes = sign_and_encode(grant_tx.into_transaction_request(), nonce_start + 1).await?;
     node.rpc.inject_tx(grant_bytes).await?;
     node.advance_block().await?;
 
     // Mint tokens
     let token = ITIP20::ITIP20Instance::new(token_addr, provider.clone());
     let mint_tx = token.mint(sender_address, U256::from(1_000_000));
-    let mint_bytes = sign_and_encode(mint_tx.into_transaction_request(), 2).await?;
+    let mint_bytes = sign_and_encode(mint_tx.into_transaction_request(), nonce_start + 2).await?;
     node.rpc.inject_tx(mint_bytes).await?;
     node.advance_block().await?;
 
@@ -600,14 +622,23 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
 
     let fee_beneficiary = Address::ZERO;
 
-    // Create a custom fee token for the user
-    let user_fee_token =
+    // Create a two-hop fee route: user_fee_token -> hop_fee_token -> PATH_USD.
+    let hop_fee_token =
         setup_token_manual(&mut setup.node, &user_provider, &user_signer, chain_id).await?;
+    let user_fee_token = setup_token_manual_with_quote_and_nonce(
+        &mut setup.node,
+        &user_provider,
+        &user_signer,
+        chain_id,
+        *hop_fee_token.address(),
+        3,
+    )
+    .await?;
 
     let fee_amm = ITIPFeeAMM::new(TIP_FEE_MANAGER_ADDRESS, user_provider.clone());
     let fee_manager = IFeeManager::new(TIP_FEE_MANAGER_ADDRESS, user_provider.clone());
 
-    // Seed AMM liquidity for user_token <-> PATH_USD
+    // Seed AMM liquidity for user_token <-> hop_token <-> PATH_USD.
     let liquidity = U256::from(500_000u64);
     sign_and_inject(
         &mut setup.node,
@@ -616,12 +647,28 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
         fee_amm
             .mint(
                 *user_fee_token.address(),
+                *hop_fee_token.address(),
+                liquidity,
+                user_address,
+            )
+            .into_transaction_request(),
+        6,
+    )
+    .await?;
+    setup.node.advance_block().await?;
+    sign_and_inject(
+        &mut setup.node,
+        &user_signer,
+        chain_id,
+        fee_amm
+            .mint(
+                *hop_fee_token.address(),
                 PATH_USD_ADDRESS,
                 liquidity,
                 user_address,
             )
             .into_transaction_request(),
-        3,
+        7,
     )
     .await?;
     setup.node.advance_block().await?;
@@ -634,7 +681,7 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
         fee_manager
             .setUserToken(*user_fee_token.address())
             .into_transaction_request(),
-        4,
+        8,
     )
     .await?;
     setup.node.advance_block().await?;
@@ -645,7 +692,7 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
         .call()
         .await?;
 
-    // Submit a transaction that pays fees in user_fee_token (not validator's PATH_USD)
+    // Submit a transaction that pays fees in user_fee_token and settles through the two-hop route.
     let attack_tx_hash = sign_and_inject(
         &mut setup.node,
         &user_signer,
@@ -653,7 +700,7 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
         ITIP20::new(PATH_USD_ADDRESS, user_provider.clone())
             .transfer(Address::random(), U256::from(1))
             .into_transaction_request(),
-        5,
+        9,
     )
     .await?;
 
@@ -669,7 +716,8 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
         attack_receipt.gas_used,
         attack_receipt.effective_gas_price(),
     );
-    let expected_post_swap = compute_amount_out(nominal_spending)?;
+    let one_hop_post_swap = compute_amount_out(nominal_spending)?;
+    let expected_post_swap = compute_amount_out(one_hop_post_swap)?;
 
     // Verify collected fees reflect the haircut
     let collected_after = fee_manager
@@ -678,6 +726,10 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
         .await?;
     let collected_delta = collected_after - collected_before;
 
+    assert!(
+        collected_delta < one_hop_post_swap,
+        "two-hop validator accrual ({collected_delta}) should be less than one-hop accrual ({one_hop_post_swap})"
+    );
     // The payload fee score must not exceed the actual validator revenue
     assert!(
         payload_fees <= nominal_spending,
@@ -687,9 +739,9 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
         collected_delta, expected_post_swap,
         "validator accrual should reflect AMM haircut"
     );
-    assert!(
-        payload_fees <= collected_delta,
-        "payload fee score ({payload_fees}) should not overstate actual validator revenue ({collected_delta})"
+    assert_eq!(
+        payload_fees, collected_delta,
+        "payload fee score should match actual validator revenue"
     );
 
     Ok(())

--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -616,8 +616,6 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
     let fee_beneficiary = Address::ZERO;
 
     // Create a two-hop fee route: user_fee_token -> hop_fee_token -> PATH_USD.
-    // Track the next available nonce so CodeQL doesn't flag sequential test nonces as
-    // hard-coded cryptographic values.
     let mut nonce = 0u64;
     let hop_fee_token = setup_token_manual_with_quote_and_nonce(
         &mut setup.node,

--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -33,15 +33,8 @@ async fn setup_token_manual<P>(
 where
     P: Provider + Clone,
 {
-    setup_token_manual_with_quote_and_nonce(
-        node,
-        provider,
-        sender,
-        chain_id,
-        PATH_USD_ADDRESS,
-        0,
-    )
-    .await
+    setup_token_manual_with_quote_and_nonce(node, provider, sender, chain_id, PATH_USD_ADDRESS, 0)
+        .await
 }
 
 async fn setup_token_manual_with_quote_and_nonce<P>(

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -537,9 +537,6 @@ where
 
                     // Score payload value by the validator-credited fee amount that the
                     // FeeManager precompile actually wrote during this transaction.
-                    if pool_tx.transaction.resolved_fee_token().is_none() {
-                        warn!("no resolved fee token for a pool transaction");
-                    }
                     total_fees += result.validator_fee();
 
                     // Notify transactions iterator about the new state.

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -19,7 +19,7 @@ use reth_engine_tree::tree::instrumented_state::InstrumentedStateProvider;
 use reth_errors::{ConsensusError, ProviderError};
 use reth_evm::{
     ConfigureEvm, Database, Evm, NextBlockEnvAttributes,
-    block::{BlockExecutionError, BlockExecutor, BlockValidationError, TxResult},
+    block::{BlockExecutionError, BlockExecutor, BlockValidationError},
     execute::{BlockBuilder, BlockBuilderOutcome},
 };
 use reth_execution_types::BlockExecutionOutput;
@@ -42,14 +42,11 @@ use std::{
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_evm::{TempoEvmConfig, TempoNextBlockEnvAttributes, TempoStateAccess, evm::TempoEvm};
 use tempo_payload_types::{TempoBuiltPayload, TempoPayloadAttributes};
-use tempo_precompiles::{tip_fee_manager::TipFeeManager, validator_config_v2::ValidatorConfigV2};
+use tempo_precompiles::validator_config_v2::ValidatorConfigV2;
 use tempo_primitives::{
     RecoveredSubBlock, SubBlockMetadata, TempoHeader, TempoTxEnvelope,
     subblock::PartialValidatorKey,
-    transaction::{
-        calc_gas_balance_spending,
-        envelope::{TEMPO_SYSTEM_TX_SENDER, TEMPO_SYSTEM_TX_SIGNATURE},
-    },
+    transaction::envelope::{TEMPO_SYSTEM_TX_SENDER, TEMPO_SYSTEM_TX_SIGNATURE},
 };
 use tempo_transaction_pool::{
     StateAwareBestTransactions, TempoTransactionPool,
@@ -422,7 +419,6 @@ where
             .record(prepare_system_txs_elapsed);
 
         let base_fee = builder.evm_mut().block().basefee;
-        let validator_fee_token = resolve_validator_fee_token(&mut builder)?;
         let pool_fetch_start = Instant::now();
         // Wrap best transactions into state-aware wrapper to skip transactions that
         // get invalidated by already-executed ones.
@@ -525,8 +521,6 @@ where
                 continue;
             }
 
-            let effective_gas_price = pool_tx.transaction.effective_gas_price(Some(base_fee));
-
             let tx_debug_repr = tracing::enabled!(Level::TRACE)
                 .then(|| format!("{:?}", pool_tx.transaction))
                 .unwrap_or_default();
@@ -541,27 +535,12 @@ where
                         non_payment_gas_used += result.block_gas_used();
                     }
 
-                    // Score payload value by actual validator payout, applying the AMM
-                    // haircut when the transaction's fee token differs from the validator's.
-                    let nominal_spending = calc_gas_balance_spending(
-                        result.result().result.tx_gas_used(),
-                        effective_gas_price,
-                    );
-                    if let Some(fee_token) = pool_tx.transaction.resolved_fee_token() {
-                        if fee_token == validator_fee_token {
-                            total_fees += nominal_spending;
-                        } else {
-                            total_fees +=
-                                tempo_precompiles::tip_fee_manager::amm::compute_amount_out(
-                                    nominal_spending,
-                                )
-                                .expect(
-                                    "execution succeeded, so compute_amount_out should not fail",
-                                );
-                        }
-                    } else {
-                        warn!("no resolved fee token for a pool transaction")
+                    // Score payload value by the validator-credited fee amount that the
+                    // FeeManager precompile actually wrote during this transaction.
+                    if pool_tx.transaction.resolved_fee_token().is_none() {
+                        warn!("no resolved fee token for a pool transaction");
                     }
+                    total_fees += result.validator_fee();
 
                     // Notify transactions iterator about the new state.
                     best_txs.on_new_result(result);
@@ -965,22 +944,6 @@ fn maybe_override_fee_recipient<DB: Database>(
             warn!(%err, "failed resolving fee recipient from contract; using fallback");
         }
     }
-}
-
-/// Resolves the validator's preferred fee token.
-fn resolve_validator_fee_token(
-    builder: &mut impl BlockBuilder<Executor: BlockExecutor<Evm = TempoEvm<impl Database>>>,
-) -> Result<Address, PayloadBuilderError> {
-    let ctx = builder.evm_mut().ctx_mut();
-    // We are using the database as a read-only storage context to avoid modifying the journal state.
-    // Reading slots here might be dangerous because they would end up being warmed and might affect gas accounting.
-    ctx.journaled_state
-        .database
-        .with_read_only_storage_ctx(ctx.cfg.spec, || {
-            TipFeeManager::new()
-                .get_validator_token(ctx.block.beneficiary)
-                .map_err(PayloadBuilderError::other)
-        })
 }
 
 #[cfg(test)]

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -568,14 +568,14 @@ mod tests {
             )?;
 
             // Call collect_fee_post_tx directly
-            let result = fee_manager.collect_fee_post_tx(
+            let credited = fee_manager.collect_fee_post_tx(
                 user,
                 actual_used,
                 refund_amount,
                 token.address(),
                 validator,
-            );
-            assert!(result.is_ok());
+            )?;
+            assert_eq!(credited, actual_used);
 
             // Verify fees were tracked
             let tracked_amount = fee_manager.collected_fees[validator][token.address()].read()?;
@@ -756,7 +756,7 @@ mod tests {
             )?;
 
             // Then call collect_fee_post_tx (executes swap immediately)
-            fee_manager.collect_fee_post_tx(
+            let credited = fee_manager.collect_fee_post_tx(
                 user,
                 actual_spending,
                 refund_amount,
@@ -766,6 +766,7 @@ mod tests {
 
             // Expected output: 800 * 9970 / 10000 = 797
             let expected_fee_amount = (actual_spending * U256::from(9970)) / U256::from(10000);
+            assert_eq!(credited, expected_fee_amount);
             let collected =
                 fee_manager.collected_fees[validator][validator_token.address()].read()?;
             assert_eq!(collected, expected_fee_amount);
@@ -1222,7 +1223,13 @@ mod tests {
 
                     let amount_u = U256::from(amount);
                     fm.collect_fee_pre_tx(user, t.user, amount_u, validator, false)?;
-                    fm.collect_fee_post_tx(user, amount_u, U256::ZERO, t.user, validator)?;
+                    let credited =
+                        fm.collect_fee_post_tx(user, amount_u, U256::ZERO, t.user, validator)?;
+                    let one_hop_amount = compute_amount_out(amount_u)?;
+                    assert!(
+                        credited < one_hop_amount,
+                        "amount={amount}: two-hop credit ({credited}) should be less than one-hop credit ({one_hop_amount})",
+                    );
 
                     assert_eq!(
                         fm.collected_fees[validator][t.validator].read()?,

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -226,7 +226,9 @@ impl TipFeeManager {
     /// Finalizes fee collection after transaction execution.
     ///
     /// Refunds unused `user_token` to `fee_payer` via [`TIP20Token`], executes the fee swap
-    /// through the AMM pool if tokens differ, and accumulates fees for the validator.
+    /// through the AMM pool if tokens differ, and accumulates fees for the validator. Returns
+    /// the validator-credited amount (post-feeAMM haircut, in the validator's fee token), which
+    /// is used by the payload builder to score blocks by actual proposer revenue.
     ///
     /// # Errors
     /// - `InvalidToken` — `fee_token` does not have a valid TIP-20 prefix
@@ -239,7 +241,7 @@ impl TipFeeManager {
         refund_amount: U256,
         fee_token: Address,
         beneficiary: Address,
-    ) -> Result<()> {
+    ) -> Result<U256> {
         // Refund unused tokens to user
         let mut tip20_token = TIP20Token::from_address(fee_token)?;
         tip20_token.transfer_fee_post_tx(fee_payer, refund_amount, actual_spending)?;
@@ -267,7 +269,7 @@ impl TipFeeManager {
 
         self.increment_collected_fees(beneficiary, validator_token, amount)?;
 
-        Ok(())
+        Ok(amount)
     }
 
     /// Increment collected fees for a specific validator and token combination.

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -31,6 +31,11 @@ pub struct TempoEvm<DB: Database, I> {
     >,
     /// The fee collected in `collectFeePreTx` call.
     pub(crate) collected_fee: U256,
+    /// The validator-credited amount (post-feeAMM haircut, in the validator's fee token) returned
+    /// by the most recent `collectFeePostTx` call.
+    ///
+    /// Reset to zero before each transaction so it reflects only the current tx.
+    pub validator_fee: U256,
     /// The fee token used to pay fees for the current transaction.
     pub(crate) fee_token: Option<Address>,
     /// The expiry timestamp of the access key used by the current transaction.
@@ -77,6 +82,7 @@ impl<DB: Database, I> TempoEvm<DB, I> {
         Self {
             inner,
             collected_fee: U256::ZERO,
+            validator_fee: U256::ZERO,
             fee_token: None,
             key_expiry: None,
             skip_valid_after_check: false,

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1481,7 +1481,7 @@ where
         let (journal, block, tx) = (&mut context.journaled_state, &context.block, &context.tx);
         let beneficiary = context.block.beneficiary();
 
-        StorageCtx::enter_evm(&mut *journal, block, &context.cfg, tx, || {
+        let credited = StorageCtx::enter_evm(&mut *journal, block, &context.cfg, tx, || {
             let mut fee_manager = TipFeeManager::new();
 
             if !actual_spending.is_zero() || !refund_amount.is_zero() {
@@ -1498,11 +1498,16 @@ where
                         fee_token,
                         beneficiary,
                     )
-                    .map_err(|e| EVMError::Custom(format!("{e:?}")))?;
+                    .map_err(|e| EVMError::Custom(format!("{e:?}")))
+            } else {
+                Ok(U256::ZERO)
             }
+        })?;
 
-            Ok(())
-        })
+        // Stash the per-tx credit so `TempoBlockExecutor` can surface it on `TempoTxResult`
+        // for payload scoring. Reset to zero on every tx entry below in `validate_env`.
+        evm.validator_fee = credited;
+        Ok(())
     }
 
     #[inline]
@@ -1523,6 +1528,9 @@ where
     /// - Time window validation (validAfter/validBefore)
     #[inline]
     fn validate_env(&self, evm: &mut Self::Evm) -> Result<(), Self::Error> {
+        // Reset per-tx validator fee.
+        evm.validator_fee = U256::ZERO;
+
         // Validate the fee payer signature
         let fee_payer = evm.ctx.tx.fee_payer()?;
 


### PR DESCRIPTION
this PR fixes payload fee scoring for the feeAMM routes introduced by TIP-1033.

it uses the validator-credited amount reported during post-transaction fee collection so block value reflects actual proposer revenue after one-hop or two-hop AMM haircuts, instead of estimating it in the payload builder.