### PR TITLE
chore(tips): add tip naming pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=A)
+ADDED_TIPS_FILES=$(echo "$STAGED_FILES" | grep '^tips/')
+ADDED_TIPS_COUNT=$(echo "$ADDED_TIPS_FILES" | grep -c .)
+
+if [ "$ADDED_TIPS_COUNT" -gt 1 ]; then
+  echo "❌ Only one file can be added under tips/ at a time:"
+  echo "$ADDED_TIPS_FILES" | sed 's/^/  - /'
+  exit 1
+fi
+
+if [ "$ADDED_TIPS_COUNT" -eq 1 ]; then
+  TIP_FILE="$ADDED_TIPS_FILES"
+  TIP_BASENAME=$(basename "$TIP_FILE")
+
+  if ! echo "$TIP_BASENAME" | grep -qE '^tip-[0-9]{4}\.md$'; then
+    echo "❌ New files under tips/ must be named 'tip-XXXX.md' (got: '$TIP_BASENAME')"
+    exit 1
+  fi
+
+  TIP_ID=$(basename "$TIP_FILE" .md | sed 's/^tip-//')
+  EXPECTED="tip/$TIP_ID"
+
+  if [ "$BRANCH" != "$EXPECTED" ]; then
+    echo "❌ Branch must be named '$EXPECTED' when adding $TIP_FILE (current: '$BRANCH')"
+    exit 1
+  fi
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Tempo is a blockchain node built on [Reth SDK](https://github.com/paradigmxyz/re
 
 When creating a new TIP:
 
+- Run `./scripts/setup-hooks.sh` once per clone so Git runs the TIP naming hook.
 - Branch: `tip/XXXX` where `XXXX` is the next available TIP number (check `tips/` directory and existing branches).
 - File: `tips/tip-XXXX.md` matching the branch number.
 - Follow the template in `tips/tip_template.md`.

--- a/Justfile
+++ b/Justfile
@@ -1,12 +1,3 @@
-[doc('Install local development hooks')]
-default: setup
-
-[group('dev')]
-[doc('Configure local development hooks')]
-setup:
-    git config core.hooksPath .githooks
-    @echo "Configured git hooks from .githooks"
-
 [group('deps')]
 [doc('Bump all reth dependencies to a specific commit hash')]
 bump-reth commit:

--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,12 @@
+[doc('Install local development hooks')]
+default: setup
+
+[group('dev')]
+[doc('Configure local development hooks')]
+setup:
+    git config core.hooksPath .githooks
+    @echo "Configured git hooks from .githooks"
+
 [group('deps')]
 [doc('Bump all reth dependencies to a specific commit hash')]
 bump-reth commit:

--- a/README.md
+++ b/README.md
@@ -118,7 +118,11 @@ Install the dependencies:
 just
 ```
 
-This also configures Git to run the repository hooks from `.githooks`.
+Configure Git to run the repository hooks:
+
+```bash
+./scripts/setup-hooks.sh
+```
 
 Build Tempo:
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Install the dependencies:
 just
 ```
 
+This also configures Git to run the repository hooks from `.githooks`.
+
 Build Tempo:
 
 ```bash

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git config core.hooksPath .githooks
+echo "Configured git hooks from .githooks"


### PR DESCRIPTION
this PR adds a pre-commit hook that enforces the `tip/xxxx` rules.

specially useful for AI-powered tips when the agent forgets to follow the instructions in https://github.com/tempoxyz/tempo/blob/main/AGENTS.md