### PR TITLE
feat(bench): use Grafana Performance dashboard with proper variables

### DIFF
--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -119,6 +119,13 @@ function repoLink(repo) {
   return `<https://github.com/${repo}|Tempo>`;
 }
 
+function buildGrafanaUrl(benchmarkId, referenceEpoch) {
+  if (!benchmarkId || !referenceEpoch) return null;
+  const fromMs = referenceEpoch * 1000;
+  const toMs = Date.now();
+  return `https://tempoxyz.grafana.net/d/dffj6qf1o30oowe/performance?orgId=1&from=${fromMs}&to=${toMs}&var-datasource=efk1hcn87dnnkd&var-filter_label=benchmark_id&var-filter_value=${benchmarkId}&var-group_by=benchmark_run`;
+}
+
 function fmtBlockCount(baselineBlocks, featureBlocks) {
   if (baselineBlocks == null && featureBlocks == null) return '-';
   if (baselineBlocks === featureBlocks) return `\`${baselineBlocks}\``;
@@ -196,6 +203,15 @@ function buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, re
       text: { type: 'plain_text', text: 'Diff :github:', emoji: true },
       url: diffUrl,
       action_id: 'diff_button',
+    });
+  }
+  const grafanaUrl = buildGrafanaUrl(summary.benchmark_id, summary.reference_epoch);
+  if (grafanaUrl) {
+    buttons.push({
+      type: 'button',
+      text: { type: 'plain_text', text: 'Grafana :chart_with_upwards_trend:', emoji: true },
+      url: grafanaUrl,
+      action_id: 'grafana_button',
     });
   }
 
@@ -440,6 +456,15 @@ function buildReplaySuccessBlocks({ summary, prNumber, actor, actorSlackId, jobU
           url: diffUrl,
           action_id: 'diff_button',
         },
+        ...((() => {
+          const gUrl = buildGrafanaUrl(process.env.BENCH_BENCHMARK_ID, Number(process.env.BENCH_REFERENCE_EPOCH));
+          return gUrl ? [{
+            type: 'button',
+            text: { type: 'plain_text', text: 'Grafana :chart_with_upwards_trend:', emoji: true },
+            url: gUrl,
+            action_id: 'grafana_button',
+          }] : [];
+        })()),
       ],
     },
   ];

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -51,6 +51,12 @@ WARMUP="${BENCH_WARMUP_BLOCKS:-1000}"
 
 mkdir -p "$BENCH_WORK_DIR"
 
+# Generate benchmark ID and reference epoch for Grafana dashboard links
+BENCH_BENCHMARK_ID="bench-replay-${CHAIN_NAME}-$(date -u +%Y%m%d-%H%M%S)"
+BENCH_REFERENCE_EPOCH=$(date +%s)
+echo "BENCH_BENCHMARK_ID=$BENCH_BENCHMARK_ID" >> "${GITHUB_ENV:-/dev/null}"
+echo "BENCH_REFERENCE_EPOCH=$BENCH_REFERENCE_EPOCH" >> "${GITHUB_ENV:-/dev/null}"
+
 # `cargo install` writes binaries to CARGO_HOME/bin, but self-hosted runner
 # services do not necessarily inherit a login-shell PATH for the runner user.
 CARGO_BIN_DIR="${CARGO_HOME:-$HOME/.cargo}/bin"
@@ -239,14 +245,26 @@ run_single() {
   total_mem_kb=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
   local mem_limit=$(( total_mem_kb * 95 / 100 * 1024 ))
 
+  # Build OTEL_RESOURCE_ATTRIBUTES with benchmark_id and benchmark_run labels
+  local run_type="" run_git_ref=""
+  case "$label" in
+    baseline*) run_type="baseline"; run_git_ref="${BASELINE_REF:-}" ;;
+    feature*)  run_type="feature"; run_git_ref="${FEATURE_REF:-}" ;;
+  esac
+  local otel_attrs="benchmark_id=${BENCH_BENCHMARK_ID},benchmark_run=${label},run_type=${run_type},git_ref=${run_git_ref}"
+  if [ -n "${OTEL_RESOURCE_ATTRIBUTES:-}" ]; then
+    otel_attrs="${OTEL_RESOURCE_ATTRIBUTES},${otel_attrs}"
+  fi
+
   local scope_env=(env)
   local env_name env_value
-  for env_name in TEMPO_TELEMETRY_URL OTEL_EXPORTER_OTLP_TRACES_ENDPOINT OTEL_RESOURCE_ATTRIBUTES OTEL_BSP_MAX_QUEUE_SIZE OTEL_BLRP_MAX_QUEUE_SIZE; do
+  for env_name in TEMPO_TELEMETRY_URL OTEL_EXPORTER_OTLP_TRACES_ENDPOINT OTEL_BSP_MAX_QUEUE_SIZE OTEL_BLRP_MAX_QUEUE_SIZE; do
     env_value="${!env_name:-}"
     if [ -n "$env_value" ]; then
       scope_env+=("${env_name}=${env_value}")
     fi
   done
+  scope_env+=("OTEL_RESOURCE_ATTRIBUTES=${otel_attrs}")
 
   # Start tempo node (drop back to runner user, matching bench-e2e.nu)
   local run_uid run_gid

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -711,7 +711,7 @@ jobs:
               if (refEpoch && benchId) {
                 const fromMs = refEpoch * 1000;
                 const toMs = Date.now();
-                const grafanaUrl = `https://tempoxyz.grafana.net/d/tikv2tn/tempo-bench?orgId=1&from=${fromMs}&to=${toMs}&var-benchmark_id=${benchId}&var-job=github-tempo-bench-e2e`;
+                const grafanaUrl = `https://tempoxyz.grafana.net/d/dffj6qf1o30oowe/performance?orgId=1&from=${fromMs}&to=${toMs}&var-datasource=efk1hcn87dnnkd&var-filter_label=benchmark_id&var-filter_value=${benchId}&var-group_by=benchmark_run`;
                 const logsPane = JSON.stringify({
                   pw4: {
                     datasource: 'ffdsfozmb3eo0e',

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -424,6 +424,12 @@ jobs:
           FEATURE_JSONS="$BENCH_WORK_DIR/feature-1/report.json $BENCH_WORK_DIR/feature-2/report.json"
           SUMMARY_ARGS="$SUMMARY_ARGS --baseline-json $BASELINE_JSONS"
           SUMMARY_ARGS="$SUMMARY_ARGS --feature-json $FEATURE_JSONS"
+          if [ -n "${BENCH_BENCHMARK_ID:-}" ] && [ -n "${BENCH_REFERENCE_EPOCH:-}" ]; then
+            FROM_MS=$(( BENCH_REFERENCE_EPOCH * 1000 ))
+            TO_MS=$(( $(date +%s) * 1000 ))
+            GRAFANA_URL="https://tempoxyz.grafana.net/d/dffj6qf1o30oowe/performance?orgId=1&from=${FROM_MS}&to=${TO_MS}&var-datasource=efk1hcn87dnnkd&var-filter_label=benchmark_id&var-filter_value=${BENCH_BENCHMARK_ID}&var-group_by=benchmark_run"
+            SUMMARY_ARGS="$SUMMARY_ARGS --grafana-url ${GRAFANA_URL}"
+          fi
           # shellcheck disable=SC2086
           python3 .github/scripts/bench-replay-summary.py $SUMMARY_ARGS
 


### PR DESCRIPTION
Updates both e2e and replay benchmarks to link to the new [Performance dashboard](https://tempoxyz.grafana.net/d/dffj6qf1o30oowe/performance) instead of the old `tempo-bench` dashboard.

### E2E
- PR comment Grafana URL now points to `dffj6qf1o30oowe/performance` with `var-datasource`, `var-filter_label=benchmark_id`, `var-filter_value`, `var-group_by=benchmark_run`
- Slack notification includes a Grafana button

### Replay
- Generates `benchmark_id` (`bench-replay-{chain}-{timestamp}`) and `reference_epoch` in the replay script
- Sets `OTEL_RESOURCE_ATTRIBUTES` per run with `benchmark_id`, `benchmark_run`, `run_type`, `git_ref` (mirrors e2e behavior)
- Passes `--grafana-url` to `bench-replay-summary.py` so the PR comment includes the dashboard link
- Slack notification includes a Grafana button