### PR TITLE
Fix bench summary compressed samples

### DIFF
--- a/tempo.nu
+++ b/tempo.nu
@@ -836,8 +836,14 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
         }
         let report = (open $report_path)
         let samples_path = $"($results_dir)/report-($label).samples.ndjson"
-        let metric_samples = if ($samples_path | path exists) {
+        let samples_gz_path = $"($samples_path).gz"
+        let samples_raw = if ($samples_path | path exists) {
             open --raw $samples_path
+        } else if ($samples_gz_path | path exists) {
+            gzip -dc $samples_gz_path
+        } else { "" }
+        let metric_samples = if $samples_raw != "" {
+            $samples_raw
                 | lines
                 | where { |line| ($line | str trim) != "" }
                 | each { |line| $line | from json }


### PR DESCRIPTION
## Summary
- Read compressed txgen metric sample archives in tempo.nu generate-summary
- Keep legacy uncompressed .samples.ndjson support

## Context
Txgen writes JSON report samples to report-*.samples.ndjson.gz, while generate-summary only checked report-*.samples.ndjson. That leaves builder/validator metric sample lists empty and renders Validator metrics as 0.0.

## Validation
- Not run: nushell is not installed in this sandbox.