### PR TITLE
ci(bench): internal perf dashboard link in bench-e2e output

### DIFF
--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -199,6 +199,22 @@ function buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, re
       action_id: 'diff_button',
     });
   }
+  if (summary.internal_perf_url) {
+    buttons.push({
+      type: 'button',
+      text: { type: 'plain_text', text: 'Internal dashboard', emoji: true },
+      url: summary.internal_perf_url,
+      action_id: 'internal_perf_button',
+    });
+  }
+  if (summary.grafana_url) {
+    buttons.push({
+      type: 'button',
+      text: { type: 'plain_text', text: 'Grafana', emoji: true },
+      url: summary.grafana_url,
+      action_id: 'grafana_button',
+    });
+  }
 
   return [
     {

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -852,6 +852,7 @@ jobs:
               if (benchId && metricsFrom && metricsTo && actualFrom && actualTo) {
                 const traceqlQuery = `{resource.benchmark_id="${benchId}"}`;
                 const grafanaUrl = meta.grafana_url || `https://tempoxyz.grafana.net/d/dffj6qf1o30oowe/performance?orgId=1&from=${encodeURIComponent(metricsFrom)}&to=${encodeURIComponent(metricsTo)}&timezone=browser&var-datasource=efk1hcn87dnnkd&var-filter_label=benchmark_id&var-filter_value=${encodeURIComponent(benchId)}&var-group_by=benchmark_run`;
+                const internalPerfUrl = meta.internal_perf_url || '';
                 const logsPane = JSON.stringify({
                   pw4: {
                     datasource: 'cfk1hzy08xekgd',
@@ -887,7 +888,8 @@ jobs:
                   },
                 });
                 const tracesUrl = `https://tempoxyz.grafana.net/explore?schemaVersion=1&panes=${encodeURIComponent(tracesPane)}&orgId=1`;
-                grafanaSection = `\n\n### Observability\n\n- [Metrics dashboard](${grafanaUrl})\n- [Logs](${logsUrl})\n- [Traces](${tracesUrl})\n`;
+                const internalPerfLine = internalPerfUrl ? `- [Internal dashboard](${internalPerfUrl})\n` : '';
+                grafanaSection = `\n\n### Observability\n\n${internalPerfLine}- [Metrics dashboard](${grafanaUrl})\n- [Logs](${logsUrl})\n- [Traces](${tracesUrl})\n`;
               }
             } catch (e) {}
 

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -889,7 +889,7 @@ jobs:
                 });
                 const tracesUrl = `https://tempoxyz.grafana.net/explore?schemaVersion=1&panes=${encodeURIComponent(tracesPane)}&orgId=1`;
                 const internalPerfLine = internalPerfUrl ? `- [Internal dashboard](${internalPerfUrl})\n` : '';
-                grafanaSection = `\n\n### Observability\n\n${internalPerfLine}- [Metrics dashboard](${grafanaUrl})\n- [Logs](${logsUrl})\n- [Traces](${tracesUrl})\n`;
+                grafanaSection = `\n\n### Observability\n\n${internalPerfLine}- [Grafana](${grafanaUrl})\n- [Logs](${logsUrl})\n- [Traces](${tracesUrl})\n`;
               }
             } catch (e) {}
 

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -40,30 +40,6 @@ def run-bench-schelk [...args: string] {
     }
 }
 
-def lookup-clickhouse-run-id [clickhouse_url: string, benchmark_id: string, benchmark_run: string] {
-    let query = "SELECT toString(run_id) FROM txgen_runs WHERE metadata['benchmark_id'] = {benchmark_id:String} AND metadata['benchmark_run'] = {benchmark_run:String} ORDER BY started_at DESC LIMIT 1 FORMAT TSVRaw"
-    let result = (with-env { CLICKHOUSE_URL: $clickhouse_url, BENCHMARK_ID: $benchmark_id, BENCHMARK_RUN: $benchmark_run, CLICKHOUSE_QUERY: $query } {
-        bash -lc '
-            set -euo pipefail
-            db="${CLICKHOUSE_DATABASE:-${CLICKHOUSE_DB:-default}}"
-            args=(-fsS -G "$CLICKHOUSE_URL/" --data-urlencode "database=$db" --data-urlencode "query=$CLICKHOUSE_QUERY" --data-urlencode "param_benchmark_id=$BENCHMARK_ID" --data-urlencode "param_benchmark_run=$BENCHMARK_RUN")
-            if [ -n "${CLICKHOUSE_USER:-}" ]; then
-                args+=(-H "X-ClickHouse-User: $CLICKHOUSE_USER")
-            fi
-            if [ -n "${CLICKHOUSE_PASSWORD:-}" ]; then
-                args+=(-H "X-ClickHouse-Key: $CLICKHOUSE_PASSWORD")
-            fi
-            curl "${args[@]}"
-        ' | complete
-    })
-    if $result.exit_code != 0 {
-        print $"Warning: failed to look up ClickHouse run id for ($benchmark_id)/($benchmark_run)"
-        if $result.stderr != "" { print $result.stderr }
-        return ""
-    }
-    $result.stdout | str trim
-}
-
 def schelk-state [state_path: string] {
     sudo cat $state_path | from json
 }
@@ -913,11 +889,12 @@ def run-local-e2e-phase [run: record, ctx: record] {
             print $"Error: local e2e txgen sender failed for ($phase): ($e.msg)"
             1
         })
-        if $sender_exit == 0 and $phase_clickhouse_url != "" {
-            let clickhouse_run_id = (lookup-clickhouse-run-id $phase_clickhouse_url $ctx.benchmark_id $phase)
-            if $clickhouse_run_id != "" {
-                $clickhouse_run_id | save -f $"($ctx.results_dir)/clickhouse-run-id-($phase).txt"
-                $clickhouse_run_id | save -f $"($ctx.results_dir)/clickhouse-run-id.txt"
+        if $sender_exit == 0 {
+            let report = (open $"($ctx.results_dir)/report-($phase).json")
+            let report_benchmark_id = ($report | get --optional benchmark_id | default "")
+            if $report_benchmark_id != "" {
+                $report_benchmark_id | save -f $"($ctx.results_dir)/clickhouse-run-id-($phase).txt"
+                $report_benchmark_id | save -f $"($ctx.results_dir)/clickhouse-run-id.txt"
             }
         }
         let phase_finished_ms = ((date now | into int) / 1_000_000 | into int)

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -889,7 +889,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
             print $"Error: local e2e txgen sender failed for ($phase): ($e.msg)"
             1
         })
-        if $sender_exit == 0 {
+        if $sender_exit == 0 and $phase_clickhouse_url != "" {
             let report = (open $"($ctx.results_dir)/report-($phase).json")
             let report_benchmark_id = ($report | get --optional benchmark_id | default "")
             if $report_benchmark_id != "" {

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -40,6 +40,30 @@ def run-bench-schelk [...args: string] {
     }
 }
 
+def lookup-clickhouse-run-id [clickhouse_url: string, benchmark_id: string, benchmark_run: string] {
+    let query = "SELECT toString(run_id) FROM txgen_runs WHERE metadata['benchmark_id'] = {benchmark_id:String} AND metadata['benchmark_run'] = {benchmark_run:String} ORDER BY started_at DESC LIMIT 1 FORMAT TSVRaw"
+    let result = (with-env { CLICKHOUSE_URL: $clickhouse_url, BENCHMARK_ID: $benchmark_id, BENCHMARK_RUN: $benchmark_run, CLICKHOUSE_QUERY: $query } {
+        bash -lc '
+            set -euo pipefail
+            db="${CLICKHOUSE_DATABASE:-${CLICKHOUSE_DB:-default}}"
+            args=(-fsS -G "$CLICKHOUSE_URL/" --data-urlencode "database=$db" --data-urlencode "query=$CLICKHOUSE_QUERY" --data-urlencode "param_benchmark_id=$BENCHMARK_ID" --data-urlencode "param_benchmark_run=$BENCHMARK_RUN")
+            if [ -n "${CLICKHOUSE_USER:-}" ]; then
+                args+=(-H "X-ClickHouse-User: $CLICKHOUSE_USER")
+            fi
+            if [ -n "${CLICKHOUSE_PASSWORD:-}" ]; then
+                args+=(-H "X-ClickHouse-Key: $CLICKHOUSE_PASSWORD")
+            fi
+            curl "${args[@]}"
+        ' | complete
+    })
+    if $result.exit_code != 0 {
+        print $"Warning: failed to look up ClickHouse run id for ($benchmark_id)/($benchmark_run)"
+        if $result.stderr != "" { print $result.stderr }
+        return ""
+    }
+    $result.stdout | str trim
+}
+
 def schelk-state [state_path: string] {
     sudo cat $state_path | from json
 }
@@ -889,6 +913,13 @@ def run-local-e2e-phase [run: record, ctx: record] {
             print $"Error: local e2e txgen sender failed for ($phase): ($e.msg)"
             1
         })
+        if $sender_exit == 0 and $phase_clickhouse_url != "" {
+            let clickhouse_run_id = (lookup-clickhouse-run-id $phase_clickhouse_url $ctx.benchmark_id $phase)
+            if $clickhouse_run_id != "" {
+                $clickhouse_run_id | save -f $"($ctx.results_dir)/clickhouse-run-id-($phase).txt"
+                $clickhouse_run_id | save -f $"($ctx.results_dir)/clickhouse-run-id.txt"
+            }
+        }
         let phase_finished_ms = ((date now | into int) / 1_000_000 | into int)
         {
             phase: $phase

--- a/tempo.nu
+++ b/tempo.nu
@@ -1266,7 +1266,6 @@ def generate-summary [
         $"- Duration: ($duration)s"
         $"- Run pairs: ($run_pairs)"
         $"- Snapshot: (if (has-schelk) { 'schelk' } else { 'cp fallback' })"
-        (if $internal_perf_url != "" { $"- Internal dashboard: [Internal dashboard]($internal_perf_url)" } else { "" })
         $"- Baseline blocks: ($b_lat.n)"
         $"- Feature blocks: ($f_lat.n)"
     ])

--- a/tempo.nu
+++ b/tempo.nu
@@ -785,6 +785,14 @@ def grafana-performance-url [benchmark_id: string, from_ms: int, to_ms: int] {
     $"https://tempoxyz.grafana.net/d/performance/performance?orgId=1&from=($from)&to=($to)&timezone=browser&var-datasource=efk1hcn87dnnkd&var-filter_label=benchmark_id&var-filter_value=($benchmark_id)&var-group_by=benchmark_run"
 }
 
+def internal-perf-url [clickhouse_run_id: string] {
+    if $clickhouse_run_id == "" {
+        return ""
+    }
+
+    $"http://go/dev/tempo-internal-perf/benchmark/($clickhouse_run_id)"
+}
+
 
 def generate-summary [
     results_dir: string,
@@ -1235,6 +1243,13 @@ def generate-summary [
 
     # Build summary markdown
     let grafana_url = (grafana-performance-url $benchmark_id $observability_from_ms $observability_to_ms)
+    let clickhouse_run_id_path = $"($results_dir)/clickhouse-run-id.txt"
+    let clickhouse_run_id = if ($clickhouse_run_id_path | path exists) {
+        open --raw $clickhouse_run_id_path | str trim
+    } else {
+        ""
+    }
+    let internal_perf_url = (internal-perf-url $clickhouse_run_id)
     mut config_lines = [
         $"# Bench Comparison: ($baseline_ref) vs ($feature_ref)"
         ""
@@ -1251,6 +1266,7 @@ def generate-summary [
         $"- Duration: ($duration)s"
         $"- Run pairs: ($run_pairs)"
         $"- Snapshot: (if (has-schelk) { 'schelk' } else { 'cp fallback' })"
+        (if $internal_perf_url != "" { $"- Internal dashboard: [Internal dashboard]($internal_perf_url)" } else { "" })
         $"- Baseline blocks: ($b_lat.n)"
         $"- Feature blocks: ($f_lat.n)"
     ])
@@ -1331,6 +1347,8 @@ def generate-summary [
             to: (if $actual_observability_to_ms > 0 { iso-from-epoch-ms $actual_observability_to_ms } else { "" })
         }
         grafana_url: $grafana_url
+        clickhouse_run_id: $clickhouse_run_id
+        internal_perf_url: $internal_perf_url
         baseline_ref: $baseline_ref
         feature_ref: $feature_ref
         config: {


### PR DESCRIPTION
## Summary
- add an internal perf dashboard URL derived from the benchmark id to bench summary metadata
- include the internal perf dashboard in PR/job observability output beside Grafana logs/traces
- add Slack action buttons for the internal perf dashboard and Grafana metrics dashboard

## Validation
- node --check .github/scripts/bench-slack-notify.js
- git diff --check

Note: Nushell is not installed in this sandbox, so I could not run a local Nu parse check.