### PR TITLE
TIP-1059: contract storage gas tokens

### DIFF
--- a/tips/tip-1059.md
+++ b/tips/tip-1059.md
@@ -1,0 +1,164 @@
+---
+id: TIP-1059
+title: Contract Storage Gas Tokens
+description: Generalizes reusable storage to all smart contracts by giving each contract a protocol-managed counter for deleted storage slots that can offset later storage creation costs.
+authors: Dan Robinson
+status: Draft
+related: TIP-1000, TIP-1058
+protocolVersion: T5
+---
+
+# TIP-1059: Contract Storage Gas Tokens
+
+## Abstract
+
+This TIP introduces contract-level storage gas tokens. Whenever a contract deletes a storage element, the protocol increments that contract's gas token balance. Whenever the same contract creates a new storage element, the contract may either pay the TIP-1000 storage creation cost or consume one available gas token instead.
+
+Contracts control this behavior through a new precompile that can query the contract's gas token balance and select whether storage creation should consume gas tokens by default. The default mode for all smart contracts is to consume gas tokens when available, allowing existing contracts to benefit from cheaper storage churn without modification.
+
+## Motivation
+
+TIP-1000 makes net-new storage creation expensive to protect Tempo from state growth attacks. That cost is appropriate when a contract increases its long-term state footprint, but it overcharges contracts that repeatedly delete and recreate storage slots while staying within a previously paid state footprint.
+
+TIP-1058 applies reusable storage accounting to selected precompile-owned state with owner attribution. This TIP generalizes the underlying mechanism to all smart contracts at contract granularity. Contracts that need user-level attribution can implement their own owner accounting on top of the contract-level token balance; contracts that do not need attribution can use the default behavior and receive lower costs for storage churn automatically.
+
+## Assumptions
+
+- The protocol can identify storage transitions for each contract account, including `zero -> nonzero` creation and `nonzero -> zero` deletion.
+- The TIP-1000 state creation component can be omitted independently from the rest of the normal storage write cost.
+- Contract storage gas tokens are scoped to a single contract address and are not transferable across contracts.
+- A gas token represents previously deleted contract storage capacity, not a claim on gas refunds or execution gas.
+
+If the implementation cannot distinguish storage creation from storage update, or cannot debit the correct contract balance atomically with the storage write, this TIP MUST NOT activate.
+
+---
+
+# Specification
+
+## Terminology
+
+- **Contract gas token balance**: A protocol-maintained unsigned integer associated with one contract account.
+- **Storage creation**: A contract storage slot transition from zero to nonzero.
+- **Storage deletion**: A contract storage slot transition from nonzero to zero.
+- **Consume-token mode**: The contract's storage creation mode in which storage creation consumes one available gas token before charging the TIP-1000 creation cost.
+- **Preserve-token mode**: The contract's storage creation mode in which storage creation always pays gas and leaves any gas token balance unchanged.
+
+## State
+
+The protocol MUST maintain the following state in a new precompile:
+
+```text
+gas_token_balance: mapping(address contract => uint256)
+storage_creation_mode: mapping(address contract => StorageCreationMode)
+```
+
+`StorageCreationMode` has two values:
+
+```text
+enum StorageCreationMode {
+    ConsumeTokens,
+    PreserveTokens
+}
+```
+
+The default mode for every contract is `ConsumeTokens`. Implementations MAY omit explicit storage for default-mode contracts.
+
+The precompile's own accounting state MUST be ordinary protocol state. Creating or updating the precompile's accounting slots MUST NOT itself mint or consume gas tokens.
+
+## Gas Token Minting
+
+When contract `C` executes an SSTORE that changes one of `C`'s storage slots from nonzero to zero:
+
+1. Apply the normal storage deletion gas behavior.
+2. Increment `gas_token_balance[C]` by one.
+
+Deleting a slot mints exactly one gas token regardless of the deleted value, the slot key, the transaction sender, or the call path that caused the deletion.
+
+## Gas Token Consumption
+
+When contract `C` executes an SSTORE that changes one of `C`'s storage slots from zero to nonzero:
+
+1. If `storage_creation_mode[C] == ConsumeTokens` and `gas_token_balance[C] > 0`:
+   - Decrement `gas_token_balance[C]` by one.
+   - Charge the normal zero-to-nonzero storage write cost except for the TIP-1000 storage creation component.
+2. Otherwise:
+   - Leave `gas_token_balance[C]` unchanged.
+   - Charge the full TIP-1000-mandated storage creation cost.
+
+The token debit and storage write MUST be atomic. If the storage write reverts, the gas token balance and mode changes made in the same execution scope MUST revert according to normal EVM revert semantics.
+
+## Other Storage Transitions
+
+- `nonzero -> nonzero`: does not mint or consume gas tokens and pays normal update gas.
+- `zero -> zero`: does not mint or consume gas tokens and pays normal no-op gas.
+- Same-transaction transitions follow normal journal and revert behavior. A write that consumes a gas token MUST NOT later receive a refund for a storage creation cost that it did not pay.
+
+## Precompile Interface
+
+The protocol introduces a precompile at an address to be assigned by the implementation.
+
+```solidity
+/// @title Contract Storage Gas Tokens
+/// @notice Exposes contract-scoped reusable storage accounting.
+/// @dev Balances and modes are keyed by contract address, not by tx.origin or by a user address.
+interface IContractStorageGasTokens {
+    /// @notice Returns the gas token balance for a contract.
+    /// @param contractAddress The contract whose gas token balance should be queried.
+    /// @return balance The number of gas tokens available to the contract.
+    function gasTokenBalance(address contractAddress) external view returns (uint256 balance);
+
+    /// @notice Returns the storage creation mode for a contract.
+    /// @param contractAddress The contract whose mode should be queried.
+    /// @return consumeTokens True if storage creation consumes gas tokens when available; false if storage creation preserves tokens and pays gas.
+    function usesGasTokensByDefault(address contractAddress) external view returns (bool consumeTokens);
+
+    /// @notice Sets whether the calling contract consumes gas tokens by default for storage creation.
+    /// @param consumeTokens True to consume one gas token when available before paying the TIP-1000 creation cost; false to always pay gas and preserve tokens.
+    /// @dev This changes only the mode for msg.sender. EOAs MUST NOT be able to set the mode for a contract, and one contract MUST NOT be able to set the mode for another contract.
+    function setUseGasTokensByDefault(bool consumeTokens) external;
+}
+```
+
+`setUseGasTokensByDefault` applies to `msg.sender`. If `msg.sender` is an EOA, the call MUST revert. A contract may call this precompile during construction; in that case the mode applies to the address under construction even though runtime code has not yet been installed.
+
+The precompile MUST NOT expose any method that transfers gas tokens, mints gas tokens, burns gas tokens except through storage creation, or changes another contract's mode.
+
+## Default Behavior
+
+All contracts default to `ConsumeTokens`. This means an existing contract that deletes a storage slot and later creates a storage slot will automatically consume one gas token for the later creation if one is available.
+
+Contracts that need to preserve gas tokens for their own accounting can call `setUseGasTokensByDefault(false)` before creating storage and later restore `ConsumeTokens` if desired. This mode is contract-global state. Contracts that need per-user or per-operation attribution MUST implement that policy internally before deciding whether to preserve or consume their contract-level tokens.
+
+## Relationship to TIP-1058
+
+This TIP can serve as the underlying mechanism for TIP-1058. A precompile that wants owner-level reusable storage can keep its own owner accounting in contract state, set its storage creation mode to preserve gas tokens when it wants a user to pay the TIP-1000 creation cost, and set it to consume tokens when the user is entitled to reuse deleted storage capacity.
+
+Alternatively, a precompile or ordinary contract can use the default mode and receive contract-level reuse without attributing savings to specific users. In that mode, cheaper storage creation benefits the contract as a whole and may not correspond to the user who originally caused the deletion.
+
+## Abuse and Scope
+
+Gas tokens are not transferable and cannot be created without deleting contract storage. This preserves TIP-1000's protection against net state growth: a contract that increases its live storage footprint beyond its deleted-slot balance still pays the full storage creation cost for each net-new slot.
+
+The mechanism intentionally uses contract-level accounting rather than protocol-level user attribution. This keeps the core rule simple and lets applications decide whether they need stricter attribution. Contracts that expose arbitrary storage writes to users remain responsible for ensuring their own economics are not exploitable.
+
+## Compatibility
+
+Existing contracts receive the default `ConsumeTokens` mode. This can lower the gas cost of storage creation after prior deletion without requiring contract changes.
+
+Gas estimation becomes somewhat less predictable because the same zero-to-nonzero write may cost less when the contract has an available gas token. Traces and debug tooling SHOULD expose token minting, token consumption, and storage creation mode reads or writes so developers can explain gas differences.
+
+Contracts that assume a fixed gas cost for zero-to-nonzero storage writes may observe lower costs after this TIP. Contracts that explicitly need to pay the storage creation cost despite having available tokens can opt into `PreserveTokens`.
+
+---
+
+# Invariants
+
+1. A contract gas token balance increases only when that contract deletes one of its own nonzero storage slots.
+2. A contract gas token balance decreases only when that contract creates a storage slot while in `ConsumeTokens` mode and the balance is nonzero.
+3. A gas token can offset at most one storage creation.
+4. Gas tokens cannot be transferred between contracts.
+5. Gas token minting, consumption, and mode changes revert with the execution scope that caused them.
+6. The precompile's own accounting writes do not mint or consume gas tokens.
+7. A storage creation that consumed a gas token cannot receive a refund for a storage creation cost it did not pay.
+8. The default mode for every contract is `ConsumeTokens`.
+9. No EOA or contract can set another contract's storage creation mode.


### PR DESCRIPTION
## Summary
- add TIP-1059 for contract-level storage gas token accounting
- define mint/consume rules for deleted and newly-created contract storage slots
- specify the precompile interface for querying balances and setting default consume/preserve behavior
- explain how the mechanism can underlie TIP-1058 owner-level reusable storage

## Testing
- not run; docs-only TIP