### PR TITLE
fix(ci): disambiguate stale tempo cargo updates

### DIFF
--- a/scripts/foundry-patch.sh
+++ b/scripts/foundry-patch.sh
@@ -140,6 +140,7 @@ stale_tempo_pkgs="$(
   awk '
     /^\[\[package\]\]/ {
       name = ""
+      version = ""
       next
     }
     /^name = / {
@@ -147,9 +148,14 @@ stale_tempo_pkgs="$(
       gsub(/"/, "", name)
       next
     }
+    /^version = / {
+      version = $3
+      gsub(/"/, "", version)
+      next
+    }
     /^source = "git\+https:\/\/github.com\/tempoxyz\/tempo\?rev=/ {
-      if (name != "") {
-        print name
+      if (name != "" && version != "") {
+        print name "@" version
       }
     }
   ' Cargo.lock | sort -u


### PR DESCRIPTION
## Summary
- include Cargo.lock versions when building stale Tempo package specs for `cargo update -p`
- turns ambiguous specs like `tempo-alloy` into `tempo-alloy@1.6.0` when both old and new versions are present

## Verification
- `bash -n scripts/foundry-patch.sh`
- synthetic lockfile extraction emits `tempo-alloy@1.6.0` for a stale git package