### PR TITLE
Update TIP-1034 with channel storage credits

### DIFF
--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -4,7 +4,7 @@ title: TIP-20 Channel Escrow Precompile
 description: Enshrines TIP-20 channel escrow as a Tempo precompile with payment-lane admission and native escrow transfer semantics.
 authors: Tanishk Goyal, Brendan Ryan
 status: Devnet
-related: TIP-20, TIP-1000, TIP-1009, TIP-1020, Tempo Session, Tempo Charge
+related: TIP-20, TIP-1000, TIP-1009, TIP-1020, TIP-1060, Tempo Session, Tempo Charge
 protocolVersion: T5
 ---
 
@@ -14,7 +14,7 @@ protocolVersion: T5
 
 This TIP enshrines TIP-20 channel escrow in Tempo as a native precompile. The implementation follows the existing reference channel model (`open`, `settle`, `topUp`, `requestClose`, `close`, `withdraw`) and keeps the same EIP-712 voucher flow, with explicit partial-capture updates defined in this spec.
 
-The precompile is introduced to reduce execution overhead, remove the separate `approve` UX via native escrow movement, and make channel operations first-class payment-lane traffic under congestion.
+The precompile is introduced to reduce execution overhead, remove the separate `approve` UX via native escrow movement, make channel operations first-class payment-lane traffic under congestion, and let users reuse storage they previously freed when opening later channels.
 
 ## Motivation
 
@@ -23,6 +23,7 @@ TIP-20 channel escrow is currently specified as a Solidity contract reference im
 1. **Efficiency**: Channel operations become native precompile execution instead of generic contract execution, reducing overhead and making gas behavior more predictable for high-frequency payment flows.
 2. **Canonical implementation, evolved at network-upgrade cadence**: The escrow lives at a single canonical address on every Tempo node (`0x4D50500…`, ASCII "MPP"), with no admin or proxy admin, and ships behavior via network upgrades alongside the rest of the protocol. Wallets, indexers, and partner integrations bind to one stable surface rather than to a moving set of redeployments.
 3. **Approve-less Escrow UX**: `open` and `topUp` can escrow TIP-20 funds through native system transfer (`systemTransferFrom` semantics), removing the extra `approve` transaction from the user flow and works uniformly for passkey accounts.
+4. **Reusable channel storage**: Closed or withdrawn channels delete their mutable state. Users who free that payer-attributable state should receive storage credits that can make later channel opens cheaper, following the TIP-1060 precompile storage gas token model.
 
 This produces a simpler and more reliable path for session and auth/capture style integrations without changing the core channel model developers already use.
 
@@ -105,6 +106,98 @@ high 32 bits MUST remain zero.
    exact close-request timestamp.
 
 Closed channels MUST not retain any packed `ChannelState` slot at all.
+
+### Channel Storage Credits
+
+The channel escrow precompile MUST maintain:
+
+```text
+channel_storage_credits: mapping(address payer => uint64 credits)
+```
+
+A channel storage credit is a protocol-maintained counter associated with one payer address in the
+channel escrow precompile. It represents one previously deleted, payer-attributable channel state
+slot that can offset the TIP-1000 storage creation cost for a later `open` by the same payer.
+
+The `channel_storage_credits` mapping is channel escrow precompile state. Creating or updating a
+payer's `channel_storage_credits` counter, including the first creation of that counter's backing
+storage slot, is subject to normal TIP-1000 state gas and TIP-1060 rules. The channel escrow
+precompile MUST consume a TIP-1060 storage token to change `channel_storage_credits[payer]` from
+`0` to `1`. Inversely it obtains a TIP-1060 storage token when `channel_storage_credits[payer]`
+returns to zero. One of the payer's channel storage credits is effectively stored in the slot
+occupied by the `channel_storage_credits[payer]` value.
+
+If `channel_storage_credits[payer] == type(uint64).max`, additional credits for that payer MUST
+saturate at `type(uint64).max`.
+
+The only storage covered by channel storage credits is the packed `ChannelState` slot keyed by
+`channelId`. Its storage owner is `descriptor.payer`. Transient same-transaction opened-channel
+tracking, TIP-1060 precompile gas token state, `channel_storage_credits` counters, token balances,
+token allowances, policy state, EOA state, and ordinary smart-contract storage MUST NOT mint or
+consume channel storage credits for any user.
+
+The channel escrow precompile MUST explicitly control TIP-1060 storage creation mode for every
+zero-to-nonzero storage write it performs:
+
+```text
+tip1060_use_storage_token(TIP20_CHANNEL_ESCROW)
+tip1060_use_gas(TIP20_CHANNEL_ESCROW)
+```
+
+`tip1060_use_storage_token(P)` selects TIP-1060 consume-token mode for eligible precompile `P`, so
+the next eligible storage creation by `P` consumes one available TIP-1060 storage token before
+charging the TIP-1000 storage creation component. `tip1060_use_gas(P)` selects TIP-1060
+preserve-token mode for eligible precompile `P`, so the next eligible storage creation by `P` pays
+the full TIP-1000 storage creation cost and leaves any available TIP-1060 storage tokens untouched.
+
+These are internal protocol calls made by the channel escrow precompile during its own execution.
+They are not exposed through the channel escrow ABI and MUST NOT let ordinary contracts or users
+change another precompile's TIP-1060 mode.
+
+When terminal `close` or `withdraw` changes a packed `ChannelState` slot owned by payer `P` from
+nonzero to zero:
+
+1. Apply the normal channel state transition.
+2. The TIP-1060 precompile automatically credits the channel escrow precompile with a storage token.
+3. Increment `channel_storage_credits[P]` by one, saturating at `type(uint64).max`.
+
+Deleting a packed `ChannelState` slot credits exactly one channel storage credit to its payer,
+regardless of the payee, operator, token, salt, authorized signer, transaction sender, or terminal
+call path.
+
+When `open` changes a packed `ChannelState` slot for payer `P` from zero to nonzero:
+
+1. If `channel_storage_credits[P] > 0`:
+   - Decrement `channel_storage_credits[P]` by one.
+   - Call `tip1060_use_storage_token(TIP20_CHANNEL_ESCROW)`.
+   - Create the packed `ChannelState` slot, consuming one available channel escrow TIP-1060 token
+     instead of charging the TIP-1000 storage creation component.
+2. Otherwise:
+   - Leave `channel_storage_credits[P]` unchanged.
+   - Call `tip1060_use_gas(TIP20_CHANNEL_ESCROW)`.
+   - Create the packed `ChannelState` slot, charging the payer the full TIP-1000-mandated storage
+     creation cost and leaving the channel escrow TIP-1060 token balance untouched.
+
+Before creating any storage that is not eligible for channel storage credits, the channel escrow
+precompile MUST call `tip1060_use_gas(TIP20_CHANNEL_ESCROW)`. In particular, the storage backing a
+new `channel_storage_credits[P]` counter MUST NOT consume a channel storage credit owned by `P`;
+only the actual packed `ChannelState` slot may do so.
+
+The channel storage credit debit, TIP-1060 control call, TIP-1060 token debit if any, and packed
+`ChannelState` write MUST be atomic. If the operation reverts, all credit, mode, and token changes
+made in the same execution scope MUST revert according to normal EVM revert semantics.
+
+The channel escrow interface MUST expose:
+
+```solidity
+/// @notice Returns the number of reusable channel storage credits owned by a payer.
+/// @param payer The payer whose channel storage credit balance is queried.
+/// @return credits The number of storage credits available to that payer.
+function storageCredits(address payer) external view returns (uint64 credits);
+```
+
+This function is read-only and does not expose any ability to transfer, mint, burn, or set storage
+credits.
 
 `channelId` MUST use the following deterministic domain-separated construction:
 
@@ -207,7 +300,7 @@ behalf, but all settlement and close-capture payouts still transfer to `payee`.
 Execution semantics are:
 
 1. `open` MUST reject zero deposit, invalid token address, and invalid payee address.
-2. `open` MUST derive `expiringNonceHash` from the enclosing transaction's replay-protected context hash, persist only the packed `ChannelState` slot, and MUST emit the full immutable descriptor in `ChannelOpened`.
+2. `open` MUST derive `expiringNonceHash` from the enclosing transaction's replay-protected context hash, persist only the packed `ChannelState` slot for the channel, apply the channel storage credit rules above for that slot, and MUST emit the full immutable descriptor in `ChannelOpened`.
 3. Post-open methods (`settle`, `topUp`, `close`, `requestClose`, `withdraw`, and descriptor-based views) MUST recompute `channelId` from the supplied descriptor and use that derived id for storage lookup.
 4. If `closeRequestedAt != 0`, a successful `topUp` MUST clear it back to `0` and emit `CloseRequestCancelled`.
 5. `requestClose` MUST set `closeRequestedAt = uint32(block.timestamp)` on the first successful call and leave it unchanged on later successful calls.
@@ -219,7 +312,7 @@ Execution semantics are:
 11. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
 12. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
 13. `withdraw` MUST be allowed only when the close grace period has elapsed from `closeRequestedAt`.
-14. Terminal `close` and `withdraw` MUST delete the stored slot entirely. Reopening the same logical channel in a later transaction MUST produce a different `channelId` because the replay-protected context hash changes.
+14. Terminal `close` and `withdraw` MUST delete the stored channel slot entirely and apply the channel storage credit rules above. Reopening the same logical channel in a later transaction MUST produce a different `channelId` because the replay-protected context hash changes.
 15. Within one top-level transaction, `open` MUST reject any `channelId` that was already opened earlier in that same transaction, even if the channel was terminally closed or withdrawn before the later `open` call.
 
 The `cumulativeAmount > deposit` allowance is specific to `close`, because `close` has a separate
@@ -320,10 +413,10 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 4. Only payer can `topUp`, `requestClose`, and `withdraw`.
 5. Only payee, or a nonzero operator, can `settle` and `close`.
 6. A zero operator does not authorize any caller.
-7. A channel MUST consume exactly one storage slot of mutable on-chain state.
+7. A channel MUST consume exactly one packed `ChannelState` storage slot of mutable on-chain channel state, excluding separate channel storage credit accounting.
 8. `closeRequestedAt == 0` MUST mean active with no close request.
 9. `closeRequestedAt != 0` MUST mean active with a close request timestamp equal to `closeRequestedAt`.
-10. Closed channels MUST have no remaining mutable on-chain state.
+10. Closed channels MUST have no remaining packed `ChannelState` slot, excluding separate channel storage credit accounting.
 11. Reopening the same logical channel in a later transaction MUST yield a different `channelId` because the replay-protected context hash is different.
 12. Reopening the same `channelId` within one top-level transaction MUST be impossible.
 13. Fund conservation MUST hold at all terminal states.
@@ -332,6 +425,12 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 16. `withdraw` MUST require an active close request whose grace period has elapsed.
 17. Channel spend authorization MUST follow the logical `payer -> payee` path: funding operations require an authorized recipient payee, and new payee payouts require an authorized sender payer.
 18. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`, and `captureAmount <= deposit`.
+19. A payer's channel storage credit balance increases only when a packed `ChannelState` slot attributed to that payer changes from nonzero to zero.
+20. A payer's channel storage credit balance decreases only when `open` creates a packed `ChannelState` slot attributed to that payer and a channel escrow TIP-1060 token is consumed.
+21. A channel storage credit can offset at most one packed `ChannelState` storage creation.
+22. Channel storage credits are not transferable between users.
+23. Channel escrow TIP-1060 tokens cannot be consumed for a payer who has no channel storage credits.
+24. Channel storage credit accounting changes revert with the execution scope that caused them.
 
 ## References
 
@@ -339,5 +438,6 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 - [TIP-1000](tip-1000.md)
 - [TIP-1009](tip-1009.md)
 - [TIP-1020](tip-1020.md)
+- [TIP-1060](tip-1060.md)
 - [Tempo Session Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-session-00.html)
 - [Tempo Charge Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-charge-00.html)

--- a/tips/verify/src/TIP20ChannelEscrow.sol
+++ b/tips/verify/src/TIP20ChannelEscrow.sol
@@ -31,6 +31,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
     bytes32 internal constant _VERSION_HASH = keccak256("1");
 
     mapping(bytes32 => uint256) internal channelStates;
+    mapping(address => uint64) internal channelStorageCredits;
     bytes32 internal _expiringNonceHashContext;
 
     // Reference-contract-only approximation of the precompile's transient per-transaction guard.
@@ -82,6 +83,17 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         // context hash, and thus the derived channel ID, is unchanged for later calls in the same
         // top-level transaction.
         if (_openedChannelIdsForTest[channelId]) revert ChannelAlreadyExists();
+
+        if (channelStorageCredits[msg.sender] > 0) {
+            // Reference-contract approximation of consuming one payer-owned channel storage
+            // credit. The enshrined precompile must call
+            // `tip1060_use_storage_token(TIP20_CHANNEL_ESCROW)` before this write.
+            channelStorageCredits[msg.sender] -= 1;
+        } else {
+            // The enshrined precompile must call `tip1060_use_gas(TIP20_CHANNEL_ESCROW)` before
+            // this write so precompile-level TIP-1060 tokens are preserved when the payer has no
+            // channel storage credit.
+        }
 
         channelStates[channelId] = _encodeChannelState(
             ChannelState({ settled: 0, deposit: deposit, closeRequestedAt: 0 })
@@ -222,6 +234,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         uint96 refund = channel.deposit - captureAmount;
 
         delete channelStates[channelId];
+        _creditDeletedChannelStorage(descriptor.payer);
 
         if (delta > 0) {
             bool payeeTransferSucceeded = ITIP20(descriptor.token).transfer(descriptor.payee, delta);
@@ -251,6 +264,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
         uint96 refund = channel.deposit - channel.settled;
         delete channelStates[channelId];
+        _creditDeletedChannelStorage(descriptor.payer);
 
         if (refund > 0) {
             bool success = ITIP20(descriptor.token).transfer(descriptor.payer, refund);
@@ -292,6 +306,10 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         for (uint256 i = 0; i < length; ++i) {
             states[i] = _decodeChannelState(channelStates[channelIds[i]]);
         }
+    }
+
+    function storageCredits(address payer) external view returns (uint64 credits) {
+        return channelStorageCredits[payer];
     }
 
     function computeChannelId(
@@ -406,6 +424,13 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         }
 
         if (!isValid) revert InvalidSignature();
+    }
+
+    function _creditDeletedChannelStorage(address payer) internal {
+        uint64 credits = channelStorageCredits[payer];
+        if (credits != type(uint64).max) {
+            channelStorageCredits[payer] = credits + 1;
+        }
     }
 
     function _domainSeparator() internal view returns (bytes32) {

--- a/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
+++ b/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
@@ -73,6 +73,8 @@ interface ITIP20ChannelEscrow {
         view
         returns (ChannelState[] memory);
 
+    function storageCredits(address payer) external view returns (uint64 credits);
+
     function computeChannelId(
         address payer,
         address payee,

--- a/tips/verify/test/TIP20ChannelEscrow.t.sol
+++ b/tips/verify/test/TIP20ChannelEscrow.t.sol
@@ -453,6 +453,22 @@ contract TIP20ChannelEscrowTest is Test {
         assertNotEq(reopenedChannelId, channelId);
     }
 
+    function test_close_creditsDeletedChannelStorage_and_openConsumesCredit() public {
+        bytes32 channelId = _openChannel();
+        bytes memory sig = _signVoucher(channelId, 600_000);
+
+        vm.prank(payee);
+        channel.close(_descriptor(), 600_000, 600_000, sig);
+
+        assertEq(channel.getChannelState(channelId).deposit, 0);
+        assertEq(channel.storageCredits(payer), 1);
+
+        bytes32 reopenedChannelId = _openChannel();
+
+        assertNotEq(reopenedChannelId, channelId);
+        assertEq(channel.storageCredits(payer), 0);
+    }
+
     function test_withdraw_afterGracePeriod() public {
         bytes32 channelId = _openChannel();
 
@@ -467,6 +483,21 @@ contract TIP20ChannelEscrowTest is Test {
 
         assertEq(channel.getChannelState(channelId).closeRequestedAt, 0);
         assertEq(token.balanceOf(payer), payerBalanceBefore + DEPOSIT);
+    }
+
+    function test_withdraw_creditsDeletedChannelStorage() public {
+        bytes32 channelId = _openChannel();
+
+        vm.prank(payer);
+        channel.requestClose(_descriptor());
+
+        vm.warp(block.timestamp + channel.CLOSE_GRACE_PERIOD() + 1);
+
+        vm.prank(payer);
+        channel.withdraw(_descriptor());
+
+        assertEq(channel.getChannelState(channelId).deposit, 0);
+        assertEq(channel.storageCredits(payer), 1);
     }
 
     function test_getChannelStatesBatch_success() public {


### PR DESCRIPTION
## Summary
- add TIP-1060-backed payer storage credits to TIP-1034
- specify crediting on terminal close/withdraw and debit on later open
- align the Solidity reference interface/contract and add focused reference tests

## Testing
- git diff --check
- FOUNDRY_HARDFORK=cancun forge test --match-path test/TIP20ChannelEscrow.t.sol *(fails: sandbox could not clone forge-std/solady submodules; default Forge also does not recognize tempo:T5 without hardfork override)*