### PR TITLE
bench: enable payload builder sharing flags by default

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -239,6 +239,8 @@ run_single() {
     --disable-discovery
     --no-persist-peers
     --debug.startup-sync-state-idle
+    --builder.max-tasks 1
+    --engine.share-sparse-trie-with-payload-builder
   )
 
   # Per-label extra node args

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -25,6 +25,8 @@ const E2E_LOCAL_RETH_ARGS = [
     "--disable-discovery"
     "--trusted-only"
     "--tempo.bootnodes-endpoint" "none"
+    "--builder.max-tasks" "1"
+    "--engine.share-sparse-trie-with-payload-builder"
 ]
 
 def run-bench-schelk [...args: string] {


### PR DESCRIPTION
## Summary
- enable sparse-trie sharing by default for bench-e2e baseline/feature node runs
- enable the same flag by default for replay baseline/feature node runs
- set `--builder.max-tasks 1` alongside the sparse-trie sharing flag because the tempo binary requires it

## Validation
- `bash -n .github/scripts/bench-tempo-replay.sh`
- Not run: `nu` syntax check (`nu` is not installed in this sandbox)