### PR TITLE
ci(bench): use txgen benchmark_id for bench uploads

### DIFF
--- a/contrib/bench/upload-clickhouse-txgen.sh
+++ b/contrib/bench/upload-clickhouse-txgen.sh
@@ -78,7 +78,8 @@ def normalized_blocks(report):
 
 blocks = normalized_blocks(report)
 
-run_id = str(uuid.uuid4())
+benchmark_id = report.get("benchmark_id") or ""
+run_id = str(uuid.UUID(benchmark_id)) if benchmark_id else str(uuid.uuid4())
 
 # Compute aggregates
 total_tx = sum(b["tx_count"] for b in blocks)


### PR DESCRIPTION
## Summary
- use the top-level txgen `benchmark_id` from `report.json` as the ClickHouse `run_id`
- keep generating a UUID for older reports that do not include `benchmark_id`

## Test
- dry-ran `contrib/bench/upload-clickhouse-txgen.sh` with a sample txgen report and fake ClickHouse curl; captured SQL used the report UUID for inserted block rows

Relates to tempoxyz/txgen#109