### PR TITLE
TIP-1056: versioned DEX order storage

### DIFF
--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -4,7 +4,7 @@ pub mod error;
 pub mod order;
 pub mod orderbook;
 
-pub use order::Order;
+pub use order::{Order, Orders};
 pub use orderbook::{
     MAX_TICK, MIN_TICK, Orderbook, PRICE_SCALE, RoundingDirection, TickLevel, base_to_quote,
     quote_to_base, tick_to_price, validate_tick_spacing,
@@ -40,7 +40,7 @@ pub const TICK_SPACING: i16 = 10;
 #[contract(addr = STABLECOIN_DEX_ADDRESS)]
 pub struct StablecoinDEX {
     books: Mapping<B256, Orderbook>,
-    orders: Mapping<u128, Order>,
+    orders: Orders,
     balances: Mapping<Address, Mapping<Address, u128>>,
     next_order_id: u128,
     book_keys: Vec<B256>,
@@ -97,7 +97,7 @@ impl StablecoinDEX {
     /// Fetch order from storage. If the order is currently pending or filled, this function returns
     /// `StablecoinDEXError::OrderDoesNotExist`
     pub fn get_order(&self, order_id: u128) -> Result<Order> {
-        let order = self.orders[order_id].read()?;
+        let order = self.orders.read(order_id)?;
 
         // If the order is not filled and currently active
         if !order.maker().is_zero() && order.order_id() < self.next_order_id()? {
@@ -491,9 +491,7 @@ impl StablecoinDEX {
             }
         } else {
             // Update previous tail's next pointer
-            let mut prev_order = self.orders[prev_tail].read()?;
-            prev_order.next = order.order_id();
-            self.orders[prev_tail].write(prev_order)?;
+            self.orders.set_next(prev_tail, order.order_id())?;
 
             // Set current order's prev pointer
             order.prev = prev_tail;
@@ -510,7 +508,7 @@ impl StablecoinDEX {
             .tick_level_handler_mut(order.tick(), order.is_bid())
             .write(level)?;
 
-        self.orders[order.order_id()].write(order)
+        self.orders.write(order.order_id(), order)
     }
 
     /// Place a flip order that auto-flips when filled
@@ -648,9 +646,7 @@ impl StablecoinDEX {
 
         // Update order remaining amount
         let new_remaining = order.remaining() - fill_amount;
-        self.orders[order.order_id()]
-            .remaining
-            .write(new_remaining)?;
+        self.orders.set_remaining(order.order_id(), new_remaining)?;
 
         // Calculate quote amount for this fill (used by both maker settlement and taker output)
         let quote_amount = base_to_quote(
@@ -754,7 +750,7 @@ impl StablecoinDEX {
         }
 
         // Delete the filled order
-        self.orders[order.order_id()].delete()?;
+        self.orders.delete(order.order_id())?;
 
         // Advance tick if liquidity is exhausted
         let next_tick_info = if order.next() == 0 {
@@ -782,14 +778,14 @@ impl StablecoinDEX {
                 let new_level = self.books[book_key]
                     .tick_level_handler(tick, order.is_bid())
                     .read()?;
-                let new_order = self.orders[new_level.head].read()?;
+                let new_order = self.orders.read(new_level.head)?;
 
                 Some((new_level, new_order))
             }
         } else {
             // If there are subsequent orders at tick, advance to next order
             level.head = order.next();
-            self.orders[order.next()].prev.delete()?;
+            self.orders.set_prev(order.next(), 0)?;
 
             let new_liquidity = level
                 .total_liquidity
@@ -801,7 +797,7 @@ impl StablecoinDEX {
                 .tick_level_handler_mut(order.tick(), order.is_bid())
                 .write(level)?;
 
-            let new_order = self.orders[order.next()].read()?;
+            let new_order = self.orders.read(order.next())?;
             Some((level, new_order))
         };
 
@@ -817,7 +813,7 @@ impl StablecoinDEX {
         taker: Address,
     ) -> Result<u128> {
         let mut level = self.get_best_price_level(book_key, bid)?;
-        let mut order = self.orders[level.head].read()?;
+        let mut order = self.orders.read(level.head)?;
 
         let mut total_amount_in: u128 = 0;
 
@@ -897,7 +893,7 @@ impl StablecoinDEX {
         taker: Address,
     ) -> Result<u128> {
         let mut level = self.get_best_price_level(book_key, bid)?;
-        let mut order = self.orders[level.head].read()?;
+        let mut order = self.orders.read(level.head)?;
 
         let mut total_amount_out: u128 = 0;
 
@@ -994,7 +990,7 @@ impl StablecoinDEX {
     /// Cancel an order and refund tokens to maker
     /// Only the order maker can cancel their own order
     pub fn cancel(&mut self, sender: Address, order_id: u128) -> Result<()> {
-        let order = self.orders[order_id].read()?;
+        let order = self.orders.read(order_id)?;
 
         if order.maker().is_zero() {
             return Err(StablecoinDEXError::order_does_not_exist().into());
@@ -1019,13 +1015,13 @@ impl StablecoinDEX {
 
         // Update linked list
         if order.prev() != 0 {
-            self.orders[order.prev()].next.write(order.next())?;
+            self.orders.set_next(order.prev(), order.next())?;
         } else {
             level.head = order.next();
         }
 
         if order.next() != 0 {
-            self.orders[order.next()].prev.write(order.prev())?;
+            self.orders.set_prev(order.next(), order.prev())?;
         } else {
             level.tail = order.prev();
         }
@@ -1083,7 +1079,7 @@ impl StablecoinDEX {
         }
 
         // Clear the order from storage
-        self.orders[order.order_id()].delete()?;
+        self.orders.delete(order.order_id())?;
 
         // Emit OrderCancelled event
         self.emit_event(StablecoinDEXEvents::OrderCancelled(
@@ -1101,7 +1097,7 @@ impl StablecoinDEX {
     /// [TIP-403]: <https://docs.tempo.xyz/protocol/tip403>
     /// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
     pub fn cancel_stale_order(&mut self, order_id: u128) -> Result<()> {
-        let order = self.orders[order_id].read()?;
+        let order = self.orders.read(order_id)?;
 
         if order.maker().is_zero() {
             return Err(StablecoinDEXError::order_does_not_exist().into());
@@ -1762,7 +1758,7 @@ mod tests {
             assert_eq!(exchange.next_order_id()?, 2);
 
             // Verify the order was stored correctly
-            let stored_order = exchange.orders[order_id].read()?;
+            let stored_order = exchange.orders.read(order_id)?;
             assert_eq!(stored_order.maker(), alice);
             assert_eq!(stored_order.amount(), min_order_amount);
             assert_eq!(stored_order.remaining(), min_order_amount);
@@ -1822,7 +1818,7 @@ mod tests {
             assert_eq!(exchange.next_order_id()?, 2);
 
             // Verify the order was stored correctly
-            let stored_order = exchange.orders[order_id].read()?;
+            let stored_order = exchange.orders.read(order_id)?;
             assert_eq!(stored_order.maker(), alice);
             assert_eq!(stored_order.amount(), min_order_amount);
             assert_eq!(stored_order.remaining(), min_order_amount);
@@ -1992,7 +1988,7 @@ mod tests {
             assert_eq!(exchange.next_order_id()?, 2);
 
             // Verify the order was stored correctly
-            let stored_order = exchange.orders[order_id].read()?;
+            let stored_order = exchange.orders.read(order_id)?;
             assert_eq!(stored_order.maker(), alice);
             assert_eq!(stored_order.amount(), min_order_amount);
             assert_eq!(stored_order.remaining(), min_order_amount);
@@ -2394,14 +2390,14 @@ mod tests {
                 .expect("Swap should succeed");
 
             // Assert that the order has filled (remaining should be 0)
-            let filled_order = exchange.orders[flip_order_id].read()?;
+            let filled_order = exchange.orders.read(flip_order_id)?;
             assert_eq!(filled_order.remaining(), 0);
 
             // The flipped order should be created with id = flip_order_id + 1
             let new_order_id = exchange.next_order_id()? - 1;
             assert_eq!(new_order_id, flip_order_id + 1);
 
-            let new_order = exchange.orders[new_order_id].read()?;
+            let new_order = exchange.orders.read(new_order_id)?;
             assert_eq!(new_order.maker(), alice);
             assert_eq!(new_order.tick(), flip_tick);
             assert_eq!(new_order.flip_tick(), tick);
@@ -3152,8 +3148,8 @@ mod tests {
             let order2_id = exchange.place(bob, base_token, order2_amount, false, tick)?;
 
             // Verify linked list is set up correctly
-            let order1 = exchange.orders[order1_id].read()?;
-            let order2 = exchange.orders[order2_id].read()?;
+            let order1 = exchange.orders.read(order1_id)?;
+            let order2 = exchange.orders.read(order2_id)?;
             assert_eq!(order1.next(), order2_id);
             assert_eq!(order2.prev(), order1_id);
 
@@ -3168,7 +3164,7 @@ mod tests {
             )?;
 
             // After filling order1, order2 should be the new head with prev = 0
-            let order2_after = exchange.orders[order2_id].read()?;
+            let order2_after = exchange.orders.read(order2_id)?;
             assert_eq!(
                 order2_after.prev(),
                 0,
@@ -3734,7 +3730,7 @@ mod tests {
                 "Best bid tick should be updated"
             );
 
-            let stored_order = exchange.orders[order_id].read()?;
+            let stored_order = exchange.orders.read(order_id)?;
             assert!(stored_order.is_flip(), "Order should be a flip order");
             assert_eq!(
                 stored_order.flip_tick(),
@@ -3776,7 +3772,7 @@ mod tests {
 
             let order_id = exchange.place(alice, base_token, min_order_amount, true, tick)?;
 
-            let stored_order = exchange.orders[order_id].read()?;
+            let stored_order = exchange.orders.read(order_id)?;
             assert_eq!(stored_order.maker(), alice);
             assert_eq!(stored_order.remaining(), min_order_amount);
             assert_eq!(stored_order.tick(), tick);

--- a/crates/precompiles/src/stablecoin_dex/order.rs
+++ b/crates/precompiles/src/stablecoin_dex/order.rs
@@ -4,8 +4,15 @@
 //! Orders support price-time priority matching, partial fills, and flip orders that
 //! automatically place opposite-side orders when filled.
 
-use crate::stablecoin_dex::{IStablecoinDEX, error::OrderError};
-use alloy::primitives::{Address, B256};
+use crate::{
+    error::{Result as StorageResult, TempoPrecompileError},
+    stablecoin_dex::{IStablecoinDEX, error::OrderError},
+    storage::{
+        FromWord, Handler, Layout, LayoutCtx, Mapping, StorableType, StorageCtx, StorageKey,
+        packing,
+    },
+};
+use alloy::primitives::{Address, B256, U256};
 use tempo_precompiles_macros::Storable;
 
 /// Represents an order in the stablecoin DEX orderbook.
@@ -57,6 +64,235 @@ pub struct Order {
     /// For bid flips: flip_tick must be > tick
     /// For ask flips: flip_tick must be < tick
     pub flip_tick: i16,
+}
+
+/// Version-aware storage wrapper for DEX orders.
+///
+/// The wrapper intentionally hides the raw mapping so all order reads, writes, and linked-list
+/// pointer mutations pass through a single version discriminator. Legacy orders use the original
+/// Solidity-compatible V1 layout. New writes use V2, which stores the version byte in the high byte
+/// of slot 0 and synthesizes `order_id` from the mapping key.
+#[derive(Debug, Clone)]
+pub struct Orders {
+    base_slot: U256,
+    address: Address,
+    legacy: Mapping<u128, Order>,
+}
+
+impl StorableType for Orders {
+    const LAYOUT: Layout = Layout::Slots(1);
+
+    type Handler = Self;
+
+    fn handle(slot: U256, _ctx: LayoutCtx, address: Address) -> Self::Handler {
+        Self {
+            base_slot: slot,
+            address,
+            legacy: Mapping::new(slot, address),
+        }
+    }
+}
+
+impl Orders {
+    const VERSION_LEGACY: u8 = 0;
+    const VERSION_V2: u8 = 1;
+
+    const V2_MAKER_OFFSET: usize = 0;
+    const V2_IS_BID_OFFSET: usize = 20;
+    const V2_TICK_OFFSET: usize = 21;
+    const V2_IS_FLIP_OFFSET: usize = 23;
+    const V2_FLIP_TICK_OFFSET: usize = 24;
+    const V2_VERSION_OFFSET: usize = 31;
+
+    const V2_BOOK_KEY_SLOT: u64 = 1;
+    const V2_AMOUNTS_SLOT: u64 = 2;
+    const V2_LINKS_SLOT: u64 = 3;
+
+    const V2_AMOUNT_OFFSET: usize = 0;
+    const V2_REMAINING_OFFSET: usize = 16;
+    const V2_PREV_OFFSET: usize = 0;
+    const V2_NEXT_OFFSET: usize = 16;
+
+    fn order_base_slot(&self, order_id: u128) -> U256 {
+        order_id.mapping_slot(self.base_slot)
+    }
+
+    fn slot(base_slot: U256, offset: u64) -> U256 {
+        base_slot + U256::from(offset)
+    }
+
+    fn load_slot(&self, base_slot: U256, offset: u64) -> StorageResult<U256> {
+        StorageCtx.sload(self.address, Self::slot(base_slot, offset))
+    }
+
+    fn store_slot(&mut self, base_slot: U256, offset: u64, value: U256) -> StorageResult<()> {
+        StorageCtx.sstore(self.address, Self::slot(base_slot, offset), value)
+    }
+
+    fn version_from_header(header: U256) -> StorageResult<u8> {
+        packing::extract_from_word(header, Self::V2_VERSION_OFFSET, 1)
+    }
+
+    /// Returns the stored order-layout version for an order ID.
+    pub fn version(&self, order_id: u128) -> StorageResult<u8> {
+        let base_slot = self.order_base_slot(order_id);
+        let header = self.load_slot(base_slot, 0)?;
+        Self::version_from_header(header)
+    }
+
+    /// Reads an order from storage, decoding either the legacy V1 layout or the V2 layout.
+    pub fn read(&self, order_id: u128) -> StorageResult<Order> {
+        let base_slot = self.order_base_slot(order_id);
+        let header = self.load_slot(base_slot, 0)?;
+
+        match Self::version_from_header(header)? {
+            Self::VERSION_LEGACY => self.legacy[order_id].read(),
+            Self::VERSION_V2 => self.read_v2(order_id, base_slot, header),
+            version => Err(TempoPrecompileError::Fatal(format!(
+                "unknown StablecoinDEX order storage version {version}"
+            ))),
+        }
+    }
+
+    /// Writes an order using the V2 storage layout.
+    pub fn write(&mut self, order_id: u128, order: Order) -> StorageResult<()> {
+        debug_assert_eq!(order_id, order.order_id());
+
+        let base_slot = self.order_base_slot(order_id);
+        self.store_slot(base_slot, 0, Self::encode_v2_header(&order)?)?;
+        self.store_slot(base_slot, Self::V2_BOOK_KEY_SLOT, order.book_key.to_word())?;
+        self.store_slot(
+            base_slot,
+            Self::V2_AMOUNTS_SLOT,
+            Self::encode_v2_amounts(&order)?,
+        )?;
+        self.store_slot(
+            base_slot,
+            Self::V2_LINKS_SLOT,
+            Self::encode_v2_links(&order)?,
+        )
+    }
+
+    /// Deletes an order according to its storage layout.
+    pub fn delete(&mut self, order_id: u128) -> StorageResult<()> {
+        match self.version(order_id)? {
+            Self::VERSION_LEGACY => self.legacy[order_id].delete(),
+            Self::VERSION_V2 => {
+                let base_slot = self.order_base_slot(order_id);
+                for offset in 0..=Self::V2_LINKS_SLOT {
+                    self.store_slot(base_slot, offset, U256::ZERO)?;
+                }
+                Ok(())
+            }
+            version => Err(TempoPrecompileError::Fatal(format!(
+                "unknown StablecoinDEX order storage version {version}"
+            ))),
+        }
+    }
+
+    /// Updates the remaining amount without exposing the underlying layout.
+    pub fn set_remaining(&mut self, order_id: u128, remaining: u128) -> StorageResult<()> {
+        match self.version(order_id)? {
+            Self::VERSION_LEGACY => self.legacy[order_id].remaining.write(remaining),
+            Self::VERSION_V2 => self.update_packed_slot(
+                order_id,
+                Self::V2_AMOUNTS_SLOT,
+                Self::V2_REMAINING_OFFSET,
+                &remaining,
+            ),
+            version => Err(TempoPrecompileError::Fatal(format!(
+                "unknown StablecoinDEX order storage version {version}"
+            ))),
+        }
+    }
+
+    /// Updates the previous linked-list pointer without exposing the underlying layout.
+    pub fn set_prev(&mut self, order_id: u128, prev: u128) -> StorageResult<()> {
+        match self.version(order_id)? {
+            Self::VERSION_LEGACY => self.legacy[order_id].prev.write(prev),
+            Self::VERSION_V2 => {
+                self.update_packed_slot(order_id, Self::V2_LINKS_SLOT, Self::V2_PREV_OFFSET, &prev)
+            }
+            version => Err(TempoPrecompileError::Fatal(format!(
+                "unknown StablecoinDEX order storage version {version}"
+            ))),
+        }
+    }
+
+    /// Updates the next linked-list pointer without exposing the underlying layout.
+    pub fn set_next(&mut self, order_id: u128, next: u128) -> StorageResult<()> {
+        match self.version(order_id)? {
+            Self::VERSION_LEGACY => self.legacy[order_id].next.write(next),
+            Self::VERSION_V2 => {
+                self.update_packed_slot(order_id, Self::V2_LINKS_SLOT, Self::V2_NEXT_OFFSET, &next)
+            }
+            version => Err(TempoPrecompileError::Fatal(format!(
+                "unknown StablecoinDEX order storage version {version}"
+            ))),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn write_legacy(&mut self, order_id: u128, order: Order) -> StorageResult<()> {
+        self.legacy[order_id].write(order)
+    }
+
+    fn read_v2(&self, order_id: u128, base_slot: U256, header: U256) -> StorageResult<Order> {
+        let amounts = self.load_slot(base_slot, Self::V2_AMOUNTS_SLOT)?;
+        let links = self.load_slot(base_slot, Self::V2_LINKS_SLOT)?;
+
+        Ok(Order {
+            order_id,
+            maker: packing::extract_from_word(header, Self::V2_MAKER_OFFSET, 20)?,
+            book_key: B256::from_word(self.load_slot(base_slot, Self::V2_BOOK_KEY_SLOT)?)?,
+            is_bid: packing::extract_from_word(header, Self::V2_IS_BID_OFFSET, 1)?,
+            tick: packing::extract_from_word(header, Self::V2_TICK_OFFSET, 2)?,
+            amount: packing::extract_from_word(amounts, Self::V2_AMOUNT_OFFSET, 16)?,
+            remaining: packing::extract_from_word(amounts, Self::V2_REMAINING_OFFSET, 16)?,
+            prev: packing::extract_from_word(links, Self::V2_PREV_OFFSET, 16)?,
+            next: packing::extract_from_word(links, Self::V2_NEXT_OFFSET, 16)?,
+            is_flip: packing::extract_from_word(header, Self::V2_IS_FLIP_OFFSET, 1)?,
+            flip_tick: packing::extract_from_word(header, Self::V2_FLIP_TICK_OFFSET, 2)?,
+        })
+    }
+
+    fn encode_v2_header(order: &Order) -> StorageResult<U256> {
+        let mut header = U256::ZERO;
+        header = packing::insert_into_word(header, &order.maker, Self::V2_MAKER_OFFSET, 20)?;
+        header = packing::insert_into_word(header, &order.is_bid, Self::V2_IS_BID_OFFSET, 1)?;
+        header = packing::insert_into_word(header, &order.tick, Self::V2_TICK_OFFSET, 2)?;
+        header = packing::insert_into_word(header, &order.is_flip, Self::V2_IS_FLIP_OFFSET, 1)?;
+        header = packing::insert_into_word(header, &order.flip_tick, Self::V2_FLIP_TICK_OFFSET, 2)?;
+        packing::insert_into_word(header, &Self::VERSION_V2, Self::V2_VERSION_OFFSET, 1)
+    }
+
+    fn encode_v2_amounts(order: &Order) -> StorageResult<U256> {
+        let mut amounts = U256::ZERO;
+        amounts = packing::insert_into_word(amounts, &order.amount, Self::V2_AMOUNT_OFFSET, 16)?;
+        packing::insert_into_word(amounts, &order.remaining, Self::V2_REMAINING_OFFSET, 16)
+    }
+
+    fn encode_v2_links(order: &Order) -> StorageResult<U256> {
+        let mut links = U256::ZERO;
+        links = packing::insert_into_word(links, &order.prev, Self::V2_PREV_OFFSET, 16)?;
+        packing::insert_into_word(links, &order.next, Self::V2_NEXT_OFFSET, 16)
+    }
+
+    fn update_packed_slot<T>(
+        &mut self,
+        order_id: u128,
+        slot_offset: u64,
+        byte_offset: usize,
+        value: &T,
+    ) -> StorageResult<()>
+    where
+        T: FromWord + StorableType,
+    {
+        let base_slot = self.order_base_slot(order_id);
+        let slot = self.load_slot(base_slot, slot_offset)?;
+        let updated = packing::insert_into_word(slot, value, byte_offset, T::BYTES)?;
+        self.store_slot(base_slot, slot_offset, updated)
+    }
 }
 
 impl Order {
@@ -302,7 +538,7 @@ impl From<Order> for IStablecoinDEX::Order {
 mod tests {
     use crate::{
         stablecoin_dex::StablecoinDEX,
-        storage::{Handler, StorageCtx, hashmap::HashMapStorageProvider},
+        storage::{StorageCtx, hashmap::HashMapStorageProvider},
     };
 
     use super::*;
@@ -567,9 +803,11 @@ mod tests {
 
             let id = 42;
             let order = Order::new_flip(id, TEST_MAKER, TEST_BOOK_KEY, 1000, 5, true, 10).unwrap();
-            exchange.orders[id].write(order)?;
+            exchange.orders.write(id, order)?;
 
-            let loaded_order = exchange.orders[id].read()?;
+            assert_eq!(exchange.orders.version(id)?, 1);
+
+            let loaded_order = exchange.orders.read(id)?;
             assert_eq!(loaded_order.order_id(), 42);
             assert_eq!(loaded_order.maker(), TEST_MAKER);
             assert_eq!(loaded_order.book_key(), TEST_BOOK_KEY);
@@ -594,10 +832,10 @@ mod tests {
 
             let id = 42;
             let order = Order::new_flip(id, TEST_MAKER, TEST_BOOK_KEY, 1000, 5, true, 10).unwrap();
-            exchange.orders[id].write(order)?;
-            exchange.orders[id].delete()?;
+            exchange.orders.write(id, order)?;
+            exchange.orders.delete(id)?;
 
-            let deleted_order = exchange.orders[id].read()?;
+            let deleted_order = exchange.orders.read(id)?;
             assert_eq!(deleted_order.order_id(), 0);
             assert_eq!(deleted_order.maker(), Address::ZERO);
             assert_eq!(deleted_order.book_key(), B256::ZERO);
@@ -609,6 +847,83 @@ mod tests {
             assert_eq!(deleted_order.flip_tick(), 0);
             assert_eq!(deleted_order.prev(), 0);
             assert_eq!(deleted_order.next(), 0);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_read_legacy_order_has_zero_version_byte() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+
+            let id = 42;
+            let order = Order::new_flip(id, TEST_MAKER, TEST_BOOK_KEY, 1000, 5, true, 10).unwrap();
+            exchange.orders.write_legacy(id, order)?;
+
+            assert_eq!(exchange.orders.version(id)?, 0);
+
+            let loaded_order = exchange.orders.read(id)?;
+            assert_eq!(loaded_order.order_id(), id);
+            assert_eq!(loaded_order.maker(), TEST_MAKER);
+            assert_eq!(loaded_order.book_key(), TEST_BOOK_KEY);
+            assert_eq!(loaded_order.amount(), 1000);
+            assert_eq!(loaded_order.remaining(), 1000);
+            assert_eq!(loaded_order.prev(), 0);
+            assert_eq!(loaded_order.next(), 0);
+            assert!(loaded_order.is_flip());
+            assert_eq!(loaded_order.flip_tick(), 10);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_update_v2_order_links_and_remaining() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+
+            let id = 42;
+            let order = Order::new_bid(id, TEST_MAKER, TEST_BOOK_KEY, 1000, 5);
+            exchange.orders.write(id, order)?;
+
+            exchange.orders.set_remaining(id, 600)?;
+            exchange.orders.set_prev(id, 10)?;
+            exchange.orders.set_next(id, 11)?;
+
+            let loaded_order = exchange.orders.read(id)?;
+            assert_eq!(loaded_order.remaining(), 600);
+            assert_eq!(loaded_order.prev(), 10);
+            assert_eq!(loaded_order.next(), 11);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_update_mixed_version_order_links() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+
+            let mut legacy_order = Order::new_bid(1, TEST_MAKER, TEST_BOOK_KEY, 1000, 5);
+            legacy_order.set_next(2);
+            exchange.orders.write_legacy(1, legacy_order)?;
+
+            let mut v2_order = Order::new_bid(2, TEST_MAKER, TEST_BOOK_KEY, 1000, 5);
+            v2_order.set_prev(1);
+            exchange.orders.write(2, v2_order)?;
+
+            assert_eq!(exchange.orders.version(1)?, 0);
+            assert_eq!(exchange.orders.version(2)?, 1);
+
+            exchange.orders.set_next(1, 0)?;
+            exchange.orders.set_prev(2, 0)?;
+
+            assert_eq!(exchange.orders.read(1)?.next(), 0);
+            assert_eq!(exchange.orders.read(2)?.prev(), 0);
 
             Ok(())
         })

--- a/tips/tip-1056.md
+++ b/tips/tip-1056.md
@@ -1,0 +1,110 @@
+---
+id: TIP-1056
+title: Versioned DEX order storage
+description: Introduce a versioned Stablecoin DEX order storage layout that keeps the existing orders mapping while allowing future order structs to be decoded by version.
+authors: Dan Robinson
+status: Draft
+---
+
+# TIP-1056: Versioned DEX order storage
+
+## Abstract
+
+This TIP changes the Stablecoin DEX order storage model from a single fixed `Order` struct layout to a versioned layout behind the existing `orders` mapping. The mapping key remains the canonical order ID, and the first storage word for each order carries a version discriminator. Legacy orders remain readable as version `0`; new orders use version `1`.
+
+## Motivation
+
+The current DEX order struct stores `orderId` inside the value even though the order ID is already the mapping key:
+
+```solidity
+mapping(uint128 orderId => Order order) orders;
+```
+
+That duplicates data and fixes the order value to a layout that is awkward to evolve. The DEX also has several hot paths that read and update individual order fields (`remaining`, `prev`, and `next`) directly. To support deeper layout changes without scattering version checks through matching, cancellation, and flip-order logic, order storage should be accessed through a dedicated abstraction.
+
+## Specification
+
+The top-level storage slot of `orders` is unchanged. The mapping key remains `uint128 orderId`, and `orderId` is no longer stored in new order values.
+
+### Legacy layout
+
+Existing orders are version `0`. Version `0` is detected by reading byte offset `31` of the order's first storage slot. In the current layout, slot `0` stores only a `uint128 orderId` at byte offset `0`, so byte offset `31` is guaranteed to be zero for all legacy orders.
+
+Legacy layout:
+
+```text
+slot 0: orderId (uint128)
+slot 1: maker (address)
+slot 2: bookKey (bytes32)
+slot 3: isBid (bool), tick (int16), amount (uint128)
+slot 4: remaining (uint128), prev (uint128)
+slot 5: next (uint128), isFlip (bool), flipTick (int16)
+```
+
+### Version 1 layout
+
+New orders use version `1`, stored at byte offset `31` of slot `0`.
+
+```text
+slot 0:
+  offset 0   maker      address  20 bytes
+  offset 20  isBid      bool      1 byte
+  offset 21  tick       int16     2 bytes
+  offset 23  isFlip     bool      1 byte
+  offset 24  flipTick   int16     2 bytes
+  offset 26  unused               5 bytes
+  offset 31  version    uint8     1 byte
+
+slot 1:
+  offset 0   bookKey    bytes32   32 bytes
+
+slot 2:
+  offset 0   amount     uint128   16 bytes
+  offset 16  remaining  uint128   16 bytes
+
+slot 3:
+  offset 0   prev       uint128   16 bytes
+  offset 16  next       uint128   16 bytes
+```
+
+### Read behavior
+
+All order reads MUST use the versioned order storage abstraction.
+
+1. Compute the existing mapping value base slot from `orderId`.
+2. Read slot `0`.
+3. Decode byte offset `31` as `version`.
+4. If `version == 0`, decode the legacy layout.
+5. If `version == 1`, decode the version 1 layout and synthesize `orderId` from the mapping key.
+6. Unknown versions MUST fail.
+
+`getOrder(uint128)` keeps returning the existing ABI shape for compatibility. The returned `orderId` is synthesized from the function argument for versioned layouts.
+
+### Write behavior
+
+New orders SHOULD be written using the latest versioned layout. Mutations to active order fields (`remaining`, `prev`, `next`) MUST go through version-aware order storage methods rather than direct generated field accessors.
+
+### Deletion
+
+Deleting an order clears the storage slots used by that order's versioned layout. After deletion, `getOrder` continues to report `OrderDoesNotExist` because the decoded maker is zero.
+
+## Rationale
+
+Keeping one mapping avoids a migration of order IDs, orderbook linked lists, and external references. A discriminator in slot `0` allows the DEX to support old and new order values indefinitely. Placing the discriminator in the currently unused high byte avoids ambiguity with existing `orderId` values.
+
+The abstraction requirement is part of the protocol design: mixed-version linked lists are expected. A legacy order may point to a version 1 order, and a version 1 order may point to a legacy order. Therefore, updating a neighbor's `prev` or `next` pointer must be based on the neighbor's own version, not the current order's version.
+
+## Invariants
+
+- The `orders` mapping slot and mapping key type remain unchanged.
+- Existing version `0` orders decode exactly as before.
+- New version `1` orders synthesize `orderId` from the mapping key.
+- Direct order storage access is not used outside the versioned order abstraction.
+- Mixed-version linked lists remain valid: `prev` and `next` updates are version-aware per target order.
+- `getOrder` remains ABI-compatible.
+
+## Backwards Compatibility
+
+Existing onchain orders remain readable and cancellable. Existing clients using `getOrder(uint128)` continue to receive the same return fields.
+
+Indexers that reconstruct orders solely from events are unaffected by the storage layout. Tools that read raw storage must add version-aware decoding.


### PR DESCRIPTION
## Summary
- add TIP-1056 for versioned Stablecoin DEX order storage behind the existing `orders` mapping
- introduce an `Orders` abstraction that decodes legacy version 0 orders and writes new version 1 orders
- move DEX reads, deletes, and hot field mutations (`remaining`, `prev`, `next`) through version-aware methods

## Notes
- The version discriminator is byte offset 31 of slot 0. Legacy orders store only the `uint128 order_id` at byte offset 0, so that byte is guaranteed to decode as zero.
- `getOrder(uint128)` stays ABI-compatible; versioned layouts synthesize `order_id` from the mapping key.
- Mixed-version linked lists are supported by updating neighbor pointers based on the neighbor order's own version.

## Validation
- `cargo test -p tempo-precompiles stablecoin_dex:: --lib`
- `cargo test -p tempo-precompiles --features test-utils --test storage test_stablecoin_dex_layout`

Replaces #4072.
