### PR TITLE
docs(tip-1063): clarify feature registry, scheduling and activation

### DIFF
--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -28,7 +28,7 @@ Feature flags separate code distribution from feature activation. Validators upg
 
 A feature flag controls whether a specific Tempo protocol change is active. Feature gated code ships inactive in a release. Each feature is recorded in an onchain feature registry with a minimum supported Tempo version. A validator supports the feature when its reported version is greater than or equal to that minimum specified version.
 
-A feature can be scheduled for activation once enough active validators have signaled support. A designated multisig schedules the feature by setting a future activation timestamp in an onchain feature registry. When the activation timestamp is scheduled, Tempo validates that enough active validators support the feature, and that timestamp becomes the upgrade deadline. When block time reaches the timestamp, the feature becomes active. Validators that have not upgraded must stop before processing blocks that require the active feature.
+A feature can be scheduled for activation once enough active validators have reported a Tempo version that supports it. A designated multisig schedules the feature by setting a future activation timestamp in an onchain feature registry. When the activation timestamp is scheduled, Tempo validates that enough active validators support the feature, and that timestamp becomes the upgrade deadline. When block time reaches the timestamp, the feature becomes active. Validators that have not upgraded must stop before processing blocks that require the active feature.
 
 ## Feature Registry
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -28,7 +28,7 @@ Feature flags separate code distribution from feature activation. Validators upg
 
 A feature flag controls whether a specific Tempo protocol change is active. Feature gated code ships inactive in a release. Each feature is recorded in an onchain feature registry with a minimum supported Tempo version. A validator supports the feature when its reported version is greater than or equal to that `minimum_supported_version`.
 
-A feature can be scheduled for activation once enough active validators have reported a Tempo version that supports it. A designated multisig schedules the feature by setting a future activation timestamp in an onchain feature registry. When the feature is scheduled, Tempo validates that enough active validators support the feature, and the activiation timestamp becomes the upgrade deadline. When block time reaches the timestamp, the feature becomes active. Validators that have not upgraded must stop before processing blocks that require the active feature.
+A feature can be scheduled for activation once enough active validators have reported a Tempo version that supports it. A designated multisig schedules the feature by setting a future activation timestamp in an onchain feature registry. When the feature is scheduled, Tempo validates that enough active validators support the feature, and the activation timestamp becomes the upgrade deadline. When block time reaches the timestamp, the feature becomes active. Validators that have not upgraded must stop before processing blocks that require the active feature.
 
 ## Feature Registry
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -77,13 +77,3 @@ Before activation, the authorized signer can also reschedule a pending feature b
 After activation, a feature cannot be cancelled or locally disabled. Active features are part of chain history, and removing or toggling off their code can break syncing, state assumptions, or protocol behavior where the feature was active.
 
 If an active feature needs to be fixed, disabled, or replaced, the change ships as a new protocol feature with its own `feature_id` and `minimum_supported_version`. For example, a fix to `fee_amm` can be registered as `fee_amm_rounding_fix`. The original `fee_amm` feature remains available for historical execution, and the new feature gates the corrected behavior from its own activation point.
-
-## Security Considerations
-
-Validator version reports are readiness signals used before activation. After activation, enforcement comes from deterministic protocol validation of the active feature's behavior.
-
-The authorized signer is not a replacement for validator readiness. The authorized signer cannot schedule a feature until that feature has quorum.
-
-Feature activation must not rely on local node configuration. Any local override that changes active protocol behavior can split the network.
-
-Irreversible features require extra review. A feature that performs a state migration, deploys a system contract, changes consensus encoding, changes account or token invariants, or affects transaction validity defines its rollback and supersession story before approval.

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -44,6 +44,23 @@ Each registry entry includes:
 - `status`: the status of the feature. Available statuses are `pending`, `active`, and `cancelled`
 - `activation_timestamp`: the timestamp when the feature becomes active, if scheduled
 
+```solidity
+contract FeatureRegistry {
+  // --snip--
+
+  struct Feature {
+    string description;
+    string minimum_supported_version;
+    Status status;
+    uint64 activation_timestamp;
+  }
+
+  mapping(string feature_id => Feature) features;
+
+  // --snip--
+}
+```
+
 Registered feature metadata is immutable. After registration, the registry must not allow edits to feature fields, including `feature_id` or `minimum_supported_version`. Mutable registry state is limited to status and activation timestamp.
 
 The registry also tracks the Tempo version each validator reports. This is used to ensure that enough active validators are running a Tempo version that supports a given feature before the feature can be scheduled for activation. A version report counts only if it is deterministic from chain history. For a given feature, a validator supports the feature when its latest reported Tempo version is greater than or equal to the feature's `minimum_supported_version`.

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -41,7 +41,7 @@ Each registry entry includes:
 - `feature_id`: a globally unique, lowercase, dot-separated feature identifier
 - `description`: a short description of the behavior; linking the TIP
 - `minimum_supported_version`: the lowest Tempo version expected to validate, build, simulate, and serve the feature correctly after activation
-- `status`: the status of the feature. Available statuses are `pending`, `active`, and `cancelled`
+- `status`: the status of the feature. Available statuses are `pending` and `active`
 - `activation_timestamp`: the timestamp when the feature becomes active, if scheduled; set to 0 means the feature is not scheduled
 
 ```solidity

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -67,7 +67,7 @@ Feature lifecycle state is mutable. Mutable state is limited to `status` and `ac
 
 The registry also tracks the Tempo version each validator reports. This is used to ensure that enough active validators are running a Tempo version that supports a given feature before the feature can be scheduled for activation. A version report counts only if it is deterministic from chain history. For a given feature, a validator supports the feature when its latest reported Tempo version is greater than or equal to the feature's `minimum_supported_version`.
 
-Releases are monotonic for feature support. A newer release supports every feature supported by earlier releases. Selectively opting out of features or non-monotonic support would require per-feature signaling and are not part of this design.
+Releases are monotonic for feature support. A newer release supports every feature supported by earlier releases. Selectively opting out of features or non-monotonic support would require per-feature signaling and is not part of this design for simplicity.
 
 A feature has quorum when enough validators in the active validator set support it. The threshold is Tempo's consensus threshold, expressed as `n/m`, where `m` is the active validator set size and `n` is the required number of active validators that support the feature. Quorum does not activate the feature by itself. It only makes the feature eligible to be scheduled for activation.
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -30,59 +30,31 @@ A feature flag controls whether a specific Tempo protocol change is active. Feat
 
 A feature can be scheduled for activation once enough active validators have signaled support. A designated multisig schedules the feature by setting a future activation timestamp in an onchain feature registry. When the activation timestamp is scheduled, Tempo validates that enough active validators support the feature, and that timestamp becomes the upgrade deadline. When block time reaches the timestamp, the feature becomes active. Validators that have not upgraded must stop before processing blocks that require the active feature.
 
-## Protocol Features
+## Feature Registry
 
-A protocol feature is a specific protocol behavior that can be tracked and activated independently.
+Tempo stores protocol feature data in an onchain feature registry. For a given feature, the registry records the feature ID, minimum supported version, status, and activation timestamp. Registry state is the source of truth for feature activation on Tempo.
 
-Protocol features are listed in a source-controlled feature manifest. The manifest is a single file that contains the feature metadata used by release tooling and the feature registry.
+The registry specifies a designated signer authorized to add new features and schedule activation timestamps for registered features.
 
-Each feature entry includes:
+Each registry entry includes:
 
 - `feature_id`: a globally unique, lowercase, dot-separated feature identifier
 - `description`: a short description of the behavior
-- `tip`: the TIP that specifies the behavior
-- `minimum_supported_version`: the first Tempo release expected to support the feature, for operator and tooling visibility
-- `status`: the feature's manifest status, such as draft, approved, deprecated, or cancelled
+- `minimum_supported_version`: the lowest Tempo version expected to validate, build, simulate, and serve the feature correctly after activation
+- `status`: the status of the feature. Available statuses are `pending`, `active`, and `deprecated`
+- `activation_timestamp`: the timestamp when the feature becomes active, if scheduled
 
-Feature IDs are append-only. Once a `feature_id` has been assigned to a feature, that ID is not reused for a different behavior.
+Registered feature metadata is immutable. After registration, the registry must not allow edits to feature fields, including `feature_id` or `minimum_supported_version`. Mutable registry state is limited to status and activation timestamp.
 
-The feature's `minimum_supported_version` is the first Tempo release expected to validate, build, simulate, and serve protocol behavior correctly after that feature becomes active.
+The registry also tracks the Tempo version each validator reports. This is used to ensure that enough active validators are running a Tempo version that supports a given feature before the feature can be scheduled for activation. A version report counts only if it is deterministic from chain history. For a given feature, a validator supports the feature when its latest reported Tempo version is greater than or equal to the feature's `minimum_supported_version`.
 
-This model infers feature support from reported Tempo versions. It assumes release support is mostly monotonic: if an official release supports a feature, later official releases are expected to keep supporting that feature unless the feature is cancelled before activation or superseded by a later protocol feature.
+Releases are monotonic for feature support. A newer release supports every feature supported by earlier releases. Selectively opting out of features or non-monotonic support would require per-feature signaling and are not part of this design.
 
-## Validator Version Reporting
+Activation quorum is validator-count based and uses one global threshold for all features. The threshold is Tempo's consensus threshold, expressed as `n/m`, where `m` is the active validator set size and `n` is the required number of active validators that support the feature. Activation quorum does not activate the feature by itself. It only makes the feature eligible to be scheduled for activation.
 
-Validators report the Tempo version they are running. The reported version is the readiness signal used for features whose `minimum_supported_version` is less than or equal to that version.
+The registry should expose enough read methods for nodes, indexers, and operators to inspect feature state, validator reported versions, current support counts, and the global activation quorum threshold. Callers should be able to determine whether a feature is known, scheduled, or active, including for a specific block or timestamp.
 
-The exact reporting path is an implementation detail. The report must be deterministic from chain history before it can count toward quorum.
-
-Quorum is calculated from reported validator versions.
-
-Each validator's latest reported version is used for quorum. A validator contributes support for a feature only when its reported version is greater than or equal to the feature's `minimum_supported_version`.
-
-Tempo versions used for quorum must have a deterministic ordering.
-
-Implementations must expose enough information to determine validator versions and feature support counts.
-
-Only eligible active validators count toward quorum.
-
-## Quorum
-
-Quorum is validator-count based and uses one global threshold for all features. The threshold is Tempo's consensus threshold, expressed as `n/m`, where `m` is the active validator set size and `n` is the required number of active validators with committed support for the feature.
-
-Changing the global quorum threshold after deployment is outside the scope of this TIP and should be defined by a separate protocol change.
-
-For a feature at block `B`:
-
-```text
-m = number of eligible active validators at B
-n = required active-validator support threshold
-support = number of eligible active validators whose latest reported version is greater than or equal to the feature's minimum_supported_version
-```
-
-Quorum means enough of the current active validator set has reported a Tempo version that supports the feature. It does not activate the feature by itself.
-
-Version reporting is the readiness signal. Scheduling happens through a multisig transaction after quorum has been reached.
+Registry state changes must be observable through events for registration, activation scheduling/updates, support count changes, and deprecation.
 
 ## Scheduling and Activation
 
@@ -127,56 +99,6 @@ Cancellation is allowed only if the feature is scheduled and not active. Cancell
 Rescheduling is allowed only if the feature is scheduled and not active. Rescheduling replaces `activation_timestamp` with a new future timestamp.
 
 Cancellation and rescheduling must be onchain, deterministic from chain history, and observable through feature registry events and read methods.
-
-## Feature Registry
-
-Tempo introduces a feature registry precompile exposed through a normal contract ABI.
-
-The registry is where features are registered and where activation state is tracked. Operators and tooling can inspect registry state to see which features are known, scheduled, active, or waiting on validator support.
-
-The registry stores feature identity, scheduling, activation, and quorum data:
-
-```text
-activation_quorum => {
-  quorum_numerator,
-  quorum_denominator
-}
-
-feature_activation[feature_id] => {
-  min_supported_version,
-  status, // pending | active | deprecated
-  activation_timestamp
-}
-```
-
-The exact contract ABI and storage layout are implementation details, but the observable behavior must match this TIP.
-
-Only the multisig can register features in the onchain registry. Feature registration must reject duplicate `feature_id` values and feature IDs that do not match the canonical lowercase dot-separated format.
-
-Registered feature metadata is immutable. After registration, the registry must not allow edits to registered feature fields, including `feature_id` or `min_supported_version`. Mutable registry state is limited to activation lifecycle state, including scheduling, cancellation, rescheduling, activation, and deprecation.
-
-The registry must expose enough read methods for nodes, indexers, and operators to determine:
-
-- whether a feature is known
-- a feature's minimum supported version
-- validator-reported Tempo versions
-- whether a validator's reported version supports a feature
-- the current validator support count for a feature
-- the global activation quorum threshold
-- whether a feature is scheduled
-- whether a feature is active at a given block or timestamp
-
-At minimum, the registry emits:
-
-```solidity
-event FeatureRegistered(string featureId, string minSupportedVersion);
-event FeatureScheduled(string featureId, uint64 activationTimestamp);
-event FeatureScheduleCancelled(string featureId);
-event FeatureRescheduled(string featureId, uint64 activationTimestamp);
-event FeatureSupportUpdated(string featureId);
-event FeatureActivated(string featureId, uint64 activationTimestamp);
-event FeatureDeprecated(string featureId);
-```
 
 ## Runtime Integration
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -41,7 +41,7 @@ Each registry entry includes:
 - `feature_id`: a globally unique, lowercase, dot-separated feature identifier
 - `description`: a short description of the behavior
 - `minimum_supported_version`: the lowest Tempo version expected to validate, build, simulate, and serve the feature correctly after activation
-- `status`: the status of the feature. Available statuses are `pending`, `active`, and `deprecated`
+- `status`: the status of the feature. Available statuses are `pending`, `active`, and `cancelled`
 - `activation_timestamp`: the timestamp when the feature becomes active, if scheduled
 
 Registered feature metadata is immutable. After registration, the registry must not allow edits to feature fields, including `feature_id` or `minimum_supported_version`. Mutable registry state is limited to status and activation timestamp.
@@ -52,9 +52,9 @@ Releases are monotonic for feature support. A newer release supports every featu
 
 A feature has quorum when enough validators in the active validator set support it. The threshold is Tempo's consensus threshold, expressed as `n/m`, where `m` is the active validator set size and `n` is the required number of active validators that support the feature. Quorum does not activate the feature by itself. It only makes the feature eligible to be scheduled for activation.
 
-The registry should expose enough read methods for nodes, indexers, and operators to inspect feature state, validator reported versions, current support counts, and the global activation quorum threshold. Callers should be able to determine whether a feature is known, scheduled, or active, including for a specific block or timestamp.
+The registry should expose enough read methods for nodes, indexers, and operators to inspect feature state, validator reported versions, current support counts, and the global activation quorum threshold. Callers should be able to determine whether a feature is known, scheduled, active, or cancelled, including for a specific block or timestamp.
 
-Registry state changes must be observable through events for registration, activation scheduling/updates, support count changes, and deprecation.
+Registry state changes must be observable through events for registration, activation scheduling, schedule updates, support count changes, activation, and cancellation.
 
 ## Scheduling and Activation
 
@@ -66,23 +66,23 @@ A scheduled feature becomes active when block time reaches its activation timest
 
 Nodes derive the active feature set from registry state. Validators, RPC nodes, and other infrastructure must use the same active feature state when evaluating protocol behavior for a block. Once a feature is active, any node that validates, builds, simulates, or serves protocol behavior at or after the activation timestamp must support that feature.
 
-## Disabling and Rollback
+## Cancellation and Supersession
 
-Before activation, rollback is handled by leaving the feature unscheduled, cancelling the schedule, rescheduling to a later timestamp, or shipping a new Tempo release and not scheduling the feature. If quorum is never reached, the feature cannot be scheduled for activation.
+A feature can be cancelled after registration and before activation. This includes features that have reached quorum, and features that already have a scheduled activation timestamp.
 
-After quorum but before scheduling, the activation signer can choose not to schedule the feature. The feature remains inactive.
+Cancelling a feature marks its status as `cancelled` in the feature registry. If the feature had a scheduled activation timestamp, cancellation clears the timestamp. A cancelled feature can be rescheduled for activation at a later date under the same `feature_id`.
 
-After a feature is scheduled but before it is active, the activation signer can cancel or reschedule the feature.
+Before activation, the authorized signer can also reschedule a pending feature by replacing its activation timestamp with a new future timestamp.
 
-After activation, local disabling is not allowed. An operator must not be able to turn off an active feature through local configuration.
+After activation, a feature cannot be cancelled or locally disabled. Active features are part of chain history, and removing or toggling off their code can break syncing, state assumptions, or protocol behavior where the feature was active.
 
-Post-activation disabling through local configuration or the feature registry is not supported by this TIP. An active feature that needs to be changed, disabled, or replaced must be handled by a new protocol feature, hardfork, or emergency upgrade that supersedes the old behavior. This is especially important for features that change state, deploy contracts, perform migrations, or alter assumptions that are unsafe to unwind locally.
+If an active feature needs to be fixed, disabled, or replaced, the change ships as a new protocol feature with its own `feature_id` and `minimum_supported_version`. For example, a fix to `fee_amm` can be registered as `fee_amm_rounding_fix`. The original `fee_amm` feature remains available for historical execution, and the new feature gates the corrected behavior from its own activation point.
 
 ## Security Considerations
 
 Validator version reports are readiness signals used before activation. After activation, enforcement comes from deterministic protocol validation of the active feature's behavior.
 
-The activation signer is not a replacement for validator readiness. The activation signer cannot schedule a feature until that feature has quorum.
+The authorized signer is not a replacement for validator readiness. The authorized signer cannot schedule a feature until that feature has quorum.
 
 Feature activation must not rely on local node configuration. Any local override that changes active protocol behavior can split the network.
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -39,7 +39,7 @@ The registry specifies a designated signer authorized to add new features and sc
 Each registry entry includes:
 
 - `feature_id`: a globally unique, lowercase, dot-separated feature identifier
-- `description`: a short description of the behavior
+- `description`: a short description of the behavior, incl the TIP
 - `minimum_supported_version`: the lowest Tempo version expected to validate, build, simulate, and serve the feature correctly after activation
 - `status`: the status of the feature. Available statuses are `pending`, `active`, and `cancelled`
 - `activation_timestamp`: the timestamp when the feature becomes active, if scheduled

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -77,7 +77,7 @@ Registry state changes must be observable through events for registration, activ
 
 ## Scheduling and Activation
 
-A registered feature can be scheduled for activation once the active validator set has reached quorum over the minimum supported version that the network is running. The authorized signer/multisig specified by the registry contract then schedules activation by submitting a registry transaction with the feature ID and a future activation timestamp. The registry accepts the scheduling transaction only if the feature is registered, the status is `pending` and quorum over active validators is satisfied. The requested activation timestamp must also be in the future.
+ registered feature can be scheduled for activation once the active validator set has reached quorum for the feature's `minimum_supported_version`. The authorised signer/multisig specified by the registry contract then schedules activation by submitting a registry transaction with the feature ID and a future activation timestamp. The registry accepts the scheduling transaction only if the feature is registered, the status is `pending` and quorum over active validators is satisfied. The requested activation timestamp must also be in the future.
 
 Scheduling writes the activation timestamp to the feature metadata, an event is emitted to notify network participants and the scheduled timestamp becomes the upgrade deadline for any nodes running a version older than the minimum supported version. Network quorum on version support is validated when the timestamp is scheduled and is not revalidated at activation time.
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -26,7 +26,7 @@ Feature flags separate code distribution from feature activation. Validators upg
 
 ## Overview
 
-A feature flag controls whether a specific Tempo protocol change is active. Feature gated code ships inactive in a release. Each feature is recorded in an onchain feature registry with a minimum supported Tempo version. A validator supports the feature when its reported version is greater than or equal to that minimum specified version.
+A feature flag controls whether a specific Tempo protocol change is active. Feature gated code ships inactive in a release. Each feature is recorded in an onchain feature registry with a minimum supported Tempo version. A validator supports the feature when its reported version is greater than or equal to that `minimum_supported_version`.
 
 A feature can be scheduled for activation once enough active validators have reported a Tempo version that supports it. A designated multisig schedules the feature by setting a future activation timestamp in an onchain feature registry. When the feature is scheduled, Tempo validates that enough active validators support the feature, and the activiation timestamp becomes the upgrade deadline. When block time reaches the timestamp, the feature becomes active. Validators that have not upgraded must stop before processing blocks that require the active feature.
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -115,7 +115,6 @@ interface IFeatureRegistry {
     }
 
     struct Feature {
-        string featureId;
         string description;
         string minimumSupportedVersion;
         FeatureStatus status;

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -61,7 +61,9 @@ contract FeatureRegistry {
 }
 ```
 
-Registered feature metadata is immutable. After registration, the registry must not allow edits to feature fields, including `feature_id` or `minimum_supported_version`. Mutable registry state is limited to status and activation timestamp.
+Registered feature identity is immutable. After registration, the registry must not allow edits to `feature_id` or `minimum_supported_version`.
+
+Feature lifecycle state is mutable. Mutable state is limited to `status` and `activation_timestamp`.
 
 The registry also tracks the Tempo version each validator reports. This is used to ensure that enough active validators are running a Tempo version that supports a given feature before the feature can be scheduled for activation. A version report counts only if it is deterministic from chain history. For a given feature, a validator supports the feature when its latest reported Tempo version is greater than or equal to the feature's `minimum_supported_version`.
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -87,7 +87,7 @@ Nodes derive the active feature set from registry state. Validators, RPC nodes, 
 
 ## Cancellation and Supersession
 
-A feature can be cancelled after registration and before activation. This includes features that have reached quorum, and features that already have a scheduled activation timestamp.
+Before activation, the authorised signer can cancel a feature's scheduled activation. Cancellation clears `activation_timestamp` and leaves the feature `pending`. The feature can be scheduled again later.
 
 
 Before activation, the authorized signer can also reschedule a pending feature by replacing its activation timestamp with a new future timestamp.

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -50,7 +50,7 @@ The registry also tracks the Tempo version each validator reports. This is used 
 
 Releases are monotonic for feature support. A newer release supports every feature supported by earlier releases. Selectively opting out of features or non-monotonic support would require per-feature signaling and are not part of this design.
 
-Activation quorum is validator-count based and uses one global threshold for all features. The threshold is Tempo's consensus threshold, expressed as `n/m`, where `m` is the active validator set size and `n` is the required number of active validators that support the feature. Activation quorum does not activate the feature by itself. It only makes the feature eligible to be scheduled for activation.
+A feature has quorum when enough validators in the active validator set support it. The threshold is Tempo's consensus threshold, expressed as `n/m`, where `m` is the active validator set size and `n` is the required number of active validators that support the feature. Quorum does not activate the feature by itself. It only makes the feature eligible to be scheduled for activation.
 
 The registry should expose enough read methods for nodes, indexers, and operators to inspect feature state, validator reported versions, current support counts, and the global activation quorum threshold. Callers should be able to determine whether a feature is known, scheduled, or active, including for a specific block or timestamp.
 
@@ -58,47 +58,11 @@ Registry state changes must be observable through events for registration, activ
 
 ## Scheduling and Activation
 
-Each feature has an activation signer configured in the feature registry. The activation signer is the multisig.
+A registered feature can be scheduled for activation once the active validator set has reached quorum over the minimum supported version that the network is running. The authorized signer/multisig specified by the registry contract then schedules activation by submitting a registry transaction with the feature ID and a future activation timestamp. The registry accepts the scheduling transaction only if the feature is registered, the status is `pending` and the required version for a given feature is <= the network's minimum active version. The requested activation timestamp must also be in the future.
 
-The activation signer can schedule a feature only if all of the following are true at transaction execution time:
+Scheduling writes the activation timestamp to the feature metadata, an event is emitted to notify network participants and the scheduled timestamp becomes the upgrade deadline for any nodes running a version older than the minimum supported version. Network quorum on version support is validated when the timestamp is scheduled and is not revalidated at activation time.
 
-- the feature is known to the registry
-- the feature is not already active
-- the feature is not already scheduled for activation
-- the feature has quorum
-- `activation_timestamp` is in the future
-
-Scheduling a feature establishes an upgrade deadline. Quorum is checked when the feature is scheduled. Activation does not wait for additional validators after scheduling.
-
-When the scheduling transaction is accepted, the registry sets:
-
-```text
-activation_timestamp = requested_activation_timestamp
-```
-
-The feature becomes active once the activation timestamp has been reached:
-
-```text
-block.timestamp >= activation_timestamp
-```
-
-Activation is applied during the pre-execution phase at the start of block processing. Before user transactions execute, protocol handlers check scheduled inactive features.
-
-If a feature's activation timestamp has been reached, the pre-execution phase marks the feature active and emits the activation event. User transactions in that block then observe the feature as active.
-
-Quorum is not re-evaluated at activation time. Validators that have not upgraded to a supporting release by the activation timestamp must fail closed before processing blocks where the feature is active.
-
-`activation_timestamp` records the timestamp at which the feature becomes active.
-
-Activation must be deterministic from chain history. Given the same chain, all nodes must compute the same active feature set for every block.
-
-Before activation, the activation signer can cancel or reschedule a feature.
-
-Cancellation is allowed only if the feature is scheduled and not active. Cancellation clears `activation_timestamp` and leaves the feature inactive. The feature can be scheduled again later by the activation signer.
-
-Rescheduling is allowed only if the feature is scheduled and not active. Rescheduling replaces `activation_timestamp` with a new future timestamp.
-
-Cancellation and rescheduling must be onchain, deterministic from chain history, and observable through feature registry events and read methods.
+A scheduled feature becomes active when block time reaches its activation timestamp and activation is applied during the pre-execution hooks at the start of block processing. If a feature's activation timestamp has been reached, the registry marks the feature `active` and emits the activation event and subsequent user transactions are processed with the feature as active.
 
 ## Runtime Integration
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -62,41 +62,9 @@ A registered feature can be scheduled for activation once the active validator s
 
 Scheduling writes the activation timestamp to the feature metadata, an event is emitted to notify network participants and the scheduled timestamp becomes the upgrade deadline for any nodes running a version older than the minimum supported version. Network quorum on version support is validated when the timestamp is scheduled and is not revalidated at activation time.
 
-A scheduled feature becomes active when block time reaches its activation timestamp and activation is applied during the pre-execution hooks at the start of block processing. If a feature's activation timestamp has been reached, the registry marks the feature `active` and emits the activation event and subsequent user transactions are processed with the feature as active.
+A scheduled feature becomes active when block time reaches its activation timestamp and activation is applied during the pre-execution hooks at the start of block processing. If a feature's activation timestamp has been reached, the registry marks the feature `active` and emits the activation event. User transactions in that block are processed with the feature active.
 
-## Runtime Integration
-
-Nodes maintain an active feature set that backs protocol checks such as `feature.is_active(feature_id)`.
-
-Nodes may cache the active feature set at the current head, but protocol checks must derive feature state for the specific block being validated, built, simulated, or replayed. If a feature is active in registry state at the node's current head, `feature.is_active(feature_id)` returns true before the node validates, builds, simulates, or serves protocol behavior at that head.
-
-During block processing, the feature registry emits events when feature lifecycle state changes, including scheduling, cancellation, rescheduling, and activation. Registry state is the source of truth for feature lifecycle state. Feature state changes must happen in fixed steps that every node runs deterministically; events are only for indexing and debugging.
-
-Activation is applied before user transaction execution, so protocol checks observe the updated active feature set during that block's execution. All nodes must update the active feature set at the same deterministic pre-execution point in block processing.
-
-A scheduling transaction included in block `B` cannot activate the feature earlier than its activation timestamp. It records scheduling state and emits the corresponding registry event.
-
-All protocol-facing paths that depend on feature state must use the same active feature set for the block they are evaluating. This includes:
-
-- block validation
-- block building
-- transaction validation
-- transaction execution
-- mempool admission and eviction
-- RPC simulation
-- precompiles and system contracts
-- protocol handlers
-- tracing and debugging paths that replay protocol behavior
-
-The first rollout preserves existing hardfork behavior while representative callsites move from hardfork-only checks toward feature checks.
-
-## Unsupported Active Features
-
-Once a feature is active, every node that validates, builds, simulates, or serves protocol behavior at or after the activation timestamp must understand that feature.
-
-A node whose binary does not support an active feature must fail closed. It must not silently continue applying old protocol rules.
-
-If a feature activates during the pre-execution phase and the node binary does not support it, the node fails closed before user transaction execution for that block. The failure must be explicit and observable.
+Nodes derive the active feature set from registry state. Validators, RPC nodes, and other infrastructure must use the same active feature state when evaluating protocol behavior for a block. Once a feature is active, any node that validates, builds, simulates, or serves protocol behavior at or after the activation timestamp must support that feature.
 
 ## Disabling and Rollback
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -89,7 +89,6 @@ Nodes derive the active feature set from registry state. Validators, RPC nodes, 
 
 A feature can be cancelled after registration and before activation. This includes features that have reached quorum, and features that already have a scheduled activation timestamp.
 
-Cancelling a feature marks its status as `cancelled` in the feature registry. If the feature had a scheduled activation timestamp, cancellation clears the timestamp. A cancelled feature can be rescheduled for activation at a later date under the same `feature_id`.
 
 Before activation, the authorized signer can also reschedule a pending feature by replacing its activation timestamp with a new future timestamp.
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -71,7 +71,7 @@ Releases are monotonic for feature support. A newer release supports every featu
 
 A feature has quorum when enough validators in the active validator set support it. The threshold is Tempo's consensus threshold, expressed as `n/m`, where `m` is the active validator set size and `n` is the required number of active validators that support the feature. Quorum does not activate the feature by itself. It only makes the feature eligible to be scheduled for activation.
 
-The registry should expose enough read methods for nodes, indexers, and operators to inspect feature state, validator reported versions, current support counts, and the global activation quorum threshold. Callers should be able to determine whether a feature is known, scheduled, active, or cancelled, including for a specific block or timestamp.
+The registry should expose enough read methods for nodes, indexers, and operators to inspect feature state, validator reported versions, current support counts, and the global activation quorum threshold. Callers should be able to determine whether a feature is known, scheduled, or active, including for a specific block or timestamp.
 
 Registry state changes must be observable through events for registration, activation scheduling, schedule updates, support count changes, activation, and cancellation.
 
@@ -90,7 +90,6 @@ Nodes derive the active feature set from registry state. Validators, RPC nodes, 
 Before activation, the authorised signer can cancel a feature's scheduled activation. Cancellation clears `activation_timestamp` and leaves the feature `pending`. The feature can be scheduled again later.
 
 
-Before activation, the authorized signer can cancel a feature's scheduled activation. Cancellation clears `activation_timestamp` and leaves the feature `pending`. The feature can be scheduled again later.
 
 After activation, a feature cannot be cancelled or locally disabled. Active features are part of chain history, and removing or toggling off their code can break syncing, state assumptions, or protocol behavior where the feature was active.
 
@@ -139,8 +138,8 @@ interface IFeatureRegistry {
     /// @notice Replaces the activation timestamp for a scheduled pending feature.
     function rescheduleActivation(string calldata featureId, uint64 activationTimestamp) external;
 
-    /// @notice Cancels a pending feature before activation.
-    function cancelFeature(string calldata featureId) external;
+    /// @notice Cancels a scheduled activation before the feature become active.
+    function cancelScheduledActivation(string calldata featureId) external;
 
     /// @notice Returns the registered feature metadata and current status.
     function getFeature(string calldata featureId) external view returns (Feature memory);

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -90,7 +90,7 @@ Nodes derive the active feature set from registry state. Validators, RPC nodes, 
 Before activation, the authorised signer can cancel a feature's scheduled activation. Cancellation clears `activation_timestamp` and leaves the feature `pending`. The feature can be scheduled again later.
 
 
-Before activation, the authorized signer can also reschedule a pending feature by replacing its activation timestamp with a new future timestamp.
+Before activation, the authorized signer can cancel a feature's scheduled activation. Cancellation clears `activation_timestamp` and leaves the feature `pending`. The feature can be scheduled again later.
 
 After activation, a feature cannot be cancelled or locally disabled. Active features are part of chain history, and removing or toggling off their code can break syncing, state assumptions, or protocol behavior where the feature was active.
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -39,7 +39,7 @@ The registry specifies a designated signer authorized to add new features and sc
 Each registry entry includes:
 
 - `feature_id`: a globally unique, lowercase, dot-separated feature identifier
-- `description`: a short description of the behavior; linking the TIP
+- `description`: a short description of the behavior; including the TIP reference
 - `minimum_supported_version`: the lowest Tempo version expected to validate, build, simulate, and serve the feature correctly after activation
 - `status`: the status of the feature. Available statuses are `pending` and `active`
 - `activation_timestamp`: the timestamp when the feature becomes active, if scheduled; set to 0 means the feature is not scheduled

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -42,7 +42,7 @@ Each registry entry includes:
 - `description`: a short description of the behavior, incl the TIP
 - `minimum_supported_version`: the lowest Tempo version expected to validate, build, simulate, and serve the feature correctly after activation
 - `status`: the status of the feature. Available statuses are `pending`, `active`, and `cancelled`
-- `activation_timestamp`: the timestamp when the feature becomes active, if scheduled
+- `activation_timestamp`: the timestamp when the feature becomes active, if scheduled; set to 0 means the feature is not scheduled
 
 ```solidity
 contract FeatureRegistry {

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -39,7 +39,7 @@ The registry specifies a designated signer authorized to add new features and sc
 Each registry entry includes:
 
 - `feature_id`: a globally unique, lowercase, dot-separated feature identifier
-- `description`: a short description of the behavior, incl the TIP
+- `description`: a short description of the behavior; linking the TIP
 - `minimum_supported_version`: the lowest Tempo version expected to validate, build, simulate, and serve the feature correctly after activation
 - `status`: the status of the feature. Available statuses are `pending`, `active`, and `cancelled`
 - `activation_timestamp`: the timestamp when the feature becomes active, if scheduled; set to 0 means the feature is not scheduled

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -177,8 +177,8 @@ event FeatureScheduled(string featureId, uint64 activationTimestamp);
 /// @notice Emitted when a pending feature's activation timestamp is replaced.
 event FeatureRescheduled(string featureId, uint64 activationTimestamp);
 
-/// @notice Emitted when a pending feature is cancelled.
-event FeatureCancelled(string featureId);
+/// @notice Emitted when a scheduled feature is cancelled.
+event FeatureScheduleCancelled(string featureId);
 
 /// @notice Emitted when a scheduled feature becomes active.
 event FeatureActivated(string featureId, uint64 activationTimestamp);

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -34,7 +34,7 @@ A feature can be scheduled for activation once enough active validators have rep
 
 Tempo stores protocol feature data in an onchain feature registry. For a given feature, the registry records the feature ID, minimum supported version, status, and activation timestamp. Registry state is the source of truth for feature activation on Tempo.
 
-The registry specifies a designated signer authorized to add new features and schedule activation timestamps for registered features.
+The registry specifies a designated signer authorized to register approved features onchain and schedule activation timestamps.
 
 Each registry entry includes:
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -77,7 +77,7 @@ Registry state changes must be observable through events for registration, activ
 
 ## Scheduling and Activation
 
-A registered feature can be scheduled for activation once the active validator set has reached quorum over the minimum supported version that the network is running. The authorized signer/multisig specified by the registry contract then schedules activation by submitting a registry transaction with the feature ID and a future activation timestamp. The registry accepts the scheduling transaction only if the feature is registered, the status is `pending` and the required version for a given feature is <= the network's minimum active version. The requested activation timestamp must also be in the future.
+A registered feature can be scheduled for activation once the active validator set has reached quorum over the minimum supported version that the network is running. The authorized signer/multisig specified by the registry contract then schedules activation by submitting a registry transaction with the feature ID and a future activation timestamp. The registry accepts the scheduling transaction only if the feature is registered, the status is `pending` and quorum over active validators is satisfied. The requested activation timestamp must also be in the future.
 
 Scheduling writes the activation timestamp to the feature metadata, an event is emitted to notify network participants and the scheduled timestamp becomes the upgrade deadline for any nodes running a version older than the minimum supported version. Network quorum on version support is validated when the timestamp is scheduled and is not revalidated at activation time.
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -28,7 +28,7 @@ Feature flags separate code distribution from feature activation. Validators upg
 
 A feature flag controls whether a specific Tempo protocol change is active. Feature gated code ships inactive in a release. Each feature is recorded in an onchain feature registry with a minimum supported Tempo version. A validator supports the feature when its reported version is greater than or equal to that minimum specified version.
 
-A feature can be scheduled for activation once enough active validators have reported a Tempo version that supports it. A designated multisig schedules the feature by setting a future activation timestamp in an onchain feature registry. When the activation timestamp is scheduled, Tempo validates that enough active validators support the feature, and that timestamp becomes the upgrade deadline. When block time reaches the timestamp, the feature becomes active. Validators that have not upgraded must stop before processing blocks that require the active feature.
+A feature can be scheduled for activation once enough active validators have reported a Tempo version that supports it. A designated multisig schedules the feature by setting a future activation timestamp in an onchain feature registry. When the feature is scheduled, Tempo validates that enough active validators support the feature, and the activiation timestamp becomes the upgrade deadline. When block time reaches the timestamp, the feature becomes active. Validators that have not upgraded must stop before processing blocks that require the active feature.
 
 ## Feature Registry
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -104,8 +104,6 @@ If an active feature needs to be fixed, disabled, or replaced, the change ships 
 The feature registry exposes the following interface:
 
 ```solidity
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
 
 /// @title IFeatureRegistry
 /// @notice Registry for Tempo protocol feature activation.

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -77,3 +77,128 @@ Before activation, the authorized signer can also reschedule a pending feature b
 After activation, a feature cannot be cancelled or locally disabled. Active features are part of chain history, and removing or toggling off their code can break syncing, state assumptions, or protocol behavior where the feature was active.
 
 If an active feature needs to be fixed, disabled, or replaced, the change ships as a new protocol feature with its own `feature_id` and `minimum_supported_version`. For example, a fix to `fee_amm` can be registered as `fee_amm_rounding_fix`. The original `fee_amm` feature remains available for historical execution, and the new feature gates the corrected behavior from its own activation point.
+
+## Interfaces
+
+### Feature Registry
+
+The feature registry exposes the following interface:
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title IFeatureRegistry
+/// @notice Registry for Tempo protocol feature activation.
+interface IFeatureRegistry {
+    enum FeatureStatus {
+        Pending,
+        Active,
+        Cancelled
+    }
+
+    struct Feature {
+        string featureId;
+        string description;
+        string minimumSupportedVersion;
+        FeatureStatus status;
+        uint64 activationTimestamp;
+    }
+
+    /// @notice Returns the address authorized to register features and schedule activation.
+    function authorizedSigner() external view returns (address);
+
+    /// @notice Returns the global validator quorum threshold.
+    function activationQuorum() external view returns (uint256 numerator, uint256 denominator);
+
+    /// @notice Registers a new pending feature.
+    function registerFeature(
+        string calldata featureId,
+        string calldata description,
+        string calldata minimumSupportedVersion
+    ) external;
+
+    /// @notice Schedules activation for a pending feature.
+    function scheduleActivation(string calldata featureId, uint64 activationTimestamp) external;
+
+    /// @notice Replaces the activation timestamp for a scheduled pending feature.
+    function rescheduleActivation(string calldata featureId, uint64 activationTimestamp) external;
+
+    /// @notice Cancels a pending feature before activation.
+    function cancelFeature(string calldata featureId) external;
+
+    /// @notice Returns the registered feature metadata and current status.
+    function getFeature(string calldata featureId) external view returns (Feature memory);
+
+    /// @notice Returns whether a feature is registered.
+    function isFeatureRegistered(string calldata featureId) external view returns (bool);
+
+    /// @notice Returns whether a feature is active at the current block.
+    function isFeatureActive(string calldata featureId) external view returns (bool);
+
+    /// @notice Returns the latest Tempo version reported by a validator.
+    function validatorVersion(address validator) external view returns (string memory);
+
+    /// @notice Returns whether a validator's reported version supports a feature.
+    function validatorSupportsFeature(address validator, string calldata featureId) external view returns (bool);
+
+    /// @notice Returns current active-validator support for a feature.
+    function featureSupportCount(string calldata featureId) external view returns (uint256 support, uint256 required);
+
+    /// @notice Returns whether a feature has quorum support from the active validator set.
+    function hasQuorum(string calldata featureId) external view returns (bool);
+}
+```
+
+### Events
+
+```solidity
+/// @notice Emitted when a feature is registered.
+event FeatureRegistered(string featureId, string minimumSupportedVersion);
+
+/// @notice Emitted when a pending feature is scheduled for activation.
+event FeatureScheduled(string featureId, uint64 activationTimestamp);
+
+/// @notice Emitted when a pending feature's activation timestamp is replaced.
+event FeatureRescheduled(string featureId, uint64 activationTimestamp);
+
+/// @notice Emitted when a pending feature is cancelled.
+event FeatureCancelled(string featureId);
+
+/// @notice Emitted when a scheduled feature becomes active.
+event FeatureActivated(string featureId, uint64 activationTimestamp);
+
+/// @notice Emitted when the active validator support count changes.
+event FeatureSupportUpdated(string featureId, uint256 support, uint256 required);
+```
+
+### Errors
+
+```solidity
+/// @notice Caller is not authorized to update feature registry state.
+error Unauthorized();
+
+/// @notice Feature ID is not canonical lowercase dot-separated text.
+error InvalidFeatureId();
+
+/// @notice Feature is already registered.
+error FeatureAlreadyRegistered();
+
+/// @notice Feature is not registered.
+error FeatureNotRegistered();
+
+/// @notice Feature is not pending.
+error FeatureNotPending();
+
+/// @notice Feature already has a scheduled activation timestamp.
+error FeatureAlreadyScheduled();
+
+/// @notice Feature does not have a scheduled activation timestamp.
+error FeatureNotScheduled();
+
+/// @notice Requested activation timestamp is not in the future.
+error ActivationTimestampNotFuture();
+
+/// @notice Active validator support has not reached quorum.
+error QuorumNotReached();
+```

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -77,7 +77,7 @@ Registry state changes must be observable through events for registration, activ
 
 ## Scheduling and Activation
 
- registered feature can be scheduled for activation once the active validator set has reached quorum for the feature's `minimum_supported_version`. The authorised signer/multisig specified by the registry contract then schedules activation by submitting a registry transaction with the feature ID and a future activation timestamp. The registry accepts the scheduling transaction only if the feature is registered, the status is `pending` and quorum over active validators is satisfied. The requested activation timestamp must also be in the future.
+A registered feature can be scheduled for activation once the active validator set has reached quorum for the feature's `minimum_supported_version`. The authorised signer/multisig specified by the registry contract then schedules activation by submitting a registry transaction with the feature ID and a future activation timestamp. The registry accepts the scheduling transaction only if the feature is registered, the status is `pending` and quorum over active validators is satisfied. The requested activation timestamp must also be in the future.
 
 Scheduling writes the activation timestamp to the feature metadata, an event is emitted to notify network participants and the scheduled timestamp becomes the upgrade deadline for any nodes running a version older than the minimum supported version. Network quorum on version support is validated when the timestamp is scheduled and is not revalidated at activation time.
 


### PR DESCRIPTION
This PR refactors TIP-1063 to specify the feature registry, scheduling, activation, cancellation, and supersession model. This PR also adds the feature registry interface.