### PR TITLE
Fix replay bench cleanup and chart regression

### DIFF
--- a/.github/scripts/bench-replay-charts.py
+++ b/.github/scripts/bench-replay-charts.py
@@ -156,8 +156,15 @@ def _add_regression(ax, x, y, color, label):
     """Add a linear regression line to the axes."""
     if len(x) < 2:
         return
-    xa, ya = np.array(x), np.array(y)
-    m, b = np.polyfit(xa, ya, 1)
+    xa, ya = np.array(x, dtype=float), np.array(y, dtype=float)
+    finite = np.isfinite(xa) & np.isfinite(ya)
+    xa, ya = xa[finite], ya[finite]
+    if len(xa) < 2 or np.allclose(xa, xa[0]):
+        return
+    try:
+        m, b = np.polyfit(xa, ya, 1)
+    except np.linalg.LinAlgError:
+        return
     x_range = np.linspace(xa.min(), xa.max(), 100)
     ax.plot(x_range, m * x_range + b, color=color, linewidth=1.5, alpha=0.8,
             label=label)

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -282,12 +282,15 @@ run_single() {
       "${scope_env[@]}" "$binary" "${NODE_ARGS[@]}" \
       > "$log" 2>&1 &
   fi
+  local tail_pid=""
   stdbuf -oL tail -f "$log" | sed -u "s/^/[$label] /" &
-  local tail_pid=$!
+  tail_pid=$!
 
   # Ensure node and tail are cleaned up on any exit from run_single
   cleanup_run() {
-    kill "$tail_pid" 2>/dev/null || true
+    if [ -n "${tail_pid:-}" ]; then
+      kill "$tail_pid" 2>/dev/null || true
+    fi
     if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
       sudo pkill -INT -x tempo 2>/dev/null || true
       for _i in $(seq 1 60); do

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -45,6 +45,15 @@ def txgen-resolve-binaries [] {
     }
 }
 
+def txgen-bench-supports-metrics-align [txgen_bench_bin: string] {
+    let help = (^$txgen_bench_bin send --help | complete)
+    if $help.exit_code != 0 {
+        return false
+    }
+
+    $help.stdout | str contains "--metrics-align"
+}
+
 def txgen-repo-root [] {
     let result = (git rev-parse --show-toplevel | complete)
     if $result.exit_code == 0 {
@@ -224,6 +233,16 @@ def txgen-run-preset-pipeline [
         "--rpc" $generate_rpc_url
     ]
     let metrics_url_args = ($metrics_url | each { |url| ["--metrics-url" $url] } | flatten)
+    let metrics_align_args = if $victoriametrics_url != "" and $benchmark_start > 0 {
+        if (txgen-bench-supports-metrics-align $txgen_bench_bin) {
+            ["--metrics-align" $"($benchmark_start)"]
+        } else {
+            print "  Skipping --metrics-align: txgen bench binary does not support it"
+            []
+        }
+    } else {
+        []
+    }
     let bench_base_cmd = [
         $txgen_bench_bin
         "send"
@@ -234,7 +253,7 @@ def txgen-run-preset-pipeline [
         "--scrape-interval-ms" $TXGEN_HELPER_SCRAPE_INTERVAL_MS
         "--drain-timeout" $TXGEN_HELPER_DRAIN_TIMEOUT_SECS
     ]
-        | append (if $victoriametrics_url != "" and $benchmark_start > 0 { ["--metrics-align" $"($benchmark_start)"] } else { [] })
+        | append $metrics_align_args
     let report_args = ["--report" $"json:($report_path)"]
         | append (if $victoriametrics_url != "" { ["--report" $"victoriametrics:($victoriametrics_url)"] } else { [] })
         | append (if $clickhouse_url != "" { ["--report" $"clickhouse:($clickhouse_url)"] } else { [] })


### PR DESCRIPTION
Fixes two hourly replay bench failure modes observed on May 18, 2026:\n\n- Guard replay cleanup so an unset tail process does not trip `set -u` after the benchmark exits.\n- Make chart regression skip non-finite or degenerate input and tolerate `np.polyfit` linear algebra failures.\n\nVerification:\n- `bash -n .github/scripts/bench-tempo-replay.sh`\n- `uv run --with numpy --with matplotlib python - <<'PY' ...` to exercise degenerate and valid regression inputs.