### PR TITLE
Fix bench workflow issue permissions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,6 +17,7 @@ name: bench
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary
- Allow the bench caller workflow to grant issues: write so bench-e2e.yml can create/update PR comments when invoked as a reusable workflow.

## Validation
- uv run --with pyyaml python -c "import yaml; [yaml.safe_load(open(p)) for p in ['.github/workflows/bench.yml','.github/workflows/bench-e2e.yml']]; print('ok')"