### PR TITLE
ci(bench): mask derived telemetry output in bench e2e

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -398,6 +398,8 @@ jobs:
         run: |
           if [ -n "$TEMPO_TELEMETRY_URL_SECRET" ]; then
             echo "::add-mask::$TEMPO_TELEMETRY_URL_SECRET"
+            telemetry_base_no_auth="$(printf '%s' "$TEMPO_TELEMETRY_URL_SECRET" | sed -E 's#^(https?://)[^/@]+@#\1#; s#/*$##')"
+            echo "::add-mask::$telemetry_base_no_auth"
             printf 'TEMPO_TELEMETRY_URL=%s\n' "$TEMPO_TELEMETRY_URL_SECRET" >> "$GITHUB_ENV"
           fi
           if [ -n "$GRAFANA_TEMPO_SECRET" ]; then


### PR DESCRIPTION
Updates the bench e2e workflow to register the derived telemetry base value with GitHub Actions masking before the benchmark runs.

Validation: extracted workflow shell block passes bash -n.