### PR TITLE
Increase benchmark proposal transaction prep time

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -252,6 +252,7 @@ run_single() {
     --debug.startup-sync-state-idle
     --builder.max-tasks 1
     --engine.share-sparse-trie-with-payload-builder
+    --consensus.time-to-prepare-proposal-transactions 400ms
   )
 
   # Per-label extra node args

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -479,6 +479,7 @@ def build-e2e-consensus-args [node_dir: string, trusted_peers: string, port: int
         "--authrpc.port" $"($authrpc_port)"
         "--consensus.use-local-defaults"
         "--consensus.bypass-ip-check"
+        "--consensus.time-to-prepare-proposal-transactions" "400ms"
     ]
 }
 


### PR DESCRIPTION
## Summary
- Set `--consensus.time-to-prepare-proposal-transactions 400ms` for bench-e2e validator args
- Set the same proposal transaction prep time for bench-replay node args

## Testing
- `bash -n .github/scripts/bench-tempo-replay.sh`
- Not run: Nushell syntax check for `bench-e2e.nu` because `nu` is not installed in this sandbox