### PR TITLE
ci(bench): scrape metrics from both e2e validators

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -758,7 +758,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --preset-path $ctx.preset_path
                 --generate-rpc-url $a_rpc
                 --submit-rpc-url $a_rpc
-                --metrics-url "http://127.0.0.1:9001/metrics"
+                --metrics-url ["a:http://127.0.0.1:9001/metrics" "b:http://127.0.0.1:9101/metrics"]
                 --report-path $"($ctx.results_dir)/report-($phase).json"
                 --tps $ctx.tps
                 --duration $ctx.duration

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -141,7 +141,7 @@ def run-txgen-bench-single [
         --preset-path $preset_path
         --generate-rpc-url "http://localhost:8545"
         --submit-rpc-url "http://localhost:8545"
-        --metrics-url "http://127.0.0.1:9090/metrics"
+        --metrics-url ["http://127.0.0.1:9090/metrics"]
         --report-path $report_path
         --tps $tps
         --duration $duration

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -181,7 +181,7 @@ def txgen-run-preset-pipeline [
     --preset-path: string
     --generate-rpc-url: string
     --submit-rpc-url: string
-    --metrics-url: string
+    --metrics-url: list<string>
     --report-path: string
     --tps: int
     --duration: int
@@ -223,13 +223,14 @@ def txgen-run-preset-pipeline [
         "--seed" $TXGEN_HELPER_DEFAULT_SEED
         "--rpc" $generate_rpc_url
     ]
+    let metrics_url_args = ($metrics_url | each { |url| ["--metrics-url" $url] } | flatten)
     let bench_base_cmd = [
         $txgen_bench_bin
         "send"
         "--rpc-url" $submit_rpc_url
         "--tps" $tps
         "--max-concurrent" $max_concurrent_requests
-        "--metrics-url" $metrics_url
+        ...$metrics_url_args
         "--scrape-interval-ms" $TXGEN_HELPER_SCRAPE_INTERVAL_MS
         "--drain-timeout" $TXGEN_HELPER_DRAIN_TIMEOUT_SECS
     ]

--- a/tempo.nu
+++ b/tempo.nu
@@ -518,7 +518,7 @@ def run-bench-single [
     --txgen-tempo-bin: string
     --txgen-bench-bin: string
     --rpc-urls: string
-    --metrics-url: string
+    --metrics-url: list<string>
     --genesis-path: string
     --datadir: string
     --run-label: string
@@ -2185,7 +2185,7 @@ def "main bench" [
                 --txgen-tempo-bin $txgen.txgen_tempo_bin
                 --txgen-bench-bin $txgen.txgen_bench_bin
                 --rpc-urls "http://localhost:8545"
-                --metrics-url "http://127.0.0.1:9090/metrics"
+                --metrics-url ["http://127.0.0.1:9090/metrics"]
                 --genesis-path $run.genesis --datadir $run.datadir
                 --run-label $run.label --results-dir $results_dir
                 --tps $tps --duration $duration --accounts $accounts
@@ -2310,7 +2310,7 @@ def "main bench" [
             --preset-path $preset_path
             --generate-rpc-url $primary_rpc_url
             --submit-rpc-url $submit_rpc_url
-            --metrics-url "http://127.0.0.1:9001/metrics"
+            --metrics-url ["http://127.0.0.1:9001/metrics"]
             --report-path "report.json"
             --tps $tps
             --duration $duration
@@ -2725,7 +2725,7 @@ tempo-precompiles = { path = '($tempo_root)/crates/precompiles' }
                         --preset-path $live_preset_path
                         --generate-rpc-url "http://localhost:8545"
                         --submit-rpc-url "http://localhost:8545"
-                        --metrics-url "http://127.0.0.1:9001/metrics"
+                        --metrics-url ["http://127.0.0.1:9001/metrics"]
                         --report-path "report.json"
                         --tps $tps
                         --duration $duration


### PR DESCRIPTION
Uses txgen's multiple metric labels feature to scrape Prometheus metrics from both local e2e validators (a and b) during benchmark runs.

Previously only validator a's metrics (port 9001) were scraped. Now both a (9001) and b (9101) are scraped with `node=a` and `node=b` labels, so per-validator metrics are distinguishable in reports and VictoriaMetrics exports.

### Changes

- **`contrib/bench/txgen/helpers.nu`**: Change `--metrics-url` param from `string` to `list<string>`, expand into repeated `--metrics-url` CLI args
- **`bench-e2e.nu`**: Pass labeled URLs for both validators: `a:http://127.0.0.1:9001/metrics` and `b:http://127.0.0.1:9101/metrics`
- **`contrib/bench/bench-txgen.nu`**: Wrap single-validator URL in a list for compatibility with the updated helper signature