### PR TITLE
bench: add TIP20 preset for existing recipients

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -860,6 +860,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --tps $ctx.tps
                 --duration $ctx.duration
                 --accounts $ctx.accounts
+                --existing-recipient-accounts (state-bloat-accounts-per-token $ctx.bloat)
                 --max-concurrent-requests $ctx.max_concurrent_requests
                 --bench-args $ctx.bench_args
                 --bench-env $ctx.bench_env
@@ -1093,7 +1094,7 @@ def "main e2e" [
             ensure-bloat-space $bloat_mib
             print $"Generating local e2e state bloat \(($bloat_mib) MiB\)..."
             let token_args = ($TIP20_TOKEN_IDS | each { |id| ["--token" $"($id)"] } | flatten)
-            cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat_mib --out $bloat_file ...$token_args
+            cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat_mib --out $bloat_file --signable-count (state-bloat-accounts-per-token $bloat_mib) ...$token_args
         }
 
         let marker = {

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -125,6 +125,7 @@ def run-txgen-bench-single [
         --tps $tps
         --duration $duration
         --accounts $accounts
+        --existing-recipient-accounts (state-bloat-accounts-per-token $bloat)
         --max-concurrent-requests $max_concurrent_requests
         --bench-args $bench_args
         --bench-env $bench_env
@@ -418,11 +419,11 @@ def "main run" [
             if $bloat > 0 and not ($bloat_file | path exists) {
                 let token_args = ($TIP20_TOKEN_IDS | each { |id| ["--token" $"($id)"] } | flatten)
                 if $baseline == "local" {
-                    cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file ...$token_args
+                    cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file --signable-count (state-bloat-accounts-per-token $bloat) ...$token_args
                 } else {
                     do {
                         cd $baseline_wt
-                        cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file ...$token_args
+                        cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file --signable-count (state-bloat-accounts-per-token $bloat) ...$token_args
                     }
                 }
             }
@@ -479,11 +480,11 @@ def "main run" [
             if $bloat > 0 and not ($bloat_file | path exists) {
                 let token_args = ($TIP20_TOKEN_IDS | each { |id| ["--token" $"($id)"] } | flatten)
                 if $baseline == "local" {
-                    cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file ...$token_args
+                    cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file --signable-count (state-bloat-accounts-per-token $bloat) ...$token_args
                 } else {
                     do {
                         cd $baseline_wt
-                        cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file ...$token_args
+                        cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file --signable-count (state-bloat-accounts-per-token $bloat) ...$token_args
                     }
                 }
             }

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -173,6 +173,7 @@ def txgen-run-preset-pipeline [
     --tps: int
     --duration: int
     --accounts: int
+    --existing-recipient-accounts: int = 0
     --max-concurrent-requests: int
     --bench-args: string = ""
     --bench-env: string = ""
@@ -192,6 +193,7 @@ def txgen-run-preset-pipeline [
 ] {
     let chain_id = (txgen-fetch-chain-id $generate_rpc_url)
     $env.TXGEN_ACCOUNTS = ($accounts | into string)
+    $env.TXGEN_EXISTING_RECIPIENT_ACCOUNTS = ((if $existing_recipient_accounts > 0 { $existing_recipient_accounts } else { $accounts }) | into string)
     let spec_path = ($preset_path | path expand)
     if not ($spec_path | path exists) {
         error make { msg: $"txgen preset file not found: ($spec_path)" }

--- a/contrib/bench/txgen/presets/tip20_random_existing_recipients.yml
+++ b/contrib/bench/txgen/presets/tip20_random_existing_recipients.yml
@@ -1,0 +1,46 @@
+chain_id: 1337
+
+gas:
+  max_fee_per_gas: 100000000000
+  max_priority_fee_per_gas: 100000000000
+
+accounts:
+  users:
+    mnemonic: "test test test test test test test test test test test junk"
+    range:
+      - 0
+      - ${TXGEN_ACCOUNTS}
+  existing_recipients:
+    mnemonic: "test test test test test test test test test test test junk"
+    range:
+      - 0
+      - ${TXGEN_EXISTING_RECIPIENT_ACCOUNTS}
+
+artifacts:
+  ERC20: ../erc20.abi.json
+
+templates:
+  tip20_transfer:
+    type: tempo
+    from:
+      pool: users
+      select: random
+    gas_limit: 300000
+    max_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 100000000000
+    fee_token: "0x20c0000000000000000000000000000000000000"
+    expiring_nonce: true
+    valid_for_secs: 10
+    call:
+      to: "0x20c0000000000000000000000000000000000000"
+      abi: ERC20
+      function: transfer
+      args:
+        - pool:
+            pool: existing_recipients
+            select: random
+        - 1
+
+mix:
+  - template: tip20_transfer
+    weight: 100

--- a/tempo.nu
+++ b/tempo.nu
@@ -22,6 +22,19 @@ const TIP20_TOKEN_IDS = [0, 1, 2, 3]
 # Helper functions
 # ============================================================================
 
+def state-bloat-accounts-per-token [bloat_mib: int] {
+    if $bloat_mib <= 0 {
+        return 0
+    }
+
+    let target_bytes = $bloat_mib * 1024 * 1024
+    let num_tokens = ($TIP20_TOKEN_IDS | length)
+    let overhead_per_token = 40 + 64
+    let available_for_balances = [($target_bytes - ($num_tokens * $overhead_per_token)) 0] | math max
+    let total_balance_entries = ($available_for_balances / 64 | into int)
+    ($total_balance_entries / $num_tokens | into int)
+}
+
 # Convert consensus port to node index (e.g., 8000 -> 0, 8100 -> 1)
 def port-to-node-index [port: int] {
     ($port - 8000) / 100 | into int
@@ -99,7 +112,7 @@ def generate-bloat-file [bloat_size: int, profile: string] {
     }
     print $"Generating state bloat \(($bloat_size) MiB\)..."
     let token_args = ($TIP20_TOKEN_IDS | each { |id| ["--token" $"($id)"] } | flatten)
-    cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat_size --out $bloat_file ...$token_args
+    cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat_size --out $bloat_file --signable-count (state-bloat-accounts-per-token $bloat_size) ...$token_args
 }
 
 # Load the bloat file into a single node's database
@@ -621,6 +634,7 @@ def run-bench-single [
             --tps $tps
             --duration $duration
             --accounts $accounts
+            --existing-recipient-accounts (state-bloat-accounts-per-token $bloat)
             --max-concurrent-requests $max_concurrent_requests
             --bench-args $bench_args
             --bench-env $bench_env
@@ -1825,7 +1839,7 @@ def "main bench-init" [
     if $bloat > 0 {
         print $"Generating state bloat \(($bloat) MiB\)..."
         let token_args = ($TIP20_TOKEN_IDS | each { |id| ["--token" $"($id)"] } | flatten)
-        cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file ...$token_args
+        cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file --signable-count (state-bloat-accounts-per-token $bloat) ...$token_args
     }
 
     bench-clean-datadir $datadir
@@ -2155,11 +2169,11 @@ def "main bench" [
                     print $"Generating state bloat \(($bloat) MiB\)..."
                     let token_args = ($TIP20_TOKEN_IDS | each { |id| ["--token" $"($id)"] } | flatten)
                     if $baseline == "local" {
-                        cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file ...$token_args
+                        cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file --signable-count (state-bloat-accounts-per-token $bloat) ...$token_args
                     } else {
                         do {
                             cd $baseline_wt
-                            cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file ...$token_args
+                            cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file --signable-count (state-bloat-accounts-per-token $bloat) ...$token_args
                         }
                     }
                 }
@@ -2227,11 +2241,11 @@ def "main bench" [
                     print $"Generating state bloat \(($bloat) MiB\) from baseline..."
                     let token_args = ($TIP20_TOKEN_IDS | each { |id| ["--token" $"($id)"] } | flatten)
                     if $baseline == "local" {
-                        cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file ...$token_args
+                        cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file --signable-count (state-bloat-accounts-per-token $bloat) ...$token_args
                     } else {
                         do {
                             cd $baseline_wt
-                            cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file ...$token_args
+                            cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file --signable-count (state-bloat-accounts-per-token $bloat) ...$token_args
                         }
                     }
                 }
@@ -2312,6 +2326,7 @@ def "main bench" [
                 --genesis-path $run.genesis --datadir $run.datadir
                 --run-label $run.label --results-dir $results_dir
                 --tps $tps --duration $duration --accounts $accounts
+                --existing-recipient-accounts (state-bloat-accounts-per-token $bloat)
                 --max-concurrent-requests $max_concurrent_requests
                 --preset-path $preset_path --bench-args $bench_args
                 --loud=$loud --node-args $effective_node_args --bloat $bloat
@@ -2438,6 +2453,7 @@ def "main bench" [
             --tps $tps
             --duration $duration
             --accounts $accounts
+            --existing-recipient-accounts (state-bloat-accounts-per-token $bloat)
             --max-concurrent-requests $max_concurrent_requests
             --bench-args $bench_args
             --bench-env $bench_env


### PR DESCRIPTION
Closes RETH-831

## Summary
- add `tip20_random_existing_recipients.yml` preset with recipients selected from mnemonic-derived existing accounts
- expose `TXGEN_EXISTING_RECIPIENT_ACCOUNTS` for preset env expansion
- derive that env value from the state-bloat account count in all bench harnesses
- pass the same count to `generate-state-bloat --signable-count` so every txgen recipient in the pool is actually present in bloat state and derived from the mnemonic

## Tests
- `uv run --with pyyaml python -c "import yaml; yaml.safe_load(open('contrib/bench/txgen/presets/tip20_random_existing_recipients.yml')); print('yaml ok')"`
- `git diff --check`

Note: `nu` is not installed in this sandbox, so I could not run Nushell parser checks locally. `cargo test -p txgen-core env_expansion --quiet` was attempted, but this repo has no `txgen-core` package ID.