### PR TITLE
Simplify tempoup release verification flow

### DIFF
--- a/tempoup/tempoup
+++ b/tempoup/tempoup
@@ -6,7 +6,7 @@ set -e
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-TEMPOUP_INSTALLER_VERSION="0.0.10"
+TEMPOUP_INSTALLER_VERSION="0.0.11"
 
 REPO="tempoxyz/tempo"
 # GPG key fingerprint for release signing verification
@@ -95,6 +95,37 @@ check_cmd() {
     command -v "$1" >/dev/null 2>&1
 }
 
+# Returns true only when gh is installed and can access GitHub APIs.
+gh_authenticated() {
+    check_cmd gh && gh auth status >/dev/null 2>&1
+}
+
+# Verifies GitHub's SLSA provenance, failing hard only when it is required.
+verify_slsa_attestation() {
+    local archive_path="$1"
+    local mode="$2"
+
+    if [[ "$mode" == "required" ]]; then
+        info "gpg not found; verifying SLSA build provenance with gh..."
+    else
+        info "Verifying SLSA build provenance..."
+    fi
+
+    if gh attestation verify "$archive_path" --repo "$REPO" \
+            --predicate-type https://slsa.dev/provenance/v1 >/dev/null 2>&1; then
+        info "SLSA provenance verified ✓"
+        return 0
+    fi
+
+    if [[ "$mode" == "required" ]]; then
+        error "SLSA provenance attestation not found or failed verification. Install gpg, or re-run with --unsafe-skip-verify to bypass signature verification."
+    fi
+
+    warn "SLSA provenance attestation not found or failed verification."
+    warn "(Older releases may not carry attestations.)"
+    return 1
+}
+
 preflight_dependencies() {
     if ! check_cmd curl; then
         error "curl not found. Please install curl."
@@ -107,14 +138,16 @@ preflight_dependencies() {
     info "Install prerequisites: curl found, checksum tool found"
 
     if [[ "$UNSAFE_SKIP_VERIFY" == "1" ]]; then
-        warn "Skipping GPG signature verification (--unsafe-skip-verify)."
+        warn "Skipping release signature and SLSA attestation verification (--unsafe-skip-verify)."
     elif check_cmd gpg; then
         info "gpg found; release signature verification enabled"
+    elif gh_authenticated; then
+        info "gpg not found; authenticated gh found, SLSA attestation verification enabled"
     else
-        error "gpg not found. Install gpg, or re-run with --unsafe-skip-verify to bypass signature verification."
+        error "gpg not found and gh is unavailable or unauthenticated. Install gpg, run 'gh auth login', or re-run with --unsafe-skip-verify to bypass signature verification."
     fi
 
-    if check_cmd gh && gh auth status >/dev/null 2>&1; then
+    if gh_authenticated; then
         info "gh found and authenticated; SLSA attestation verification enabled"
     elif check_cmd gh; then
         warn "gh found but not authenticated; optional SLSA attestation verification will be skipped"
@@ -404,7 +437,10 @@ main() {
 
     info "Checksum verified ✓"
 
-    # GPG signature verification (only for versions >= 1.1.3, as earlier releases lack .asc files)
+    GPG_VERIFIED=0
+    SLSA_VERIFIED=0
+
+    # GPG signature verification (only for versions >= 1.1.3, as earlier releases lack .asc files).
     if [[ "$UNSAFE_SKIP_VERIFY" == "1" ]]; then
         warn "GPG signature verification skipped (--unsafe-skip-verify)."
     elif version_gt "$VERSION_TAG" "1.1.2"; then
@@ -426,17 +462,26 @@ main() {
             if gpg --list-keys "$GPG_KEY_FINGERPRINT" >/dev/null 2>&1; then
                 if gpg --batch --verify "$TMP_DIR/${ARCHIVE_NAME}.asc" "$ARCHIVE_PATH" 2>/dev/null; then
                     info "GPG signature verified ✓"
+                    GPG_VERIFIED=1
                 else
                     error "GPG signature verification failed. The binary may have been tampered with."
                 fi
             else
                 error "GPG key is not available. Re-run with --unsafe-skip-verify to bypass signature verification."
             fi
+        elif gh_authenticated; then
+            verify_slsa_attestation "$ARCHIVE_PATH" required
+            SLSA_VERIFIED=1
         else
-            error "gpg not found. Install gpg, or re-run with --unsafe-skip-verify to bypass signature verification."
+            error "gpg not found and gh is unavailable or unauthenticated. Install gpg, run 'gh auth login', or re-run with --unsafe-skip-verify to bypass signature verification."
         fi
     else
         info "Skipping GPG signature verification (not available for versions <= 1.1.1)"
+    fi
+
+    if [[ "$UNSAFE_SKIP_VERIFY" != "1" ]] && ! check_cmd gpg && [[ "$SLSA_VERIFIED" != "1" ]]; then
+        verify_slsa_attestation "$ARCHIVE_PATH" required
+        SLSA_VERIFIED=1
     fi
 
     # SLSA build provenance verification (Sigstore-signed via GitHub OIDC at
@@ -446,14 +491,11 @@ main() {
     # or for older releases that predate attestations.
     if [[ "$UNSAFE_SKIP_VERIFY" == "1" ]]; then
         warn "Skipping SLSA attestation verification (--unsafe-skip-verify)."
-    elif check_cmd gh && gh auth status >/dev/null 2>&1; then
-        info "Verifying SLSA build provenance..."
-        if gh attestation verify "$ARCHIVE_PATH" --repo "$REPO" \
-                --predicate-type https://slsa.dev/provenance/v1 >/dev/null 2>&1; then
-            info "SLSA provenance verified ✓"
-        else
-            warn "SLSA provenance attestation not found or failed verification."
-            warn "(Older releases may not carry attestations.)"
+    elif [[ "$SLSA_VERIFIED" == "1" ]]; then
+        : # SLSA was already verified above because gpg was unavailable.
+    elif gh_authenticated; then
+        if verify_slsa_attestation "$ARCHIVE_PATH" optional; then
+            SLSA_VERIFIED=1
         fi
     elif check_cmd gh; then
         warn "gh is not authenticated; skipping optional SLSA attestation verification."

--- a/tempoup/tempoup
+++ b/tempoup/tempoup
@@ -100,28 +100,19 @@ gh_authenticated() {
     check_cmd gh && gh auth status >/dev/null 2>&1
 }
 
-# Verifies GitHub's SLSA provenance, failing hard only when it is required.
-verify_slsa_attestation() {
+# Verifies the GitHub attestation for the downloaded archive.
+verify_github_attestation() {
     local archive_path="$1"
-    local mode="$2"
 
-    if [[ "$mode" == "required" ]]; then
-        info "gpg not found; verifying SLSA build provenance with gh..."
-    else
-        info "Verifying SLSA build provenance..."
-    fi
+    info "Verifying github attestation..."
 
     if gh attestation verify "$archive_path" --repo "$REPO" \
             --predicate-type https://slsa.dev/provenance/v1 >/dev/null 2>&1; then
-        info "SLSA provenance verified ✓"
+        info "github attestation verified ✓"
         return 0
     fi
 
-    if [[ "$mode" == "required" ]]; then
-        error "SLSA provenance attestation not found or failed verification. Install gpg, or re-run with --unsafe-skip-verify to bypass signature verification."
-    fi
-
-    warn "SLSA provenance attestation not found or failed verification."
+    warn "github attestation not found or failed verification."
     warn "(Older releases may not carry attestations.)"
     return 1
 }
@@ -136,24 +127,6 @@ preflight_dependencies() {
     fi
 
     info "Install prerequisites: curl found, checksum tool found"
-
-    if [[ "$UNSAFE_SKIP_VERIFY" == "1" ]]; then
-        warn "Skipping release signature and SLSA attestation verification (--unsafe-skip-verify)."
-    elif check_cmd gpg; then
-        info "gpg found; release signature verification enabled"
-    elif gh_authenticated; then
-        info "gpg not found; authenticated gh found, SLSA attestation verification enabled"
-    else
-        error "gpg not found and gh is unavailable or unauthenticated. Install gpg, run 'gh auth login', or re-run with --unsafe-skip-verify to bypass signature verification."
-    fi
-
-    if gh_authenticated; then
-        info "gh found and authenticated; SLSA attestation verification enabled"
-    elif check_cmd gh; then
-        warn "gh found but not authenticated; optional SLSA attestation verification will be skipped"
-    else
-        info "gh not found; optional SLSA attestation verification will be skipped"
-    fi
 }
 
 # Check if tempoup installer is up to date
@@ -437,71 +410,55 @@ main() {
 
     info "Checksum verified ✓"
 
-    GPG_VERIFIED=0
-    SLSA_VERIFIED=0
+    VERIFIED=0
 
-    # GPG signature verification (only for versions >= 1.1.3, as earlier releases lack .asc files).
     if [[ "$UNSAFE_SKIP_VERIFY" == "1" ]]; then
-        warn "GPG signature verification skipped (--unsafe-skip-verify)."
-    elif version_gt "$VERSION_TAG" "1.1.2"; then
-        if command -v gpg >/dev/null 2>&1; then
+        warn "Release verification skipped (--unsafe-skip-verify)."
+    else
+        # GPG signatures are only available for versions >= 1.1.3.
+        if version_gt "$VERSION_TAG" "1.1.2" && check_cmd gpg; then
             info "Verifying GPG signature..."
             download_file "$VERSION_TAG" "${ARCHIVE_NAME}.asc" "$TMP_DIR"
 
             # Import the release signing key if not already present
             if ! gpg --list-keys "$GPG_KEY_FINGERPRINT" >/dev/null 2>&1; then
-                GPG_KEY_URL="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x${GPG_KEY_FINGERPRINT}"
+                local gpg_key_url="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x${GPG_KEY_FINGERPRINT}"
                 info "Fetching Tempo release signing key..."
-                if curl -sSfL "$GPG_KEY_URL" 2>/dev/null | gpg --import 2>/dev/null; then
+                if curl -sSfL "$gpg_key_url" 2>/dev/null | gpg --import 2>/dev/null; then
                     : # key imported via HTTPS
                 else
                     error "Failed to fetch GPG key. Re-run with --unsafe-skip-verify to bypass signature verification."
                 fi
             fi
 
-            if gpg --list-keys "$GPG_KEY_FINGERPRINT" >/dev/null 2>&1; then
-                if gpg --batch --verify "$TMP_DIR/${ARCHIVE_NAME}.asc" "$ARCHIVE_PATH" 2>/dev/null; then
-                    info "GPG signature verified ✓"
-                    GPG_VERIFIED=1
-                else
-                    error "GPG signature verification failed. The binary may have been tampered with."
-                fi
-            else
+            if ! gpg --list-keys "$GPG_KEY_FINGERPRINT" >/dev/null 2>&1; then
                 error "GPG key is not available. Re-run with --unsafe-skip-verify to bypass signature verification."
             fi
-        elif gh_authenticated; then
-            verify_slsa_attestation "$ARCHIVE_PATH" required
-            SLSA_VERIFIED=1
+
+            if gpg --batch --verify "$TMP_DIR/${ARCHIVE_NAME}.asc" "$ARCHIVE_PATH" 2>/dev/null; then
+                info "GPG signature verified ✓"
+                VERIFIED=1
+            else
+                error "GPG signature verification failed. The binary may have been tampered with."
+            fi
+        elif version_gt "$VERSION_TAG" "1.1.2"; then
+            warn "gpg not found; skipping GPG signature verification."
         else
-            error "gpg not found and gh is unavailable or unauthenticated. Install gpg, run 'gh auth login', or re-run with --unsafe-skip-verify to bypass signature verification."
+            info "Skipping GPG signature verification (not available for versions <= 1.1.1)"
         fi
-    else
-        info "Skipping GPG signature verification (not available for versions <= 1.1.1)"
-    fi
 
-    if [[ "$UNSAFE_SKIP_VERIFY" != "1" ]] && ! check_cmd gpg && [[ "$SLSA_VERIFIED" != "1" ]]; then
-        verify_slsa_attestation "$ARCHIVE_PATH" required
-        SLSA_VERIFIED=1
-    fi
-
-    # SLSA build provenance verification (Sigstore-signed via GitHub OIDC at
-    # release time). Requires the `gh` CLI with authentication. Keep this
-    # best-effort: GPG is the required release verification by default, while
-    # attestation verification should not make installs fail on clean machines
-    # or for older releases that predate attestations.
-    if [[ "$UNSAFE_SKIP_VERIFY" == "1" ]]; then
-        warn "Skipping SLSA attestation verification (--unsafe-skip-verify)."
-    elif [[ "$SLSA_VERIFIED" == "1" ]]; then
-        : # SLSA was already verified above because gpg was unavailable.
-    elif gh_authenticated; then
-        if verify_slsa_attestation "$ARCHIVE_PATH" optional; then
-            SLSA_VERIFIED=1
+        if gh_authenticated && verify_github_attestation "$ARCHIVE_PATH"; then
+            VERIFIED=1
+        elif check_cmd gh; then
+            warn "gh is not authenticated; skipping github attestation verification."
+            warn "Run 'gh auth login' to enable github attestation verification."
+        else
+            info "gh not found; skipping github attestation verification."
         fi
-    elif check_cmd gh; then
-        warn "gh is not authenticated; skipping optional SLSA attestation verification."
-        warn "Run 'gh auth login' to enable attestation verification."
-    else
-        info "gh not found; skipping optional SLSA attestation verification."
+
+        if version_gt "$VERSION_TAG" "1.1.2" && [[ "$VERIFIED" != "1" ]]; then
+            error "Release verification failed. Install gpg, run 'gh auth login', or re-run with --unsafe-skip-verify."
+        fi
     fi
 
     # Extract archive


### PR DESCRIPTION
Simplifies tempoup release verification control flow so it checks --unsafe-skip-verify first, then attempts GPG verification when available, then falls back to GitHub attestation verification via gh when available.\n\nValidation:\n- bash -n tempoup/tempoup\n- ./tempoup/tempoup --help\n- git diff --check