### PR TITLE
chore: default tips verification to T5

### DIFF
--- a/tips/verify/README.md
+++ b/tips/verify/README.md
@@ -6,7 +6,7 @@ This directory contains Solidity spec verification tests and fuzz harnesses for 
 
 ## Profiles
 
-The checked-in `foundry.toml` uses two profiles, which always run against a Tempo-native EVM with enabled Rust precompiles:
+The checked-in `foundry.toml` uses two profiles, which default to the Tempo T5 hardfork and run against a Tempo-native EVM with enabled Rust precompiles:
 
 - `default`: config for standard Foundry build/fmt/ABI tasks. Lighter optimizer and fuzz/invariant settings, for quicker output.
 - `fuzz500`: config for extended invariant runs.

--- a/tips/verify/foundry.toml
+++ b/tips/verify/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-hardfork = "tempo:T3"
+hardfork = "tempo:T5"
 
 # layout and file system
 src = "src"
@@ -20,6 +20,9 @@ invariant = { runs = 10, depth = 50, fail_on_revert = true, show_solidity = true
 
 [profile.fuzz500]
 invariant = { runs = 500, depth = 500, fail_on_revert = true, show_solidity = true }
+
+[lint]
+lint_on_build = false
 
 [fmt]
 line_length = 100

--- a/tips/verify/test/StablecoinDEX.t.sol
+++ b/tips/verify/test/StablecoinDEX.t.sol
@@ -33,6 +33,16 @@ contract StablecoinDEXTest is TempoTest {
         bool partialFill
     );
 
+    event OrderFlipped(
+        uint128 indexed orderId,
+        address indexed maker,
+        address indexed base,
+        uint128 amount,
+        bool isBid,
+        int16 tick,
+        int16 flipTick
+    );
+
     event PairCreated(bytes32 indexed key, address indexed base, address indexed quote);
 
     function setUp() public override {
@@ -364,20 +374,28 @@ contract StablecoinDEXTest is TempoTest {
         vm.prank(alice);
         uint128 flipOrderId = exchange.placeFlip(address(token1), 1e18, true, 100, 200);
 
-        // Orders are immediately active, no executeBlock needed
-        // Event order: Transfer (in), OrderFilled, FlipOrderPlaced, Transfer (out)
+        // Orders are immediately active, no executeBlock needed.
+        // T5 flips in place under the same order ID.
 
         vm.expectEmit(true, true, true, true);
         emit OrderFilled(flipOrderId, alice, bob, 1e18, false);
 
         vm.expectEmit(true, true, true, true);
-        emit OrderPlaced(2, alice, address(token1), 1e18, false, 200, true, 100);
+        emit OrderFlipped(flipOrderId, alice, address(token1), 1e18, false, 200, 100);
 
         vm.prank(bob);
         exchange.swapExactAmountIn(address(token1), address(pathUSD), 1e18, 0);
 
-        assertEq(exchange.nextOrderId(), 3);
-        // TODO: pull the order from orders mapping and assert state changes
+        assertEq(exchange.nextOrderId(), 2);
+
+        IStablecoinDEX.Order memory flipped = exchange.getOrder(flipOrderId);
+        assertEq(flipped.orderId, flipOrderId);
+        assertEq(flipped.maker, alice);
+        assertFalse(flipped.isBid);
+        assertEq(flipped.tick, 200);
+        assertEq(flipped.flipTick, 100);
+        assertEq(flipped.amount, 1e18);
+        assertEq(flipped.remaining, 1e18);
     }
 
     function test_OrdersImmediatelyActive() public {
@@ -755,10 +773,10 @@ contract StablecoinDEXTest is TempoTest {
         } else if (flipTick % exchange.TICK_SPACING() != 0) {
             shouldRevert = true;
             expectedSelector = IStablecoinDEX.InvalidFlipTick.selector;
-        } else if (isBid && flipTick <= tick) {
+        } else if (isBid && flipTick < tick) {
             shouldRevert = true;
             expectedSelector = IStablecoinDEX.InvalidFlipTick.selector;
-        } else if (!isBid && flipTick >= tick) {
+        } else if (!isBid && flipTick > tick) {
             shouldRevert = true;
             expectedSelector = IStablecoinDEX.InvalidFlipTick.selector;
         }

--- a/tips/verify/test/invariants/FeeAMM.t.sol
+++ b/tips/verify/test/invariants/FeeAMM.t.sol
@@ -9,8 +9,6 @@ import { ITIP403Registry } from "tempo-std/interfaces/ITIP403Registry.sol";
 
 /// @title FeeAMM Invariant Test
 /// @notice Invariant tests for the FeeAMM/FeeManager implementation
-/// forge-config: default.hardfork = "tempo:T5"
-/// forge-config: fuzz500.hardfork = "tempo:T5"
 contract FeeAMMInvariantTest is InvariantBaseTest {
 
     /// @dev Constants from Rust tip_fee_manager/amm.rs

--- a/tips/verify/test/invariants/StablecoinDEX.t.sol
+++ b/tips/verify/test/invariants/StablecoinDEX.t.sol
@@ -11,8 +11,6 @@ import { ITIP20 } from "tempo-std/interfaces/ITIP20.sol";
 /// @dev Tests invariants TEMPO-DEX1 through TEMPO-DEX19 as documented in README.md.
 /// Pinned to T5 so TEMPO-DEX17 covers TIP-1030's same-tick flip path
 /// (`flipTick == tick`).
-/// forge-config: default.hardfork = "tempo:T5"
-/// forge-config: fuzz500.hardfork = "tempo:T5"
 contract StablecoinDEXInvariantTest is InvariantBaseTest {
 
     /// @dev Mapping of actor address to their placed order IDs

--- a/tips/verify/test/invariants/TIP1026.t.sol
+++ b/tips/verify/test/invariants/TIP1026.t.sol
@@ -13,8 +13,6 @@ import { ITIP20RolesAuthErr } from "tempo-std/interfaces/ITIP20RolesAuth.sol";
 ///      TEMPO-1026-1: `bytes(logoURI()).length <= 256` must always hold.
 ///      TEMPO-1026-2: The legacy 6-argument `createToken` selector and the
 ///                    `TokenCreated` event signature are unchanged by this TIP.
-/// forge-config: default.hardfork = "tempo:T5"
-/// forge-config: fuzz500.hardfork = "tempo:T5"
 contract TIP1026InvariantTest is InvariantBaseTest {
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- set tips/verify Foundry default hardfork to tempo:T5
- update the tips verification README to mention the T5 default
- remove redundant inline tempo:T5 forge-config pins now covered by the default
- update StablecoinDEX tests for T5 DEX behavior:
  - TIP-1056: filled flip orders are rewritten in place, reuse the original order ID, and emit OrderFlipped instead of creating a new order and emitting OrderPlaced. Because no new flipped order is allocated, nextOrderId() stays at 2 instead of advancing to 3 in the updated test.
  - TIP-1030: same-tick flips are allowed, so bid validation is flipTick >= tick and ask validation is flipTick <= tick; only the wrong side still reverts
- temporarily disable Forge build-time lint because the GitHub `nightly` binary still panics in the calls-loop analyzer; source-built Foundry after PR 14845 passes locally with lint enabled

## Validation
- git diff --check
- local: built foundry-rs/foundry at 054857e2acd14a437dce38af5f2d39a1793944cc, which includes merged PR 14845, then ran tips/verify `forge build --sizes` successfully with lint enabled
- CI before this note: GitHub `nightly` still panicked in Forge Build, so lint remains disabled until a usable nightly includes PR 14845
- prior CI on this PR with lint disabled: Forge Build, Forge Fmt, Forge Test (Rust Precompiles), and specs success passed