### PR TITLE
Rename invariant entrypoints for per-campaign metrics

### DIFF
--- a/tips/verify/test/invariants/AccountKeychain.t.sol
+++ b/tips/verify/test/invariants/AccountKeychain.t.sol
@@ -871,7 +871,7 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
 
     /// @notice Run all invariant checks in a single pass over actors
     /// @dev Consolidates TEMPO-KEY13, KEY14, KEY15, KEY16 into unified loops
-    function invariant_globalInvariants() public view {
+    function invariant_accountKeychainGlobal() public view {
         // Single pass over all actors and their keys
         for (uint256 a = 0; a < _actors.length; a++) {
             address account = _actors[a];

--- a/tips/verify/test/invariants/BlockGasLimits.t.sol
+++ b/tips/verify/test/invariants/BlockGasLimits.t.sol
@@ -102,7 +102,7 @@ contract BlockGasLimitsInvariantTest is InvariantBase {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Run all invariant checks
-    function invariant_globalInvariants() public view {
+    function invariant_blockGasLimitsGlobal() public view {
         _invariantTxGasCap();
         _invariantMaxDeploymentFits();
     }

--- a/tips/verify/test/invariants/FeeAMM.t.sol
+++ b/tips/verify/test/invariants/FeeAMM.t.sol
@@ -1211,7 +1211,7 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
     ///      Pre/post-tx state is mocked via `vm.store`. The handler:
     ///        1. Predicts the route locally (mirror of `plan_fee_route`).
     ///        2. Applies the resulting reserve / collected-fees deltas with `vm.store`.
-    ///        3. Records a `TwoHopWitness` so `invariantFeeAMM` can verify TIP-1033 properties.
+    ///        3. Records a `TwoHopWitness` so `invariant_feeAMM` can verify TIP-1033 properties.
     /// @param userSeed Seed for selecting the fee-paying actor.
     /// @param validatorSeed Seed for selecting the validatorToken among `{token1..token4}`.
     /// @param feeAmountRaw Seed for the fee amount.
@@ -1813,7 +1813,7 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Main invariant function called after each fuzz sequence
-    function invariantFeeAMM() public view {
+    function invariant_feeAMM() public view {
         _invariantPoolStateChecks(); // Unified: AMM13, AMM14, AMM15, AMM20, FEE5
         _invariantRebalanceRoundingFavorsPool();
         _invariantBurnRoundingFavorsPool();
@@ -2186,7 +2186,7 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
     /// dispatches each witness to `_assertDirectWitness` or `_assertFallbackWitness`. Aggregate
     /// checks (cumulative sums, regression-amount sanity, max-fallback) live outside the loop.
     /// Replaces eight separate full-array iterations: with N witnesses up to
-    /// `MAX_TWO_HOP_WITNESSES = 256`, this saves ~25k storage slot reads per `invariantFeeAMM`.
+    /// `MAX_TWO_HOP_WITNESSES = 256`, this saves ~25k storage slot reads per `invariant_feeAMM`.
     /// Same pattern as `_invariantPoolStateChecks` for the AMM/FEE invariants.
     /// Covers: TEMPO-AMM35/36/37, TEMPO-FEE7/8/9/11, and TIP-1033 inv. 2 (single-hop).
     function _invariantTwoHopWitnessChecks() internal view {

--- a/tips/verify/test/invariants/GasPricing.t.sol
+++ b/tips/verify/test/invariants/GasPricing.t.sol
@@ -110,7 +110,7 @@ contract GasPricingInvariantTest is InvariantBase {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Run all invariant checks
-    function invariant_globalInvariants() public view {
+    function invariant_gasPricingGlobal() public view {
         _invariantSstoreNewSlotCost();
         _invariantCreateCost();
         _invariantMultiSlotScaling();

--- a/tips/verify/test/invariants/Nonce.t.sol
+++ b/tips/verify/test/invariants/Nonce.t.sol
@@ -406,7 +406,7 @@ contract NonceInvariantTest is InvariantBaseTest {
     /// @notice Run all invariant checks in a single unified loop
     /// @dev Combines TEMPO-NON1 (never decrease) and TEMPO-NON2 (ghost consistency) checks
     ///      Caches nonce.getNonce() result to avoid duplicate external calls
-    function invariant_globalInvariants() public view {
+    function invariant_nonceGlobal() public view {
         for (uint256 a = 0; a < _actors.length; a++) {
             address actor = _actors[a];
             uint256[] storage keys = _accountNonceKeys[actor];

--- a/tips/verify/test/invariants/StablecoinDEX.t.sol
+++ b/tips/verify/test/invariants/StablecoinDEX.t.sol
@@ -736,7 +736,7 @@ contract StablecoinDEXInvariantTest is InvariantBaseTest {
     /// @notice Main invariant function called after each fuzz sequence
     /// @dev Verifies TEMPO-DEX10 (balance solvency), TEMPO-DEX11/15 (tick consistency), TEMPO-DEX12/13 (best tick)
     ///      Optimized: unified loops over actors and tokens to reduce iteration overhead
-    function invariantStablecoinDEX() public view {
+    function invariant_stablecoinDEX() public view {
         // Compute expected escrowed amounts from all orders (including flip-created orders)
         (uint256 expectedPathUsdEscrowed, uint256[] memory expectedTokenEscrowed,) =
             _computeExpectedEscrow();

--- a/tips/verify/test/invariants/TIP1015.t.sol
+++ b/tips/verify/test/invariants/TIP1015.t.sol
@@ -921,7 +921,7 @@ contract TIP1015InvariantTest is InvariantBaseTest {
 
     /// @notice Combined invariant check - single loop through compound policies
     /// @dev Checks TEMPO-1015-2, TEMPO-1015-3, TEMPO-1015-5, TEMPO-1015-6 in one pass
-    function invariant_globalInvariants() public view {
+    function invariant_tip1015PolicyGlobal() public view {
         _invariantSimplePolicyEquivalence();
         _invariantCompoundPoliciesCombined();
     }

--- a/tips/verify/test/invariants/TIP1026.t.sol
+++ b/tips/verify/test/invariants/TIP1026.t.sol
@@ -223,7 +223,7 @@ contract TIP1026InvariantTest is InvariantBaseTest {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice TEMPO-1026-1: `bytes(logoURI()).length <= 256` for every tracked token.
-    function invariant_logoURILengthBounded() public view {
+    function invariant_tip1026LogoURILengthBounded() public view {
         for (uint256 i = 0; i < _logoTokens.length; i++) {
             assertLe(
                 bytes(_logoTokens[i].logoURI()).length,

--- a/tips/verify/test/invariants/TIP20.t.sol
+++ b/tips/verify/test/invariants/TIP20.t.sol
@@ -1369,7 +1369,7 @@ contract TIP20InvariantTest is InvariantBaseTest {
     /// @notice Run all invariant checks in a single unified loop
     /// @dev Combines TEMPO-TIP18, TIP19, TIP20, TIP22, and rewards conservation checks
     ///      Decimals (TIP21) and quote token acyclic checks moved to setUp() as they're immutable
-    function invariant_globalInvariants() public view {
+    function invariant_tip20SupplyGlobal() public view {
         for (uint256 i = 0; i < _tokens.length; i++) {
             ITIP20 token = _tokens[i];
             address tokenAddr = address(token);

--- a/tips/verify/test/invariants/TIP20Factory.t.sol
+++ b/tips/verify/test/invariants/TIP20Factory.t.sol
@@ -408,7 +408,7 @@ contract TIP20FactoryInvariantTest is InvariantBaseTest {
     /// @dev FAC1 verified at creation time, FAC2/FAC11/FAC12 verified inline
     ///      FAC8 system contract checks in setUp() as they're immutable
     ///      This function uses sampling to avoid O(n) on every call
-    function invariant_globalInvariants() public view {
+    function invariant_tip20FactoryGlobal() public view {
         // Only sample-check if we have created tokens
         if (_createdTokens.length == 0) return;
 

--- a/tips/verify/test/invariants/TIP403Registry.t.sol
+++ b/tips/verify/test/invariants/TIP403Registry.t.sol
@@ -486,7 +486,7 @@ contract TIP403RegistryInvariantTest is InvariantBaseTest {
     /// @notice Run all invariant checks in a single unified loop
     /// @dev Combines TEMPO-REG3, REG15, REG16, REG19 checks
     ///      Special policies check (REG13) moved to setUp() as they're immutable
-    function invariant_globalInvariants() public {
+    function invariant_tip403RegistryGlobal() public {
         // TEMPO-REG15: Counter monotonicity (done once, not per-policy)
         uint64 counter = registry.policyIdCounter();
         assertTrue(counter >= 2, "TEMPO-REG15: Counter should be at least 2");

--- a/tips/verify/test/invariants/ValidatorConfig.t.sol
+++ b/tips/verify/test/invariants/ValidatorConfig.t.sol
@@ -467,7 +467,7 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Run all invariant checks
-    function invariant_globalInvariants() public view {
+    function invariant_validatorConfigGlobal() public view {
         _invariantOwnerConsistency();
         _invariantValidatorCountConsistency();
         _invariantValidatorDataConsistency();

--- a/tips/verify/test/invariants/ValidatorConfigV2.t.sol
+++ b/tips/verify/test/invariants/ValidatorConfigV2.t.sol
@@ -1101,7 +1101,7 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Run all invariant checks
-    function invariant_globalInvariants() public view {
+    function invariant_validatorConfigV2Global() public view {
         _invariantAppendOnlyCount(); // VALV2-8
         _invariantDeleteOnce(); // VALV2-9
         _invariantHeightTracking(); // VALV2-10
@@ -1519,7 +1519,7 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
     }
 
     /// @notice Regression test for fuzz sequence: migrate one validator then rotate it.
-    /// @dev Reproduces the shrunk sequence from invariant_globalInvariants failure.
+    /// @dev Reproduces the shrunk sequence from invariant_validatorConfigV2Global failure.
     function test_regression_migrateAndRotate() public {
         // Step 1: migrate validator index 0 (exact args from shrunk sequence)
         this.handler_migrateValidator(
@@ -1531,7 +1531,7 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
         this.handler_rotateValidator(10_000_000_000, 900_000_000_000_000_000_000, 100_000);
 
         // Verify all global invariants hold
-        invariant_globalInvariants();
+        invariant_validatorConfigV2Global();
     }
 
 }

--- a/tips/verify/test/invariants/VirtualAddresses.t.sol
+++ b/tips/verify/test/invariants/VirtualAddresses.t.sol
@@ -831,7 +831,7 @@ contract VirtualAddressesInvariantTest is InvariantBaseTest {
                            GLOBAL INVARIANTS
     //////////////////////////////////////////////////////////////*/
 
-    function invariant_globalInvariants() public view {
+    function invariant_virtualAddressesGlobal() public view {
         for (uint256 i = 0; i < _masters.length; i++) {
             MasterFixture memory fixture = _masters[i];
             bytes32 registrationHash = keccak256(abi.encodePacked(fixture.master, fixture.salt));


### PR DESCRIPTION
## Summary
- rename duplicate public invariant entrypoints so metrics labels are unique per invariant contract
- normalize existing non-underscore entrypoints like invariantStablecoinDEX and invariantFeeAMM to invariant_* form
- update stale self-call/comment references for renamed entrypoints

## Validation
- static check: 16 public invariant entrypoints, 16 unique names, all start with invariant_
- git diff --check

Note: local stock forge cannot parse the repo's tempo:T5 hardfork; full forge validation requires the workflow-patched Foundry used by invariant-tests.