### PR TITLE
chore: consolidate `validate_<transfer/mint>` checks

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -817,9 +817,7 @@ impl TIP20Token {
     pub fn transfer(&mut self, msg_sender: Address, call: ITIP20::transferCall) -> Result<bool> {
         trace!(%msg_sender, ?call, "transferring TIP20");
         let Some(to) =
-            self.validate_transfer(msg_sender, call.to, call.amount, B256::ZERO, |this| {
-                this.check_and_update_spending_limit(msg_sender, call.amount)
-            })?
+            self.validate_transfer(msg_sender, msg_sender, call.to, call.amount, B256::ZERO)?
         else {
             return Ok(true);
         };
@@ -847,9 +845,7 @@ impl TIP20Token {
         call: ITIP20::transferFromCall,
     ) -> Result<bool> {
         let Some(to) =
-            self.validate_transfer(call.from, call.to, call.amount, B256::ZERO, |this| {
-                this.consume_allowance(call.from, msg_sender, call.amount)
-            })?
+            self.validate_transfer(msg_sender, call.from, call.to, call.amount, B256::ZERO)?
         else {
             return Ok(true);
         };
@@ -869,9 +865,7 @@ impl TIP20Token {
         call: ITIP20::transferFromWithMemoCall,
     ) -> Result<bool> {
         let Some(to) =
-            self.validate_transfer(call.from, call.to, call.amount, call.memo, |this| {
-                this.consume_allowance(call.from, msg_sender, call.amount)
-            })?
+            self.validate_transfer(msg_sender, call.from, call.to, call.amount, call.memo)?
         else {
             return Ok(true);
         };
@@ -920,10 +914,7 @@ impl TIP20Token {
             return Err(TIP20Error::unauthorized().into());
         }
 
-        let Some(to) = self.validate_transfer(from, caller, amount, B256::ZERO, |this| {
-            this.check_and_update_spending_limit(from, amount)
-        })?
-        else {
+        let Some(to) = self.validate_transfer(from, from, caller, amount, B256::ZERO)? else {
             return Ok(true);
         };
 
@@ -958,9 +949,7 @@ impl TIP20Token {
         call: ITIP20::transferWithMemoCall,
     ) -> Result<()> {
         let Some(to) =
-            self.validate_transfer(msg_sender, call.to, call.amount, call.memo, |this| {
-                this.check_and_update_spending_limit(msg_sender, call.amount)
-            })?
+            self.validate_transfer(msg_sender, msg_sender, call.to, call.amount, call.memo)?
         else {
             return Ok(());
         };
@@ -1066,27 +1055,29 @@ impl TIP20Token {
     /// authorization, and runs the caller-specific spend check. Additionally (+T6) applies
     /// TIP-1028 address-level receive policies.
     ///
-    /// `validate_spend` updates the sender's [`AccountKeychain`] spending limit for direct
-    /// transfers, or consumes allowance for `transfer_from` style calls.
+    /// Updates the sender's [`AccountKeychain`] spending limit for direct transfers, and
+    /// consumes allowance for `transfer_from` style calls.
     ///
     /// Returns `Some(to)` when the caller should perform the normal transfer.
     /// Returns `None` when funds were escrowed, and the caller should return immediately.
-    fn validate_transfer<F>(
+    fn validate_transfer(
         &mut self,
+        msg_sender: Address,
         from: Address,
         to: Address,
         amount: U256,
         memo: B256,
-        validate_spend: F,
-    ) -> Result<Option<Recipient>>
-    where
-        F: FnOnce(&mut Self) -> Result<()>,
-    {
+    ) -> Result<Option<Recipient>> {
         let to = Recipient::resolve(to)?;
         self.check_not_paused()?;
         to.validate()?;
         self.ensure_transfer_authorized(from, to.target)?;
-        validate_spend(self)?;
+
+        if msg_sender == from {
+            self.check_and_update_spending_limit(msg_sender, amount)?;
+        } else {
+            self.consume_allowance(from, msg_sender, amount)?;
+        }
 
         if self.validate_inbound_or_escrow(from, &to, amount, InboundKind::TRANSFER, memo)? {
             return Ok(None);

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -817,7 +817,7 @@ impl TIP20Token {
     pub fn transfer(&mut self, msg_sender: Address, call: ITIP20::transferCall) -> Result<bool> {
         trace!(%msg_sender, ?call, "transferring TIP20");
         let Some(to) =
-            self.validate_transfer(msg_sender, msg_sender, call.to, call.amount, B256::ZERO)?
+            self.validate_transfer(None, msg_sender, call.to, call.amount, B256::ZERO)?
         else {
             return Ok(true);
         };
@@ -844,8 +844,13 @@ impl TIP20Token {
         msg_sender: Address,
         call: ITIP20::transferFromCall,
     ) -> Result<bool> {
-        let Some(to) =
-            self.validate_transfer(msg_sender, call.from, call.to, call.amount, B256::ZERO)?
+        let Some(to) = self.validate_transfer(
+            Some(msg_sender),
+            call.from,
+            call.to,
+            call.amount,
+            B256::ZERO,
+        )?
         else {
             return Ok(true);
         };
@@ -865,7 +870,7 @@ impl TIP20Token {
         call: ITIP20::transferFromWithMemoCall,
     ) -> Result<bool> {
         let Some(to) =
-            self.validate_transfer(msg_sender, call.from, call.to, call.amount, call.memo)?
+            self.validate_transfer(Some(msg_sender), call.from, call.to, call.amount, call.memo)?
         else {
             return Ok(true);
         };
@@ -914,7 +919,7 @@ impl TIP20Token {
             return Err(TIP20Error::unauthorized().into());
         }
 
-        let Some(to) = self.validate_transfer(from, from, caller, amount, B256::ZERO)? else {
+        let Some(to) = self.validate_transfer(None, from, caller, amount, B256::ZERO)? else {
             return Ok(true);
         };
 
@@ -948,8 +953,7 @@ impl TIP20Token {
         msg_sender: Address,
         call: ITIP20::transferWithMemoCall,
     ) -> Result<()> {
-        let Some(to) =
-            self.validate_transfer(msg_sender, msg_sender, call.to, call.amount, call.memo)?
+        let Some(to) = self.validate_transfer(None, msg_sender, call.to, call.amount, call.memo)?
         else {
             return Ok(());
         };
@@ -1062,7 +1066,7 @@ impl TIP20Token {
     /// Returns `None` when funds were escrowed, and the caller should return immediately.
     fn validate_transfer(
         &mut self,
-        msg_sender: Address,
+        spender: Option<Address>,
         from: Address,
         to: Address,
         amount: U256,
@@ -1073,10 +1077,10 @@ impl TIP20Token {
         to.validate()?;
         self.ensure_transfer_authorized(from, to.target)?;
 
-        if msg_sender == from {
-            self.check_and_update_spending_limit(msg_sender, amount)?;
+        if let Some(spender) = spender {
+            self.consume_allowance(from, spender, amount)?;
         } else {
-            self.consume_allowance(from, msg_sender, amount)?;
+            self.check_and_update_spending_limit(from, amount)?;
         }
 
         if self.validate_inbound_or_escrow(from, &to, amount, InboundKind::TRANSFER, memo)? {

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -829,16 +829,9 @@ impl TIP20Token {
     pub fn transfer(&mut self, msg_sender: Address, call: ITIP20::transferCall) -> Result<bool> {
         trace!(%msg_sender, ?call, "transferring TIP20");
         let to = Recipient::resolve(call.to)?;
-        self.validate_transfer(msg_sender, &to)?;
-        self.check_and_update_spending_limit(msg_sender, call.amount)?;
-
-        if self.validate_inbound_or_escrow(
-            msg_sender,
-            &to,
-            call.amount,
-            InboundKind::TRANSFER,
-            B256::ZERO,
-        )? {
+        if self.validate_transfer(msg_sender, &to, call.amount, B256::ZERO, |this| {
+            this.check_and_update_spending_limit(msg_sender, call.amount)
+        })? {
             return Ok(true);
         }
 
@@ -865,16 +858,9 @@ impl TIP20Token {
         call: ITIP20::transferFromCall,
     ) -> Result<bool> {
         let to = Recipient::resolve(call.to)?;
-        self.validate_transfer(call.from, &to)?;
-        self.consume_allowance(call.from, msg_sender, call.amount)?;
-
-        if self.validate_inbound_or_escrow(
-            call.from,
-            &to,
-            call.amount,
-            InboundKind::TRANSFER,
-            B256::ZERO,
-        )? {
+        if self.validate_transfer(call.from, &to, call.amount, B256::ZERO, |this| {
+            this.consume_allowance(call.from, msg_sender, call.amount)
+        })? {
             return Ok(true);
         }
 
@@ -882,6 +868,7 @@ impl TIP20Token {
         if let Some(hop) = to.build_virtual_transfer_event(call.amount) {
             self.emit_event(hop)?;
         }
+
         Ok(true)
     }
 
@@ -892,16 +879,9 @@ impl TIP20Token {
         call: ITIP20::transferFromWithMemoCall,
     ) -> Result<bool> {
         let to = Recipient::resolve(call.to)?;
-        self.validate_transfer(call.from, &to)?;
-        self.consume_allowance(call.from, msg_sender, call.amount)?;
-
-        if self.validate_inbound_or_escrow(
-            call.from,
-            &to,
-            call.amount,
-            InboundKind::TRANSFER,
-            call.memo,
-        )? {
+        if self.validate_transfer(call.from, &to, call.amount, call.memo, |this| {
+            this.consume_allowance(call.from, msg_sender, call.amount)
+        })? {
             return Ok(true);
         }
 
@@ -950,10 +930,9 @@ impl TIP20Token {
         }
 
         let to = Recipient::resolve(caller)?;
-        self.validate_transfer(from, &to)?;
-        self.check_and_update_spending_limit(from, amount)?;
-
-        if self.validate_inbound_or_escrow(from, &to, amount, InboundKind::TRANSFER, B256::ZERO)? {
+        if self.validate_transfer(from, &to, amount, B256::ZERO, |this| {
+            this.check_and_update_spending_limit(from, amount)
+        })? {
             return Ok(true);
         }
 
@@ -988,16 +967,9 @@ impl TIP20Token {
         call: ITIP20::transferWithMemoCall,
     ) -> Result<()> {
         let to = Recipient::resolve(call.to)?;
-        self.validate_transfer(msg_sender, &to)?;
-        self.check_and_update_spending_limit(msg_sender, call.amount)?;
-
-        if self.validate_inbound_or_escrow(
-            msg_sender,
-            &to,
-            call.amount,
-            InboundKind::TRANSFER,
-            call.memo,
-        )? {
+        if self.validate_transfer(msg_sender, &to, call.amount, call.memo, |this| {
+            this.check_and_update_spending_limit(msg_sender, call.amount)
+        })? {
             return Ok(());
         }
 
@@ -1100,10 +1072,22 @@ impl TIP20Token {
 
     /// Checks pause state, validates the effective recipient, and ensures the transfer
     /// is authorized. Shared by public entrypoints that resolve a [`Recipient`] up front.
-    fn validate_transfer(&self, from: Address, to: &Recipient) -> Result<()> {
+    fn validate_transfer<F>(
+        &mut self,
+        from: Address,
+        to: &Recipient,
+        amount: U256,
+        memo: B256,
+        validate_spend: F,
+    ) -> Result<bool>
+    where
+        F: FnOnce(&mut Self) -> Result<()>,
+    {
         self.check_not_paused()?;
         to.validate()?;
-        self.ensure_transfer_authorized(from, to.target)
+        self.ensure_transfer_authorized(from, to.target)?;
+        validate_spend(self)?;
+        self.validate_inbound_or_escrow(from, to, amount, InboundKind::TRANSFER, memo)
     }
 
     /// Resolves the effective recipient and verifies that `msg_sender` has the issuer role.

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -497,17 +497,11 @@ impl TIP20Token {
     /// - `PolicyForbids` — TIP-403 policy rejects the mint recipient
     /// - `SupplyCapExceeded` — minting would push total supply above the cap
     pub fn mint(&mut self, msg_sender: Address, call: ITIP20::mintCall) -> Result<()> {
-        let (to, total_supply) = self.validate_mint(msg_sender, call.to)?;
-
-        if self.validate_inbound_or_escrow(
-            msg_sender,
-            &to,
-            call.amount,
-            InboundKind::MINT,
-            B256::ZERO,
-        )? {
+        let Some((to, total_supply)) =
+            self.validate_mint(msg_sender, call.to, call.amount, B256::ZERO)?
+        else {
             return Ok(());
-        }
+        };
 
         self._mint(&to, call.amount, total_supply)?;
         self.emit_event(TIP20Event::Mint(ITIP20::Mint {
@@ -527,17 +521,11 @@ impl TIP20Token {
         msg_sender: Address,
         call: ITIP20::mintWithMemoCall,
     ) -> Result<()> {
-        let (to, total_supply) = self.validate_mint(msg_sender, call.to)?;
-
-        if self.validate_inbound_or_escrow(
-            msg_sender,
-            &to,
-            call.amount,
-            InboundKind::MINT,
-            call.memo,
-        )? {
+        let Some((to, total_supply)) =
+            self.validate_mint(msg_sender, call.to, call.amount, call.memo)?
+        else {
             return Ok(());
-        }
+        };
 
         self._mint(&to, call.amount, total_supply)?;
         self.emit_event(TIP20Event::TransferWithMemo(ITIP20::TransferWithMemo {
@@ -828,12 +816,13 @@ impl TIP20Token {
     /// - `InsufficientBalance` — sender balance lower than transfer amount
     pub fn transfer(&mut self, msg_sender: Address, call: ITIP20::transferCall) -> Result<bool> {
         trace!(%msg_sender, ?call, "transferring TIP20");
-        let to = Recipient::resolve(call.to)?;
-        if self.validate_transfer(msg_sender, &to, call.amount, B256::ZERO, |this| {
-            this.check_and_update_spending_limit(msg_sender, call.amount)
-        })? {
+        let Some(to) =
+            self.validate_transfer(msg_sender, call.to, call.amount, B256::ZERO, |this| {
+                this.check_and_update_spending_limit(msg_sender, call.amount)
+            })?
+        else {
             return Ok(true);
-        }
+        };
 
         self._transfer(msg_sender, &to, call.amount)?;
         if let Some(hop) = to.build_virtual_transfer_event(call.amount) {
@@ -857,12 +846,13 @@ impl TIP20Token {
         msg_sender: Address,
         call: ITIP20::transferFromCall,
     ) -> Result<bool> {
-        let to = Recipient::resolve(call.to)?;
-        if self.validate_transfer(call.from, &to, call.amount, B256::ZERO, |this| {
-            this.consume_allowance(call.from, msg_sender, call.amount)
-        })? {
+        let Some(to) =
+            self.validate_transfer(call.from, call.to, call.amount, B256::ZERO, |this| {
+                this.consume_allowance(call.from, msg_sender, call.amount)
+            })?
+        else {
             return Ok(true);
-        }
+        };
 
         self._transfer(call.from, &to, call.amount)?;
         if let Some(hop) = to.build_virtual_transfer_event(call.amount) {
@@ -878,12 +868,13 @@ impl TIP20Token {
         msg_sender: Address,
         call: ITIP20::transferFromWithMemoCall,
     ) -> Result<bool> {
-        let to = Recipient::resolve(call.to)?;
-        if self.validate_transfer(call.from, &to, call.amount, call.memo, |this| {
-            this.consume_allowance(call.from, msg_sender, call.amount)
-        })? {
+        let Some(to) =
+            self.validate_transfer(call.from, call.to, call.amount, call.memo, |this| {
+                this.consume_allowance(call.from, msg_sender, call.amount)
+            })?
+        else {
             return Ok(true);
-        }
+        };
 
         self._transfer(call.from, &to, call.amount)?;
         self.emit_event(TIP20Event::TransferWithMemo(ITIP20::TransferWithMemo {
@@ -929,12 +920,12 @@ impl TIP20Token {
             return Err(TIP20Error::unauthorized().into());
         }
 
-        let to = Recipient::resolve(caller)?;
-        if self.validate_transfer(from, &to, amount, B256::ZERO, |this| {
+        let Some(to) = self.validate_transfer(from, caller, amount, B256::ZERO, |this| {
             this.check_and_update_spending_limit(from, amount)
-        })? {
+        })?
+        else {
             return Ok(true);
-        }
+        };
 
         self._transfer(from, &to, amount)?;
         if let Some(hop) = to.build_virtual_transfer_event(amount) {
@@ -966,12 +957,13 @@ impl TIP20Token {
         msg_sender: Address,
         call: ITIP20::transferWithMemoCall,
     ) -> Result<()> {
-        let to = Recipient::resolve(call.to)?;
-        if self.validate_transfer(msg_sender, &to, call.amount, call.memo, |this| {
-            this.check_and_update_spending_limit(msg_sender, call.amount)
-        })? {
+        let Some(to) =
+            self.validate_transfer(msg_sender, call.to, call.amount, call.memo, |this| {
+                this.check_and_update_spending_limit(msg_sender, call.amount)
+            })?
+        else {
             return Ok(());
-        }
+        };
 
         self._transfer(msg_sender, &to, call.amount)?;
         self.emit_event(TIP20Event::TransferWithMemo(ITIP20::TransferWithMemo {
@@ -1070,32 +1062,53 @@ impl TIP20Token {
         Ok(())
     }
 
-    /// Checks pause state, validates the effective recipient, and ensures the transfer
-    /// is authorized. Shared by public entrypoints that resolve a [`Recipient`] up front.
+    /// Resolves `to`, checks pause state and recipient validity, ensures TIP-403 transfer
+    /// authorization, and runs the caller-specific spend check. Additionally (+T6) applies
+    /// TIP-1028 address-level receive policies.
+    ///
+    /// `validate_spend` updates the sender's [`AccountKeychain`] spending limit for direct
+    /// transfers, or consumes allowance for `transfer_from` style calls.
+    ///
+    /// Returns `Some(to)` when the caller should perform the normal transfer.
+    /// Returns `None` when funds were escrowed, and the caller should return immediately.
     fn validate_transfer<F>(
         &mut self,
         from: Address,
-        to: &Recipient,
+        to: Address,
         amount: U256,
         memo: B256,
         validate_spend: F,
-    ) -> Result<bool>
+    ) -> Result<Option<Recipient>>
     where
         F: FnOnce(&mut Self) -> Result<()>,
     {
+        let to = Recipient::resolve(to)?;
         self.check_not_paused()?;
         to.validate()?;
         self.ensure_transfer_authorized(from, to.target)?;
         validate_spend(self)?;
-        self.validate_inbound_or_escrow(from, to, amount, InboundKind::TRANSFER, memo)
+
+        if self.validate_inbound_or_escrow(from, &to, amount, InboundKind::TRANSFER, memo)? {
+            return Ok(None);
+        }
+
+        Ok(Some(to))
     }
 
-    /// Resolves the effective recipient and verifies that `msg_sender` has the issuer role.
+    /// Resolves `to`, checks the issuer role, and ensures TIP-403 mint-recipient authorization.
     /// To preserve re-execution of old transactions (pre-T6), also reads total_supply.
-    /// Additionally (+T3) checks pause state and validates the effective recipient.
+    /// Additionally (+T3) checks pause state and validates the effective recipient; also
+    /// (+T6) applies TIP-1028 address-level receive policies.
     ///
-    /// Returns the resolved [`Recipient`] and, pre-T6, the total_supply.
-    fn validate_mint(&self, msg_sender: Address, to: Address) -> Result<(Recipient, Option<U256>)> {
+    /// Returns `Some((to, total_supply))` when the caller should proceed with the regular mint.
+    /// Returns `None` when funds were minted and escrowed, and the caller should return immediately.
+    fn validate_mint(
+        &mut self,
+        msg_sender: Address,
+        to: Address,
+        amount: U256,
+        memo: B256,
+    ) -> Result<Option<(Recipient, Option<U256>)>> {
         let to = Recipient::resolve(to)?;
         self.check_role(msg_sender, *ISSUER_ROLE)?;
 
@@ -1119,7 +1132,11 @@ impl TIP20Token {
             return Err(TIP20Error::policy_forbids().into());
         }
 
-        Ok((to, total_supply))
+        if self.validate_inbound_or_escrow(msg_sender, &to, amount, InboundKind::MINT, memo)? {
+            return Ok(None);
+        }
+
+        Ok(Some((to, total_supply)))
     }
 
     /// Check whether a transfer is authorized by the token's [`TIP403Registry`] policy.


### PR DESCRIPTION
this PR consolidates all the transfer and mint check —including the receive policy validation—  inside their corresponding validation functions.

motivation:
- https://github.com/tempoxyz/tempo/pull/3800#discussion_r3242606609
- https://github.com/tempoxyz/tempo/pull/3800#discussion_r3242633818