### PR TITLE
TIP-1058: reusable precompile-owned storage slots

### DIFF
--- a/tips/tip-1058.md
+++ b/tips/tip-1058.md
@@ -1,0 +1,153 @@
+---
+id: TIP-1058
+title: Reusable Precompile-Owned Storage Slots
+description: Adds precompile-only owned storage accounting so selected enshrined precompiles can reuse previously paid storage capacity without exposing arbitrary contract key-value storage.
+authors: Dan Robinson
+status: Draft
+related: TIP-1000, TIP-1016, TIP-1030, TIP-1033, TIP-1034, TIP-1056
+protocolVersion: T5
+---
+
+# TIP-1058: Reusable Precompile-Owned Storage Slots
+
+## Abstract
+
+This TIP introduces a precompile-only storage primitive for reusable owned state. Selected enshrined precompiles may attribute specific fixed-schema storage slots to an owner account, track that owner's current live slot count and historical high-water mark, and omit the state-gas component when the owner reuses storage capacity they already paid to create.
+
+The mechanism is not exposed through an ABI and MUST NOT be available to arbitrary contracts. V1 usage is limited to fixed-schema precompile state where the slot exists to support a real protocol position rather than caller-chosen key-value storage.
+
+## Motivation
+
+Tempo charges a high state-gas component for new persistent storage under TIP-1000 and splits that cost from execution gas under TIP-1016. This is appropriate for net-new state growth, but it is expensive for users who repeatedly create and delete the same kind of protocol position. For example, a user who opens several channel escrow slots, closes them, and later opens the same number again has not increased their long-term peak state footprint, but without this TIP every later open still pays the full storage-creation charge.
+
+The goal is to let selected enshrined precompiles charge users for growth in their peak state footprint while making churn below that peak cheaper. This is deliberately narrower than expiring state and narrower than a general contract storage product. It gives the protocol a reusable-state tool for known fixed-schema objects without creating a second storage plane that contracts can use for arbitrary data.
+
+## Assumptions
+
+- TIP-1016 is active, so storage creation costs are split into regular gas and state gas.
+- Included precompiles can identify an owner account for every counted slot.
+- Included slots have fixed protocol semantics and are not caller-controlled arbitrary `bytes32 => bytes32` records.
+- Deleting a counted slot means the associated protocol position is no longer live and can no longer be read as active state.
+
+If any precompile cannot identify a clear owner, cannot ensure user-controlled cleanup, or gives callers arbitrary keys and values, that precompile MUST NOT use this mechanism.
+
+---
+
+# Specification
+
+## Overview
+
+The protocol adds an internal storage operation for selected precompiles:
+
+```text
+owned_storage_set(owner, slot, old_value, new_value)
+```
+
+This operation is an implementation concept, not an EVM opcode and not an ABI-exposed precompile method. It may be called only by protocol code implementing allow-listed precompiles.
+
+For each `owner`, the protocol tracks two counters:
+
+| Field | Meaning |
+|-------|---------|
+| `current_owned_slots` | Number of currently live reusable owned slots attributed to `owner` across all included precompiles. |
+| `owned_slot_high_water` | Maximum value `current_owned_slots` has ever reached for `owner`. |
+
+These counters are global across all included precompiles, not per-precompile.
+
+## Counter Storage
+
+The counters MUST be stored in the `NonceManager` account state. Implementations MAY pack them into an existing nonce-related storage slot if the packing is hardfork-gated and preserves all existing nonce semantics.
+
+Creating the counter storage for an owner receives no special discount. The first transaction that initializes the owner's reusable-storage accounting MUST pay normal gas for the accounting slot and normal gas for any payload slot it creates.
+
+## Gas Semantics
+
+For a counted owned slot:
+
+1. `zero -> nonzero`
+   - Increment `current_owned_slots`.
+   - If `current_owned_slots > owned_slot_high_water` after the increment:
+     - Set `owned_slot_high_water = current_owned_slots`.
+     - Charge the normal zero-to-nonzero storage cost, including TIP-1016 state gas.
+   - Otherwise:
+     - Charge the regular zero-to-nonzero write path, including cold access if applicable.
+     - Do not charge the TIP-1016 state-gas component for this payload slot.
+2. `nonzero -> zero`
+   - Decrement `current_owned_slots`.
+   - Apply normal delete behavior under TIP-1016.
+   - No ordinary deletion of old state creates a new state-gas refund.
+3. `nonzero -> nonzero`
+   - Do not change either counter.
+   - Charge normal update gas.
+4. `zero -> zero`
+   - Do not change either counter.
+   - Charge normal no-op behavior.
+
+For a reused owned write, the regular write cost is the regular component of a zero-to-nonzero SSTORE under TIP-1016. At the time of this TIP, TIP-1016 defines that as `20,100` regular gas for the warm write path, plus the normal `2,100` cold-slot access charge when the slot is cold, and omits the `230,000` state-gas component.
+
+Same-transaction slot restoration follows TIP-1016 refund behavior. A slot that paid state gas in the same transaction and is restored from `0 -> X -> 0` may receive the corresponding TIP-1016 state-gas restoration refund. A reused owned write that did not pay state gas MUST NOT later refund state gas.
+
+## Allow-Listed Uses
+
+V1 includes only the following storage classes:
+
+| Component | Counted owned slot | Owner |
+|-----------|--------------------|-------|
+| TIP-20 Channel Escrow | One live channel state slot created by `open` and deleted by terminal `close` or `withdraw`. | Channel payer. |
+| Stablecoin DEX orders | Live order storage created by placing an order and deleted when the order is fully filled or canceled. | Order maker. |
+| Stablecoin DEX internal balances | Nonzero internal balance slots created by deposits or by proceeds from a user-created resting order. | Balance owner. |
+| FeeAMM LP balances | Nonzero LP balance slots created by liquidity operations and deleted when the LP balance returns to zero. | LP balance owner. |
+
+These are the first places this mechanism is intended to be used.
+
+V1 excludes:
+
+- TIP-20 balances.
+- TIP-403 policy state.
+- AccountKeychain state.
+- Address-level policy state.
+- Any contract-facing API.
+- Any precompile state where callers can use the mechanism as arbitrary key-value storage.
+
+## Abuse Guardrails
+
+A storage class MUST NOT be added to the allow-list unless all of the following are true:
+
+1. The slot has fixed protocol meaning and a constrained value format.
+2. The owner is determined by the precompile's protocol semantics, not by an arbitrary user-supplied `owner` parameter.
+3. A third party cannot create counted slots for an owner unless the owner first created the relevant protocol position or otherwise explicitly opted into the state.
+4. The owner, or the normal protocol lifecycle for that owner, has a path to return the slot to zero.
+5. The slot is not useful as a general-purpose key-value store.
+
+For channel escrow, the caller can influence the channel id through channel parameters, but the value is fixed packed channel state and opening the slot requires real TIP-20 escrow. This is not a useful arbitrary key-value store.
+
+For DEX and FeeAMM balances, fake tokens or pools may create additional balance classes, but doing so requires token or pool setup and real protocol operations. Implementations MUST charge slots to the party that controls creation and cleanup. If a path lets Alice create a counted DEX or FeeAMM balance slot for Bob without Bob first placing an order, depositing, adding liquidity, or otherwise opting into the position, that path MUST either be excluded or charged to Alice instead of Bob.
+
+AccountKeychain is excluded from V1 because its user-chosen keys, witnesses, limits, and call scopes are closer to arbitrary structured storage.
+
+## Integration With Existing Storage
+
+This TIP changes only gas accounting for allow-listed precompile storage transitions. It does not change:
+
+- State root computation.
+- Storage proof semantics.
+- RPC visibility for precompile state.
+- Event requirements of the underlying precompiles.
+- The logical lifecycle of channels, DEX orders, balances, or FeeAMM LP positions.
+
+All counted slots remain ordinary persistent protocol state. The distinction is whether their zero-to-nonzero transition pays the state-gas component.
+
+---
+
+# Invariants
+
+1. For every owner, `current_owned_slots <= owned_slot_high_water`.
+2. `owned_slot_high_water` never decreases.
+3. `current_owned_slots` equals the number of live counted slots attributed to the owner across all included precompiles.
+4. A reused owned write may omit state gas only when `current_owned_slots <= owned_slot_high_water` after the new slot is counted.
+5. First growth above the high-water mark always pays normal state gas.
+6. First initialization of the owner's accounting slot receives no discount.
+7. No contract can call `owned_storage_set` or use this mechanism through an ABI.
+8. No included storage class may expose arbitrary caller-chosen key-value storage.
+9. A reused owned write that did not pay state gas cannot generate a state-gas refund.
+10. Adding a new precompile storage class to this mechanism requires a TIP or hardfork-gated allow-list update that identifies the slot class, owner rule, cleanup rule, and abuse analysis.

--- a/tips/tip-1058.md
+++ b/tips/tip-1058.md
@@ -12,19 +12,19 @@ protocolVersion: T5
 
 ## Abstract
 
-This TIP introduces Reusable Storage: a user-owned storage accounting primitive that may only be written by selected enshrined precompiles. Those precompiles may attribute specific fixed-schema storage slots to an owner account, track that owner's current live slot count and historical high-water mark, and omit the state-gas component when the owner reuses storage capacity they already paid to create.
+This TIP introduces Reusable Storage: a user-owned storage accounting primitive that may only be written by selected enshrined precompiles. Those precompiles may attribute specific fixed-schema storage slots to an owner account, track that owner's current live slot count and historical high-water mark, and omit the persistent-storage initialization cost when the owner reuses storage capacity they already paid to create.
 
 The mechanism is not exposed through an ABI and MUST NOT be available to arbitrary contracts. V1 usage is limited to fixed-schema precompile state where the slot exists to support a real protocol position rather than caller-chosen key-value storage. Before any new use is added, the protocol MUST consider all ways that use could be abused. New uses MUST NOT allow anyone other than the owner to cause one of that owner's reusable storage slots to be written, such as by using this mechanism for TIP-20 balances. New uses SHOULD NOT allow a contract or user to arbitrarily specify both the key and value for a reusable storage slot, because that makes the mechanism easier to adapt for unintended purposes.
 
 ## Motivation
 
-Tempo charges a high state-gas component for new persistent storage under TIP-1000 and splits that cost from execution gas under TIP-1016. This is appropriate for net-new state growth, but it is expensive for users who repeatedly create and delete the same kind of protocol position. For example, a user who opens several channel escrow slots, closes them, and later opens the same number again has not increased their long-term peak state footprint, but without this TIP every later open still pays the full storage-creation charge.
+Tempo charges a high initialization cost for new persistent storage under TIP-1000. TIP-1016 describes this as a state-gas component split from execution gas, and this TIP uses that terminology when describing the cost that reusable writes omit. That cost is appropriate for net-new state growth, but it is expensive for users who repeatedly create and delete the same kind of protocol position. For example, a user who opens several channel escrow slots, closes them, and later opens the same number again has not increased their long-term peak state footprint, but without this TIP every later open still pays the full storage-creation charge.
 
 The goal is to let selected enshrined precompiles charge users for growth in their peak state footprint while making churn below that peak cheaper. This is deliberately narrower than expiring state and narrower than a general contract storage product. It gives the protocol a reusable-state tool for known fixed-schema objects without creating a second storage plane that contracts can use for arbitrary data.
 
 ## Assumptions
 
-- TIP-1016 is active, so storage creation costs are split into regular gas and state gas.
+- The implementation can distinguish the persistent-storage initialization cost from the remaining zero-to-nonzero write cost. TIP-1016 provides the current state-gas terminology and cost split used by this TIP, but this mechanism does not require TIP-1016 as an independent prerequisite.
 - Included precompiles can identify an owner account for every counted slot.
 - Included slots have fixed protocol semantics and are not caller-controlled arbitrary `bytes32 => bytes32` records.
 - Deleting a counted slot means the associated protocol position is no longer live and can no longer be read as active state.
@@ -68,14 +68,14 @@ For a counted owned slot:
    - Increment `current_owned_slots`.
    - If `current_owned_slots > owned_slot_high_water` after the increment:
      - Set `owned_slot_high_water = current_owned_slots`.
-     - Charge the normal zero-to-nonzero storage cost, including TIP-1016 state gas.
+     - Charge the normal zero-to-nonzero storage cost, including the persistent-storage initialization cost.
    - Otherwise:
      - Charge the regular zero-to-nonzero write path, including cold access if applicable.
-     - Do not charge the TIP-1016 state-gas component for this payload slot.
+     - Do not charge the persistent-storage initialization cost for this payload slot.
 2. `nonzero -> zero`
    - Decrement `current_owned_slots`.
-   - Apply normal delete behavior under TIP-1016.
-   - No ordinary deletion of old state creates a new state-gas refund.
+   - Apply normal delete behavior for persistent storage.
+   - No ordinary deletion of old state creates a new initialization-cost refund.
 3. `nonzero -> nonzero`
    - Do not change either counter.
    - Charge normal update gas.
@@ -83,9 +83,9 @@ For a counted owned slot:
    - Do not change either counter.
    - Charge normal no-op behavior.
 
-For a reused owned write, the regular write cost is the regular component of a zero-to-nonzero SSTORE under TIP-1016. At the time of this TIP, TIP-1016 defines that as `20,100` regular gas for the warm write path, plus the normal `2,100` cold-slot access charge when the slot is cold, and omits the `230,000` state-gas component.
+For a reused owned write, the write cost is the zero-to-nonzero SSTORE cost after excluding the persistent-storage initialization cost. Under TIP-1016 terminology and current costs, that is `20,100` regular gas for the warm write path, plus the normal `2,100` cold-slot access charge when the slot is cold, and omits the `230,000` state-gas component.
 
-Same-transaction slot restoration follows TIP-1016 refund behavior. A slot that paid state gas in the same transaction and is restored from `0 -> X -> 0` may receive the corresponding TIP-1016 state-gas restoration refund. A reused owned write that did not pay state gas MUST NOT later refund state gas.
+Same-transaction slot restoration follows the normal refund behavior for the applicable storage gas schedule. A slot that paid the persistent-storage initialization cost in the same transaction and is restored from `0 -> X -> 0` may receive the corresponding restoration refund. A reused owned write that did not pay the initialization cost MUST NOT later refund that cost.
 
 ## Allow-Listed Uses
 
@@ -135,7 +135,7 @@ This TIP changes only gas accounting for allow-listed precompile storage transit
 - Event requirements of the underlying precompiles.
 - The logical lifecycle of channels, DEX orders, balances, or FeeAMM LP positions.
 
-All counted slots remain ordinary persistent protocol state. The distinction is whether their zero-to-nonzero transition pays the state-gas component.
+All counted slots remain ordinary persistent protocol state. The distinction is whether their zero-to-nonzero transition pays the persistent-storage initialization cost.
 
 ---
 
@@ -149,5 +149,5 @@ All counted slots remain ordinary persistent protocol state. The distinction is 
 6. First initialization of the owner's accounting slot receives no discount.
 7. No contract can call `owned_storage_set` or use this mechanism through an ABI.
 8. No included storage class may expose arbitrary caller-chosen key-value storage.
-9. A reused owned write that did not pay state gas cannot generate a state-gas refund.
+9. A reused owned write that did not pay the persistent-storage initialization cost cannot generate a refund for that cost.
 10. Adding a new precompile storage class to this mechanism requires a TIP or hardfork-gated allow-list update that identifies the slot class, owner rule, cleanup rule, and abuse analysis.

--- a/tips/tip-1058.md
+++ b/tips/tip-1058.md
@@ -14,7 +14,7 @@ protocolVersion: T5
 
 This TIP introduces Reusable Storage: a user-owned storage accounting primitive that may only be written by selected enshrined precompiles. Those precompiles may attribute specific fixed-schema storage slots to an owner account, track that owner's current live slot count and historical high-water mark, and omit the persistent-storage initialization cost when the owner reuses storage capacity they already paid to create.
 
-The mechanism is not exposed through an ABI and MUST NOT be available to arbitrary contracts. V1 usage is limited to fixed-schema precompile state where the slot exists to support a real protocol position rather than caller-chosen key-value storage. Before any new use is added, the protocol MUST consider all ways that use could be abused. New uses MUST NOT allow anyone other than the owner to cause one of that owner's reusable storage slots to be written, such as by using this mechanism for TIP-20 balances. New uses SHOULD NOT allow a contract or user to arbitrarily specify both the key and value for a reusable storage slot, because that makes the mechanism easier to adapt for unintended purposes.
+The mechanism is not exposed through an ABI and MUST NOT be available to arbitrary contracts. Initial usage is limited to fixed-schema precompile state where the slot exists to support a real protocol position rather than caller-chosen key-value storage. Before any new use is added, the protocol MUST consider all ways that use could be abused. New uses MUST NOT allow anyone other than the owner to cause one of that owner's reusable storage slots to be written, such as by using this mechanism for TIP-20 balances. New uses SHOULD NOT allow a contract or user to arbitrarily specify both the key and value for a reusable storage slot, because that makes the mechanism easier to adapt for unintended purposes.
 
 ## Motivation
 
@@ -89,7 +89,7 @@ Same-transaction slot restoration follows the normal refund behavior for the app
 
 ## Allow-Listed Uses
 
-V1 includes only the following storage classes:
+The following storage classes are the initial precompile uses of Reusable Storage:
 
 | Component | Counted owned slot | Owner |
 |-----------|--------------------|-------|
@@ -98,16 +98,16 @@ V1 includes only the following storage classes:
 | Stablecoin DEX internal balances | Nonzero internal balance slots created by deposits or by proceeds from a user-created resting order. | Balance owner. |
 | FeeAMM LP balances | Nonzero LP balance slots created by liquidity operations and deleted when the LP balance returns to zero. | LP balance owner. |
 
-These are the first places this mechanism is intended to be used.
+Other precompile storage classes may be added later if they are determined to be useful and safe under the abuse guardrails below.
 
-V1 excludes:
+The initial use set excludes:
 
-- TIP-20 balances.
-- TIP-403 policy state.
-- AccountKeychain state.
-- Address-level policy state.
-- Any contract-facing API.
-- Any precompile state where callers can use the mechanism as arbitrary key-value storage.
+- TIP-20 balances, because any account can generally cause another account's balance slot to be written by sending tokens, so charging the slot to the recipient would violate the owner-only write rule.
+- TIP-403 policy state, because policy configuration is durable account or token configuration rather than a churn-heavy protocol position with a natural reusable-slot lifecycle.
+- AccountKeychain state, because its user-chosen keys, witnesses, limits, and call scopes are closer to arbitrary structured storage.
+- Address-level policy state, because it is account configuration rather than a protocol position, and its slots may be written as a consequence of policy administration rather than reusable owner-created positions.
+- Any contract-facing API, because exposing Reusable Storage through an ABI would let contracts adapt it into a general storage product.
+- Any precompile state where callers can use the mechanism as arbitrary key-value storage, because that would defeat the fixed-schema safety boundary.
 
 ## Abuse Guardrails
 
@@ -122,8 +122,6 @@ A storage class MUST NOT be added to the allow-list unless all of the following 
 For channel escrow, the caller can influence the channel id through channel parameters, but the value is fixed packed channel state and opening the slot requires real TIP-20 escrow. This is not a useful arbitrary key-value store.
 
 For DEX and FeeAMM balances, fake tokens or pools may create additional balance classes, but doing so requires token or pool setup and real protocol operations. Implementations MUST charge slots to the party that controls creation and cleanup. If a path lets Alice create a counted DEX or FeeAMM balance slot for Bob without Bob first placing an order, depositing, adding liquidity, or otherwise opting into the position, that path MUST either be excluded or charged to Alice instead of Bob.
-
-AccountKeychain is excluded from V1 because its user-chosen keys, witnesses, limits, and call scopes are closer to arbitrary structured storage.
 
 ## Integration With Existing Storage
 

--- a/tips/tip-1058.md
+++ b/tips/tip-1058.md
@@ -103,10 +103,9 @@ Other precompile storage classes may be added later if they are determined to be
 The initial use set excludes:
 
 - TIP-20 balances, because any account can generally cause another account's balance slot to be written by sending tokens, so charging the slot to the recipient would violate the owner-only write rule.
-- TIP-403 policy state, because policy configuration is durable account or token configuration rather than a churn-heavy protocol position with a natural reusable-slot lifecycle.
+- TIP-403 policy state, because the policy admin can change, so the account that controls policy changes may not be stable over the slot's lifecycle.
 - AccountKeychain state, because its user-chosen keys, witnesses, limits, and call scopes are closer to arbitrary structured storage.
-- Address-level policy state, because it is account configuration rather than a protocol position, and its slots may be written as a consequence of policy administration rather than reusable owner-created positions.
-- Any contract-facing API, because exposing Reusable Storage through an ABI would let contracts adapt it into a general storage product.
+- Any contract-facing API, because exposing Reusable Storage through an ABI would let contracts adapt it into a general storage product, which increases the surface area for possible unintended consequences.
 - Any precompile state where callers can use the mechanism as arbitrary key-value storage, because that would defeat the fixed-schema safety boundary.
 
 ## Abuse Guardrails

--- a/tips/tip-1058.md
+++ b/tips/tip-1058.md
@@ -56,7 +56,7 @@ These counters are global across all included precompiles, not per-precompile.
 
 ## Counter Storage
 
-The counters MUST be stored in the `NonceManager` account state. Implementations MAY pack them into an existing nonce-related storage slot if the packing is hardfork-gated and preserves all existing nonce semantics.
+The counters MUST be stored as contract state in one of the precompiles that implements Reusable Storage. Implementations MAY pack the counters with other precompile state if the packing is hardfork-gated and preserves all existing precompile semantics.
 
 Creating the counter storage for an owner receives no special discount. The first transaction that initializes the owner's reusable-storage accounting MUST pay normal gas for the accounting slot and normal gas for any payload slot it creates.
 
@@ -134,6 +134,14 @@ This TIP changes only gas accounting for allow-listed precompile storage transit
 
 All counted slots remain ordinary persistent protocol state. The distinction is whether their zero-to-nonzero transition pays the persistent-storage initialization cost.
 
+## Compatibility
+
+Reusable Storage changes the gas cost of the initial operation in each included storage class. The first time an owner opens a channel, places a DEX order, creates an internal balance slot, or creates a FeeAMM LP balance, the transaction must also initialize that owner's reusable-storage counters. That fresh counter storage write increases the first-time cost of those operations.
+
+Reusable Storage also makes gas somewhat less predictable. The same operation may pay different storage costs depending on whether the owner's reusable-storage accounting is already initialized, whether the write increases the owner's high-water mark, and whether the write reuses previously paid storage capacity.
+
+This TIP does not introduce an EVM opcode, ABI method, or contract-facing API. Existing contracts cannot call Reusable Storage directly, and the reusable-storage counters are ordinary precompile contract state.
+
 ---
 
 # Invariants
@@ -141,8 +149,8 @@ All counted slots remain ordinary persistent protocol state. The distinction is 
 1. For every owner, `current_owned_slots <= owned_slot_high_water`.
 2. `owned_slot_high_water` never decreases.
 3. `current_owned_slots` equals the number of live counted slots attributed to the owner across all included precompiles.
-4. A reused owned write may omit state gas only when `current_owned_slots <= owned_slot_high_water` after the new slot is counted.
-5. First growth above the high-water mark always pays normal state gas.
+4. A reused owned write may omit the persistent-storage initialization cost only when `current_owned_slots <= owned_slot_high_water` after the new slot is counted.
+5. First growth above the high-water mark always pays the normal persistent-storage initialization cost.
 6. First initialization of the owner's accounting slot receives no discount.
 7. No contract can call `owned_storage_set` or use this mechanism through an ABI.
 8. No included storage class may expose arbitrary caller-chosen key-value storage.

--- a/tips/tip-1058.md
+++ b/tips/tip-1058.md
@@ -1,20 +1,20 @@
 ---
 id: TIP-1058
-title: Reusable Precompile-Owned Storage Slots
-description: Adds precompile-only owned storage accounting so selected enshrined precompiles can reuse previously paid storage capacity without exposing arbitrary contract key-value storage.
+title: Reusable Storage
+description: Adds precompile-only reusable storage accounting so selected enshrined precompiles can let users reuse previously paid storage capacity without exposing arbitrary contract key-value storage.
 authors: Dan Robinson
 status: Draft
 related: TIP-1000, TIP-1016, TIP-1030, TIP-1033, TIP-1034, TIP-1056
 protocolVersion: T5
 ---
 
-# TIP-1058: Reusable Precompile-Owned Storage Slots
+# TIP-1058: Reusable Storage
 
 ## Abstract
 
-This TIP introduces a precompile-only storage primitive for reusable owned state. Selected enshrined precompiles may attribute specific fixed-schema storage slots to an owner account, track that owner's current live slot count and historical high-water mark, and omit the state-gas component when the owner reuses storage capacity they already paid to create.
+This TIP introduces Reusable Storage: a user-owned storage accounting primitive that may only be written by selected enshrined precompiles. Those precompiles may attribute specific fixed-schema storage slots to an owner account, track that owner's current live slot count and historical high-water mark, and omit the state-gas component when the owner reuses storage capacity they already paid to create.
 
-The mechanism is not exposed through an ABI and MUST NOT be available to arbitrary contracts. V1 usage is limited to fixed-schema precompile state where the slot exists to support a real protocol position rather than caller-chosen key-value storage.
+The mechanism is not exposed through an ABI and MUST NOT be available to arbitrary contracts. V1 usage is limited to fixed-schema precompile state where the slot exists to support a real protocol position rather than caller-chosen key-value storage. Before any new use is added, the protocol MUST consider all ways that use could be abused. New uses MUST NOT allow anyone other than the owner to cause one of that owner's reusable storage slots to be written, such as by using this mechanism for TIP-20 balances. New uses SHOULD NOT allow a contract or user to arbitrarily specify both the key and value for a reusable storage slot, because that makes the mechanism easier to adapt for unintended purposes.
 
 ## Motivation
 


### PR DESCRIPTION
## Summary
- add TIP-1058 for precompile-only reusable owned storage slots
- define global per-owner current/high-water accounting stored in NonceManager
- scope v1 usage to channel escrow, DEX orders/internal balances, and FeeAMM LP balances while excluding arbitrary contract KV use

## Testing
- not run; docs-only TIP