### PR TITLE
bench: add ref input to bench-e2e-scheduled for manual release runs

### DIFF
--- a/.github/scripts/bench-e2e-scheduled-refs.sh
+++ b/.github/scripts/bench-e2e-scheduled-refs.sh
@@ -68,10 +68,16 @@ IS_STALE="false"
 AGE_HOURS="0"
 CREATED_AT=""
 
-if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+if [ -n "${INPUT_REF:-}" ] || [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
   RUN_TYPE="release"
   ACTOR="e2e-release"
-  CURRENT_TAG="${GITHUB_REF_NAME:-}"
+
+  if [ -n "${INPUT_REF:-}" ]; then
+    CURRENT_TAG="$INPUT_REF"
+    echo "Using manually provided ref: $CURRENT_TAG"
+  else
+    CURRENT_TAG="${GITHUB_REF_NAME:-}"
+  fi
 
   if [ -z "$CURRENT_TAG" ]; then
     echo "::error::GITHUB_REF_NAME is not set for tag run"

--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -16,6 +16,11 @@ on:
       - "v*.*.*"
   workflow_dispatch:
     inputs:
+      ref:
+        description: "Git ref (tag or branch) to benchmark as a release run. When set, the workflow runs as a release comparison (ref vs. previous tag) without needing `--ref`."
+        required: false
+        default: ""
+        type: string
       force:
         description: "Force run even if no new nightly commit is available"
         required: false
@@ -51,6 +56,7 @@ jobs:
           DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           INPUT_FORCE: ${{ inputs.force || 'false' }}
+          INPUT_REF: ${{ inputs.ref || '' }}
         run: |
           presets=(tip20 mix)
           bench_entries=()


### PR DESCRIPTION
## Problem

`gh workflow run bench-e2e-scheduled.yml --ref v1.7.0` fails because GitHub tries to find the workflow on the `v1.7.0` tag, which doesn't have the `workflow_dispatch` trigger:

```
could not create workflow dispatch event: HTTP 422: Workflow does not have 'workflow_dispatch' trigger
```

## Solution

Adds a `ref` input to the `workflow_dispatch` trigger so the workflow can be dispatched from `main` while benchmarking an arbitrary tag/ref:

```
gh workflow run bench-e2e-scheduled.yml -f ref=v1.7.0
```

When `ref` is set, `bench-e2e-scheduled-refs.sh` treats it as a release run and resolves the previous tag for the baseline comparison, exactly as a real tag push would.

## Changes

- **`.github/workflows/bench-e2e-scheduled.yml`**: Added `ref` string input to `workflow_dispatch`, passed as `INPUT_REF` env var
- **`.github/scripts/bench-e2e-scheduled-refs.sh`**: When `INPUT_REF` is set, enter the release tag code path using the provided ref instead of `GITHUB_REF_NAME`