### PR TITLE
ci: disable OTLP for release e2e benches

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -365,8 +365,8 @@ jobs:
       BENCH_TRACY: ${{ (inputs.profiling == 'Tracy' || inputs.profiling == 'Both') && 'on' || ((inputs.profiling == 'Off' || inputs.profiling == 'Samply') && 'off' || inputs.tracy) }}
       BENCH_TRACY_SECONDS: ${{ inputs.tracy-seconds || '30' }}
       BENCH_TRACY_OFFSET: ${{ inputs.tracy-offset || '120' }}
-      BENCH_OTLP: ${{ inputs.otlp != false && inputs.otlp != 'false' }}
-      BENCH_FEATURES: ${{ (inputs.otlp != false && inputs.otlp != 'false') && 'jemalloc,asm-keccak,keccak-cache-global,otlp' || 'jemalloc,asm-keccak,keccak-cache-global' }}
+      BENCH_OTLP: ${{ inputs.run-type != 'release' && inputs.otlp != false && inputs.otlp != 'false' }}
+      BENCH_FEATURES: ${{ (inputs.run-type != 'release' && inputs.otlp != false && inputs.otlp != 'false') && 'jemalloc,asm-keccak,keccak-cache-global,otlp' || 'jemalloc,asm-keccak,keccak-cache-global' }}
       BENCH_BASELINE_ARGS: ${{ inputs.baseline-args }}
       BENCH_FEATURE_ARGS: ${{ inputs.feature-args }}
       BENCH_GAS_LIMIT: ${{ inputs.gas-limit || '1000000000' }}


### PR DESCRIPTION
## Summary
- force OTLP off when the reusable e2e benchmark workflow is invoked with run-type=release
- keep nightly/manual OTLP behavior unchanged
- build release benches without the otlp feature so older baseline refs are not passed new telemetry flags

## Validation
- git diff --check
- uv run python YAML parse for .github/workflows/bench-e2e.yml