### PR TITLE
bench: add manual CodSpeed workflow

### DIFF
--- a/.github/workflows/codspeed-microbench.yml
+++ b/.github/workflows/codspeed-microbench.yml
@@ -49,9 +49,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
-        with:
-          tool: cargo-codspeed@4.6.0
+      - name: Install cargo-codspeed
+        run: |
+          cargo install cargo-codspeed \
+            --git https://github.com/CodSpeedHQ/codspeed-rust \
+            --rev 0c6ccae11dc48654fd83c8dd77d231e386ebd9bd \
+            --locked
       - name: Resolve cargo codspeed arguments
         id: args
         env:

--- a/.github/workflows/codspeed-microbench.yml
+++ b/.github/workflows/codspeed-microbench.yml
@@ -1,0 +1,112 @@
+name: CodSpeed microbenchmarks
+
+permissions:
+  contents: read
+  id-token: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: "Cargo package(s) containing benchmark targets, separated by spaces"
+        required: true
+        default: "tempo-evm"
+        type: string
+      benchmarks:
+        description: "Cargo bench target(s), separated by spaces; leave empty for every bench in the package(s)"
+        required: false
+        default: "tip20_execution"
+        type: string
+      filters:
+        description: "Optional benchmark name filter passed to cargo codspeed run"
+        required: false
+        default: ""
+        type: string
+      measurement_modes:
+        description: "CodSpeed measurement mode(s), separated by commas"
+        required: true
+        default: "simulation"
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.packages }}-${{ inputs.benchmarks }}-${{ inputs.filters }}-${{ inputs.measurement_modes }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+  RUSTC_WRAPPER: "sccache"
+
+jobs:
+  codspeed:
+    name: CodSpeed microbenchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
+        with:
+          tool: cargo-codspeed@4.6.0
+      - name: Resolve cargo codspeed arguments
+        id: args
+        env:
+          INPUT_PACKAGES: ${{ inputs.packages }}
+          INPUT_BENCHMARKS: ${{ inputs.benchmarks }}
+          INPUT_FILTERS: ${{ inputs.filters }}
+          INPUT_MEASUREMENT_MODES: ${{ inputs.measurement_modes }}
+        run: |
+          set -euo pipefail
+
+          split_words() {
+            local value="$1"
+            value="${value//,/ }"
+            read -r -a words <<< "$value"
+            printf '%s\n' "${words[@]}"
+          }
+
+          cargo_args=()
+          while IFS= read -r package; do
+            [ -n "$package" ] && cargo_args+=("-p" "$package")
+          done < <(split_words "$INPUT_PACKAGES")
+
+          while IFS= read -r benchmark; do
+            [ -n "$benchmark" ] && cargo_args+=("--bench" "$benchmark")
+          done < <(split_words "$INPUT_BENCHMARKS")
+
+          build_args=("${cargo_args[@]}")
+          while IFS= read -r mode; do
+            [ -n "$mode" ] && build_args+=("-m" "$mode")
+          done < <(split_words "$INPUT_MEASUREMENT_MODES")
+
+          run_args=("${cargo_args[@]}")
+          while IFS= read -r filter; do
+            [ -n "$filter" ] && run_args+=("$filter")
+          done < <(split_words "$INPUT_FILTERS")
+
+          {
+            printf 'build_args<<EOF\n'
+            printf '%q ' "${build_args[@]}"
+            printf '\nEOF\n'
+            printf 'run_args<<EOF\n'
+            printf '%q ' "${run_args[@]}"
+            printf '\nEOF\n'
+          } >> "$GITHUB_OUTPUT"
+
+          printf 'cargo codspeed build '
+          printf '%q ' "${build_args[@]}"
+          printf '\n'
+          printf 'cargo codspeed run '
+          printf '%q ' "${run_args[@]}"
+          printf '\n'
+      - name: Build benchmark target(s)
+        run: cargo codspeed build ${{ steps.args.outputs.build_args }}
+      - name: Run benchmark target(s)
+        uses: CodSpeedHQ/action@c5e3fca5233fb854c7193713adfbe99d3910f8d2 # v4.15.1
+        with:
+          mode: ${{ inputs.measurement_modes }}
+          run: cargo codspeed run ${{ steps.args.outputs.run_args }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,15 +105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloca"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,6 +1173,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "aquamarine"
@@ -2751,6 +2751,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
 
 [[package]]
+name = "codspeed"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ce4a32373a5c84f4fa785099b300b9b1796311abc122b9eb62c65fa615145d"
+dependencies = [
+ "anyhow",
+ "cc",
+ "colored",
+ "getrandom 0.2.17",
+ "glob",
+ "libc",
+ "nix 0.31.3",
+ "serde",
+ "serde_json",
+ "statrs",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5557c4e023f427ba208b849193c51c2ebd40534828490cd3f5f7f7fc0284ce5"
+dependencies = [
+ "clap",
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored",
+ "regex",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ac19f0a5c3542301e9d011d658f93c3f550698ec8ba7d7c072692e7924c401"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot 0.5.0",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "coins-bip32"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2828,6 +2886,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "combine"
@@ -3068,7 +3136,7 @@ dependencies = [
  "commonware-macros",
  "commonware-parallel",
  "commonware-utils",
- "criterion 0.7.0",
+ "criterion",
  "crossbeam-queue",
  "futures",
  "getrandom 0.2.17",
@@ -3390,28 +3458,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.8.2"
+name = "criterion-plot"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
- "alloca",
- "anes",
  "cast",
- "ciborium",
- "clap",
- "criterion-plot 0.8.2",
- "itertools 0.13.0",
- "num-traits",
- "oorandom",
- "page_size",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "tinytemplate",
- "walkdir",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -3419,16 +3472,6 @@ name = "criterion-plot"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
-dependencies = [
- "cast",
- "itertools 0.13.0",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -5627,6 +5670,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6707,6 +6761,18 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -12229,6 +12295,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12760,9 +12836,9 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
+ "codspeed-criterion-compat",
  "commonware-codec",
  "commonware-cryptography",
- "criterion 0.8.2",
  "derive_more",
  "rayon",
  "reth-chainspec",
@@ -12952,9 +13028,9 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
+ "codspeed-criterion-compat",
  "commonware-codec",
  "commonware-cryptography",
- "criterion 0.8.2",
  "derive_more",
  "eyre",
  "p256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,7 +253,7 @@ bytes = "1.11.1"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 coins-bip32 = "0.12"
 const-hex = { version = "1.17.0" }
-criterion = "0.8.2"
+criterion = { package = "codspeed-criterion-compat", version = "4.6.0" }
 dashmap = "6"
 dirs-next = "2.0.0"
 derive_more = { version = "2.1.1", default-features = false }

--- a/crates/evm/benches/tip20_execution.rs
+++ b/crates/evm/benches/tip20_execution.rs
@@ -15,22 +15,14 @@ use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::{MnemonicBuilder, PrivateKeySigner};
 use alloy_sol_types::SolCall;
-use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use revm::{
     DatabaseCommit,
     context::{BlockEnv, CfgEnv},
     database::{CacheDB, EmptyDB},
     inspector::JournalExt,
 };
-use std::{
-    collections::BTreeSet,
-    fs,
-    hint::black_box,
-    num::NonZeroU64,
-    path::Path,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{collections::BTreeSet, fs, hint::black_box, num::NonZeroU64, path::Path, sync::Arc};
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork, spec::TEMPO_T1_BASE_FEE};
 use tempo_contracts::precompiles::ITIP20;
 use tempo_evm::{
@@ -360,24 +352,19 @@ fn tip20_execution(c: &mut Criterion) {
     let mut group = c.benchmark_group("tip20_execution");
     group.throughput(Throughput::Elements(workload.transactions.len() as u64));
     group.bench_function("txgen_tip20_pure_execution", |b| {
-        b.iter_custom(|iters| {
-            let mut elapsed = Duration::ZERO;
-            let mut total_gas = 0u64;
-            for _ in 0..iters {
-                let db = db.clone();
-                let start = Instant::now();
+        b.iter_batched(
+            || db.clone(),
+            |db| {
                 let stats = execute_txs(
                     &config,
                     db,
                     &workload.transactions,
                     workload.block_timestamp,
                 );
-                elapsed += start.elapsed();
-                total_gas = total_gas.saturating_add(stats.gas_used);
-            }
-            black_box(total_gas);
-            elapsed
-        })
+                black_box(stats.gas_used);
+            },
+            BatchSize::SmallInput,
+        )
     });
     group.finish();
 }


### PR DESCRIPTION
Adds a workflow_dispatch-only CodSpeed workflow that defaults to `tempo-evm` / `tip20_execution`, while allowing package, bench target, filter, and measurement-mode inputs.

Switches Criterion benchmarks to CodSpeed's compatibility crate and updates the TIP20 execution benchmark away from `iter_custom` so CodSpeed can measure it.