### PR TITLE
ci(bench): fix scheduled e2e benchmark workflow permissions

### DIFF
--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -145,6 +145,7 @@ jobs:
       matrix: ${{ fromJSON(needs.resolve-refs.outputs.bench-matrix) }}
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     with:
       actor: ${{ matrix.actor }}


### PR DESCRIPTION
## Summary
- grant the scheduled bench-e2e reusable workflow call issues: write
- matches the permissions requested by .github/workflows/bench-e2e.yml, preventing GitHub Actions validation from rejecting the caller

## Validation
- inspected the caller and reusable workflow permission blocks
- actionlint is not installed in the sandbox