### PR TITLE
Increase proposal transaction preparation time

### DIFF
--- a/crates/commonware-node/src/args.rs
+++ b/crates/commonware-node/src/args.rs
@@ -95,7 +95,7 @@ pub struct Args {
     /// include the state root calculation time. For this reason, we keep it well below `consensus.time-to-build-proposal`.
     #[arg(
         long = "consensus.time-to-prepare-proposal-transactions",
-        default_value = "200ms"
+        default_value = "400ms"
     )]
     pub time_to_prepare_proposal_transactions: PositiveDuration,
 


### PR DESCRIPTION
## Summary
- increase the default consensus.time-to-prepare-proposal-transactions from 200ms to 400ms

## Test
- cargo check -p tempo-commonware-node