### PR TITLE
ci: pin txgen rev for benchmarks

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -68,6 +68,7 @@ CARGO_BIN_DIR="${CARGO_HOME:-$HOME/.cargo}/bin"
 export PATH="$CARGO_BIN_DIR:$PATH"
 TXGEN_TEMPO_BIN="${TXGEN_TEMPO_BIN:-txgen-tempo}"
 TXGEN_BENCH_BIN="${TXGEN_BENCH_BIN:-bench}"
+BENCH_TXGEN_REF="${BENCH_TXGEN_REF:-7c0de9684e0b2fa9466fa05f6e7b5cb3792c4116}"
 BENCH_FEATURES="${BENCH_FEATURES:-jemalloc,asm-keccak,keccak-cache-global}"
 
 if [ "${BENCH_OTLP:-false}" = "true" ]; then
@@ -94,7 +95,9 @@ bench_schelk() {
 # ============================================================================
 
 echo "Installing txgen-tempo and bench-cli..."
-cargo install --git "https://x-access-token:${DEREK_BENCH_TOKEN}@github.com/tempoxyz/txgen" --locked txgen-tempo bench-cli
+TXGEN_GIT_URL="https://x-access-token:${DEREK_BENCH_TOKEN}@github.com/tempoxyz/txgen"
+TXGEN_REV="$(git ls-remote "$TXGEN_GIT_URL" "$BENCH_TXGEN_REF" "refs/heads/$BENCH_TXGEN_REF" "refs/tags/$BENCH_TXGEN_REF" | awk 'BEGIN { rev = "" } /\^\{\}$/ { rev = $1; exit } rev == "" { rev = $1 } END { if (rev != "") print rev }')"
+cargo install --git "$TXGEN_GIT_URL" --rev "${TXGEN_REV:-$BENCH_TXGEN_REF}" --locked txgen-tempo bench-cli
 command -v "$TXGEN_TEMPO_BIN"
 command -v "$TXGEN_BENCH_BIN"
 

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -88,7 +88,7 @@ on:
         description: Optional ref to pin in tempoxyz/txgen.
         type: string
         required: false
-        default: ""
+        default: "7c0de9684e0b2fa9466fa05f6e7b5cb3792c4116"
       profiling:
         description: Profiling.
         type: choice
@@ -219,7 +219,7 @@ on:
       txgen-ref:
         type: string
         required: false
-        default: ""
+        default: "7c0de9684e0b2fa9466fa05f6e7b5cb3792c4116"
       baseline-name:
         type: string
         required: false


### PR DESCRIPTION
## Summary
- Pin default benchmark txgen ref to 7c0de9684e0b2fa9466fa05f6e7b5cb3792c4116
- Pin bench replay txgen install to the same rev, while preserving BENCH_TXGEN_REF overrides

## Validation
- bash -n .github/scripts/bench-tempo-replay.sh
- uv run --with pyyaml python -c "import yaml; yaml.safe_load(open('.github/workflows/bench-e2e.yml')); print('yaml ok')"
- gh api repos/tempoxyz/txgen/commits/7c0de9684e0b2fa9466fa05f6e7b5cb3792c4116