### PR TITLE
chore: downgrade FCU no-op log from info to debug

### DIFF
--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -468,7 +468,7 @@ where
         if new_canonicalized == self.last_canonicalized
             && let JustCanonicalizeOrAlsoBuild::JustCanonicalize { response } = maybe_build
         {
-            info!("would not change forkchoice state; not sending it to the execution layer");
+            debug!("would not change forkchoice state; not sending it to the execution layer");
             let _ = response.send(Ok(()));
             return;
         }


### PR DESCRIPTION
The application actor calls `canonicalize_head(parent)` before verifying each new proposal. Since the parent is almost always already the canonical head from the previous round, the executor's dedup check fires and logs `"would not change forkchoice state"` at **info** level on every block — producing significant log noise.

Downgrade to **debug**.

Context: https://tempoxyz.slack.com/archives/C0A87C21805/p1778849298697289