### PR TITLE
ci: skip test workflow for docs-only PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,25 +21,45 @@ env:
   TEMPO_DEVNET_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
 
 jobs:
-  check-precompiles:
-    name: Check precompiles changes
+  check-ci-changes:
+    name: Check CI changes
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
       coverage: ${{ steps.check.outputs.coverage }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Check for precompiles changes
+      - name: Check changed files
         id: check
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
         run: |
-          # Only run coverage on pull_request events when precompiles/contracts changed
+          echo "coverage=false" >> "$GITHUB_OUTPUT"
+
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "Running tests: not a pull_request event (event: $EVENT_NAME)"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only origin/"$BASE_REF"...HEAD)"
+          echo "$changed_files"
+
+          if echo "$changed_files" | grep -qvE '^(docs/|\.amp/|\.changelog/|\.github/assets/|\.vscode/)|\.(md|txt)$|^(LICENSE|CODEOWNERS)$|^$'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "Running tests: code or CI-sensitive files changed"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping tests: only docs, markdown, or editor/assets metadata changed"
+          fi
+
+          # Only run coverage on pull_request events when precompiles/contracts changed.
           if [[ "$EVENT_NAME" != "pull_request" ]]; then
             echo "coverage=false" >> "$GITHUB_OUTPUT"
             echo "Skipping coverage: not a pull_request event (event: $EVENT_NAME)"
@@ -53,6 +73,8 @@ jobs:
 
   genesis:
     name: Genesis generation
+    needs: check-ci-changes
+    if: needs.check-ci-changes.outputs.should_run == 'true'
     runs-on: depot-ubuntu-latest-4
     timeout-minutes: 30
     permissions:
@@ -84,7 +106,8 @@ jobs:
 
   test:
     name: test (${{ matrix.partition }}/2)
-    needs: check-precompiles
+    needs: check-ci-changes
+    if: needs.check-ci-changes.outputs.should_run == 'true'
     runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     permissions:
@@ -99,7 +122,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: ${{ needs.check-precompiles.outputs.coverage == 'true' && 'llvm-tools-preview' || '' }}
+          components: ${{ needs.check-ci-changes.outputs.coverage == 'true' && 'llvm-tools-preview' || '' }}
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
@@ -107,12 +130,12 @@ jobs:
           tool: nextest@0.9.124
       # Build and run tests WITH coverage (only when precompiles changed)
       - name: Build and compile tests with coverage
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: needs.check-ci-changes.outputs.coverage == 'true'
         run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2 --no-run
         env:
           RUSTFLAGS: -C instrument-coverage
       - name: Run tests with coverage
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: needs.check-ci-changes.outputs.coverage == 'true'
         run: |
           mkdir -p coverage
           cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2
@@ -121,13 +144,13 @@ jobs:
           LLVM_PROFILE_FILE: ${{ github.workspace }}/coverage/cargo-%p-%m.profraw
       # Build and run tests WITHOUT coverage (when precompiles not changed)
       - name: Build and compile tests
-        if: needs.check-precompiles.outputs.coverage != 'true'
+        if: needs.check-ci-changes.outputs.coverage != 'true'
         run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2 --no-run
       - name: Run tests
-        if: needs.check-precompiles.outputs.coverage != 'true'
+        if: needs.check-ci-changes.outputs.coverage != 'true'
         run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2
       - name: Generate precompiles coverage profdata
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: needs.check-ci-changes.outputs.coverage == 'true'
         run: |
           LLVM_BIN="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | grep host | cut -d' ' -f2)/bin"
           "$LLVM_BIN/llvm-profdata" merge -sparse coverage/*.profraw -o coverage/cargo-test.profdata
@@ -136,7 +159,7 @@ jobs:
           find target/debug/deps -name 'tempo_precompiles-*' -type f -executable ! -name '*.d' -exec cp {} coverage/precompiles-bin/ \;
           find target/debug/deps -name 'tempo_contracts-*' -type f -executable ! -name '*.d' -exec cp {} coverage/precompiles-bin/ \;
       - name: Upload precompiles coverage artifacts
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: needs.check-ci-changes.outputs.coverage == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cargo-test-coverage-${{ matrix.partition }}
@@ -147,6 +170,8 @@ jobs:
 
   e2e:
     name: e2e (${{ matrix.partition }}/3)
+    needs: check-ci-changes
+    if: needs.check-ci-changes.outputs.should_run == 'true'
     runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     permissions:
@@ -175,6 +200,8 @@ jobs:
 
   e2e-flaky:
     name: e2e-flaky
+    needs: check-ci-changes
+    if: needs.check-ci-changes.outputs.should_run == 'true'
     runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     continue-on-error: true
@@ -199,6 +226,8 @@ jobs:
 
   cli:
     name: CLI smoke tests
+    needs: check-ci-changes
+    if: needs.check-ci-changes.outputs.should_run == 'true'
     runs-on: depot-ubuntu-latest-4
     timeout-minutes: 10
     permissions:
@@ -217,6 +246,8 @@ jobs:
 
   msrv:
     name: MSRV
+    needs: check-ci-changes
+    if: needs.check-ci-changes.outputs.should_run == 'true'
     runs-on: depot-ubuntu-latest-4
     timeout-minutes: 30
     permissions:
@@ -241,7 +272,7 @@ jobs:
     if: always()
     permissions: {}
     needs:
-      - check-precompiles
+      - check-ci-changes
       - test
       - e2e
       - cli
@@ -252,4 +283,5 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
+          allowed-skips: ${{ needs.check-ci-changes.outputs.should_run != 'true' && 'test,e2e,cli,msrv,genesis' || '' }}
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- keep the Test workflow status reporting on every PR
- skip expensive Test jobs when a PR only changes docs, markdown, GitHub assets, or editor metadata
- keep the full Test workflow for pushes, merge queues, workflow changes, and code-like changes

## Why
Recent PR Test runs spend about 9 minutes wall-clock on the full matrix, with the slowest e2e partition taking about 8m46s. Docs-only PRs do not need that runner spend, but branch protection still needs a completed Test status.

## Validation
- parsed .github/workflows/test.yml with PyYAML
- ran actionlint against .github/workflows/test.yml, ignoring only Tempo's custom Depot runner labels
- simulated the changed-file regex for docs/assets/editor metadata and code/CI paths
