### PR TITLE
fix(consensus): speed up validator peer recovery

### DIFF
--- a/crates/commonware-node/src/args.rs
+++ b/crates/commonware-node/src/args.rs
@@ -151,15 +151,18 @@ pub struct Args {
     /// including the newly discovered ones.
     #[arg(
         long = "consensus.wait-before-peers-redial",
-        default_value = "1s",
+        default_value = "500ms",
         default_value_if("use_local_defaults", "true", "500ms")
     )]
     pub wait_before_peers_redial: PositiveDuration,
 
     /// How long to wait before sending a ping message to peers for liveness detection.
+    ///
+    /// Keep this short enough that restarted validators can replace stale connections
+    /// before they miss several proposal rounds.
     #[arg(
         long = "consensus.wait-before-peers-reping",
-        default_value = "50s",
+        default_value = "10s",
         default_value_if("use_local_defaults", "true", "5s")
     )]
     pub wait_before_peers_reping: PositiveDuration,
@@ -174,9 +177,13 @@ pub struct Args {
 
     /// Minimum time between connection attempts to the same peer. A rate-limit
     /// on connection attempts.
+    ///
+    /// Commonware applies this after failed reservations and dials. A long
+    /// value makes validator restarts reconnect gradually when peers still
+    /// have stale connections to the old process.
     #[arg(
         long = "consensus.connection-per-peer-min-period",
-        default_value = "60s",
+        default_value = "10s",
         default_value_if("use_local_defaults", "true", "1s")
     )]
     pub connection_per_peer_min_period: PositiveDuration,
@@ -185,7 +192,7 @@ pub struct Args {
     /// on attempts.
     #[arg(
         long = "consensus.handshake-per-ip-min-period",
-        default_value = "5s",
+        default_value = "1s",
         default_value_if("use_local_defaults", "true", "62ms")
     )]
     pub handshake_per_ip_min_period: PositiveDuration,

--- a/crates/commonware-node/src/peer_manager/actor.rs
+++ b/crates/commonware-node/src/peer_manager/actor.rs
@@ -72,7 +72,7 @@ where
             peers.clone(),
         );
         let context = ContextCell::new(context);
-        let peer_update_timer = Box::pin(context.sleep(BOOTSTRAP_UPDATE_INTERVAL));
+        let peer_update_timer = Box::pin(context.sleep(Duration::ZERO));
         Self {
             context,
             oracle,


### PR DESCRIPTION
Reduces CL restart recovery latency while keeping the riskiest reconnect limits less aggressive than the first pass. Validators now dial globally every 500ms, ping peers every 10s, retry the same peer after 10s, and allow one inbound handshake per IP per second by default.

The peer manager also refreshes the on-chain peer set immediately at startup instead of waiting for its bootstrap timer. The per-peer and per-IP defaults intentionally leave more friction for bad peer data, stale connections, and shared-IP deployments than the fastest recovery settings.

Tested with `cargo fmt --check`, `cargo check -p tempo-commonware-node`, and `cargo test -p tempo-commonware-node --lib`.