### PR TITLE
Clarify TIP-1035 helper activation semantics

### DIFF
--- a/tips/tip-1035.md
+++ b/tips/tip-1035.md
@@ -65,7 +65,7 @@ The AddressRegistry precompile MUST expose a hardfork-aware helper:
 function isImplicitlyApproved(address addr) external view returns (bool);
 ```
 
-This function returns `true` if and only if `addr` is on the Implicit Approval List for the active hardfork. Before TIP-1035 activates, it returns `false` for all addresses.
+Once TIP-1035 activates, this function returns `true` if and only if `addr` is on the Implicit Approval List for the active hardfork. Before TIP-1035 activates, this function is unavailable.
 
 ## Initial List
 
@@ -105,4 +105,4 @@ Additional precompiles may be added to or removed from the Implicit Approval Lis
 2. **List gating**: Only precompiles on the Implicit Approval List may call `system_transfer_from`. Calls from unlisted addresses MUST revert.
 3. **Standard semantics preserved**: `approve`, `permit`, `allowance`, and `transferFrom` MUST behave identically to their pre-TIP-1035 TIP-20 semantics for all addresses, including listed precompiles.
 4. **List discoverability**: `AddressRegistry.isImplicitlyApproved(addr)` MUST match the protocol-defined Implicit Approval List for the active hardfork.
-5. **Hardfork gating**: The behavior change MUST be gated behind the TIP-1035 activation hardfork. Before activation, `system_transfer_from` access restrictions and `isImplicitlyApproved` are not active.
+5. **Hardfork gating**: The behavior change MUST be gated behind the TIP-1035 activation hardfork. Before activation, `system_transfer_from` access restrictions are not active and `AddressRegistry.isImplicitlyApproved` MUST be unavailable.

--- a/tips/tip-1035.md
+++ b/tips/tip-1035.md
@@ -93,6 +93,10 @@ Listed status is not a one-way ratchet. A future TIP MAY add or remove addresses
 
 Integrators with non-upgradeable flows who want compatibility across potential future list changes SHOULD query `AddressRegistry.isImplicitlyApproved(spender)` to branch on the current protocol state and determine whether the precompile path will skip approvals.
 
+## Compatibility
+
+After TIP-1035 activation, pre-existing AccountKeychains that have not expired and either have sufficient spending limits or no spending limits may allow listed precompile flows to succeed without a prior token approval. Before activation, those flows could fail because approvals were not granted or because the approval did not cover the scoped call being attempted.
+
 ## Future Amendments
 
 Additional precompiles may be added to or removed from the Implicit Approval List via future TIPs that reference and amend this one. Each addition should include a safety argument demonstrating that the precompile satisfies the eligibility guidelines above.

--- a/tips/tip-1035.md
+++ b/tips/tip-1035.md
@@ -95,7 +95,7 @@ Integrators with non-upgradeable flows who want compatibility across potential f
 
 ## Compatibility
 
-After TIP-1035 activation, pre-existing AccountKeychains that have not expired and either have sufficient spending limits or no spending limits may allow listed precompile flows to succeed without a prior token approval. Before activation, those flows could fail because approvals were not granted or because the approval did not cover the scoped call being attempted.
+After TIP-1035 activation, pre-existing AccountKeychains that have not expired and either have sufficient spending limits or no spending limits may spend via precompiles with implicit approvals. Prior to activation, attempts would have failed due to insufficient approval.
 
 ## Future Amendments
 


### PR DESCRIPTION
## Summary
- Clarify that `AddressRegistry.isImplicitlyApproved` is unavailable before TIP-1035 activation and hardfork-aware only after activation
- Add a compatibility section for pre-existing AccountKeychains that may now succeed without prior token approvals after activation

## Testing
- Not run; documentation-only change