### PR TITLE
ci(bench): make bench-e2e preset a dropdown

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -52,9 +52,14 @@ on:
           - T6
       preset:
         description: Benchmark preset.
-        type: string
+        type: choice
         required: true
         default: tip20
+        options:
+          - tip20
+          - tip20_random_recipients
+          - mpp
+          - mix
       duration:
         description: Benchmark duration in seconds.
         type: string


### PR DESCRIPTION
## Summary
- convert the manual bench-e2e workflow preset input from a string to a choice dropdown
- populate choices from the current txgen presets: mix, mpp, tip20, tip20_random_recipients

## Validation
- uv run --with pyyaml python -c 'import yaml; yaml.safe_load(open(".github/workflows/bench-e2e.yml")); print("yaml ok")'