### PR TITLE
docs(tips): align TIP-1028 proof ABI

### DIFF
--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -215,7 +215,7 @@ The aggregate blocked balance for each TIP-20 token sits in that token's `balanc
 
 The following restrictions apply:
 
-- A TIP-20 transfer or mint with `to == TIP1028_GUARD_ADDRESS` MUST revert with `BlockedTransferAddressReserved()`. This applies to `transfer`, `transferFrom`, `transferWithMemo`, `transferFromWithMemo`, `systemTransferFrom`, `mint`, and `mintWithMemo`.
+- A TIP-20 transfer or mint with `to == TIP1028_GUARD_ADDRESS` MUST revert with `AddressReserved()`. This applies to `transfer`, `transferFrom`, `transferWithMemo`, `transferFromWithMemo`, `systemTransferFrom`, `mint`, and `mintWithMemo`.
 - A reroute claim with `to == TIP1028_GUARD_ADDRESS` MUST revert.
 - `setReceivePolicy(...)` MUST reject `account == TIP1028_GUARD_ADDRESS`.
 - The TIP-20 `burnBlocked` function MUST revert when `from == TIP1028_GUARD_ADDRESS`. Funds leave `TIP1028Guard` only by claiming a proof. Burning the `TIP1028_GUARD_ADDRESS` balance directly would leave proofs pointing at money that no longer exists.
@@ -236,15 +236,18 @@ uint64 public nonce = 1;
 mapping(bytes32 => uint256) internal balanceOf;
 ```
 
-Each blocked transfer or mint is identified by a `proofKey`. The format is versioned by `proofVersion` so future TIPs can change the layout. v1 uses this proof body:
+Each blocked transfer or mint is identified by a `proofKey`. The encoded proof is self-describing so claim and balance lookups bind the token, version, and recovery authority to the witness itself. v1 uses this proof body:
 
 ```solidity
 struct ClaimProofV1 {
+    uint8 version;
+    address token;
+    address recoveryAuthority;
     address originator;
     address recipient;
     uint64 blockedAt;
     uint64 blockedNonce;
-    BlockedReason blockedReason;
+    uint8 blockedReason;
     InboundKind kind;
     bytes32 memo;
 }
@@ -253,29 +256,16 @@ struct ClaimProofV1 {
 The v1 `proof` is computed as:
 
 ```text
-proofKey = keccak256(
-    abi.encode(
-        proofVersion,
-        token,
-        originator,
-        recipient,
-        recoveryAuthority,
-        blockedReason,
-        kind,
-        memo,
-        blockedAt,
-        blockedNonce
-    )
-)
+proofKey = keccak256(abi.encode(proof))
 ```
 
 where:
 
-- `proofVersion`: one-byte outer discriminator. MUST be `1` for proofs created under this TIP. Future proof-key formats MUST use a different value and MAY define a different version-specific proof body.
+- `version`: one-byte discriminator inside the proof. MUST be `1` for proofs created under this TIP. Future proof-key formats MUST use a different value and MAY define a different version-specific proof body.
 - `token`: the TIP-20 token whose balance ledger holds the blocked amount at `TIP1028_GUARD_ADDRESS`.
+- `recoveryAuthority`: the encoded recovery authority captured when the proof was created: `address(0)` for originator recovery (default), `address(1)` as a receiver-recovery sentinel, or a third-party address.
 - `originator`: `from` for transfers, `msg.sender` for mints.
 - `recipient`: the literal `to` supplied at the TIP-20 entrypoint. For non-virtual inbounds this is the receiver itself; for TIP-1022 inbounds this is the virtual alias. The canonical owner is derived at claim time as `tip1022.resolve(recipient)`, which is deterministic.
-- `recoveryAuthority`: the encoded recovery authority captured when the proof was created: `address(0)` for originator recovery (default), `address(1)` as a receiver-recovery sentinel, or a third-party address.
 - `blockedReason`: `TOKEN_FILTER` or `RECEIVE_POLICY`.
 - `kind`: `TRANSFER` or `MINT`.
 - `memo`: original memo for memo-bearing paths, `bytes32(0)` otherwise.
@@ -290,13 +280,13 @@ The blocked transfers precompile does not enumerate proofs onchain. Claimers MUS
 
 ### Storing Blocked Transfers and Mints
 
-When `validateReceivePolicy(...)` returns blocked, the TIP-20 path credits `TIP1028_GUARD_ADDRESS` instead of the receiver, then calls `storeBlocked(...)`. The blocked transfers precompile assigns the proof's `blockedAt` and `blockedNonce`, computes `proofKey`, sets `blockedProofAmount[proofKey] = amount`, and returns the assigned `(blockedNonce, blockedAt)` to the caller. A blocked transfer emits the regular `Transfer` event naming `TIP1028Guard` as the recipient, then emits `TransferBlocked(...)`; a blocked mint emits the regular `Transfer` and `Mint` events naming `TIP1028Guard` as the recipient, then emits `MintBlocked(...)`. Memo-bearing variants preserve the original memo in the attribution event.
+When `validateReceivePolicy(...)` returns blocked, the TIP-20 path credits `TIP1028_GUARD_ADDRESS` instead of the receiver, then calls `storeBlocked(...)`. The blocked transfers precompile assigns the proof's `blockedAt` and `blockedNonce`, computes `proofKey`, sets `blockedProofAmount[proofKey] = amount`, and returns the assigned `(blockedNonce, blockedAt)` to the caller. A blocked transfer emits the regular `Transfer` event naming `TIP1028Guard` as the recipient, then emits `TransferBlocked(...)`; a blocked mint emits the regular `Transfer` and `Mint` events naming `TIP1028Guard` as the recipient, then emits `TransferBlocked(...)` with `kind = MINT`. Memo-bearing variants preserve the original memo in the attribution event.
 
 `storeBlocked(...)` MUST be callable only by TIP-20 precompiles or protocol-internal system code. User callers MUST NOT be able to fabricate proofs. Without this restriction, an attacker could mint synthetic proofs by replaying or fabricating witnesses without any backing `TIP1028Guard` balance.
 
 ### Claiming
 
-A claim consumes one full proof and releases the funds to a single destination. `claim(...)` takes `proofVersion`, an encoded proof, and a destination `to`. For `proofVersion == 1`, it decodes the witness as `ClaimProofV1`, derives the canonical receiver as `tip1022.resolve(proof.recipient)`, recomputes `proofKey`, requires `blockedProofAmount[proofKey] > 0`, zeroes the slot to free its storage, and releases the stored amount. Once consumed, a proof is permanently retired: its `proofKey` slot is empty and any subsequent claim against the same witness MUST revert with `InvalidProof()`. Partial claims are not allowed. Claims MUST consume whole proofs.
+A claim consumes one full proof and releases the funds to a single destination. `claim(...)` takes an encoded proof and a destination `to`. For `proof.version == 1`, it decodes the witness as `ClaimProofV1`, derives the canonical receiver as `tip1022.resolve(proof.recipient)`, recomputes `proofKey`, requires `blockedProofAmount[proofKey] > 0`, zeroes the slot to free its storage, and releases the stored amount from `proof.token`. Once consumed, a proof is permanently retired: its `proofKey` slot is empty and any subsequent claim against the same witness MUST revert with `InvalidProof()`. Partial claims are not allowed. Claims MUST consume whole proofs.
 
 The release path inside the TIP-20 token debits `balances[TIP1028Guard]`, credits the destination, emits `Transfer(TIP1028Guard, to, amount)` followed by `ProofClaimed(...)`, bypasses the token-level TIP-403 sender check for `TIP1028Guard`, and treats `TIP1028Guard` as a reward-exempt always-opted-out source. Releasing a previously blocked mint does not emit a fresh `Mint` event because the claim is a transfer out of blocked transfers precompile, not a new mint.
 
@@ -316,7 +306,7 @@ The destination `to` and the proof's `recoveryAuthority` decide whether the clai
 
 When `recoveryAuthority != address(0)` and `to == receiver`, the claim resumes a previously authorized inbound. It bypasses the receiver's receive policy, token-level recipient authorization for the receiver, and AccountKeychain spending-limit metering. This is intentional. A blocked mint, for example, has already passed the token's original mint-recipient check on the inbound path. Releasing the blocked amount back to the same receiver is not a new transfer and MUST NOT be rechecked against the recipient's receive policy. A third-party recovery authority may use this resume path because the receiver selected that authority.
 
-All other claims are reroutes. This includes every originator-authorized claim, even if `to == receiver`. A reroute MUST reject `to == TIP1028_GUARD_ADDRESS`. If `to` is a TIP-1022 virtual address, it is resolved to its master address before destination checks and final credit; if resolution fails, the call MUST revert with `ClaimDestinationUnauthorized()`. The reroute enforces token-level transfer-recipient authorization and receive policy checks against the resolved destination, using the consumed proof's `originator` for the receive policy check. If either destination check fails, the call MUST revert with `ClaimDestinationUnauthorized()`. The `ProofClaimed` event preserves the literal `to` supplied by the caller for attribution. If a direct receiver-authorized reroute is initiated through an access key, the claim MUST meter the claimed amount against the receiver's AccountKeychain spending limit as an ordinary TIP-20 spend by the receiver. If an originator-authorized reroute is initiated through an access key, it MUST meter against the originator. If the receiver uses a third-party recovery authority, any equivalent delegation, timelock, multisig, or key-policy enforcement is the responsibility of that authority.
+All other claims are reroutes. This includes every originator-authorized claim, even if `to == receiver`. A reroute MUST reject `to == TIP1028_GUARD_ADDRESS`. If `to` is a TIP-1022 virtual address, it is resolved to its master address before destination checks and final credit; if resolution fails, the call MUST revert with `InvalidClaimAddress()`. The reroute enforces token-level transfer-recipient authorization and receive policy checks against the resolved destination, using the consumed proof's `originator` for the receive policy check. If either destination check fails, the call MUST revert with `InvalidClaimAddress()`. The `ProofClaimed` event preserves the literal `to` supplied by the caller for attribution. If a direct receiver-authorized reroute is initiated through an access key, the claim MUST meter the claimed amount against the receiver's AccountKeychain spending limit as an ordinary TIP-20 spend by the receiver. If an originator-authorized reroute is initiated through an access key, it MUST meter against the originator. If the receiver uses a third-party recovery authority, any equivalent delegation, timelock, multisig, or key-policy enforcement is the responsibility of that authority.
 
 The sequence diagram below shows the high level flow for a claim.
 
@@ -327,7 +317,7 @@ sequenceDiagram
     participant TIP20
     participant Destination
 
-    Claimer->>BlockedTransfers: claim(proof, to)
+    Claimer->>BlockedTransfers: claim(to, proof)
     BlockedTransfers->>BlockedTransfers: check claimer is receiver, originator, or recoveryAuthority
     BlockedTransfers->>BlockedTransfers: recompute proofKey, require amount > 0
     BlockedTransfers->>BlockedTransfers: delete blockedProofAmount[proofKey]
@@ -368,21 +358,7 @@ event TransferBlocked(
     uint64 blockedAt,
     address recipient,
     uint256 amount,
-    BlockedReason blockedReason,
-    address recoveryAuthority,
-    bytes32 memo
-);
-
-event MintBlocked(
-    address indexed token,
-    address indexed operator,
-    address indexed receiver,
-    uint8 proofVersion,
-    uint64 blockedNonce,
-    uint64 blockedAt,
-    address recipient,
-    uint256 amount,
-    BlockedReason blockedReason,
+    uint8 blockedReason,
     address recoveryAuthority,
     bytes32 memo
 );
@@ -407,11 +383,10 @@ event ProofClaimed(
 ```solidity
 error InvalidReceivePolicyType();
 error InvalidRecoveryAuthority();
-error BlockedTransferAddressReserved();
-error UnauthorizedClaimer();
 error InvalidProof();
-error ClaimDestinationUnauthorized();
-error InsufficientBalance();
+error InvalidClaimAddress();
+error UnauthorizedClaimer();
+error AddressReserved();
 ```
 
 A successful claim MUST emit exactly one `ProofClaimed` event for the consumed proof.
@@ -463,29 +438,21 @@ interface ITIP1028Guard {
     }
 
     struct ClaimProofV1 {
+        uint8 version;
+        address token;
+        address recoveryAuthority;
         address originator;
         address recipient;
         uint64 blockedAt;
         uint64 blockedNonce;
-        BlockedReason blockedReason;
+        uint8 blockedReason;
         InboundKind kind;
         bytes32 memo;
     }
 
-    function balanceOf(
-        address token,
-        address recoveryAuthority,
-        uint8 proofVersion,
-        bytes calldata proof
-    ) external view returns (uint256 amount);
+    function balanceOf(bytes calldata proof) external view returns (uint256 amount);
 
-    function claim(
-        address token,
-        address recoveryAuthority,
-        uint8 proofVersion,
-        bytes calldata proof,
-        address to
-    ) external;
+    function claim(address to, bytes calldata proof) external;
 
     function storeBlocked(
         address token,
@@ -494,7 +461,7 @@ interface ITIP1028Guard {
         address recipient,
         address recoveryAuthority,
         uint256 amount,
-        BlockedReason blockedReason,
+        uint8 blockedReason,
         InboundKind kind,
         bytes32 memo
     ) external returns (uint64 blockedNonce, uint64 blockedAt);

--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -247,7 +247,7 @@ struct ClaimProofV1 {
     address recipient;
     uint64 blockedAt;
     uint64 blockedNonce;
-    uint8 blockedReason;
+    BlockedReason blockedReason;
     InboundKind kind;
     bytes32 memo;
 }
@@ -358,7 +358,7 @@ event TransferBlocked(
     uint64 blockedAt,
     address recipient,
     uint256 amount,
-    uint8 blockedReason,
+    BlockedReason blockedReason,
     address recoveryAuthority,
     bytes32 memo
 );
@@ -445,7 +445,7 @@ interface ITIP1028Guard {
         address recipient;
         uint64 blockedAt;
         uint64 blockedNonce;
-        uint8 blockedReason;
+        BlockedReason blockedReason;
         InboundKind kind;
         bytes32 memo;
     }
@@ -461,7 +461,7 @@ interface ITIP1028Guard {
         address recipient,
         address recoveryAuthority,
         uint256 amount,
-        uint8 blockedReason,
+        BlockedReason blockedReason,
         InboundKind kind,
         bytes32 memo
     ) external returns (uint64 blockedNonce, uint64 blockedAt);


### PR DESCRIPTION
## Summary
- make ClaimProofV1 self-contained with version, token, and recoveryAuthority
- update proofKey derivation, balanceOf/claim signatures, events, and errors to match 07c92a9ba6f277fa2c8ba6b900b742643d2cac53
- remove the separate MintBlocked event from the spec in favor of TransferBlocked with kind = MINT

## Validation
- git diff --check