### PR TITLE
feat(builder): stop reason metric

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -461,9 +461,10 @@ where
 
         let execution_start = Instant::now();
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
-        loop {
+        let mut skipped_oversized_block = false;
+        let block_build_stop_reason = loop {
             if attributes.is_interrupted() {
-                break;
+                break "time_limit";
             }
 
             check_cancel!();
@@ -473,7 +474,14 @@ where
                     std::thread::sleep(Duration::from_millis(1));
                     continue;
                 }
-                break;
+                let stop_reason = if cumulative_gas_used >= non_shared_gas_limit {
+                    "gas_limit"
+                } else if skipped_oversized_block {
+                    "rlp_block_size_limit"
+                } else {
+                    "tx_pool_empty"
+                };
+                break stop_reason;
             };
             pool_transactions_yielded += 1;
 
@@ -522,7 +530,7 @@ where
 
             // check if the job was interrupted, if so we can skip remaining transactions
             if attributes.is_interrupted() {
-                break;
+                break "time_limit";
             }
 
             check_cancel!();
@@ -542,6 +550,7 @@ where
                     },
                 );
                 self.metrics.inc_pool_tx_skipped("oversized_block");
+                skipped_oversized_block = true;
                 continue;
             }
 
@@ -621,8 +630,10 @@ where
 
             pool_transactions_included += 1;
             block_size_used += tx_rlp_length;
-        }
+        };
         drop(_block_fill_span);
+        self.metrics
+            .inc_block_build_stop_reason(block_build_stop_reason);
         let total_normal_transaction_execution_elapsed = execution_start.elapsed();
         self.metrics
             .total_normal_transaction_execution_duration_seconds

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -7,7 +7,7 @@ mod metrics;
 mod prewarming;
 
 use crate::{
-    metrics::{InstrumentedFinishProvider, TempoPayloadBuilderMetrics},
+    metrics::{BlockBuildStopReason, InstrumentedFinishProvider, TempoPayloadBuilderMetrics},
     prewarming::BestTransactionsPrewarming,
 };
 use alloy_consensus::{BlockHeader as _, Signed, Transaction, TxLegacy};
@@ -464,7 +464,7 @@ where
         let mut skipped_oversized_block = false;
         let block_build_stop_reason = loop {
             if attributes.is_interrupted() {
-                break "time_limit";
+                break BlockBuildStopReason::TimeLimit;
             }
 
             check_cancel!();
@@ -475,11 +475,11 @@ where
                     continue;
                 }
                 let stop_reason = if cumulative_gas_used >= non_shared_gas_limit {
-                    "gas_limit"
+                    BlockBuildStopReason::GasLimit
                 } else if skipped_oversized_block {
-                    "rlp_block_size_limit"
+                    BlockBuildStopReason::RlpBlockSizeLimit
                 } else {
-                    "tx_pool_empty"
+                    BlockBuildStopReason::TxPoolEmpty
                 };
                 break stop_reason;
             };
@@ -530,7 +530,7 @@ where
 
             // check if the job was interrupted, if so we can skip remaining transactions
             if attributes.is_interrupted() {
-                break "time_limit";
+                break BlockBuildStopReason::TimeLimit;
             }
 
             check_cancel!();

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -105,6 +105,7 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) state_root_with_updates_duration_seconds: Histogram,
 }
 
+/// Reason the payload builder stopped adding pool transactions to the block.
 pub(crate) enum BlockBuildStopReason {
     TimeLimit,
     GasLimit,

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -123,6 +123,13 @@ impl TempoPayloadBuilderMetrics {
             .increment(1);
     }
 
+    /// Increments the counter for why the payload builder stopped adding pool transactions.
+    #[inline]
+    pub(crate) fn inc_block_build_stop_reason(&self, reason: &'static str) {
+        metrics::counter!("tempo_payload_builder_block_build_stop_total", "reason" => reason)
+            .increment(1);
+    }
+
     /// Increments the counter for subblocks dropped due to expired transactions.
     #[inline]
     pub(crate) fn inc_subblocks_expired(&self) {

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -105,6 +105,24 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) state_root_with_updates_duration_seconds: Histogram,
 }
 
+pub(crate) enum BlockBuildStopReason {
+    TimeLimit,
+    GasLimit,
+    RlpBlockSizeLimit,
+    TxPoolEmpty,
+}
+
+impl BlockBuildStopReason {
+    const fn as_str(&self) -> &'static str {
+        match self {
+            Self::TimeLimit => "time_limit",
+            Self::GasLimit => "gas_limit",
+            Self::RlpBlockSizeLimit => "rlp_block_size_limit",
+            Self::TxPoolEmpty => "tx_pool_empty",
+        }
+    }
+}
+
 impl TempoPayloadBuilderMetrics {
     /// Increments the unified pool transaction skip counter with the given reason label.
     ///
@@ -125,8 +143,8 @@ impl TempoPayloadBuilderMetrics {
 
     /// Increments the counter for why the payload builder stopped adding pool transactions.
     #[inline]
-    pub(crate) fn inc_block_build_stop_reason(&self, reason: &'static str) {
-        metrics::counter!("tempo_payload_builder_block_build_stop_total", "reason" => reason)
+    pub(crate) fn inc_block_build_stop_reason(&self, reason: BlockBuildStopReason) {
+        metrics::counter!("tempo_payload_builder_block_build_stop_total", "reason" => reason.as_str())
             .increment(1);
     }
 


### PR DESCRIPTION
## Summary
- add `tempo_payload_builder_block_build_stop_total{reason=...}` counter
- records why the payload builder stopped adding pool transactions: `time_limit`, `gas_limit`, `rlp_block_size_limit`, or `tx_pool_empty`

## Test
- `cargo check -p tempo-payload-builder`