### PR TITLE
ci(bench): use bench RPC secrets for replay benchmarks

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -13,9 +13,14 @@
 #   BENCH_BASELINE_ARGS           – extra node args for baseline (optional)
 #   BENCH_FEATURE_ARGS            – extra node args for feature (optional)
 #   BENCH_SAMPLY                  – "true" to enable samply profiling (optional)
+#   BENCH_REPLAY_RPC_URL          – RPC URL override for replay extraction (optional)
 set -euxo pipefail
 
 eval "$(nu bench-schelk.nu detect)"
+
+redact_url() {
+  sed -E 's#(https?://|wss?://)([^/@]+)@#\1***@#' <<< "$1"
+}
 
 BENCH_WORK_DIR="${BENCH_WORK_DIR:-bench-results/replay}"
 SNAPSHOT_BUCKET="r2-tempo-snapshots/tempo-node-snapshots"
@@ -27,23 +32,29 @@ case "$CHAIN" in
   mainnet)
     CHAIN_ID=4217
     CHAIN_NAME="mainnet"
-    REPLAY_RPC_URL="https://rpc.tempo.xyz"
+    DEFAULT_REPLAY_RPC_URL="https://rpc.tempo.xyz"
     ;;
   testnet)
     CHAIN_ID=42431
     CHAIN_NAME="moderato"
-    REPLAY_RPC_URL="https://rpc.moderato.tempo.xyz"
+    DEFAULT_REPLAY_RPC_URL="https://rpc.moderato.tempo.xyz"
     ;;
   *)
     echo "::error::Unknown chain: $CHAIN (must be 'mainnet' or 'testnet')"
     exit 1
     ;;
 esac
+set +x
+REPLAY_RPC_URL="${BENCH_REPLAY_RPC_URL:-$DEFAULT_REPLAY_RPC_URL}"
+if [ -n "${BENCH_REPLAY_RPC_URL:-}" ]; then
+  echo "::add-mask::$BENCH_REPLAY_RPC_URL"
+fi
+set -x
 
 DATADIR="$SCHELK_MOUNT/tempo-replay-${CHAIN_NAME}"
 SNAPSHOT_PREFIX="tempo-${CHAIN_ID}-"
 SNAPSHOT_HASH_FILE="$HOME/.tempo-replay-snapshot-hash-${CHAIN_NAME}"
-echo "Chain: $CHAIN_NAME (id=$CHAIN_ID, rpc=$REPLAY_RPC_URL)"
+echo "Chain: $CHAIN_NAME (id=$CHAIN_ID, rpc=$(redact_url "$REPLAY_RPC_URL"))"
 
 MC="mc"
 BLOCKS="${BENCH_BLOCKS:-5000}"

--- a/.github/workflows/bench-replay-scheduled.yml
+++ b/.github/workflows/bench-replay-scheduled.yml
@@ -237,6 +237,8 @@ jobs:
     secrets:
       DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
       DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
+      BENCH_MAINNET_RPC_URL: ${{ secrets.BENCH_MAINNET_RPC_URL }}
+      BENCH_TESTNET_RPC_URL: ${{ secrets.BENCH_TESTNET_RPC_URL }}
       SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
       SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
       CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -130,6 +130,10 @@ on:
         required: false
       GRAFANA_TEMPO:
         required: false
+      BENCH_MAINNET_RPC_URL:
+        required: false
+      BENCH_TESTNET_RPC_URL:
+        required: false
       SLACK_BENCH_BOT_TOKEN:
         required: false
       SLACK_BENCH_CHANNEL:
@@ -402,6 +406,7 @@ jobs:
           CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
           CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
           CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
+          BENCH_REPLAY_RPC_URL: ${{ env.BENCH_CHAIN == 'mainnet' && secrets.BENCH_MAINNET_RPC_URL || env.BENCH_CHAIN == 'testnet' && secrets.BENCH_TESTNET_RPC_URL || '' }}
         run: bash .github/scripts/bench-tempo-replay.sh
 
       - name: Parse results


### PR DESCRIPTION
## Summary
- pass separate BENCH_MAINNET_RPC_URL and BENCH_TESTNET_RPC_URL secrets into the reusable replay benchmark workflow
- select the replay RPC override by BENCH_CHAIN, with public RPC fallback for local/manual contexts
- mask the selected override before xtrace resumes and redact credentials in the visible chain log line

## Validation
- uv run python YAML parse for bench replay workflows
- bash -n .github/scripts/bench-tempo-replay.sh
- git diff --check