### PR TITLE
Increase benchmark proposal transaction prep time

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -250,6 +250,7 @@ run_single() {
     --disable-discovery
     --no-persist-peers
     --debug.startup-sync-state-idle
+    --consensus.time-to-prepare-proposal-transactions 400ms
     --builder.max-tasks 1
     --engine.share-sparse-trie-with-payload-builder
   )

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -477,6 +477,7 @@ def build-e2e-consensus-args [node_dir: string, trusted_peers: string, port: int
         "--discovery.v5.port" $"($discv5_port)"
         "--p2p-secret-key" $enode_key
         "--authrpc.port" $"($authrpc_port)"
+        "--consensus.time-to-prepare-proposal-transactions" "400ms"
         "--consensus.use-local-defaults"
         "--consensus.bypass-ip-check"
     ]


### PR DESCRIPTION
## Summary
- set bench-e2e consensus.time-to-prepare-proposal-transactions to 400ms
- set bench-replay consensus.time-to-prepare-proposal-transactions to 400ms

## Testing
- bash -n .github/scripts/bench-tempo-replay.sh
- git diff --check

Note: Nushell is not installed in this sandbox, so I could not run a local parse check for bench-e2e.nu.