### PR TITLE
bench: fetch tags before resolving git_ref in replay script

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -337,6 +337,7 @@ run_single() {
   # Resolve git_ref: tag if tagged, otherwise branch name, otherwise raw SHA
   local git_ref="$git_sha"
   if [ -n "$git_sha" ]; then
+    git fetch --tags --quiet 2>/dev/null || true
     local tag_name
     tag_name=$(git tag --points-at "$git_sha" 2>/dev/null | head -1)
     if [ -n "$tag_name" ]; then

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -545,50 +545,54 @@ jobs:
         id: refs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          INPUT_BASELINE: ${{ inputs.baseline }}
-          INPUT_FEATURE: ${{ inputs.feature }}
-          INPUT_SHA: ${{ github.sha }}
-          INPUT_PR_HEAD_SHA: ${{ steps.pr-info.outputs.head-sha }}
-          INPUT_PR_HEAD_REF: ${{ steps.pr-info.outputs.head-ref }}
+         INPUT_BASELINE: ${{ inputs.baseline }}
+         INPUT_FEATURE: ${{ inputs.feature }}
+         INPUT_BASELINE_NAME: ${{ inputs.baseline-name }}
+         INPUT_FEATURE_NAME: ${{ inputs.feature-name }}
+         INPUT_SHA: ${{ github.sha }}
+         INPUT_PR_HEAD_SHA: ${{ steps.pr-info.outputs.head-sha }}
+         INPUT_PR_HEAD_REF: ${{ steps.pr-info.outputs.head-ref }}
         with:
-          script: |
-            const { execSync } = require('child_process');
-            const run = (cmd) => execSync(cmd, { encoding: 'utf8' }).trim();
+         script: |
+           const { execSync } = require('child_process');
+           const run = (cmd) => execSync(cmd, { encoding: 'utf8' }).trim();
 
-            const baselineArg = process.env.INPUT_BASELINE;
-            const featureArg = process.env.INPUT_FEATURE;
+           const baselineArg = process.env.INPUT_BASELINE;
+           const featureArg = process.env.INPUT_FEATURE;
+           const baselineNameArg = process.env.INPUT_BASELINE_NAME;
+           const featureNameArg = process.env.INPUT_FEATURE_NAME;
 
-            let baselineRef, baselineName, featureRef, featureName;
+           let baselineRef, baselineName, featureRef, featureName;
 
-            if (baselineArg) {
-              try { run(`git fetch origin "${baselineArg}" --quiet`); } catch {}
-              try {
-                baselineRef = run(`git rev-parse "${baselineArg}"`);
-              } catch {
-                baselineRef = run(`git rev-parse "origin/${baselineArg}"`);
-              }
-              baselineName = baselineArg;
-            } else {
-              try {
-                baselineRef = run('git merge-base HEAD origin/main');
-              } catch {
-                baselineRef = process.env.INPUT_SHA;
-              }
-              baselineName = 'main';
-            }
+           if (baselineArg) {
+             try { run(`git fetch origin "${baselineArg}" --quiet`); } catch {}
+             try {
+               baselineRef = run(`git rev-parse "${baselineArg}"`);
+             } catch {
+               baselineRef = run(`git rev-parse "origin/${baselineArg}"`);
+             }
+             baselineName = baselineNameArg || baselineArg;
+           } else {
+             try {
+               baselineRef = run('git merge-base HEAD origin/main');
+             } catch {
+               baselineRef = process.env.INPUT_SHA;
+             }
+             baselineName = baselineNameArg || 'main';
+           }
 
-            if (featureArg) {
-              try { run(`git fetch origin "${featureArg}" --quiet`); } catch {}
-              try {
-                featureRef = run(`git rev-parse "${featureArg}"`);
-              } catch {
-                featureRef = run(`git rev-parse "origin/${featureArg}"`);
-              }
-              featureName = featureArg;
-            } else {
-              featureRef = process.env.INPUT_PR_HEAD_SHA;
-              featureName = process.env.INPUT_PR_HEAD_REF;
-            }
+           if (featureArg) {
+             try { run(`git fetch origin "${featureArg}" --quiet`); } catch {}
+             try {
+               featureRef = run(`git rev-parse "${featureArg}"`);
+             } catch {
+               featureRef = run(`git rev-parse "origin/${featureArg}"`);
+             }
+             featureName = featureNameArg || featureArg;
+           } else {
+             featureRef = process.env.INPUT_PR_HEAD_SHA;
+             featureName = featureNameArg || process.env.INPUT_PR_HEAD_REF;
+           }
 
             core.setOutput('baseline-ref', baselineRef);
             core.setOutput('baseline-name', baselineName);


### PR DESCRIPTION
The shallow checkout on benchmark runners doesn't have tags, so `git tag --points-at` always returned empty for release runs. Adds `git fetch --tags` so release tags like `v1.7.0` are properly resolved instead of posting raw SHAs to the perf dashboard.