### PR TITLE
ci(bench): parameterize benchmark run pairs

### DIFF
--- a/.github/scripts/bench-replay-summary.py
+++ b/.github/scripts/bench-replay-summary.py
@@ -500,14 +500,14 @@ def generate_markdown(
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Parse bench-cli ABBA results")
+    parser = argparse.ArgumentParser(description="Parse bench-cli multi-run results")
     parser.add_argument(
         "--baseline-json", nargs="+", required=True,
-        help="Baseline report.json files (A1, A2)",
+        help="Baseline report.json files",
     )
     parser.add_argument(
         "--feature-json", "--branch-json", nargs="+", required=True,
-        help="Feature report.json files (B1, B2)",
+        help="Feature report.json files",
     )
     parser.add_argument(
         "--output-summary", required=True, help="Output JSON summary path"
@@ -630,6 +630,7 @@ def main():
 
     summary = {
         "blocks": paired_stats["blocks"],
+        "run_pairs": len(baseline_runs),
         "big_blocks": args.big_blocks,
         "warmup_blocks": None,
         "wait_time": args.wait_time,

--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -163,6 +163,7 @@ function buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, re
 
   const config = summary.config;
   const blockCount = fmtBlockCount(b.blocks, f.blocks);
+  const runPairs = config.run_pairs ?? '-';
 
   const sectionText = [
     `*Repo:* ${repoLink(repo)}`,
@@ -172,7 +173,7 @@ function buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, re
     `*Feature:* ${featureLink}`,
     '',
     `*Preset:* \`${config.preset}\` | *Bloat:* \`${Math.round(config.bloat / 1000)} GB\``,
-    `*Duration:* \`${config.duration}s\` | *Target TPS:* \`${config.tps}\` | *Blocks:* ${blockCount}`,
+    `*Duration:* \`${config.duration}s\` | *Target TPS:* \`${config.tps}\` | *Run pairs:* \`${runPairs}\` | *Blocks:* ${blockCount}`,
   ].join('\n');
 
   const rows = buildMetricRows(summary);
@@ -281,7 +282,7 @@ async function success({ core, context }) {
   const actorSlackId = slackUsers[actor];
 
   const blocks = buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, repo });
-  const text = `Tempo bench: baseline vs feature`;
+  const text = `Tempo bench: baseline vs feature (${summary.config?.run_pairs ?? '-'} run pairs)`;
 
   const changes = e2eChanges(summary.results.deltas);
   const channel = process.env.SLACK_BENCH_CHANNEL;
@@ -397,12 +398,13 @@ function buildReplaySuccessBlocks({ summary, prNumber, actor, actorSlackId, jobU
 
   const blockCount = summary.blocks || blocks || '-';
   const warmupCount = summary.warmup_blocks || warmup || '-';
+  const runPairs = summary.run_pairs || process.env.BENCH_RUN_PAIRS || '-';
   const sectionText = [
     metaParts.join(' | '),
     '',
     `*Baseline:* ${baselineLink}`,
     `*Feature:* ${featureLink}`,
-    `*Chain:* \`${chain || '-'}\` | *Warmup:* \`${warmupCount}\` | *Blocks:* \`${blockCount}\``,
+    `*Chain:* \`${chain || '-'}\` | *Warmup:* \`${warmupCount}\` | *Blocks:* \`${blockCount}\` | *Run pairs:* \`${runPairs}\``,
   ].join('\n');
 
   const rows = buildReplayMetricRows(summary);
@@ -531,7 +533,7 @@ async function replaySuccess({ core, context }) {
     warmup,
     runLabel,
   });
-  const text = `Tempo ${runLabel.toLowerCase()}: ${summary.baseline?.name || 'baseline'} vs ${summary.feature?.name || 'feature'} (${chain})`;
+  const text = `Tempo ${runLabel.toLowerCase()}: ${summary.baseline?.name || 'baseline'} vs ${summary.feature?.name || 'feature'} (${chain}, ${summary.run_pairs ?? process.env.BENCH_RUN_PAIRS ?? '-'} run pairs)`;
 
   async function sendWithThread(channel) {
     const res = await postToSlack(token, channel, slackBlocks, text, core);

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -4,12 +4,13 @@
 # (reth-bench new-payload-fcu) against baseline and feature Tempo binaries,
 # using a schelk-managed snapshot for instant rollback between runs.
 #
-# Runs in B-F-F-B interleaved order to reduce systematic bias.
+# Runs in interleaved order to reduce systematic bias.
 #
 # Required env:
 #   BASELINE_REF, FEATURE_REF     – git SHAs to build
 #   BENCH_BLOCKS                  – number of blocks to benchmark
 #   BENCH_WARMUP_BLOCKS           – number of warmup blocks
+#   BENCH_RUN_PAIRS               – number of baseline/feature run pairs
 #   BENCH_BASELINE_ARGS           – extra node args for baseline (optional)
 #   BENCH_FEATURE_ARGS            – extra node args for feature (optional)
 #   BENCH_SAMPLY                  – "true" to enable samply profiling (optional)
@@ -59,6 +60,11 @@ echo "Chain: $CHAIN_NAME (id=$CHAIN_ID, rpc=$(redact_url "$REPLAY_RPC_URL"))"
 MC="mc"
 BLOCKS="${BENCH_BLOCKS:-5000}"
 WARMUP="${BENCH_WARMUP_BLOCKS:-1000}"
+RUN_PAIRS="${BENCH_RUN_PAIRS:-2}"
+if ! [[ "$RUN_PAIRS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::BENCH_RUN_PAIRS must be a positive integer"
+  exit 1
+fi
 
 mkdir -p "$BENCH_WORK_DIR"
 
@@ -454,16 +460,55 @@ update_bench_status() {
 }
 
 # ============================================================================
-# B-F-F-B interleaved runs
+# Interleaved runs. For run-pairs=2 this preserves the previous B-F-F-B order.
 # ============================================================================
 
-update_bench_status "Running replay phase baseline-1 (1/4)..."
-run_single baseline-1 "$BASELINE_BIN" "$BENCH_WORK_DIR/baseline-1"
-update_bench_status "Running replay phase feature-1 (2/4)..."
-run_single feature-1  "$FEATURE_BIN"  "$BENCH_WORK_DIR/feature-1"
-update_bench_status "Running replay phase feature-2 (3/4)..."
-run_single feature-2  "$FEATURE_BIN"  "$BENCH_WORK_DIR/feature-2"
-update_bench_status "Running replay phase baseline-2 (4/4)..."
-run_single baseline-2 "$BASELINE_BIN" "$BENCH_WORK_DIR/baseline-2"
+build_run_order() {
+  local run_pairs="$1"
+  if [ $((run_pairs % 2)) -eq 0 ]; then
+    printf 'BFFB%.0s' $(seq 1 $((run_pairs / 2)))
+  else
+    printf 'BF%.0s' $(seq 1 "$run_pairs")
+  fi
+  echo
+}
+
+RUN_ORDER="$(build_run_order "$RUN_PAIRS")"
+echo "$RUN_ORDER" > "$BENCH_WORK_DIR/run_order.txt"
+echo "$RUN_ORDER" | grep -o . | while read -r side; do
+  case "$side" in
+    B) echo "baseline" ;;
+    F) echo "feature" ;;
+  esac
+done | awk '
+  $1 == "baseline" { b++; print "baseline-" b; next }
+  $1 == "feature" { f++; print "feature-" f; next }
+' > "$BENCH_WORK_DIR/run-order.txt"
+echo "Run order: $RUN_ORDER (B=baseline, F=feature; run-pairs=$RUN_PAIRS)"
+
+run_total="${#RUN_ORDER}"
+run_progress=0
+baseline_index=0
+feature_index=0
+
+for ((i = 0; i < ${#RUN_ORDER}; i++)); do
+  side="${RUN_ORDER:i:1}"
+  if [ "$side" = "B" ]; then
+    baseline_index=$((baseline_index + 1))
+    run_label="baseline-${baseline_index}"
+    binary="$BASELINE_BIN"
+  elif [ "$side" = "F" ]; then
+    feature_index=$((feature_index + 1))
+    run_label="feature-${feature_index}"
+    binary="$FEATURE_BIN"
+  else
+    echo "::error::Invalid run-order entry '${side}'"
+    exit 1
+  fi
+
+  run_progress=$((run_progress + 1))
+  update_bench_status "Running replay phase ${run_label} (${run_progress}/${run_total})..."
+  run_single "$run_label" "$binary" "$BENCH_WORK_DIR/$run_label"
+done
 
 echo "All replay benchmark runs complete."

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -316,7 +316,8 @@ run_single() {
     kill "$tail_pid" 2>/dev/null || true
     if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
       sudo pkill -INT -x tempo 2>/dev/null || true
-      for _i in $(seq 1 60); do
+      local samply_wait
+      for samply_wait in $(seq 1 60); do
         sudo pgrep -x samply > /dev/null 2>&1 || break
         sleep 1
       done
@@ -330,15 +331,16 @@ run_single() {
   trap cleanup_run EXIT
 
   # Wait for RPC
-  for i in $(seq 1 120); do
+  local rpc_wait
+  for rpc_wait in $(seq 1 120); do
     if curl -sf http://127.0.0.1:8545 -X POST \
       -H 'Content-Type: application/json' \
       -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
       > /dev/null 2>&1; then
-      echo "tempo ($label) RPC is up after ${i}s"
+      echo "tempo ($label) RPC is up after ${rpc_wait}s"
       break
     fi
-    if [ "$i" -eq 120 ]; then
+    if [ "$rpc_wait" -eq 120 ]; then
       echo "::error::tempo ($label) failed to start within 120s"
       cat "$log"
       exit 1
@@ -347,15 +349,16 @@ run_single() {
   done
 
   # Wait for pipeline to finish (engine transitions to idle)
-  for i in $(seq 1 300); do
+  local sync_wait
+  for sync_wait in $(seq 1 300); do
     SYNC_RESULT=$(curl -sf http://127.0.0.1:8545 -X POST \
       -H 'Content-Type: application/json' \
       -d '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' 2>/dev/null || true)
     if [ -n "$SYNC_RESULT" ] && jq -e '.result == false' <<< "$SYNC_RESULT" > /dev/null 2>&1; then
-      echo "tempo ($label) pipeline finished after ${i}s, engine is live"
+      echo "tempo ($label) pipeline finished after ${sync_wait}s, engine is live"
       break
     fi
-    if [ "$i" -eq 300 ]; then
+    if [ "$sync_wait" -eq 300 ]; then
       echo "::error::tempo ($label) pipeline did not finish within 300s"
       cat "$log"
       exit 1
@@ -491,8 +494,8 @@ run_progress=0
 baseline_index=0
 feature_index=0
 
-for ((i = 0; i < ${#RUN_ORDER}; i++)); do
-  side="${RUN_ORDER:i:1}"
+for ((run_pos = 0; run_pos < ${#RUN_ORDER}; run_pos++)); do
+  side="${RUN_ORDER:$run_pos:1}"
   if [ "$side" = "B" ]; then
     baseline_index=$((baseline_index + 1))
     run_label="baseline-${baseline_index}"

--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -156,7 +156,7 @@ jobs:
       preset: ${{ matrix.preset }}
       tps: "20000"
       run-type: ${{ matrix.run_type }}
-      disable-abba: "true"
+      run-pairs: "1"
       clickhouse-run: feature-1
     secrets:
       DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -154,11 +154,11 @@ on:
         type: string
         required: false
         default: ""
-      disable-abba:
-        description: Run only baseline-1 and feature-1 instead of the full baseline-feature-feature-baseline sequence.
-        type: boolean
+      run-pairs:
+        description: Number of baseline/feature run pairs.
+        type: string
         required: true
-        default: false
+        default: "2"
       clickhouse-run:
         description: Benchmark phase that may use the direct ClickHouse reporter.
         type: string
@@ -292,10 +292,10 @@ on:
         type: string
         required: false
         default: ""
-      disable-abba:
+      run-pairs:
         type: string
         required: false
-        default: "false"
+        default: "2"
       clickhouse-run:
         type: string
         required: false
@@ -378,7 +378,7 @@ jobs:
       BENCH_BENCH_ENV: ${{ inputs.bench-env }}
       BENCH_BASELINE_ENV: ${{ inputs.baseline-env }}
       BENCH_FEATURE_ENV: ${{ inputs.feature-env }}
-      BENCH_DISABLE_ABBA: ${{ (inputs.disable-abba == true || inputs.disable-abba == 'true' || inputs.run-type == 'nightly') && 'true' || 'false' }}
+      BENCH_RUN_PAIRS: ${{ inputs.run-pairs || '2' }}
       BENCH_CLICKHOUSE_RUN: ${{ inputs.clickhouse-run || 'feature-1' }}
       BENCHMARK_ID: bench-e2e-${{ github.run_id }}
       BENCH_COMMENT_ID: ${{ inputs.comment-id }}
@@ -491,8 +491,9 @@ jobs:
             const noCache = process.env.BENCH_NO_CACHE === 'true';
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const gasLimit = process.env.BENCH_GAS_LIMIT;
+            const runPairs = process.env.BENCH_RUN_PAIRS || '2';
             const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
-            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${samplyNote}${tracyNote}${otlpNote}${noCacheNote}`);
+            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${samplyNote}${tracyNote}${otlpNote}${noCacheNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -706,11 +707,16 @@ jobs:
             unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
             unset OTEL_EXPORTER_OTLP_HEADERS
           fi
+          if ! [[ "$BENCH_RUN_PAIRS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::run-pairs must be a positive integer"
+            exit 1
+          fi
           cmd=(nu bench-e2e.nu e2e)
           cmd+=(
             --preset "$BENCH_PRESET"
             --bloat "$BENCH_BLOAT"
             --duration "$BENCH_DURATION"
+            --run-pairs "$BENCH_RUN_PAIRS"
             --tps "$BENCH_TPS"
             --accounts "$BENCH_ACCOUNTS"
             --max-concurrent-requests "$BENCH_MAX_CONCURRENT_REQUESTS"
@@ -738,7 +744,6 @@ jobs:
           [ -n "$BENCH_VICTORIAMETRICS_URL" ] && cmd+=(--victoriametrics-url "$BENCH_VICTORIAMETRICS_URL")
           [ -n "$CLICKHOUSE_URL" ] && cmd+=(--clickhouse-url "$CLICKHOUSE_URL")
           [ -n "$BENCH_RUN_TYPE" ] && cmd+=(--run-type "$BENCH_RUN_TYPE")
-          [ "$BENCH_DISABLE_ABBA" = "true" ] && cmd+=(--disable-abba)
           [ -n "$BENCH_CLICKHOUSE_RUN" ] && cmd+=(--clickhouse-run "$BENCH_CLICKHOUSE_RUN")
           "${cmd[@]}"
 
@@ -832,8 +837,19 @@ jobs:
               }
             } catch (e) {}
 
-            const runs = ['baseline-1', 'feature-1', 'feature-2', 'baseline-2']
-              .filter(run => fs.existsSync(`${resultsDir}/report-${run}.json`));
+            let runs = [];
+            try {
+              runs = fs.readFileSync(`${resultsDir}/run-order.txt`, 'utf8')
+                .split(/\r?\n/)
+                .map(run => run.trim())
+                .filter(run => run && fs.existsSync(`${resultsDir}/report-${run}.json`));
+            } catch (e) {}
+            if (runs.length === 0) {
+              runs = fs.readdirSync(resultsDir)
+                .map(name => /^report-(.+)\.json$/.exec(name)?.[1])
+                .filter(Boolean)
+                .sort();
+            }
 
             // Samply profile links (URLs produced by tempo.nu upload-samply-profile)
             let samplySection = '';

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -673,8 +673,9 @@ jobs:
             const noCache = process.env.BENCH_NO_CACHE === 'true';
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const gasLimit = process.env.BENCH_GAS_LIMIT;
+            const runPairs = process.env.BENCH_RUN_PAIRS || '2';
             const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
-            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${samplyNote}${tracyNote}${otlpNote}${noCacheNote}`;
+            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${samplyNote}${tracyNote}${otlpNote}${noCacheNote}`;
             core.exportVariable('BENCH_CONFIG', config);
 
             const { data: comment } = await github.rest.issues.createComment({

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -573,6 +573,13 @@ jobs:
       - name: Write job summary
         if: success()
         run: |
+          {
+            echo "Chain: \`${BENCH_CHAIN:-mainnet}\`"
+            echo "Warmup: \`${BENCH_WARMUP_BLOCKS:-}\`"
+            echo "Blocks: \`${BENCH_BLOCKS:-5000}\`"
+            echo "Run pairs: \`${BENCH_RUN_PAIRS:-2}\`"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
           if [ -f "$BENCH_WORK_DIR/comment.md" ]; then
             cat "$BENCH_WORK_DIR/comment.md" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -1,7 +1,7 @@
 # Replay benchmark job.
 #
 # Called by bench.yml when mode=replay. Replays real Tempo blocks through the
-# Engine API for an interleaved B-F-F-B comparison.
+# Engine API for an interleaved baseline/feature comparison.
 
 name: bench-replay
 
@@ -23,6 +23,10 @@ on:
         description: "Number of warmup blocks (default: one-quarter of blocks)"
         type: string
         default: ""
+      run-pairs:
+        description: "Number of baseline/feature run pairs"
+        type: string
+        default: "2"
       samply:
         description: "Enable samply profiling"
         type: string
@@ -100,6 +104,10 @@ on:
       warmup:
         type: string
         required: true
+      run-pairs:
+        type: string
+        required: false
+        default: "2"
       comment-id:
         type: string
         required: false
@@ -169,6 +177,7 @@ jobs:
       BENCH_FEATURE_ARGS: "--dev.block-time 999999s ${{ inputs.feature-args }}"
       BENCH_BLOCKS: ${{ inputs.blocks || '5000' }}
       BENCH_WARMUP_BLOCKS: ${{ inputs.warmup }}
+      BENCH_RUN_PAIRS: ${{ inputs.run-pairs || '2' }}
       BENCH_COMMENT_ID: ${{ inputs.comment-id }}
       BENCH_PR_HEAD_SHA: ${{ inputs.pr-head-sha }}
       BENCH_PR_HEAD_REF: ${{ inputs.pr-head-ref }}
@@ -181,6 +190,7 @@ jobs:
         env:
           INPUT_BLOCKS: ${{ inputs.blocks || '5000' }}
           INPUT_WARMUP: ${{ inputs.warmup || '' }}
+          INPUT_RUN_PAIRS: ${{ inputs.run-pairs || '2' }}
         run: |
           if ! [[ "$INPUT_BLOCKS" =~ ^[0-9]+$ ]]; then
             echo "::error::blocks must be a non-negative integer"
@@ -190,6 +200,10 @@ jobs:
             echo "::error::warmup must be a non-negative integer"
             exit 1
           fi
+          if ! [[ "$INPUT_RUN_PAIRS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::run-pairs must be a positive integer"
+            exit 1
+          fi
           if [ -z "$INPUT_WARMUP" ]; then
             INPUT_WARMUP=$(( INPUT_BLOCKS / 4 ))
           fi
@@ -197,6 +211,7 @@ jobs:
           {
             echo "BENCH_BLOCKS=$INPUT_BLOCKS"
             echo "BENCH_WARMUP_BLOCKS=$INPUT_WARMUP"
+            echo "BENCH_RUN_PAIRS=$INPUT_RUN_PAIRS"
           } >> "$GITHUB_ENV"
 
       - name: Configure OTLP telemetry
@@ -240,7 +255,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number,
-                  body: `cc @${'${{ github.actor }}'}\n\n🚀 Replay benchmark started! [View run](${runUrl})\n\n⏳ **Status:** Running...\n\n**Config:** chain: \`${'${{ inputs.chain || 'mainnet' }}'}\`, blocks: \`${process.env.BENCH_BLOCKS}\`, warmup: \`${process.env.BENCH_WARMUP_BLOCKS}\``,
+                  body: `cc @${'${{ github.actor }}'}\n\n🚀 Replay benchmark started! [View run](${runUrl})\n\n⏳ **Status:** Running...\n\n**Config:** chain: \`${'${{ inputs.chain || 'mainnet' }}'}\`, blocks: \`${process.env.BENCH_BLOCKS}\`, warmup: \`${process.env.BENCH_WARMUP_BLOCKS}\`, run-pairs: \`${process.env.BENCH_RUN_PAIRS || '2'}\``,
                 });
                 core.exportVariable('BENCH_COMMENT_ID', String(comment.id));
                 if (pr.mergeable) {
@@ -292,6 +307,7 @@ jobs:
 
             const blocks = process.env.BENCH_BLOCKS;
             const warmup = process.env.BENCH_WARMUP_BLOCKS;
+            const runPairs = process.env.BENCH_RUN_PAIRS || '2';
             const baseline = '${{ inputs.baseline-name }}';
             const feature = '${{ inputs.feature-name }}';
             const samply = process.env.BENCH_SAMPLY === 'true';
@@ -299,7 +315,7 @@ jobs:
             const otlp = process.env.BENCH_OTLP === 'true';
             const otlpNote = otlp ? ', otlp: `enabled`' : ', otlp: `disabled`';
             const chain = process.env.BENCH_CHAIN || 'mainnet';
-            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`replay\`, chain: \`${chain}\`, blocks: \`${blocks}\`, warmup: \`${warmup}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${otlpNote}`);
+            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`replay\`, chain: \`${chain}\`, blocks: \`${blocks}\`, warmup: \`${warmup}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${otlpNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -419,19 +435,28 @@ jobs:
           FEATURE_NAME: ${{ steps.refs.outputs.feature-name }}
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
         run: |
-          SUMMARY_ARGS="--output-summary $BENCH_WORK_DIR/summary.json"
-          SUMMARY_ARGS="$SUMMARY_ARGS --output-markdown $BENCH_WORK_DIR/comment.md"
-          SUMMARY_ARGS="$SUMMARY_ARGS --repo ${{ github.repository }}"
-          SUMMARY_ARGS="$SUMMARY_ARGS --baseline-ref ${BASELINE_REF}"
-          SUMMARY_ARGS="$SUMMARY_ARGS --baseline-name ${BASELINE_NAME}"
-          SUMMARY_ARGS="$SUMMARY_ARGS --feature-name ${FEATURE_NAME}"
-          SUMMARY_ARGS="$SUMMARY_ARGS --feature-ref ${FEATURE_REF}"
-          BASELINE_JSONS="$BENCH_WORK_DIR/baseline-1/report.json $BENCH_WORK_DIR/baseline-2/report.json"
-          FEATURE_JSONS="$BENCH_WORK_DIR/feature-1/report.json $BENCH_WORK_DIR/feature-2/report.json"
-          SUMMARY_ARGS="$SUMMARY_ARGS --baseline-json $BASELINE_JSONS"
-          SUMMARY_ARGS="$SUMMARY_ARGS --feature-json $FEATURE_JSONS"
-          # shellcheck disable=SC2086
-          python3 .github/scripts/bench-replay-summary.py $SUMMARY_ARGS
+          mapfile -t RUN_LABELS < "$BENCH_WORK_DIR/run-order.txt"
+          BASELINE_JSONS=()
+          FEATURE_JSONS=()
+          for label in "${RUN_LABELS[@]}"; do
+            [ -z "$label" ] && continue
+            report="$BENCH_WORK_DIR/$label/report.json"
+            if [[ "$label" == baseline-* ]]; then
+              BASELINE_JSONS+=("$report")
+            elif [[ "$label" == feature-* ]]; then
+              FEATURE_JSONS+=("$report")
+            fi
+          done
+          python3 .github/scripts/bench-replay-summary.py \
+            --output-summary "$BENCH_WORK_DIR/summary.json" \
+            --output-markdown "$BENCH_WORK_DIR/comment.md" \
+            --repo "${{ github.repository }}" \
+            --baseline-ref "$BASELINE_REF" \
+            --baseline-name "$BASELINE_NAME" \
+            --feature-name "$FEATURE_NAME" \
+            --feature-ref "$FEATURE_REF" \
+            --baseline-json "${BASELINE_JSONS[@]}" \
+            --feature-json "${FEATURE_JSONS[@]}"
 
       - name: Generate charts
         id: charts
@@ -440,15 +465,24 @@ jobs:
           BASELINE_NAME: ${{ steps.refs.outputs.baseline-name }}
           FEATURE_NAME: ${{ steps.refs.outputs.feature-name }}
         run: |
-          CHART_ARGS="--output-dir $BENCH_WORK_DIR/charts"
-          FEATURE_JSONS="$BENCH_WORK_DIR/feature-1/report.json $BENCH_WORK_DIR/feature-2/report.json"
-          BASELINE_JSONS="$BENCH_WORK_DIR/baseline-1/report.json $BENCH_WORK_DIR/baseline-2/report.json"
-          CHART_ARGS="$CHART_ARGS --feature $FEATURE_JSONS"
-          CHART_ARGS="$CHART_ARGS --baseline $BASELINE_JSONS"
-          CHART_ARGS="$CHART_ARGS --baseline-name ${BASELINE_NAME}"
-          CHART_ARGS="$CHART_ARGS --feature-name ${FEATURE_NAME}"
-          # shellcheck disable=SC2086
-          uv run --with matplotlib python3 .github/scripts/bench-replay-charts.py $CHART_ARGS
+          mapfile -t RUN_LABELS < "$BENCH_WORK_DIR/run-order.txt"
+          BASELINE_JSONS=()
+          FEATURE_JSONS=()
+          for label in "${RUN_LABELS[@]}"; do
+            [ -z "$label" ] && continue
+            report="$BENCH_WORK_DIR/$label/report.json"
+            if [[ "$label" == baseline-* ]]; then
+              BASELINE_JSONS+=("$report")
+            elif [[ "$label" == feature-* ]]; then
+              FEATURE_JSONS+=("$report")
+            fi
+          done
+          uv run --with matplotlib python3 .github/scripts/bench-replay-charts.py \
+            --output-dir "$BENCH_WORK_DIR/charts" \
+            --feature "${FEATURE_JSONS[@]}" \
+            --baseline "${BASELINE_JSONS[@]}" \
+            --baseline-name "$BASELINE_NAME" \
+            --feature-name "$FEATURE_NAME"
 
       - name: Upload results
         id: upload-results
@@ -526,7 +560,8 @@ jobs:
             const chain = process.env.BENCH_CHAIN || 'mainnet';
             const blocks = process.env.BENCH_BLOCKS || '5000';
             const warmup = process.env.BENCH_WARMUP_BLOCKS || String(Math.floor(Number(blocks) / 4));
-            const body = `cc @${process.env.BENCH_ACTOR}\n\n✅ Replay benchmark complete! [View job](${jobUrl})\n\nChain: \`${chain}\`\nWarmup: \`${warmup}\`\nBlocks: \`${blocks}\`\n\n${comment}`;
+            const runPairs = process.env.BENCH_RUN_PAIRS || '2';
+            const body = `cc @${process.env.BENCH_ACTOR}\n\n✅ Replay benchmark complete! [View job](${jobUrl})\n\nChain: \`${chain}\`\nWarmup: \`${warmup}\`\nBlocks: \`${blocks}\`\nRun pairs: \`${runPairs}\`\n\n${comment}`;
 
             await github.rest.issues.updateComment({
               owner: context.repo.owner,

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -61,6 +61,7 @@ jobs:
       blocks: ${{ steps.args.outputs.blocks }}
       warmup: ${{ steps.args.outputs.warmup }}
       chain: ${{ steps.args.outputs.chain }}
+      run-pairs: ${{ steps.args.outputs.run-pairs }}
       comment-id: ${{ steps.ack.outputs.comment-id }}
       pr-head-sha: ${{ steps.args.outputs.pr-head-sha }}
       pr-head-ref: ${{ steps.args.outputs.pr-head-ref }}
@@ -105,20 +106,20 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
-            let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup;
+            let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs;
             let explicitWarmup = false;
 
             pr = String(context.issue.number);
             actor = context.payload.comment.user.login;
 
             const body = context.payload.comment.body.trim();
-            const intArgs = new Set(['duration', 'bloat', 'tps', 'accounts', 'max-concurrent-requests', 'gas-limit', 'tracy-seconds', 'tracy-offset', 'blocks', 'warmup']);
+            const intArgs = new Set(['duration', 'bloat', 'tps', 'accounts', 'max-concurrent-requests', 'gas-limit', 'tracy-seconds', 'tracy-offset', 'blocks', 'warmup', 'run-pairs']);
             const refArgs = new Set(['baseline', 'feature', 'txgen-ref']);
             const stringArgs = new Set(['mode', 'preset', 'tracy', 'baseline-args', 'feature-args', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain', 'baseline-hardfork', 'feature-hardfork']);
             const boolArgs = new Set(['samply', 'force-bloat', 'no-cache', 'no-slack', 'no-existing-recipients', 'otlp']);
             const bloatValues = new Set(['1', '10', '100']);
             const hardforkValues = new Set(['T0', 'T1', 'T1A', 'T1B', 'T1C', 'T2', 'T3', 'T4', 'T5', 'T6']);
-            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '20000', accounts: '1000', 'max-concurrent-requests': '100', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'true', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet' };
+            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '20000', accounts: '1000', 'max-concurrent-requests': '100', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'true', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2' };
             const unknown = [];
             const invalid = [];
             const defaultWarmup = (blockCount) => String(Math.floor(Number(blockCount) / 4));
@@ -191,7 +192,7 @@ jobs:
             if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
             if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
             if (errors.length) {
-              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [txgen-ref=REF] [samply] [otlp] [force-bloat] [no-cache] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
+              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [txgen-ref=REF] [samply] [otlp] [force-bloat] [no-cache] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -231,6 +232,7 @@ jobs:
             featureEnv = defaults['feature-env'];
             blocks = defaults.blocks;
             warmup = defaults.warmup;
+            runPairs = defaults['run-pairs'];
             var chain = defaults.chain;
             if (!explicitWarmup) {
               warmup = defaultWarmup(blocks);
@@ -240,7 +242,7 @@ jobs:
             const erFlag = `--existing-recipients=${existingRecipients}`;
             benchArgs = benchArgs ? `${benchArgs} ${erFlag}` : erFlag;
 
-            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [txgen-ref=REF] [samply] [otlp] [force-bloat] [no-cache] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
+            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [txgen-ref=REF] [samply] [otlp] [force-bloat] [no-cache] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 
             // Validate chain value
             if (!['mainnet', 'testnet'].includes(chain)) {
@@ -325,6 +327,17 @@ jobs:
               core.setFailed(msg);
               return;
             }
+            if (Number(runPairs) < 1) {
+              const msg = `❌ **Invalid bench command**\n\n\`run-pairs=${runPairs}\` is not valid. Must be a positive integer.\n\n${usageStr}`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: msg,
+              });
+              core.setFailed(msg);
+              return;
+            }
 
             // Resolve display names for baseline/feature
             let baselineName = baseline || 'main';
@@ -377,6 +390,7 @@ jobs:
             core.setOutput('blocks', blocks);
             core.setOutput('warmup', warmup);
             core.setOutput('chain', chain);
+            core.setOutput('run-pairs', runPairs);
 
       - name: Acknowledge request
         id: ack
@@ -402,6 +416,7 @@ jobs:
           ACK_BASELINE_ARGS: ${{ steps.args.outputs.baseline-args }}
           ACK_FEATURE_ARGS: ${{ steps.args.outputs.feature-args }}
           ACK_GAS_LIMIT: ${{ steps.args.outputs.gas-limit }}
+          ACK_RUN_PAIRS: ${{ steps.args.outputs.run-pairs }}
           ACK_NO_CACHE: ${{ steps.args.outputs.no-cache }}
         with:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
@@ -443,10 +458,11 @@ jobs:
             const fNa = process.env.ACK_FEATURE_ARGS || '';
             const naNote = (bNa || fNa) ? `${bNa ? `, baseline-args: \`${bNa}\`` : ''}${fNa ? `, feature-args: \`${fNa}\`` : ''}` : '';
             const gasLimit = process.env.ACK_GAS_LIMIT;
+            const runPairs = process.env.ACK_RUN_PAIRS || '2';
             const noCache = process.env.ACK_NO_CACHE === 'true';
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
-            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${samplyNote}${tracyNote}${otlpNote}${naNote}${noCacheNote}`;
+            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${samplyNote}${tracyNote}${otlpNote}${naNote}${noCacheNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -485,6 +501,7 @@ jobs:
       baseline-args: ${{ needs.tempo-bench-ack.outputs.baseline-args }}
       feature-args: ${{ needs.tempo-bench-ack.outputs.feature-args }}
       gas-limit: ${{ needs.tempo-bench-ack.outputs.gas-limit }}
+      run-pairs: ${{ needs.tempo-bench-ack.outputs.run-pairs }}
       run-type: ${{ needs.tempo-bench-ack.outputs.run-type }}
       force-bloat: ${{ needs.tempo-bench-ack.outputs.force-bloat }}
       no-cache: ${{ needs.tempo-bench-ack.outputs.no-cache }}
@@ -525,6 +542,7 @@ jobs:
       feature-args: ${{ needs.tempo-bench-ack.outputs.feature-args }}
       blocks: ${{ needs.tempo-bench-ack.outputs.blocks }}
       warmup: ${{ needs.tempo-bench-ack.outputs.warmup }}
+      run-pairs: ${{ needs.tempo-bench-ack.outputs.run-pairs }}
       comment-id: ${{ needs.tempo-bench-ack.outputs.comment-id }}
       pr-head-sha: ${{ needs.tempo-bench-ack.outputs.pr-head-sha }}
       pr-head-ref: ${{ needs.tempo-bench-ack.outputs.pr-head-ref }}

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -911,6 +911,25 @@ def run-local-e2e-phase [run: record, ctx: record] {
     return 0
 }
 
+def e2e-run-sides [run_pairs: int] {
+    if $run_pairs <= 0 {
+        print "Error: --run-pairs must be a positive integer"
+        exit 1
+    }
+
+    mut sides = []
+    if ($run_pairs mod 2) == 0 {
+        for _ in 0..<($run_pairs // 2) {
+            $sides = ($sides | append ["baseline" "feature" "feature" "baseline"])
+        }
+    } else {
+        for _ in 0..<$run_pairs {
+            $sides = ($sides | append ["baseline" "feature"])
+        }
+    }
+    $sides
+}
+
 # Run the e2e sequence on one runner.
 def "main e2e" [
     --baseline: string                                  # Baseline git SHA/ref
@@ -937,7 +956,7 @@ def "main e2e" [
     --victoriametrics-url: string = ""                  # VictoriaMetrics base URL for txgen metric sample import
     --clickhouse-url: string = ""                       # ClickHouse HTTP endpoint for txgen result upload
     --clickhouse-run: string = "feature-1"              # Run label allowed to use the ClickHouse reporter; empty = every run
-    --disable-abba                                      # Run only baseline-1 and feature-1
+    --run-pairs: int = 2                                # Number of baseline/feature run pairs
     --run-type: string = ""                             # Run type label (dispatch, nightly, release)
     --baseline-args: string = ""                        # Additional node args for baseline phases
     --feature-args: string = ""                         # Additional node args for feature phases
@@ -959,9 +978,8 @@ def "main e2e" [
         print $"Error: --tracy must be one of: off, on, full \(got '($tracy)'\)"
         exit 1
     }
-    let valid_run_labels = ["baseline-1" "feature-1" "feature-2" "baseline-2"]
-    if $clickhouse_run != "" and $clickhouse_run not-in $valid_run_labels {
-        print $"Error: --clickhouse-run must be one of: ($valid_run_labels | str join ', ') \(got '($clickhouse_run)'\)"
+    if $run_pairs <= 0 {
+        print "Error: --run-pairs must be a positive integer"
         exit 1
     }
     let bloat_mib = (e2e-bloat-gib-to-mib $bloat)
@@ -1223,17 +1241,38 @@ def "main e2e" [
     let baseline_base_label = if $baseline_name != "" { $baseline_name } else { $baseline }
     let feature_base_label = if $feature_name != "" { $feature_name } else { $feature }
 
-    let abba_runs = [
-        { phase: "baseline-1", ref: $baseline, ref_label: $baseline_base_label, tempo: $baseline_tempo, genesis: $baseline_genesis_path, hardfork: $baseline_hardfork_name }
-        { phase: "feature-1", ref: $feature, ref_label: $feature_base_label, tempo: $feature_tempo, genesis: $feature_genesis_path, hardfork: $feature_hardfork_name }
-        { phase: "feature-2", ref: $feature, ref_label: $feature_base_label, tempo: $feature_tempo, genesis: $feature_genesis_path, hardfork: $feature_hardfork_name }
-        { phase: "baseline-2", ref: $baseline, ref_label: $baseline_base_label, tempo: $baseline_tempo, genesis: $baseline_genesis_path, hardfork: $baseline_hardfork_name }
-    ]
-    let runs = if $disable_abba {
-        $abba_runs | where { |run| $run.phase in ["baseline-1" "feature-1"] }
-    } else {
-        $abba_runs
+    mut baseline_run_index = 0
+    mut feature_run_index = 0
+    mut runs = []
+    for side in (e2e-run-sides $run_pairs) {
+        if $side == "baseline" {
+            $baseline_run_index = $baseline_run_index + 1
+            $runs = ($runs | append {
+                phase: $"baseline-($baseline_run_index)"
+                ref: $baseline
+                ref_label: $baseline_base_label
+                tempo: $baseline_tempo
+                genesis: $baseline_genesis_path
+                hardfork: $baseline_hardfork_name
+            })
+        } else {
+            $feature_run_index = $feature_run_index + 1
+            $runs = ($runs | append {
+                phase: $"feature-($feature_run_index)"
+                ref: $feature
+                ref_label: $feature_base_label
+                tempo: $feature_tempo
+                genesis: $feature_genesis_path
+                hardfork: $feature_hardfork_name
+            })
+        }
     }
+    let valid_run_labels = ($runs | get phase)
+    if $clickhouse_run != "" and $clickhouse_run not-in $valid_run_labels {
+        print $"Error: --clickhouse-run must be one of: ($valid_run_labels | str join ', ') \(got '($clickhouse_run)'\)"
+        exit 1
+    }
+    $valid_run_labels | str join "\n" | save -f $"($results_dir)/run-order.txt"
     let num_phases = ($runs | length)
     mut e2e_exit = 0
     for idx in 0..<$num_phases {

--- a/tempo.nu
+++ b/tempo.nu
@@ -786,7 +786,12 @@ def grafana-performance-url [benchmark_id: string, from_ms: int, to_ms: int] {
 
 
 def generate-summary [results_dir: string, baseline_ref: string, feature_ref: string, bloat: int, preset: string, tps: int, duration: int, --benchmark-id: string = "", --reference-epoch: int = 0] {
-    let candidate_run_labels = ["baseline-1" "feature-1" "feature-2" "baseline-2"]
+    let run_order_path = $"($results_dir)/run-order.txt"
+    let candidate_run_labels = if ($run_order_path | path exists) {
+        open $run_order_path | lines | where { |label| $label != "" }
+    } else {
+        ["baseline-1" "feature-1" "feature-2" "baseline-2"]
+    }
     let run_labels = ($candidate_run_labels | where { |label| ($"($results_dir)/report-($label).json" | path exists) })
     mut run_data = []
     mut baseline_blocks = []
@@ -995,6 +1000,7 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
     # Aggregate TPS and Mgas/s from per-run totals (total_tx / total_time)
     let baseline_runs = ($run_data | where { |r| $r.label | str starts-with "baseline" })
     let feature_runs = ($run_data | where { |r| $r.label | str starts-with "feature" })
+    let run_pairs = ([($baseline_runs | length) ($feature_runs | length)] | math max)
 
     let b_tps = if ($baseline_runs | length) > 0 { $baseline_runs | get tps | math avg | math round --precision 0 } else { 0.0 }
     let f_tps = if ($feature_runs | length) > 0 { $feature_runs | get tps | math avg | math round --precision 0 } else { 0.0 }
@@ -1035,6 +1041,7 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
         $"- Preset: ($preset)"
         $"- Target TPS: ($tps)"
         $"- Duration: ($duration)s"
+        $"- Run pairs: ($run_pairs)"
         $"- Snapshot: (if (has-schelk) { 'schelk' } else { 'cp fallback' })"
         $"- Baseline blocks: ($b_lat.n)"
         $"- Feature blocks: ($f_lat.n)"
@@ -1099,6 +1106,7 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
             preset: $preset
             tps: $tps
             duration: $duration
+            run_pairs: $run_pairs
         }
         results: {
             baseline: {


### PR DESCRIPTION
Replaces the e2e ABBA toggle and fixed replay ABBA sequence with a `run-pairs` parameter. The default remains two run pairs, while scheduled e2e keeps its explicit one-pair override.