### PR TITLE
Increase benchmark proposal tx prep timeout

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -252,6 +252,7 @@ run_single() {
     --debug.startup-sync-state-idle
     --builder.max-tasks 1
     --engine.share-sparse-trie-with-payload-builder
+    --consensus.time-to-prepare-proposal-transactions 400ms
   )
 
   # Per-label extra node args

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -27,6 +27,7 @@ const E2E_LOCAL_RETH_ARGS = [
     "--tempo.bootnodes-endpoint" "none"
     "--builder.max-tasks" "1"
     "--engine.share-sparse-trie-with-payload-builder"
+    "--consensus.time-to-prepare-proposal-transactions" "400ms"
 ]
 
 def run-bench-schelk [...args: string] {


### PR DESCRIPTION
## Summary
- set bench-e2e nodes to use `--consensus.time-to-prepare-proposal-transactions 400ms`
- set bench-replay nodes to use the same 400ms proposal transaction preparation timeout

## Testing
- `bash -n .github/scripts/bench-tempo-replay.sh`
- Not run: `bench-e2e.nu` parse/run check because `nu` is not installed in this sandbox
