### PR TITLE
Configure CodeQL for Rust

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+name: tempo-codeql
+
+query-filters:
+  - exclude:
+      id: rust/hard-coded-cryptographic-value


### PR DESCRIPTION
## Summary
- add a repo-local CodeQL advanced setup workflow for Rust
- add CodeQL config that excludes the noisy `rust/hard-coded-cryptographic-value` query

## Context
CodeQL is flagging hard-coded Ethereum transaction nonces in Rust tests as cryptographic nonce material. This keeps CodeQL coverage enabled while removing that false-positive class.

## Validation
- Parsed `.github/workflows/codeql.yml` and `.github/codeql/codeql-config.yml` with PyYAML