### PR TITLE
ci(bench): improve bench-e2e GitHub reporting

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -340,6 +340,7 @@ env:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -455,7 +456,7 @@ jobs:
           INPUT_BASELINE_NAME: ${{ inputs.baseline-name }}
           INPUT_FEATURE_NAME: ${{ inputs.feature-name }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
           script: |
             const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
@@ -625,11 +626,66 @@ jobs:
             }
             core.exportVariable('BENCH_PR', pr);
 
+      - name: Create dispatch PR comment
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_BASELINE_NAME: ${{ steps.refs.outputs.baseline-name }}
+          INPUT_FEATURE_NAME: ${{ steps.refs.outputs.feature-name }}
+        with:
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
+          script: |
+            if (process.env.BENCH_COMMENT_ID || !process.env.BENCH_PR) {
+              return;
+            }
+
+            const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+            const job = jobs.jobs.find(j => j.name === 'bench-e2e');
+            const jobUrl = job ? job.html_url : `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            core.exportVariable('BENCH_JOB_URL', jobUrl);
+
+            const mode = process.env.BENCH_MODE;
+            const preset = process.env.BENCH_PRESET;
+            const duration = process.env.BENCH_DURATION;
+            const bloat = process.env.BENCH_BLOAT;
+            const tps = process.env.BENCH_TPS;
+            const accounts = process.env.BENCH_ACCOUNTS;
+            const maxConcurrentRequests = process.env.BENCH_MAX_CONCURRENT_REQUESTS;
+            const baselineHardfork = process.env.BENCH_BASELINE_HARDFORK || '';
+            const featureHardfork = process.env.BENCH_FEATURE_HARDFORK || '';
+            const baseline = process.env.INPUT_BASELINE_NAME;
+            const feature = process.env.INPUT_FEATURE_NAME;
+            const txgenRef = process.env.BENCH_TXGEN_REF || 'default';
+            const samply = process.env.BENCH_SAMPLY === 'true';
+            const samplyNote = samply ? ', samply: `enabled`' : '';
+            const tracy = process.env.BENCH_TRACY;
+            const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
+            const otlp = process.env.BENCH_OTLP === 'true';
+            const otlpNote = otlp ? ', otlp: `enabled`' : ', otlp: `disabled`';
+            const noCache = process.env.BENCH_NO_CACHE === 'true';
+            const noCacheNote = noCache ? ', no-cache: `true`' : '';
+            const gasLimit = process.env.BENCH_GAS_LIMIT;
+            const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
+            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${samplyNote}${tracyNote}${otlpNote}${noCacheNote}`;
+            core.exportVariable('BENCH_CONFIG', config);
+
+            const { data: comment } = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: parseInt(process.env.BENCH_PR),
+              body: `cc @${process.env.BENCH_ACTOR}\n\n🚀 Benchmark started! [View job](${jobUrl})\n\n⏳ **Status:** Running benchmark...\n\n${config}`,
+            });
+            core.exportVariable('BENCH_COMMENT_ID', String(comment.id));
+
       - name: Update status (running benchmark)
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
             await s({github, context, status: 'Running benchmark...'});
@@ -708,7 +764,7 @@ jobs:
         env:
           BENCH_RESULTS_DIR: ${{ steps.results-dir.outputs.path }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
           script: |
             const fs = require('fs');
             const resultsDir = process.env.BENCH_RESULTS_DIR;
@@ -818,9 +874,9 @@ jobs:
                 comment_id: parseInt(ackCommentId),
                 body,
               });
-            } else {
-              await core.summary.addRaw(body).write();
             }
+
+            await core.summary.addRaw(body).write();
 
       - name: Send Slack notification (success)
         if: success() && steps.results-dir.outputs.path && env.BENCH_NO_SLACK != 'true'
@@ -846,7 +902,7 @@ jobs:
         if: failure() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({
@@ -860,7 +916,7 @@ jobs:
         if: cancelled() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({

--- a/tempo.nu
+++ b/tempo.nu
@@ -800,6 +800,10 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
     mut feature_intervals = []
     mut baseline_tps_samples = []
     mut feature_tps_samples = []
+    mut baseline_builder_samples = []
+    mut feature_builder_samples = []
+    mut baseline_validation_samples = []
+    mut feature_validation_samples = []
 
     let compute_tps_stats = { |samples: list<any>|
         let sorted_samples = ($samples | sort)
@@ -826,6 +830,17 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
             continue
         }
         let report = (open $report_path)
+        let samples_path = $"($results_dir)/report-($label).samples.ndjson"
+        let validation_samples = if ($samples_path | path exists) {
+            open --raw $samples_path
+                | lines
+                | where { |line| ($line | str trim) != "" }
+                | each { |line| $line | from json }
+                | where { |sample| $sample.name in ["reth_tempo_payload_builder_payload_build_duration_seconds" "reth_consensus_engine_beacon_new_payload_latency"] }
+                | where { |sample| ($sample.labels | get -o quantile | default "") in ["0.5" "0.9" "0.99"] }
+        } else { [] }
+        let builder_samples = ($validation_samples | where name == "reth_tempo_payload_builder_payload_build_duration_seconds")
+        let validation_samples = ($validation_samples | where name == "reth_consensus_engine_beacon_new_payload_latency")
         let blocks = ($report | get blocks | each { |b|
             let tx_count = ($b | get tx_count)
             let timestamp = if (($b | get -o timestamp | default null) != null) {
@@ -877,10 +892,14 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
             $baseline_blocks = ($baseline_blocks | append $blocks)
             $baseline_intervals = ($baseline_intervals | append $block_intervals)
             $baseline_tps_samples = ($baseline_tps_samples | append $block_tps_samples)
+            $baseline_builder_samples = ($baseline_builder_samples | append $builder_samples)
+            $baseline_validation_samples = ($baseline_validation_samples | append $validation_samples)
         } else {
             $feature_blocks = ($feature_blocks | append $blocks)
             $feature_intervals = ($feature_intervals | append $block_intervals)
             $feature_tps_samples = ($feature_tps_samples | append $block_tps_samples)
+            $feature_builder_samples = ($feature_builder_samples | append $builder_samples)
+            $feature_validation_samples = ($feature_validation_samples | append $validation_samples)
         }
 
         let total_tx = ($blocks | get tx_count | math sum)
@@ -948,6 +967,31 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
     let b_lat = do $compute_latency_stats $baseline_blocks
     let f_lat = do $compute_latency_stats $feature_blocks
 
+    let compute_quantile_metric_stats = { |samples: list<any>|
+        let quantile_ms = { |q: string|
+            let values = (
+                $samples
+                    | where { |sample| ($sample.labels | get -o quantile | default "") == $q }
+                    | get value
+                    | each { |v| $v * 1000.0 }
+            )
+            if ($values | length) > 0 { $values | math avg | math round --precision 1 } else { 0.0 }
+        }
+        {
+            n: ($samples | length)
+            p50: (do $quantile_ms "0.5")
+            p90: (do $quantile_ms "0.9")
+            p99: (do $quantile_ms "0.99")
+        }
+    }
+
+    let b_builder_metric = do $compute_quantile_metric_stats $baseline_builder_samples
+    let f_builder_metric = do $compute_quantile_metric_stats $feature_builder_samples
+    let b_builder = if $b_builder_metric.n > 0 { $b_builder_metric } else { { n: $b_lat.n, p50: $b_lat.p50, p90: $b_lat.p90, p99: $b_lat.p99 } }
+    let f_builder = if $f_builder_metric.n > 0 { $f_builder_metric } else { { n: $f_lat.n, p50: $f_lat.p50, p90: $f_lat.p90, p99: $f_lat.p99 } }
+    let b_validation = do $compute_quantile_metric_stats $baseline_validation_samples
+    let f_validation = do $compute_quantile_metric_stats $feature_validation_samples
+
     let b_bt = do $compute_block_time_stats $baseline_intervals
     let f_bt = do $compute_block_time_stats $feature_intervals
     let b_tps_stats = do $compute_tps_stats $baseline_tps_samples
@@ -1001,29 +1045,24 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
         $"| Block Time P90 [ms] | ($b_bt.p90) | ($f_bt.p90) | (do $delta $b_bt.p90 $f_bt.p90)% |"
         $"| Block Time P99 [ms] | ($b_bt.p99) | ($f_bt.p99) | (do $delta $b_bt.p99 $f_bt.p99)% |"
         ""
-        "## Latency (Secondary)"
+        "## Builder Latency"
         ""
         "| Metric | Baseline | Feature | Delta |"
         "|--------|----------|---------|-------|"
-        $"| Latency Mean [ms] | ($b_lat.mean) | ($f_lat.mean) | (do $delta $b_lat.mean $f_lat.mean)% |"
-        $"| Latency Std Dev [ms] | ($b_lat.stddev) | ($f_lat.stddev) | (do $delta $b_lat.stddev $f_lat.stddev)% |"
-        $"| Latency P50 [ms] | ($b_lat.p50) | ($f_lat.p50) | (do $delta $b_lat.p50 $f_lat.p50)% |"
-        $"| Latency P90 [ms] | ($b_lat.p90) | ($f_lat.p90) | (do $delta $b_lat.p90 $f_lat.p90)% |"
-        $"| Latency P99 [ms] | ($b_lat.p99) | ($f_lat.p99) | (do $delta $b_lat.p99 $f_lat.p99)% |"
+        $"| P50 [ms] | ($b_builder.p50) | ($f_builder.p50) | (do $delta $b_builder.p50 $f_builder.p50)% |"
+        $"| P90 [ms] | ($b_builder.p90) | ($f_builder.p90) | (do $delta $b_builder.p90 $f_builder.p90)% |"
+        $"| P99 [ms] | ($b_builder.p99) | ($f_builder.p99) | (do $delta $b_builder.p99 $f_builder.p99)% |"
         ""
-        "## Per-Run Details"
+        "## Validation Latency"
         ""
-        "| Run | Blocks | Total Tx | Success | Failed | Avg TPS | Block P50 | Mgas/s |"
-        "|-----|--------|----------|---------|--------|---------|-----------|--------|"
+        "| Metric | Baseline | Feature | Delta |"
+        "|--------|----------|---------|-------|"
+        $"| P50 [ms] | ($b_validation.p50) | ($f_validation.p50) | (do $delta $b_validation.p50 $f_validation.p50)% |"
+        $"| P90 [ms] | ($b_validation.p90) | ($f_validation.p90) | (do $delta $b_validation.p90 $f_validation.p90)% |"
+        $"| P99 [ms] | ($b_validation.p99) | ($f_validation.p99) | (do $delta $b_validation.p99 $f_validation.p99)% |"
+        ""
     ])
-    let summary = ($summary_lines | str join "\n")
-
-    mut per_run_rows = ""
-    for row in $run_data {
-        $per_run_rows = $"($per_run_rows)| ($row.label) | ($row.blocks) | ($row.total_tx) | ($row.ok) | ($row.err) | ($row.tps) | ($row.block_time_p50) | ($row.mgas_s) |\n"
-    }
-
-    let full_summary = $"($summary)\n($per_run_rows)"
+    let full_summary = ($summary_lines | str join "\n")
     $full_summary | save -f $"($results_dir)/summary.md"
     print $"Summary saved: ($results_dir)/summary.md"
     print $full_summary
@@ -1048,6 +1087,9 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
                 latency_p50: $b_lat.p50
                 latency_p90: $b_lat.p90
                 latency_p99: $b_lat.p99
+                builder_latency_p50: $b_builder.p50
+                builder_latency_p90: $b_builder.p90
+                builder_latency_p99: $b_builder.p99
                 tps: $b_tps
                 tps_p50: $b_tps_stats.p50
                 tps_p90: $b_tps_stats.p90
@@ -1056,6 +1098,9 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
                 block_time_p50: $b_bt.p50
                 block_time_p90: $b_bt.p90
                 block_time_p99: $b_bt.p99
+                validation_latency_p50: $b_validation.p50
+                validation_latency_p90: $b_validation.p90
+                validation_latency_p99: $b_validation.p99
                 blocks: $b_lat.n
             }
             feature: {
@@ -1064,6 +1109,9 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
                 latency_p50: $f_lat.p50
                 latency_p90: $f_lat.p90
                 latency_p99: $f_lat.p99
+                builder_latency_p50: $f_builder.p50
+                builder_latency_p90: $f_builder.p90
+                builder_latency_p99: $f_builder.p99
                 tps: $f_tps
                 tps_p50: $f_tps_stats.p50
                 tps_p90: $f_tps_stats.p90
@@ -1072,6 +1120,9 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
                 block_time_p50: $f_bt.p50
                 block_time_p90: $f_bt.p90
                 block_time_p99: $f_bt.p99
+                validation_latency_p50: $f_validation.p50
+                validation_latency_p90: $f_validation.p90
+                validation_latency_p99: $f_validation.p99
                 blocks: $f_lat.n
             }
             deltas: {
@@ -1080,6 +1131,9 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
                 latency_p50: (do $delta $b_lat.p50 $f_lat.p50)
                 latency_p90: (do $delta $b_lat.p90 $f_lat.p90)
                 latency_p99: (do $delta $b_lat.p99 $f_lat.p99)
+                builder_latency_p50: (do $delta $b_builder.p50 $f_builder.p50)
+                builder_latency_p90: (do $delta $b_builder.p90 $f_builder.p90)
+                builder_latency_p99: (do $delta $b_builder.p99 $f_builder.p99)
                 tps: (do $delta $b_tps $f_tps)
                 tps_p50: (do $delta $b_tps_stats.p50 $f_tps_stats.p50)
                 tps_p90: (do $delta $b_tps_stats.p90 $f_tps_stats.p90)
@@ -1088,6 +1142,9 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
                 block_time_p50: (do $delta $b_bt.p50 $f_bt.p50)
                 block_time_p90: (do $delta $b_bt.p90 $f_bt.p90)
                 block_time_p99: (do $delta $b_bt.p99 $f_bt.p99)
+                validation_latency_p50: (do $delta $b_validation.p50 $f_validation.p50)
+                validation_latency_p90: (do $delta $b_validation.p90 $f_validation.p90)
+                validation_latency_p99: (do $delta $b_validation.p99 $f_validation.p99)
             }
         }
         per_run: $run_data


### PR DESCRIPTION
## Summary
- Show bench-e2e GitHub output as Tempo Metrics, Builder Latency, then Validation Latency
- Remove the per-run details table from generated markdown
- Always write the same result body to the GitHub job summary, even when updating a PR comment
- Create and update a PR comment for manual workflow_dispatch runs when PR auto-discovery finds an open PR

## Validation
- git diff --check
- Not run: nu --check tempo.nu (nu is not installed in this sandbox)
- Not run: actionlint (not installed in this sandbox)