### PR TITLE
ci(bench): fix bench observability links and ids

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -69,7 +69,17 @@ export PATH="$CARGO_BIN_DIR:$PATH"
 TXGEN_TEMPO_BIN="${TXGEN_TEMPO_BIN:-txgen-tempo}"
 TXGEN_BENCH_BIN="${TXGEN_BENCH_BIN:-bench}"
 BENCH_FEATURES="${BENCH_FEATURES:-jemalloc,asm-keccak,keccak-cache-global}"
-BENCHMARK_ID="${BENCHMARK_ID:-bench-replay-${GITHUB_RUN_ID:-$(date +%s)}}"
+if [ -z "${BENCHMARK_ID:-}" ]; then
+  if [ -z "${GITHUB_RUN_ID:-}" ]; then
+    echo "Error: BENCHMARK_ID or GITHUB_RUN_ID must be set for replay benchmarks" >&2
+    exit 1
+  fi
+  BENCHMARK_ID="bench-replay-${GITHUB_RUN_ID}"
+fi
+if [ -z "$BENCHMARK_ID" ]; then
+  echo "Error: BENCHMARK_ID or GITHUB_RUN_ID must be set for replay benchmarks" >&2
+  exit 1
+fi
 
 if [ "${BENCH_OTLP:-false}" = "true" ]; then
   if [ -z "${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-}" ] && [ -n "${GRAFANA_TEMPO:-}" ]; then

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -380,6 +380,7 @@ jobs:
       BENCH_FEATURE_ENV: ${{ inputs.feature-env }}
       BENCH_DISABLE_ABBA: ${{ (inputs.disable-abba == true || inputs.disable-abba == 'true' || inputs.run-type == 'nightly') && 'true' || 'false' }}
       BENCH_CLICKHOUSE_RUN: ${{ inputs.clickhouse-run || 'feature-1' }}
+      BENCHMARK_ID: bench-e2e-${{ github.run_id }}
       BENCH_COMMENT_ID: ${{ inputs.comment-id }}
       BENCH_PR_HEAD_SHA: ${{ inputs.pr-head-sha }}
       BENCH_PR_HEAD_REF: ${{ inputs.pr-head-ref }}

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -778,19 +778,22 @@ jobs:
               summary = '⚠️ Benchmark completed but failed to read summary.';
             }
 
-            // Compute Grafana URLs from summary.json
+            // Compute observability URLs from summary.json.
             let grafanaSection = '';
             try {
               const meta = JSON.parse(fs.readFileSync(`${resultsDir}/summary.json`, 'utf8'));
-              const refEpoch = meta.reference_epoch;
               const benchId = meta.benchmark_id;
-              if (refEpoch && benchId) {
-                const fromMs = refEpoch * 1000;
-                const toMs = Date.now();
+              const metricsRange = meta.observability_range || {};
+              const actualRange = meta.actual_observability_range || metricsRange;
+              const metricsFrom = metricsRange.from || (metricsRange.from_ms ? String(metricsRange.from_ms) : '');
+              const metricsTo = metricsRange.to || (metricsRange.to_ms ? String(metricsRange.to_ms) : '');
+              const actualFrom = actualRange.from || (actualRange.from_ms ? String(actualRange.from_ms) : '');
+              const actualTo = actualRange.to || (actualRange.to_ms ? String(actualRange.to_ms) : '');
+              if (benchId && metricsFrom && metricsTo && actualFrom && actualTo) {
                 const traceqlQuery = `{resource.benchmark_id="${benchId}"}`;
-                const grafanaUrl = `https://tempoxyz.grafana.net/d/tikv2tn/tempo-bench?orgId=1&from=${fromMs}&to=${toMs}&var-benchmark_id=${benchId}&var-job=github-tempo-bench-e2e`;
+                const grafanaUrl = meta.grafana_url || `https://tempoxyz.grafana.net/d/dffj6qf1o30oowe/performance?orgId=1&from=${encodeURIComponent(metricsFrom)}&to=${encodeURIComponent(metricsTo)}&timezone=browser&var-datasource=efk1hcn87dnnkd&var-filter_label=benchmark_id&var-filter_value=${encodeURIComponent(benchId)}&var-group_by=benchmark_run`;
                 const logsPane = JSON.stringify({
-                  g39: {
+                  pw4: {
                     datasource: 'cfk1hzy08xekgd',
                     queries: [{
                       refId: 'A',
@@ -799,8 +802,8 @@ jobs:
                       expr: `benchmark_id:${benchId}`,
                       queryType: 'instant',
                     }],
-                    range: { from: String(fromMs), to: String(toMs) },
-                    panelsState: { logs: { sortOrder: 'Descending' } },
+                    range: { from: actualFrom, to: actualTo },
+                    panelsState: { logs: { sortOrder: 'Descending', columns: ['Time', 'Line'], visualisationType: 'table', labelFieldName: 'labels' } },
                     compact: false,
                   },
                 });
@@ -814,12 +817,12 @@ jobs:
                       queryType: 'traceqlSearch',
                       serviceMapUseNativeHistograms: false,
                       filters: [
-                        { id: 'benchmark-id', operator: '=', scope: 'resource', tag: 'benchmark_id', value: [`"${benchId}"`], isCustomValue: true },
-                        { id: 'span-name', tag: 'name', operator: '=', scope: 'span', value: [], isCustomValue: false },
+                        { id: 'benchmark-id', operator: '=', scope: 'resource', tag: 'benchmark_id', value: [benchId], valueType: 'string', isCustomValue: true },
                       ],
                       query: traceqlQuery,
                     }],
-                    range: { from: String(fromMs), to: String(toMs) },
+                    range: { from: actualFrom, to: actualTo },
+                    panelsState: { logs: { visualisationType: 'table' } },
                     compact: false,
                   },
                 });

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -175,6 +175,7 @@ jobs:
       BENCH_SLACK: ${{ inputs.slack || 'never' }}
       BENCH_RUN_LABEL: ${{ inputs.run-label || 'Replay Bench' }}
       BENCH_WORK_DIR: bench-results/replay-${{ inputs.chain || 'mainnet' }}
+      BENCHMARK_ID: bench-replay-${{ github.run_id }}
     steps:
       - name: Resolve benchmark config
         env:

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1009,7 +1009,17 @@ def "main e2e" [
     let a_trusted_peers_path = $"($a_db)/($BENCH_META_SUBDIR)/trusted-peers.txt"
     let run_started_at = (date now)
     let timestamp = ($run_started_at | format date "%Y%m%d-%H%M%S-%3f")
-    let benchmark_id = $"bench-e2e-local-($timestamp)"
+    let benchmark_id = ($env | get --optional BENCHMARK_ID)
+    let benchmark_id = if $benchmark_id == null or ($benchmark_id | str trim) == "" {
+        let run_id = ($env | get --optional GITHUB_RUN_ID)
+        if $run_id == null or ($run_id | str trim) == "" {
+            print "Error: BENCHMARK_ID or GITHUB_RUN_ID must be set for e2e benchmarks"
+            exit 1
+        }
+        $"bench-e2e-($run_id)"
+    } else {
+        $benchmark_id
+    }
     let reference_epoch = (($run_started_at | into int) / 1_000_000_000 | into int)
     let gas_limit_args = if $gas_limit != "" { ["--gas-limit" $gas_limit] } else { [] }
     let tracing_otlp = (derive-tracing-otlp $tracing_otlp)

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -845,6 +845,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
     }
 
     if $phase_exit == 0 {
+        let phase_started_ms = ((date now | into int) / 1_000_000 | into int)
         let sender_exit = (try {
             let bench_result = (txgen-run-preset-pipeline
                 --txgen-tempo-bin $ctx.txgen.txgen_tempo_bin
@@ -881,6 +882,12 @@ def run-local-e2e-phase [run: record, ctx: record] {
             print $"Error: local e2e txgen sender failed for ($phase): ($e.msg)"
             1
         })
+        let phase_finished_ms = ((date now | into int) / 1_000_000 | into int)
+        {
+            phase: $phase
+            started_ms: $phase_started_ms
+            finished_ms: $phase_finished_ms
+        } | to json | save -f $"($ctx.results_dir)/phase-range-($phase).json"
         $phase_exit = $sender_exit
     } else {
         print $"Skipping local e2e sender for ($phase) because readiness checks failed"

--- a/tempo.nu
+++ b/tempo.nu
@@ -774,18 +774,13 @@ def iso-from-epoch-ms [epoch_ms: int] {
     $"($base).($millis | into string | fill --alignment right --character '0' --width 3)Z"
 }
 
-def grafana-performance-url [benchmark_id: string, reference_epoch: int, duration: int] {
-    if $benchmark_id == "" or $reference_epoch <= 0 {
+def grafana-performance-url [benchmark_id: string, from_ms: int, to_ms: int] {
+    if $benchmark_id == "" or $from_ms <= 0 or $to_ms <= 0 {
         return ""
     }
 
-    let range = {
-        from: ($reference_epoch * 1000)
-        to: (($reference_epoch + $duration) * 1000)
-    }
-
-    let from = (iso-from-epoch-ms $range.from)
-    let to = (iso-from-epoch-ms $range.to)
+    let from = (iso-from-epoch-ms $from_ms)
+    let to = (iso-from-epoch-ms $to_ms)
     $"https://tempoxyz.grafana.net/d/dffj6qf1o30oowe/performance?orgId=1&from=($from)&to=($to)&timezone=browser&var-datasource=efk1hcn87dnnkd&var-filter_label=benchmark_id&var-filter_value=($benchmark_id)&var-group_by=benchmark_run"
 }
 
@@ -1009,16 +1004,29 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
     # Compute deltas (feature vs baseline)
     let delta = { |base: float, feat: float| if $base != 0.0 { ((($feat - $base) / $base) * 100) | math round --precision 1 } else { 0.0 } }
 
+    let observability_padding_ms = 5000
+    let observability_duration_ms = $duration * ($run_labels | length) * 1000
+    let observability_from_ms = if $reference_epoch > 0 {
+        (($reference_epoch * 1000) - $observability_padding_ms)
+    } else { 0 }
+    let observability_to_ms = if $reference_epoch > 0 {
+        (($reference_epoch * 1000) + $observability_duration_ms - $observability_padding_ms)
+    } else { 0 }
+    let phase_ranges = ($run_labels | each { |label|
+        let range_path = $"($results_dir)/phase-range-($label).json"
+        if ($range_path | path exists) { open $range_path } else { null }
+    } | where { |range| $range != null })
+    let phase_start_ms = ($phase_ranges | where started_ms != null | get started_ms | sort)
+    let phase_finish_ms = ($phase_ranges | where finished_ms != null | get finished_ms | sort)
+    let actual_observability_from_ms = if ($phase_start_ms | length) > 0 {
+        $phase_start_ms | first
+    } else { $observability_from_ms }
+    let actual_observability_to_ms = if ($phase_finish_ms | length) > 0 {
+        $phase_finish_ms | last
+    } else { $observability_to_ms }
+
     # Build summary markdown
-    let grafana_url = (grafana-performance-url $benchmark_id $reference_epoch $duration)
-    let observability_lines = if $grafana_url != "" {
-        [
-            "## Observability"
-            ""
-            $"- Grafana: [Performance dashboard]\(($grafana_url)\)"
-            ""
-        ]
-    } else { [] }
+    let grafana_url = (grafana-performance-url $benchmark_id $observability_from_ms $observability_to_ms)
     let summary_lines = ([
         $"# Bench Comparison: ($baseline_ref) vs ($feature_ref)"
         ""
@@ -1031,7 +1039,7 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
         $"- Baseline blocks: ($b_lat.n)"
         $"- Feature blocks: ($f_lat.n)"
         ""
-    ] | append $observability_lines | append [
+    ] | append [
         "## Tempo Metrics"
         ""
         "| Metric | Baseline | Feature | Delta |"
@@ -1071,6 +1079,18 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
     let summary_json = {
         benchmark_id: $benchmark_id
         reference_epoch: $reference_epoch
+        observability_range: {
+            from_ms: $observability_from_ms
+            to_ms: $observability_to_ms
+            from: (if $observability_from_ms > 0 { iso-from-epoch-ms $observability_from_ms } else { "" })
+            to: (if $observability_to_ms > 0 { iso-from-epoch-ms $observability_to_ms } else { "" })
+        }
+        actual_observability_range: {
+            from_ms: $actual_observability_from_ms
+            to_ms: $actual_observability_to_ms
+            from: (if $actual_observability_from_ms > 0 { iso-from-epoch-ms $actual_observability_from_ms } else { "" })
+            to: (if $actual_observability_to_ms > 0 { iso-from-epoch-ms $actual_observability_to_ms } else { "" })
+        }
         grafana_url: $grafana_url
         baseline_ref: $baseline_ref
         feature_ref: $feature_ref


### PR DESCRIPTION
## Summary
- Switch e2e bench comments and job summaries to the Grafana performance dashboard link shape.
- Keep the metrics dashboard on the aligned metrics range, and use the actual per-phase wall-clock range for VictoriaLogs and Tempo trace links.
- Add benchmark-id filtering for the VictoriaLogs Explore link and keep traces filtered by benchmark_id.
- Remove the duplicate standalone Grafana Observability section from summary.md.
- Bring in PR #4056: use run-scoped benchmark IDs for CI e2e and replay benches.

## Validation
- git diff --check
- Generated representative Metrics, Logs, and Traces URL payloads with Node.
- Compared the sample run 26101075099 against the expected metrics dashboard range.

Note: Nushell parser/runtime validation was not run because nu is not installed in this sandbox.