### PR TITLE
perf(benches): enable asm keccak for tip20 execution bench

### DIFF
--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -41,6 +41,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 alloy-eips.workspace = true
+alloy-primitives = { workspace = true, features = ["asm-keccak"] }
 alloy-signer.workspace = true
 alloy-signer-local = { workspace = true, features = ["mnemonic"] }
 alloy-sol-types.workspace = true


### PR DESCRIPTION
Enables `alloy-primitives/asm-keccak` for `tempo-evm` dev builds so the TIP20 execution benchmark uses the asm-backed keccak path by default.


```
samply record --port 3001 cargo bench -p tempo-evm --bench tip20_execution
    Finished `bench` profile [optimized + debuginfo] target(s) in 0.26s
     Running benches/tip20_execution.rs (target/release/deps/tip20_execution-f92ca7f6a3ae35d6)
Gnuplot not found, using plotters backend
tip20_execution/txgen_tip20_pure_execution
                        time:   [40.427 ms 40.519 ms 40.636 ms]
                        thrpt:  [100.80 Kelem/s 101.09 Kelem/s 101.32 Kelem/s]
                 change:
                        time:   [−2.3888% −1.9470% −1.5297%] (p = 0.00 < 0.05)
                        thrpt:  [+1.5535% +1.9856% +2.4473%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
```