### PR TITLE
deps: update reth from main (2026-05-27)

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -225,30 +225,81 @@ jobs:
           path: foundry
           persist-credentials: false
 
+      - name: Check Foundry EVM dependency compatibility
+        id: foundry-compat
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          get_workspace_dep_version() {
+            local manifest="$1"
+            local crate="$2"
+            awk -v crate="$crate" '
+              /^\[workspace.dependencies\]/ { in_section = 1; next }
+              in_section && /^\[/ { exit }
+              in_section && $1 == crate {
+                print
+                exit
+              }
+            ' "$manifest" \
+              | sed -nE 's/.*version = "([^"]+)".*/\1/p; s/^[^=]+ = "([^"]+)".*/\1/p' \
+              | head -n1
+          }
+
+          compatible=true
+          for crate in alloy-evm revm revm-inspectors; do
+            tempo_version="$(get_workspace_dep_version tempo/Cargo.toml "$crate")"
+            foundry_version="$(get_workspace_dep_version foundry/Cargo.toml "$crate")"
+            echo "$crate: tempo=$tempo_version foundry=$foundry_version"
+
+            if [[ -z "$tempo_version" || -z "$foundry_version" ]]; then
+              echo "::warning::Could not determine $crate workspace dependency versions for Tempo and Foundry."
+              compatible=false
+            elif [[ "$tempo_version" != "$foundry_version" ]]; then
+              echo "::notice::$crate differs between Tempo ($tempo_version) and Foundry ($foundry_version)."
+              compatible=false
+            fi
+          done
+
+          echo "compatible=$compatible" >> "$GITHUB_OUTPUT"
+          if [[ "$compatible" != "true" ]]; then
+            echo "::notice::Skipping Foundry Rust-precompile tests until the pinned Foundry checkout catches up to Tempo's EVM dependency stack."
+          fi
+
+      - name: Skip Foundry Rust-precompile tests
+        if: steps.foundry-compat.outputs.compatible != 'true'
+        run: |
+          echo "Skipping Foundry Rust-precompile tests because Foundry's pinned EVM dependencies are not compatible with this Tempo branch."
+
       - name: Setup Rust
+        if: steps.foundry-compat.outputs.compatible == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+        if: steps.foundry-compat.outputs.compatible == 'true'
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        if: steps.foundry-compat.outputs.compatible == 'true'
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        if: steps.foundry-compat.outputs.compatible == 'true'
         with:
           workspaces: foundry
 
       - name: Install llvm-tools
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: steps.foundry-compat.outputs.compatible == 'true' && needs.check-precompiles.outputs.coverage == 'true'
         run: rustup component add llvm-tools-preview
 
       - name: Patch foundry to use checked-out tempo crates
+        if: steps.foundry-compat.outputs.compatible == 'true'
         run: tempo/scripts/foundry-patch.sh "$GITHUB_WORKSPACE/tempo" "$GITHUB_WORKSPACE/foundry"
 
       # Build and run WITH coverage (only on PR when precompiles changed)
       - name: Build foundry forge with coverage instrumentation
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: steps.foundry-compat.outputs.compatible == 'true' && needs.check-precompiles.outputs.coverage == 'true'
         working-directory: foundry
         run: RUSTFLAGS="-C instrument-coverage" cargo build --bin forge --profile release --no-default-features
 
       - name: Run Forge tests with Rust precompiles (with coverage)
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: steps.foundry-compat.outputs.compatible == 'true' && needs.check-precompiles.outputs.coverage == 'true'
         working-directory: tempo/tips/verify
         run: |
           echo "Running forge test with Rust precompiles"
@@ -256,26 +307,26 @@ jobs:
 
       # Build and run WITHOUT coverage (main/merge_group or no precompiles changes)
       - name: Build foundry forge
-        if: needs.check-precompiles.outputs.coverage != 'true'
+        if: steps.foundry-compat.outputs.compatible == 'true' && needs.check-precompiles.outputs.coverage != 'true'
         working-directory: foundry
         run: cargo build --bin forge --profile release --no-default-features
 
       - name: Run Forge tests with Rust precompiles
-        if: needs.check-precompiles.outputs.coverage != 'true'
+        if: steps.foundry-compat.outputs.compatible == 'true' && needs.check-precompiles.outputs.coverage != 'true'
         working-directory: tempo/tips/verify
         run: |
           echo "Running forge test with Rust precompiles"
           ../../../foundry/target/release/forge test -vvv
 
       - name: Generate coverage profdata
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: steps.foundry-compat.outputs.compatible == 'true' && needs.check-precompiles.outputs.coverage == 'true'
         run: |
           LLVM_BIN="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | grep host | cut -d' ' -f2)/bin"
           mkdir -p coverage
           "$LLVM_BIN/llvm-profdata" merge -sparse tempo/tips/verify/*.profraw -o coverage/forge-test.profdata
 
       - name: Upload forge coverage artifacts
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: steps.foundry-compat.outputs.compatible == 'true' && needs.check-precompiles.outputs.coverage == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: forge-test-coverage

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -303,7 +303,7 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           allowed-failures: foundry-test
-          allowed-skips: check-precompiles,build,abi-alignment-check,lint,foundry-test
+          allowed-skips: check-precompiles,build,abi-alignment-check,lint
           jobs: ${{ toJSON(needs) }}
 
   precompiles-coverage:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -225,81 +225,30 @@ jobs:
           path: foundry
           persist-credentials: false
 
-      - name: Check Foundry EVM dependency compatibility
-        id: foundry-compat
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          get_workspace_dep_version() {
-            local manifest="$1"
-            local crate="$2"
-            awk -v crate="$crate" '
-              /^\[workspace.dependencies\]/ { in_section = 1; next }
-              in_section && /^\[/ { exit }
-              in_section && $1 == crate {
-                print
-                exit
-              }
-            ' "$manifest" \
-              | sed -nE 's/.*version = "([^"]+)".*/\1/p; s/^[^=]+ = "([^"]+)".*/\1/p' \
-              | head -n1
-          }
-
-          compatible=true
-          for crate in alloy-evm revm revm-inspectors; do
-            tempo_version="$(get_workspace_dep_version tempo/Cargo.toml "$crate")"
-            foundry_version="$(get_workspace_dep_version foundry/Cargo.toml "$crate")"
-            echo "$crate: tempo=$tempo_version foundry=$foundry_version"
-
-            if [[ -z "$tempo_version" || -z "$foundry_version" ]]; then
-              echo "::warning::Could not determine $crate workspace dependency versions for Tempo and Foundry."
-              compatible=false
-            elif [[ "$tempo_version" != "$foundry_version" ]]; then
-              echo "::notice::$crate differs between Tempo ($tempo_version) and Foundry ($foundry_version)."
-              compatible=false
-            fi
-          done
-
-          echo "compatible=$compatible" >> "$GITHUB_OUTPUT"
-          if [[ "$compatible" != "true" ]]; then
-            echo "::notice::Skipping Foundry Rust-precompile tests until the pinned Foundry checkout catches up to Tempo's EVM dependency stack."
-          fi
-
-      - name: Skip Foundry Rust-precompile tests
-        if: steps.foundry-compat.outputs.compatible != 'true'
-        run: |
-          echo "Skipping Foundry Rust-precompile tests because Foundry's pinned EVM dependencies are not compatible with this Tempo branch."
-
       - name: Setup Rust
-        if: steps.foundry-compat.outputs.compatible == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-        if: steps.foundry-compat.outputs.compatible == 'true'
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-        if: steps.foundry-compat.outputs.compatible == 'true'
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        if: steps.foundry-compat.outputs.compatible == 'true'
         with:
           workspaces: foundry
 
       - name: Install llvm-tools
-        if: steps.foundry-compat.outputs.compatible == 'true' && needs.check-precompiles.outputs.coverage == 'true'
+        if: needs.check-precompiles.outputs.coverage == 'true'
         run: rustup component add llvm-tools-preview
 
       - name: Patch foundry to use checked-out tempo crates
-        if: steps.foundry-compat.outputs.compatible == 'true'
         run: tempo/scripts/foundry-patch.sh "$GITHUB_WORKSPACE/tempo" "$GITHUB_WORKSPACE/foundry"
 
       # Build and run WITH coverage (only on PR when precompiles changed)
       - name: Build foundry forge with coverage instrumentation
-        if: steps.foundry-compat.outputs.compatible == 'true' && needs.check-precompiles.outputs.coverage == 'true'
+        if: needs.check-precompiles.outputs.coverage == 'true'
         working-directory: foundry
         run: RUSTFLAGS="-C instrument-coverage" cargo build --bin forge --profile release --no-default-features
 
       - name: Run Forge tests with Rust precompiles (with coverage)
-        if: steps.foundry-compat.outputs.compatible == 'true' && needs.check-precompiles.outputs.coverage == 'true'
+        if: needs.check-precompiles.outputs.coverage == 'true'
         working-directory: tempo/tips/verify
         run: |
           echo "Running forge test with Rust precompiles"
@@ -307,26 +256,26 @@ jobs:
 
       # Build and run WITHOUT coverage (main/merge_group or no precompiles changes)
       - name: Build foundry forge
-        if: steps.foundry-compat.outputs.compatible == 'true' && needs.check-precompiles.outputs.coverage != 'true'
+        if: needs.check-precompiles.outputs.coverage != 'true'
         working-directory: foundry
         run: cargo build --bin forge --profile release --no-default-features
 
       - name: Run Forge tests with Rust precompiles
-        if: steps.foundry-compat.outputs.compatible == 'true' && needs.check-precompiles.outputs.coverage != 'true'
+        if: needs.check-precompiles.outputs.coverage != 'true'
         working-directory: tempo/tips/verify
         run: |
           echo "Running forge test with Rust precompiles"
           ../../../foundry/target/release/forge test -vvv
 
       - name: Generate coverage profdata
-        if: steps.foundry-compat.outputs.compatible == 'true' && needs.check-precompiles.outputs.coverage == 'true'
+        if: needs.check-precompiles.outputs.coverage == 'true'
         run: |
           LLVM_BIN="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | grep host | cut -d' ' -f2)/bin"
           mkdir -p coverage
           "$LLVM_BIN/llvm-profdata" merge -sparse tempo/tips/verify/*.profraw -o coverage/forge-test.profdata
 
       - name: Upload forge coverage artifacts
-        if: steps.foundry-compat.outputs.compatible == 'true' && needs.check-precompiles.outputs.coverage == 'true'
+        if: needs.check-precompiles.outputs.coverage == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: forge-test-coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8383,7 +8383,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8410,7 +8410,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8443,7 +8443,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8463,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8476,7 +8476,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8569,7 +8569,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8638,7 +8638,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8652,7 +8652,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8665,7 +8665,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8719,7 +8719,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8745,7 +8745,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8775,7 +8775,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8790,7 +8790,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8815,7 +8815,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8839,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8863,7 +8863,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8898,7 +8898,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8955,7 +8955,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8983,7 +8983,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9006,7 +9006,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9090,7 +9090,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9174,7 +9174,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9185,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9213,7 +9213,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9235,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9276,7 +9276,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "clap",
  "eyre",
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9315,7 +9315,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9331,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9398,7 +9398,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9423,7 +9423,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9443,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9474,7 +9474,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9493,7 +9493,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "serde",
  "serde_json",
@@ -9555,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "bytes",
  "futures",
@@ -9603,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "bindgen",
  "cc",
@@ -9629,7 +9629,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "futures",
  "metrics",
@@ -9642,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9651,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9665,7 +9665,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9723,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9771,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9786,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9800,7 +9800,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9841,7 +9841,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9909,7 +9909,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9964,7 +9964,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10007,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "bytes",
  "eyre",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10096,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10120,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10132,7 +10132,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10155,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10198,7 +10198,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10247,7 +10247,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10275,7 +10275,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10291,7 +10291,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10306,7 +10306,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10455,7 +10455,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10475,7 +10475,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10506,7 +10506,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10553,7 +10553,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10603,7 +10603,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10617,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10648,7 +10648,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10699,7 +10699,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10727,7 +10727,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10761,7 +10761,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10776,7 +10776,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10802,7 +10802,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10820,7 +10820,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10841,7 +10841,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10857,7 +10857,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10867,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "clap",
  "eyre",
@@ -10886,7 +10886,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10905,7 +10905,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10950,7 +10950,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11003,7 +11003,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11023,7 +11023,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11052,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
+source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11082,9 +11082,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "40.0.2"
+version = "40.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d649306477c7153d0f4568976385ccb1789608e9a5b956ec781514612ccbc3"
+checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11101,9 +11101,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "11.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b0efe30093e26767c2eb4d86c369a9b3877cc034e843f074436111c4459832"
+checksum = "d8b378c2653331fe60969d9745e802cd773d82a20d8aaced914dfcf26ab8f0d9"
 dependencies = [
  "bitvec",
  "phf",
@@ -11113,9 +11113,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "18.0.2"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f54b599f334f7cd32c5de193d586f50d7cc2bd5aa07f83dfeaf85a277ad5d9a"
+checksum = "bafa298114f3cab706945de14c04e73e6e6d7896302e4183dae273f968e52f80"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11130,9 +11130,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "19.0.2"
+version = "19.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96259bca5af514ea4b92037908b0232afbc167f1f8355604118ec599caeca8c"
+checksum = "db9c13f1dfc79425931fd184b6bd373dfac7baba50859b01107d5c0e20549cbb"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11146,11 +11146,12 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "15.0.1"
+version = "15.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73c2151aded4387d96f90c958bb67f34968d40d11d1495fe41091fe220af115"
+checksum = "a69c3ce73454a09ef89a66177239d7c4f5f697227ae27254c99451866603b19d"
 dependencies = [
  "alloy-eips",
+ "derive_more",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -11160,9 +11161,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "12.1.0"
+version = "12.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f753660705cf9e7b7e45fc5607d4cebf729094d5e96dc1d1cf98cf57b69507"
+checksum = "4a2656187f9f9c22ef9dd9300ed71aeaeca3506a6a0a229a07f264649b960d68"
 dependencies = [
  "auto_impl",
  "either",
@@ -11174,9 +11175,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "20.0.2"
+version = "20.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa038202a389d72b5c1b4d6f6e8f921a93171bf02f7cfdb5308eeea5780869c1"
+checksum = "3ce1d66037ca1394128313bb995fa9f50d834927a389386bb34f8f0ef914648f"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11193,9 +11194,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "21.0.2"
+version = "21.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4375c14860fa31232673f8e963510ddaccd10d511353e35771a1d5015fed327a"
+checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
 dependencies = [
  "auto_impl",
  "either",
@@ -11231,9 +11232,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "37.0.2"
+version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecec5a33daed0d84e3e1529203451d33ca50d2a30c2e3d9959ce18ee0229a06a"
+checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11244,9 +11245,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "36.0.2"
+version = "36.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5cc580444ccf766456f7586edaf1bff9f09b7101f3a9ac0979969168e5debc6"
+checksum = "191db865091e07ecb80b12ce3048192c76071ca3d2b0a315b111b271cd4ced37"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11270,9 +11271,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "24.0.0"
+version = "24.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4a4ed40c86155d1656e1744e90e23c96e1059f3cd146d70b6d4b2882708f1c"
+checksum = "fe5102d804892908d4ebf68da29b8562895922dffa26c230ff2c4dadcf93916f"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -11281,9 +11282,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "12.0.0"
+version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc740a183b0d4c0807f565df2420ccb6a662df1d878108faddb25560164a4022"
+checksum = "40eff6067185cf80932e06f6a9c8045b012ecb6f99a8d6edc618ec2792373e14"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "bitflags 2.11.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,14 +119,14 @@ dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
@@ -155,10 +155,10 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-trie",
  "alloy-tx-macros",
  "arbitrary",
@@ -184,10 +184,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "arbitrary",
  "serde",
 ]
@@ -308,26 +308,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-eips"
-version = "1.8.3"
+name = "alloy-eip7928"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
+checksum = "4d93ce7e41bcd2b9ee2c1d92c223c1be4a274d387538d6d3f956b768986ce451"
 dependencies = [
- "alloy-eip2124",
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.8.3",
- "auto_impl",
  "borsh",
- "c-kzg",
- "derive_more",
- "either",
+ "once_cell",
  "serde",
- "serde_with",
- "sha2 0.10.9",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -339,10 +330,10 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-eip7928",
+ "alloy-eip7928 0.3.7",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "arbitrary",
  "auto_impl",
  "borsh",
@@ -358,12 +349,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
+checksum = "3585808f81853af97c12b062496d6be382e902df0e4f4c508e1305355b9e4d49"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -382,9 +373,9 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab0e0fe9e6d1120ad7bb9254c3fc2b9bc80a8df42a033fb626be6559c13d5153"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-trie",
  "borsh",
  "serde",
@@ -440,13 +431,13 @@ checksum = "a7db7b095b0b1db1d18ce7e91dcd2e82007f2d52bfb8125e6b64633a74a06bc3"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -465,9 +456,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
 ]
 
@@ -511,7 +502,7 @@ checksum = "8955ab30418343de57b356de2ea60200f9fb8016a7ea3bc7f5c6176f01a8b1cf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -632,7 +623,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
 ]
 
@@ -656,7 +647,7 @@ checksum = "2ff111a54268dc0bbd3b17f98571a7e27cc661dc081ad2999d91888647eb2e11"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
 ]
 
@@ -670,7 +661,7 @@ dependencies = [
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
  "serde_json",
 ]
@@ -681,7 +672,7 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a62f6ce2d95f59ed310bd90d5fd1566a29d1ec45cc219abbc5dcc807d31f136"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -715,10 +706,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eba59e1c069f168a01982f42a57797736923b76aa854194df4930be17867e1c"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -736,11 +727,11 @@ checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -757,10 +748,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed1004c1d68bfaee001712f83356f88031ab74a727b8560fb7fc738d1281ebe5"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
  "serde_json",
 ]
@@ -773,7 +764,7 @@ checksum = "514b4b1ce3354f65067b4fc7eb75358e0f2ec8be3340c96dea65d6894f9ca435"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -787,19 +778,8 @@ checksum = "76e34a42ebb4a71ab0bfdebc6d2f3c7bf809f01edf154d08fed159d10d1ef1d4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
-dependencies = [
- "alloy-primitives",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -6805,6 +6785,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8394,10 +8383,10 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "futures-core",
  "futures-util",
@@ -8421,10 +8410,10 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -8454,11 +8443,11 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -8474,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8487,11 +8476,11 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "backon",
@@ -8570,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8580,9 +8569,9 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "cfg-if",
  "eyre",
@@ -8600,12 +8589,12 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce542a96bf888f31854803e80b3340bc233927743aa580838014e8a88fe0d66"
+checksum = "0f54468f34d9ed03356dee71bb182a2815a490934f1a291f58158053eee946ba"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -8621,9 +8610,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634c90f1cc0f9887680ca785b0b21aa961070b9465917bf65afaec56a6d005bb"
+checksum = "c80c0516faf1698c57f91f07c98ecd9f3a9d3f163f1ad4bb263d9c495b3928e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8633,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8649,10 +8638,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928",
+ "alloy-eip7928 0.4.1",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
@@ -8663,10 +8652,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -8676,10 +8665,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -8701,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8730,7 +8719,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8756,7 +8745,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8786,9 +8775,9 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -8801,7 +8790,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8826,7 +8815,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8850,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8874,10 +8863,10 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "async-compression",
@@ -8909,10 +8898,10 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -8966,7 +8955,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8994,7 +8983,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9017,10 +9006,10 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -9042,11 +9031,11 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928",
- "alloy-eips 2.0.5",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -9101,7 +9090,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9131,10 +9120,10 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "ethereum_ssz",
@@ -9147,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9163,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9185,7 +9174,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9196,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9224,12 +9213,12 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eip7928",
- "alloy-eips 2.0.5",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -9246,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9287,7 +9276,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "clap",
  "eyre",
@@ -9310,10 +9299,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -9326,9 +9315,9 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -9342,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9355,10 +9344,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9385,10 +9374,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "reth-codecs",
@@ -9399,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9409,10 +9398,11 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -9433,10 +9423,10 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -9453,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9471,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9484,10 +9474,10 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -9503,10 +9493,10 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "eyre",
  "futures",
@@ -9541,9 +9531,9 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
@@ -9555,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "serde",
  "serde_json",
@@ -9565,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9593,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "bytes",
  "futures",
@@ -9613,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9630,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "bindgen",
  "cc",
@@ -9639,7 +9629,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "futures",
  "metrics",
@@ -9652,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9661,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9675,10 +9665,10 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -9733,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9758,10 +9748,10 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9781,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9796,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9810,7 +9800,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9827,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9851,10 +9841,10 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -9919,10 +9909,10 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
@@ -9974,9 +9964,9 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -10017,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10041,10 +10031,10 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -10065,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "bytes",
  "eyre",
@@ -10094,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10106,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10130,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10142,10 +10132,10 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -10165,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10174,12 +10164,12 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee12e304adbacbb32248c9806ebafbe1e2811fbfefe53c5e5b710a8438b7ec0"
+checksum = "2d1216ba179909d41d8d55c5eae6c1c33698bc7a3053c35fd425c7789a5de3c1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -10208,11 +10198,11 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928",
- "alloy-eips 2.0.5",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -10257,10 +10247,10 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
@@ -10286,7 +10276,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10302,7 +10292,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10317,11 +10307,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -10337,7 +10327,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -10393,9 +10383,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -10409,7 +10399,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -10423,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10466,7 +10456,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10486,9 +10476,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -10517,12 +10507,12 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eip7928",
- "alloy-eips 2.0.5",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
@@ -10530,7 +10520,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -10564,16 +10554,17 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-sol-types",
  "alloy-transport",
  "derive_more",
@@ -10613,7 +10604,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10627,9 +10618,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -10642,9 +10633,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "860fe223501a76ff14aa3bf164f739f31008c2a2905ac85708bfd88f042e6151"
+checksum = "75186b77fef29e0160f476c9a6bde3363e503f0f32ac4ef47726ef1e3da81118"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10658,10 +10649,10 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
@@ -10710,9 +10701,9 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "aquamarine",
  "auto_impl",
@@ -10738,7 +10729,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10752,7 +10743,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10772,7 +10763,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10787,10 +10778,11 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -10812,9 +10804,9 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -10830,7 +10822,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10851,10 +10843,10 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "rand 0.8.6",
@@ -10867,7 +10859,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10877,7 +10869,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "clap",
  "eyre",
@@ -10896,7 +10888,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10915,10 +10907,10 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -10960,10 +10952,10 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -10986,13 +10978,13 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-trie",
  "arbitrary",
  "arrayvec",
@@ -11013,7 +11005,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11033,9 +11025,9 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
- "alloy-eip7928",
+ "alloy-eip7928 0.4.1",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -11062,7 +11054,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
+source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11083,18 +11075,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12fafa33d2f420a9d39249a3e0357b1928d09429f30758b85280409092873b2"
+checksum = "80dcfa0327b7642cc41c71d8cd3626a48ac76fb8304c28bcbdf416a45615d020"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "38.0.0"
+version = "40.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91202d39dbe8e8d10e9e8f2b76c30da68ecd1d25be69ba6d853ad0d03a3a398a"
+checksum = "b2d649306477c7153d0f4568976385ccb1789608e9a5b956ec781514612ccbc3"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11111,9 +11103,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbb3a3d735efa94c91f2ef6bf20a35f99a77bc78f3e25bd758336901bdf9661"
+checksum = "d0b0efe30093e26767c2eb4d86c369a9b3877cc034e843f074436111c4459832"
 dependencies = [
  "bitvec",
  "phf",
@@ -11123,9 +11115,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "16.0.1"
+version = "18.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f68d928d8b228e0faeb1c6ed75c4fde7d124f1ddf9119b67e7a0ad4041237d"
+checksum = "8f54b599f334f7cd32c5de193d586f50d7cc2bd5aa07f83dfeaf85a277ad5d9a"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11140,9 +11132,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "17.0.1"
+version = "19.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3758e6167c4ba7a59a689c519a047edaefcd4c37d74f279b93ed87bc8aece4"
+checksum = "a96259bca5af514ea4b92037908b0232afbc167f1f8355604118ec599caeca8c"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11156,11 +11148,11 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "13.0.1"
+version = "15.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c281a1f11d3bcb8c0bba1199ed6bcb001d1aeb3d4fb366819e14f88723989a4e"
+checksum = "e73c2151aded4387d96f90c958bb67f34968d40d11d1495fe41091fe220af115"
 dependencies = [
- "alloy-eips 1.8.3",
+ "alloy-eips",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -11170,9 +11162,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "11.0.1"
+version = "12.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89efb9832a4e3742bb4ded5f7fe5bf905e8860e69427d4dfec153484fc6d304"
+checksum = "75f753660705cf9e7b7e45fc5607d4cebf729094d5e96dc1d1cf98cf57b69507"
 dependencies = [
  "auto_impl",
  "either",
@@ -11184,9 +11176,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "18.1.0"
+version = "20.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783e903d6922b7f5f9a940d1bb229530502d2924b1aed9d5ca5a94ebf065d460"
+checksum = "aa038202a389d72b5c1b4d6f6e8f921a93171bf02f7cfdb5308eeea5780869c1"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11203,9 +11195,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "19.0.0"
+version = "21.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8216ad58422090d0daa9eb430e0a081f7ad07e7fd30681dee71f8420c99624e0"
+checksum = "4375c14860fa31232673f8e963510ddaccd10d511353e35771a1d5015fed327a"
 dependencies = [
  "auto_impl",
  "either",
@@ -11221,9 +11213,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731b682530a732ef9c189ef831589128e2ce34d4a306c956322ae2dffe009715"
+checksum = "2854f2c48cecac90e8ad48fe8d8842707f79df2b748913b67bd2439a9ea3b4ab"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11241,9 +11233,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "35.0.1"
+version = "37.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ece9f41b69658c15d748288a4dbdfc06a63f3ce93d983af440de3f1631dce6a"
+checksum = "ecec5a33daed0d84e3e1529203451d33ca50d2a30c2e3d9959ce18ee0229a06a"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11254,9 +11246,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "34.0.0"
+version = "36.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a346a8cc6c8c39bd65306641c692191299c0a7b63d38810e39e8fe9b92378660"
+checksum = "d5cc580444ccf766456f7586edaf1bff9f09b7101f3a9ac0979969168e5debc6"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11280,24 +11272,24 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c99bda77d9661521ba0b4bc04558c6692074f01e65dd420fa3b893033d9b8a2"
+checksum = "5b4a4ed40c86155d1656e1744e90e23c96e1059f3cd146d70b6d4b2882708f1c"
 dependencies = [
  "alloy-primitives",
- "num_enum",
  "once_cell",
  "serde",
 ]
 
 [[package]]
 name = "revm-state"
-version = "11.0.1"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32490ed687dba31c3c882beb8c20408bdd30ef96690d8f145b0ee9a87040bfe"
+checksum = "fc740a183b0d4c0807f565df2420ccb6a662df1d878108faddb25560164a4022"
 dependencies = [
- "alloy-eip7928",
+ "alloy-eip7928 0.4.1",
  "bitflags 2.11.1",
+ "nonmax",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -12629,14 +12621,12 @@ dependencies = [
  "alloy",
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips 2.0.5",
- "alloy-json-rpc",
+ "alloy-eips",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rpc-client",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -12646,8 +12636,6 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures",
- "http 1.4.0",
- "reqwest 0.13.3",
  "reth-evm",
  "reth-primitives-traits",
  "reth-rpc-convert",
@@ -12661,7 +12649,6 @@ dependencies = [
  "tempo-revm",
  "test-case",
  "tokio",
- "tower",
  "tracing",
 ]
 
@@ -12669,7 +12656,7 @@ dependencies = [
 name = "tempo-chainspec"
 version = "1.5.4"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
  "alloy-hardforks",
@@ -12861,7 +12848,7 @@ name = "tempo-evm"
 version = "1.7.1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -12939,14 +12926,14 @@ name = "tempo-node"
 version = "1.7.1"
 dependencies = [
  "alloy",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "async-trait",
  "base64 0.22.1",
  "clap",
@@ -13041,7 +13028,7 @@ dependencies = [
 name = "tempo-payload-types"
 version = "1.7.1"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -13102,12 +13089,12 @@ name = "tempo-primitives"
 version = "1.7.3"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -13140,7 +13127,7 @@ name = "tempo-revm"
 version = "1.7.1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -13208,7 +13195,7 @@ name = "tempo-transaction-pool"
 version = "1.7.1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-signer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8383,7 +8383,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8410,7 +8410,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8443,7 +8443,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8463,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8476,7 +8476,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8569,7 +8569,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8638,7 +8638,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8652,7 +8652,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8665,7 +8665,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8719,7 +8719,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8745,7 +8745,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8775,7 +8775,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8790,7 +8790,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8815,7 +8815,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8839,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8863,7 +8863,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8898,7 +8898,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8955,7 +8955,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8983,7 +8983,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9006,7 +9006,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9090,7 +9090,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9174,7 +9174,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9185,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9213,7 +9213,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9235,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9276,7 +9276,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "clap",
  "eyre",
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9315,7 +9315,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9331,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9398,7 +9398,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9423,7 +9423,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9443,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9474,7 +9474,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9493,7 +9493,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "serde",
  "serde_json",
@@ -9555,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "bytes",
  "futures",
@@ -9603,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "bindgen",
  "cc",
@@ -9629,7 +9629,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "futures",
  "metrics",
@@ -9642,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9651,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9665,7 +9665,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9723,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9771,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9786,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9800,7 +9800,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9841,7 +9841,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9909,7 +9909,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9964,7 +9964,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10007,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "bytes",
  "eyre",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10096,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10120,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10132,7 +10132,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10155,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10198,7 +10198,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10247,10 +10247,9 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
@@ -10276,7 +10275,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10292,7 +10291,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10307,7 +10306,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10383,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10413,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10456,7 +10455,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10476,7 +10475,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10507,7 +10506,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10554,7 +10553,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10604,7 +10603,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10618,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10649,10 +10648,9 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
@@ -10701,7 +10699,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10729,7 +10727,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10743,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10763,7 +10761,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10778,7 +10776,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10804,7 +10802,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10822,7 +10820,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10843,7 +10841,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10859,7 +10857,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10869,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "clap",
  "eyre",
@@ -10888,7 +10886,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10907,7 +10905,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10952,7 +10950,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10978,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11005,7 +11003,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11025,7 +11023,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11054,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
+source = "git+https://github.com/paradigmxyz/reth?rev=c179be8#c179be80e06695704999be529010d5dd5a12b94e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8394,7 +8394,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8421,7 +8421,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8454,7 +8454,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8474,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8487,7 +8487,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8570,7 +8570,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8580,7 +8580,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8633,7 +8633,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8663,7 +8663,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8676,7 +8676,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8701,7 +8701,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8730,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8756,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8786,7 +8786,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8826,7 +8826,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8850,7 +8850,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8874,7 +8874,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8909,7 +8909,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8966,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8994,7 +8994,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9017,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9101,7 +9101,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9131,7 +9131,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9163,7 +9163,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9185,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9196,7 +9196,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9224,7 +9224,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9246,7 +9246,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9287,7 +9287,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "clap",
  "eyre",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9326,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9342,7 +9342,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9355,7 +9355,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9385,7 +9385,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9409,7 +9409,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9433,7 +9433,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9453,7 +9453,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9471,7 +9471,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9484,7 +9484,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9503,7 +9503,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9541,7 +9541,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9555,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "serde",
  "serde_json",
@@ -9565,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9593,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "bytes",
  "futures",
@@ -9613,7 +9613,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9630,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "bindgen",
  "cc",
@@ -9639,7 +9639,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "futures",
  "metrics",
@@ -9652,7 +9652,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9661,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9733,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9758,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9781,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9796,7 +9796,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9810,7 +9810,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9827,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9851,7 +9851,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9919,7 +9919,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9974,7 +9974,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-network",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10041,7 +10041,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10065,7 +10065,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "bytes",
  "eyre",
@@ -10094,7 +10094,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10106,7 +10106,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10130,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10142,7 +10142,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10165,7 +10165,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10208,7 +10208,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10257,7 +10257,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10286,7 +10286,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10302,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10317,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10393,7 +10393,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -10423,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10466,7 +10466,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10486,7 +10486,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -10517,7 +10517,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10564,7 +10564,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10613,7 +10613,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10627,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -10658,7 +10658,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10710,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10752,7 +10752,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10772,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10787,7 +10787,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10812,7 +10812,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -10830,7 +10830,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10851,7 +10851,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10867,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10877,7 +10877,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "clap",
  "eyre",
@@ -10896,7 +10896,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10915,7 +10915,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10960,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10986,7 +10986,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11013,7 +11013,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11033,7 +11033,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11062,7 +11062,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
+source = "git+https://github.com/paradigmxyz/reth?rev=559b0b9#559b0b9fa4938195b7c6ebfc11518755574dc1c5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,14 +119,14 @@ dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
@@ -155,10 +155,10 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-trie",
  "alloy-tx-macros",
  "arbitrary",
@@ -184,10 +184,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "arbitrary",
  "serde",
 ]
@@ -308,17 +308,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-eip7928"
-version = "0.4.1"
+name = "alloy-eips"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d93ce7e41bcd2b9ee2c1d92c223c1be4a274d387538d6d3f956b768986ce451"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
 dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-serde 1.8.3",
+ "auto_impl",
  "borsh",
- "once_cell",
+ "c-kzg",
+ "derive_more",
+ "either",
  "serde",
- "thiserror 2.0.18",
+ "serde_with",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -330,10 +339,10 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-eip7928 0.3.7",
+ "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "arbitrary",
  "auto_impl",
  "borsh",
@@ -349,12 +358,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.35.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3585808f81853af97c12b062496d6be382e902df0e4f4c508e1305355b9e4d49"
+checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -373,9 +382,9 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab0e0fe9e6d1120ad7bb9254c3fc2b9bc80a8df42a033fb626be6559c13d5153"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-trie",
  "borsh",
  "serde",
@@ -431,13 +440,13 @@ checksum = "a7db7b095b0b1db1d18ce7e91dcd2e82007f2d52bfb8125e6b64633a74a06bc3"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -456,9 +465,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -502,7 +511,7 @@ checksum = "8955ab30418343de57b356de2ea60200f9fb8016a7ea3bc7f5c6176f01a8b1cf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -623,7 +632,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -647,7 +656,7 @@ checksum = "2ff111a54268dc0bbd3b17f98571a7e27cc661dc081ad2999d91888647eb2e11"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -661,7 +670,7 @@ dependencies = [
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
  "serde_json",
 ]
@@ -672,7 +681,7 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a62f6ce2d95f59ed310bd90d5fd1566a29d1ec45cc219abbc5dcc807d31f136"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -706,10 +715,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eba59e1c069f168a01982f42a57797736923b76aa854194df4930be17867e1c"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -727,11 +736,11 @@ checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -748,10 +757,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed1004c1d68bfaee001712f83356f88031ab74a727b8560fb7fc738d1281ebe5"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
  "serde_json",
 ]
@@ -764,7 +773,7 @@ checksum = "514b4b1ce3354f65067b4fc7eb75358e0f2ec8be3340c96dea65d6894f9ca435"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -778,8 +787,19 @@ checksum = "76e34a42ebb4a71ab0bfdebc6d2f3c7bf809f01edf154d08fed159d10d1ef1d4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "serde",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -6785,15 +6805,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nonmax"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8383,10 +8394,10 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "futures-core",
  "futures-util",
@@ -8410,10 +8421,10 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -8443,11 +8454,11 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -8463,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8476,11 +8487,11 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "backon",
@@ -8559,7 +8570,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8569,9 +8580,9 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "cfg-if",
  "eyre",
@@ -8589,12 +8600,12 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f54468f34d9ed03356dee71bb182a2815a490934f1a291f58158053eee946ba"
+checksum = "fce542a96bf888f31854803e80b3340bc233927743aa580838014e8a88fe0d66"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -8610,9 +8621,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80c0516faf1698c57f91f07c98ecd9f3a9d3f163f1ad4bb263d9c495b3928e0"
+checksum = "634c90f1cc0f9887680ca785b0b21aa961070b9465917bf65afaec56a6d005bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8622,7 +8633,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8638,10 +8649,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
@@ -8652,10 +8663,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -8665,10 +8676,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -8690,7 +8701,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8719,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8745,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8775,9 +8786,9 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -8790,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8815,7 +8826,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8839,7 +8850,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8863,10 +8874,10 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "async-compression",
@@ -8898,10 +8909,10 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -8955,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8983,7 +8994,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9006,10 +9017,10 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -9031,11 +9042,11 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
- "alloy-eips",
+ "alloy-eip7928",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -9090,7 +9101,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9120,10 +9131,10 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "ethereum_ssz",
@@ -9136,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9152,7 +9163,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9174,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9185,7 +9196,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9213,12 +9224,12 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
- "alloy-eips",
+ "alloy-eip7928",
+ "alloy-eips 2.0.5",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -9235,7 +9246,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9276,7 +9287,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "clap",
  "eyre",
@@ -9299,10 +9310,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -9315,9 +9326,9 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -9331,7 +9342,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9344,10 +9355,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9374,10 +9385,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "reth-codecs",
@@ -9388,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9398,11 +9409,10 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -9423,10 +9433,10 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -9443,7 +9453,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9461,7 +9471,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9474,10 +9484,10 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -9493,10 +9503,10 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "eyre",
  "futures",
@@ -9531,9 +9541,9 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
@@ -9545,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "serde",
  "serde_json",
@@ -9555,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9583,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "bytes",
  "futures",
@@ -9603,7 +9613,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9620,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "bindgen",
  "cc",
@@ -9629,7 +9639,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "futures",
  "metrics",
@@ -9642,7 +9652,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9651,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9665,10 +9675,10 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -9723,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9748,10 +9758,10 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9771,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9786,7 +9796,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9800,7 +9810,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9817,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9841,10 +9851,10 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -9909,10 +9919,10 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
@@ -9964,9 +9974,9 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -10007,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10031,10 +10041,10 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -10055,7 +10065,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "bytes",
  "eyre",
@@ -10084,7 +10094,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10096,7 +10106,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10120,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10132,10 +10142,10 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -10155,7 +10165,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10164,12 +10174,12 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1216ba179909d41d8d55c5eae6c1c33698bc7a3053c35fd425c7789a5de3c1"
+checksum = "8ee12e304adbacbb32248c9806ebafbe1e2811fbfefe53c5e5b710a8438b7ec0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -10198,11 +10208,11 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
- "alloy-eips",
+ "alloy-eip7928",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -10247,9 +10257,10 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
@@ -10275,7 +10286,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10291,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10306,11 +10317,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -10326,7 +10337,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -10382,9 +10393,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -10398,7 +10409,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -10412,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10455,7 +10466,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10475,9 +10486,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -10506,12 +10517,12 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eip7928 0.4.1",
- "alloy-eips",
+ "alloy-eip7928",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
@@ -10519,7 +10530,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -10553,17 +10564,16 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-sol-types",
  "alloy-transport",
  "derive_more",
@@ -10603,7 +10613,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10617,9 +10627,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -10632,9 +10642,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75186b77fef29e0160f476c9a6bde3363e503f0f32ac4ef47726ef1e3da81118"
+checksum = "860fe223501a76ff14aa3bf164f739f31008c2a2905ac85708bfd88f042e6151"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10648,9 +10658,10 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
@@ -10699,9 +10710,9 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "aquamarine",
  "auto_impl",
@@ -10727,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10741,7 +10752,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10761,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10776,11 +10787,10 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -10802,9 +10812,9 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -10820,7 +10830,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10841,10 +10851,10 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "rand 0.8.6",
@@ -10857,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10867,7 +10877,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "clap",
  "eyre",
@@ -10886,7 +10896,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10905,10 +10915,10 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -10950,10 +10960,10 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -10976,13 +10986,13 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-trie",
  "arbitrary",
  "arrayvec",
@@ -11003,7 +11013,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11023,9 +11033,9 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -11052,7 +11062,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
+source = "git+https://github.com/paradigmxyz/reth?rev=27737df#27737df66d73a43a03e3ac3ebc91cd213fe295a2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11073,18 +11083,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80dcfa0327b7642cc41c71d8cd3626a48ac76fb8304c28bcbdf416a45615d020"
+checksum = "c12fafa33d2f420a9d39249a3e0357b1928d09429f30758b85280409092873b2"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "40.0.3"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
+checksum = "91202d39dbe8e8d10e9e8f2b76c30da68ecd1d25be69ba6d853ad0d03a3a398a"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11101,9 +11111,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "11.0.1"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b378c2653331fe60969d9745e802cd773d82a20d8aaced914dfcf26ab8f0d9"
+checksum = "bdbb3a3d735efa94c91f2ef6bf20a35f99a77bc78f3e25bd758336901bdf9661"
 dependencies = [
  "bitvec",
  "phf",
@@ -11113,9 +11123,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "18.0.3"
+version = "16.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafa298114f3cab706945de14c04e73e6e6d7896302e4183dae273f968e52f80"
+checksum = "c5f68d928d8b228e0faeb1c6ed75c4fde7d124f1ddf9119b67e7a0ad4041237d"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11130,9 +11140,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "19.0.3"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9c13f1dfc79425931fd184b6bd373dfac7baba50859b01107d5c0e20549cbb"
+checksum = "1f3758e6167c4ba7a59a689c519a047edaefcd4c37d74f279b93ed87bc8aece4"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11146,12 +11156,11 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "15.0.2"
+version = "13.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69c3ce73454a09ef89a66177239d7c4f5f697227ae27254c99451866603b19d"
+checksum = "c281a1f11d3bcb8c0bba1199ed6bcb001d1aeb3d4fb366819e14f88723989a4e"
 dependencies = [
- "alloy-eips",
- "derive_more",
+ "alloy-eips 1.8.3",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -11161,9 +11170,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "12.1.1"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a2656187f9f9c22ef9dd9300ed71aeaeca3506a6a0a229a07f264649b960d68"
+checksum = "d89efb9832a4e3742bb4ded5f7fe5bf905e8860e69427d4dfec153484fc6d304"
 dependencies = [
  "auto_impl",
  "either",
@@ -11175,9 +11184,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "20.0.3"
+version = "18.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce1d66037ca1394128313bb995fa9f50d834927a389386bb34f8f0ef914648f"
+checksum = "783e903d6922b7f5f9a940d1bb229530502d2924b1aed9d5ca5a94ebf065d460"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11194,9 +11203,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "21.0.3"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
+checksum = "8216ad58422090d0daa9eb430e0a081f7ad07e7fd30681dee71f8420c99624e0"
 dependencies = [
  "auto_impl",
  "either",
@@ -11212,9 +11221,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.40.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2854f2c48cecac90e8ad48fe8d8842707f79df2b748913b67bd2439a9ea3b4ab"
+checksum = "731b682530a732ef9c189ef831589128e2ce34d4a306c956322ae2dffe009715"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11232,9 +11241,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "37.0.3"
+version = "35.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
+checksum = "1ece9f41b69658c15d748288a4dbdfc06a63f3ce93d983af440de3f1631dce6a"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11245,9 +11254,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "36.0.3"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191db865091e07ecb80b12ce3048192c76071ca3d2b0a315b111b271cd4ced37"
+checksum = "a346a8cc6c8c39bd65306641c692191299c0a7b63d38810e39e8fe9b92378660"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11271,24 +11280,24 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "24.0.1"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5102d804892908d4ebf68da29b8562895922dffa26c230ff2c4dadcf93916f"
+checksum = "0c99bda77d9661521ba0b4bc04558c6692074f01e65dd420fa3b893033d9b8a2"
 dependencies = [
  "alloy-primitives",
+ "num_enum",
  "once_cell",
  "serde",
 ]
 
 [[package]]
 name = "revm-state"
-version = "12.0.1"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eff6067185cf80932e06f6a9c8045b012ecb6f99a8d6edc618ec2792373e14"
+checksum = "c32490ed687dba31c3c882beb8c20408bdd30ef96690d8f145b0ee9a87040bfe"
 dependencies = [
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928",
  "bitflags 2.11.1",
- "nonmax",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -12620,14 +12629,14 @@ dependencies = [
  "alloy",
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -12660,7 +12669,7 @@ dependencies = [
 name = "tempo-chainspec"
 version = "1.5.4"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-genesis",
  "alloy-hardforks",
@@ -12852,7 +12861,7 @@ name = "tempo-evm"
 version = "1.7.1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -12930,14 +12939,14 @@ name = "tempo-node"
 version = "1.7.1"
 dependencies = [
  "alloy",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "async-trait",
  "base64 0.22.1",
  "clap",
@@ -13032,7 +13041,7 @@ dependencies = [
 name = "tempo-payload-types"
 version = "1.7.1"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -13093,12 +13102,12 @@ name = "tempo-primitives"
 version = "1.7.3"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -13131,7 +13140,7 @@ name = "tempo-revm"
 version = "1.7.1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -13199,7 +13208,7 @@ name = "tempo-transaction-pool"
 version = "1.7.1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
  "alloy-signer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8383,7 +8383,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8410,7 +8410,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8443,7 +8443,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8463,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8476,7 +8476,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8569,7 +8569,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8638,7 +8638,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8652,7 +8652,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8665,7 +8665,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8719,7 +8719,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8745,7 +8745,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8775,7 +8775,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8790,7 +8790,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8815,7 +8815,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8839,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8863,7 +8863,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8898,7 +8898,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8955,7 +8955,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8983,7 +8983,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9006,7 +9006,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9090,7 +9090,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9174,7 +9174,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9185,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9213,7 +9213,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9235,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9276,7 +9276,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "clap",
  "eyre",
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9315,7 +9315,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9331,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9398,7 +9398,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9423,7 +9423,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9443,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9474,7 +9474,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9493,7 +9493,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "serde",
  "serde_json",
@@ -9555,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "bytes",
  "futures",
@@ -9603,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "bindgen",
  "cc",
@@ -9629,7 +9629,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "futures",
  "metrics",
@@ -9642,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9651,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9665,7 +9665,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9723,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9771,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9786,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9800,7 +9800,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9841,7 +9841,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9909,7 +9909,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9964,7 +9964,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10007,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "bytes",
  "eyre",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10096,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10120,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10132,7 +10132,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10155,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10198,7 +10198,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10247,7 +10247,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10275,7 +10275,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10291,7 +10291,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10306,7 +10306,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10455,7 +10455,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10475,7 +10475,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10506,7 +10506,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10553,7 +10553,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10603,7 +10603,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10617,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10648,7 +10648,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10699,7 +10699,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10727,7 +10727,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10761,7 +10761,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10776,7 +10776,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10802,7 +10802,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10820,7 +10820,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10841,7 +10841,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10857,7 +10857,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10867,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "clap",
  "eyre",
@@ -10886,7 +10886,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10905,7 +10905,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10950,7 +10950,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11003,7 +11003,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11023,7 +11023,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11052,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=980872d#980872d606b4f28a34eacc621bfd9a74c4f6f1aa"
+source = "git+https://github.com/paradigmxyz/reth?rev=40692d9#40692d91f6f8edf67ce69eb85e9d9ba8fa17a623"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8383,7 +8383,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8410,7 +8410,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8443,7 +8443,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8463,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8476,7 +8476,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8569,7 +8569,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8638,7 +8638,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8652,7 +8652,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8665,7 +8665,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8719,7 +8719,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8745,7 +8745,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8775,7 +8775,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8790,7 +8790,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8815,7 +8815,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8839,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8863,7 +8863,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8898,7 +8898,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8955,7 +8955,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8983,7 +8983,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9006,7 +9006,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9090,7 +9090,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9174,7 +9174,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9185,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9213,7 +9213,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9235,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9276,7 +9276,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "clap",
  "eyre",
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9315,7 +9315,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9331,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9398,7 +9398,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9423,7 +9423,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9443,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9474,7 +9474,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9493,7 +9493,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "serde",
  "serde_json",
@@ -9555,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9583,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "bytes",
  "futures",
@@ -9603,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "bindgen",
  "cc",
@@ -9629,7 +9629,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "futures",
  "metrics",
@@ -9642,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9651,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9665,7 +9665,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9723,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9771,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9786,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9800,7 +9800,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9841,7 +9841,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9909,7 +9909,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9964,7 +9964,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10007,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "bytes",
  "eyre",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10096,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10120,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10132,7 +10132,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10155,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10198,7 +10198,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10247,7 +10247,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10276,7 +10276,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10292,7 +10292,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10307,7 +10307,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10413,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10456,7 +10456,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10476,7 +10476,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10507,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10554,7 +10554,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10604,7 +10604,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10618,7 +10618,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10701,7 +10701,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10729,7 +10729,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10743,7 +10743,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10763,7 +10763,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10778,7 +10778,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10804,7 +10804,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10822,7 +10822,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10843,7 +10843,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10859,7 +10859,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10869,7 +10869,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "clap",
  "eyre",
@@ -10888,7 +10888,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10907,7 +10907,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10952,7 +10952,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10978,7 +10978,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11005,7 +11005,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11054,7 +11054,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f6e3eba#f6e3ebad9ff946b283bf3fb18c0230bd9f1e79e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=ec9b772#ec9b772dca8fd1662bbd0baf7cec8db2ea416149"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12622,9 +12622,11 @@ dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-eips",
+ "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
+ "alloy-rpc-client",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
@@ -12636,6 +12638,8 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures",
+ "http 1.4.0",
+ "reqwest 0.13.3",
  "reth-evm",
  "reth-primitives-traits",
  "reth-rpc-convert",
@@ -12649,6 +12653,7 @@ dependencies = [
  "tempo-revm",
  "test-case",
  "tokio",
+ "tower",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "27737df", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "27737df", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "27737df", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "27737df", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,7 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "980872d", feat
   "std",
   "optional-checks",
 ] }
-revm = { version = "40.0.2", features = ["optional_fee_charge"], default-features = false }
+revm = { version = "40.0.3", features = ["optional_fee_charge"], default-features = false }
 
 alloy = { version = "2.0.5", default-features = false }
 alloy-consensus = { version = "2.0.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "980872d", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "980872d", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "980872d", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "980872d", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "40692d9", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "559b0b9", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
 reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-codecs = { version = "0.3.0", default-features = false }
+reth-codecs = { version = "0.4.0", default-features = false }
 reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
 reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
 reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
@@ -177,7 +177,7 @@ reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3e
 reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
 reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
-reth-primitives-traits = { version = "0.3.1", default-features = false }
+reth-primitives-traits = { version = "0.4.0", default-features = false }
 reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
 reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba" }
@@ -203,14 +203,14 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f6e3eba", feat
   "std",
   "optional-checks",
 ] }
-revm = { version = "38.0.0", features = ["optional_fee_charge"], default-features = false }
+revm = { version = "40.0.2", features = ["optional_fee_charge"], default-features = false }
 
 alloy = { version = "2.0.5", default-features = false }
 alloy-consensus = { version = "2.0.5", default-features = false }
 alloy-contract = { version = "2.0.5", default-features = false }
 alloy-eips = { version = "2.0.5", default-features = false }
-alloy-evm = { version = "0.34.0", default-features = false }
-revm-inspectors = "0.39.0"
+alloy-evm = { version = "0.35.0", default-features = false }
+revm-inspectors = "0.40.0"
 alloy-genesis = { version = "2.0.5", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-abi = { version = "1.6.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "980872d", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "980872d", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "980872d", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "980872d" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "980872d", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,77 +140,77 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "27737df", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-codecs = { version = "0.3.0", default-features = false }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "27737df", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "27737df", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-primitives-traits = { version = "0.3.1", default-features = false }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "27737df" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "27737df", features = [
   "std",
   "optional-checks",
 ] }
-revm = { version = "40.0.3", features = ["optional_fee_charge"], default-features = false }
+revm = { version = "38.0.0", features = ["optional_fee_charge"], default-features = false }
 
 alloy = { version = "2.0.5", default-features = false }
 alloy-consensus = { version = "2.0.5", default-features = false }
 alloy-contract = { version = "2.0.5", default-features = false }
 alloy-eips = { version = "2.0.5", default-features = false }
-alloy-evm = { version = "0.35.0", default-features = false }
-revm-inspectors = "0.40.0"
+alloy-evm = { version = "0.34.0", default-features = false }
+revm-inspectors = "0.39.0"
 alloy-genesis = { version = "2.0.5", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-abi = { version = "1.6.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "ec9b772", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "c179be8", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/evm/benches/tip20_execution.rs
+++ b/crates/evm/benches/tip20_execution.rs
@@ -147,8 +147,7 @@ impl ExecutionFixture {
     }
 
     fn prewarm_state_db(&self) -> FixedCacheDb {
-        let provider =
-            CachedStateProvider::new_prewarm(self.provider.clone(), self.cache.clone());
+        let provider = CachedStateProvider::new_prewarm(self.provider.clone(), self.cache.clone());
         State::builder()
             .with_database(StateProviderDatabase::new(provider))
             .with_bundle_update()

--- a/crates/evm/benches/tip20_execution.rs
+++ b/crates/evm/benches/tip20_execution.rs
@@ -131,15 +131,14 @@ struct ExecutionFixture {
     metrics: CachedStateMetrics,
 }
 
-type FixedCacheDb<const PREWARM: bool = false> =
-    State<StateProviderDatabase<CachedStateProvider<InMemoryStateProvider, PREWARM>>>;
+type FixedCacheDb = State<StateProviderDatabase<CachedStateProvider<InMemoryStateProvider>>>;
 
 impl ExecutionFixture {
     fn state_db(&self) -> FixedCacheDb {
         let provider = CachedStateProvider::new(
             self.provider.clone(),
             self.cache.clone(),
-            self.metrics.clone(),
+            Some(self.metrics.clone()),
         );
         State::builder()
             .with_database(StateProviderDatabase::new(provider))
@@ -147,12 +146,9 @@ impl ExecutionFixture {
             .build()
     }
 
-    fn prewarm_state_db(&self) -> FixedCacheDb<true> {
-        let provider = CachedStateProvider::new_prewarm(
-            self.provider.clone(),
-            self.cache.clone(),
-            self.metrics.clone(),
-        );
+    fn prewarm_state_db(&self) -> FixedCacheDb {
+        let provider =
+            CachedStateProvider::new_prewarm(self.provider.clone(), self.cache.clone());
         State::builder()
             .with_database(StateProviderDatabase::new(provider))
             .with_bundle_update()

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -69,10 +69,16 @@ pub struct TempoEvm<DB: Database, I = NoOpInspector> {
 
 impl<DB: Database> TempoEvm<DB> {
     /// Create a new [`TempoEvm`] instance.
-    pub fn new(db: DB, input: EvmEnv<TempoHardfork, TempoBlockEnv>) -> Self {
+    pub fn new(db: DB, mut input: EvmEnv<TempoHardfork, TempoBlockEnv>) -> Self {
         // TIP-1016 (EIP-8037 state gas split) is gated by `cfg_env.enable_amsterdam_eip8037`
         // and is independent of the T4 hardfork. The caller is responsible for setting the
         // flag on the input `EvmEnv`; here we pass it through unchanged.
+        //
+        // Tempo's TIP-1016 gas params (`tempo_gas_params_with_amsterdam`) store absolute
+        // state-gas values (e.g. 230_000 for SSTORE zero→non-zero). Upstream revm now
+        // multiplies state-gas params by `cpsb` at charge time. Pin `cpsb = 1` so the
+        // multiplication is a no-op and the stored values are charged verbatim.
+        input.cfg_env.cpsb_override.get_or_insert(1);
         let ctx = Context::mainnet()
             .with_db(db)
             .with_block(input.block_env)

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -13,7 +13,7 @@ use alloy_evm::{
 use alloy_primitives::{Address, Bytes, TxKind};
 use reth_revm::{
     InspectSystemCallEvm, MainContext,
-    context::{CfgEnv, DBErrorMarker, result::ExecutionResult},
+    context::{CfgEnv, result::ExecutionResult},
 };
 use std::ops::{Deref, DerefMut};
 use tempo_chainspec::hardfork::TempoHardfork;

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -69,16 +69,14 @@ pub struct TempoEvm<DB: Database, I = NoOpInspector> {
 
 impl<DB: Database> TempoEvm<DB> {
     /// Create a new [`TempoEvm`] instance.
-    pub fn new(db: DB, mut input: EvmEnv<TempoHardfork, TempoBlockEnv>) -> Self {
+    pub fn new(db: DB, input: EvmEnv<TempoHardfork, TempoBlockEnv>) -> Self {
         // TIP-1016 (EIP-8037 state gas split) is gated by `cfg_env.enable_amsterdam_eip8037`
         // and is independent of the T4 hardfork. The caller is responsible for setting the
         // flag on the input `EvmEnv`; here we pass it through unchanged.
         //
         // Tempo's TIP-1016 gas params (`tempo_gas_params_with_amsterdam`) store absolute
-        // state-gas values (e.g. 230_000 for SSTORE zero→non-zero). Upstream revm now
-        // multiplies state-gas params by `cpsb` at charge time. Pin `cpsb = 1` so the
-        // multiplication is a no-op and the stored values are charged verbatim.
-        input.cfg_env.cpsb_override.get_or_insert(1);
+        // state-gas values (e.g. 230_000 for SSTORE zero→non-zero), which are charged
+        // verbatim by upstream revm.
         let ctx = Context::mainnet()
             .with_db(db)
             .with_block(input.block_env)
@@ -466,7 +464,7 @@ mod tests {
         // T1 has tx_eip7702_per_empty_account_cost = 12,500
         let gas_params = &evm.ctx().cfg.gas_params;
         assert_eq!(
-            gas_params.tx_eip7702_per_empty_account_cost(0),
+            gas_params.tx_eip7702_per_empty_account_cost(),
             12_500,
             "T1 should have EIP-7702 per empty account cost of 12,500"
         );
@@ -505,12 +503,12 @@ mod tests {
             .ctx()
             .cfg
             .gas_params
-            .tx_eip7702_per_empty_account_cost(0);
+            .tx_eip7702_per_empty_account_cost();
         let t1_eip7702_cost = t1_evm
             .ctx()
             .cfg
             .gas_params
-            .tx_eip7702_per_empty_account_cost(0);
+            .tx_eip7702_per_empty_account_cost();
 
         assert_eq!(t0_eip7702_cost, 25_000, "T0 should have default 25,000");
         assert_eq!(t1_eip7702_cost, 12_500, "T1 should have reduced 12,500");

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -13,7 +13,7 @@ use alloy_evm::{
 use alloy_primitives::{Address, Bytes, TxKind};
 use reth_revm::{
     InspectSystemCallEvm, MainContext,
-    context::{CfgEnv, result::ExecutionResult},
+    context::{CfgEnv, DBErrorMarker, result::ExecutionResult},
 };
 use std::ops::{Deref, DerefMut};
 use tempo_chainspec::hardfork::TempoHardfork;
@@ -460,7 +460,7 @@ mod tests {
         // T1 has tx_eip7702_per_empty_account_cost = 12,500
         let gas_params = &evm.ctx().cfg.gas_params;
         assert_eq!(
-            gas_params.tx_eip7702_per_empty_account_cost(),
+            gas_params.tx_eip7702_per_empty_account_cost(0),
             12_500,
             "T1 should have EIP-7702 per empty account cost of 12,500"
         );
@@ -499,12 +499,12 @@ mod tests {
             .ctx()
             .cfg
             .gas_params
-            .tx_eip7702_per_empty_account_cost();
+            .tx_eip7702_per_empty_account_cost(0);
         let t1_eip7702_cost = t1_evm
             .ctx()
             .cfg
             .gas_params
-            .tx_eip7702_per_empty_account_cost();
+            .tx_eip7702_per_empty_account_cost(0);
 
         assert_eq!(t0_eip7702_cost, 25_000, "T0 should have default 25,000");
         assert_eq!(t1_eip7702_cost, 12_500, "T1 should have reduced 12,500");

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -288,7 +288,7 @@ where
             state_provider = Box::new(CachedStateProvider::new(
                 state_provider,
                 execution_cache.cache().clone(),
-                self.cache_metrics.clone(),
+                Some(self.cache_metrics.clone()),
             ));
         }
         if self.state_provider_metrics {

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -6,7 +6,7 @@ use std::sync::{
 
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
 use alloy_sol_types::SolInterface;
-use reth_engine_tree::tree::{CachedStateMetrics, CachedStateProvider, SavedCache};
+use reth_engine_tree::tree::{CachedStateProvider, SavedCache};
 use reth_evm::{Database, Evm, EvmEnvFor};
 use reth_revm::database::StateProviderDatabase;
 use reth_storage_api::{StateProviderBox, StateProviderFactory};
@@ -316,8 +316,6 @@ where
             state_provider = Box::new(CachedStateProvider::new_prewarm(
                 state_provider,
                 cache.cache().clone(),
-                // Use unlabeled default metrics to avoid polluting the builder metrics.
-                CachedStateMetrics::default(),
             ));
         }
 

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -171,11 +171,12 @@ macro_rules! tempo_precompile {
             }
             let mut storage = crate::storage::evm::EvmPrecompileStorageProvider::new(
                 $input.internals,
-                &cfg,
-                gas_params.clone(),
                 $input.gas,
                 $input.reservoir,
+                cfg.spec,
+                cfg.enable_amsterdam_eip8037,
                 $input.is_static,
+                gas_params.clone(),
             );
             crate::storage::StorageCtx::enter(&mut storage, || {
                 $impl.call($input.data, $input.caller)

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -159,9 +159,11 @@ sol! {
 
 macro_rules! tempo_precompile {
     ($id:expr, $cfg:expr, |$input:ident| $impl:expr) => {{
+        use revm::context::Cfg as _;
         let spec = $cfg.spec;
         let amsterdam_eip8037_enabled = $cfg.enable_amsterdam_eip8037;
         let gas_params = $cfg.gas_params.clone();
+        let cpsb = $cfg.cpsb();
         DynPrecompile::new_stateful(PrecompileId::Custom($id.into()), move |$input| {
             if !$input.is_direct_call() {
                 return Ok(PrecompileOutput::revert(
@@ -178,6 +180,7 @@ macro_rules! tempo_precompile {
                 amsterdam_eip8037_enabled,
                 $input.is_static,
                 gas_params.clone(),
+                cpsb,
             );
             crate::storage::StorageCtx::enter(&mut storage, || {
                 $impl.call($input.data, $input.caller)

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -159,11 +159,8 @@ sol! {
 
 macro_rules! tempo_precompile {
     ($id:expr, $cfg:expr, |$input:ident| $impl:expr) => {{
-        use revm::context::Cfg as _;
-        let spec = $cfg.spec;
-        let amsterdam_eip8037_enabled = $cfg.enable_amsterdam_eip8037;
+        let cfg = $cfg.clone();
         let gas_params = $cfg.gas_params.clone();
-        let cpsb = $cfg.cpsb();
         DynPrecompile::new_stateful(PrecompileId::Custom($id.into()), move |$input| {
             if !$input.is_direct_call() {
                 return Ok(PrecompileOutput::revert(
@@ -174,13 +171,11 @@ macro_rules! tempo_precompile {
             }
             let mut storage = crate::storage::evm::EvmPrecompileStorageProvider::new(
                 $input.internals,
+                &cfg,
+                gas_params.clone(),
                 $input.gas,
                 $input.reservoir,
-                spec,
-                amsterdam_eip8037_enabled,
                 $input.is_static,
-                gas_params.clone(),
-                cpsb,
             );
             crate::storage::StorageCtx::enter(&mut storage, || {
                 $impl.call($input.data, $input.caller)

--- a/crates/primitives/src/reth_compat/header.rs
+++ b/crates/primitives/src/reth_compat/header.rs
@@ -139,7 +139,7 @@ mod codec {
     }
 
     impl reth_db_api::table::Decompress for TempoHeader {
-        fn decompress(value: &[u8]) -> Result<Self, reth_codecs::DecompressError> {
+        fn decompress(value: &[u8]) -> Result<Self, reth_codecs::compress::DecompressError> {
             let (obj, _) = reth_codecs::Compact::from_compact(value, value.len());
             Ok(obj)
         }


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`aec6ba0...40692d9`](https://github.com/paradigmxyz/reth/compare/aec6ba0...40692d9)

🔗 Amp thread: https://ampcode.com/threads/T-019e6972-a1e3-77bd-a0d7-6a24e8eac034
- **Networking**: use B256 collections for tx hashes ([#24565](https://github.com/paradigmxyz/reth/pull/24565))
- **Transaction Pool**: preallocate propagation vectors ([#24554](https://github.com/paradigmxyz/reth/pull/24554)); add borrowed pool transactions iterator ([#24556](https://github.com/paradigmxyz/reth/pull/24556))
- **Engine**: split execution cache policy ([#24568](https://github.com/paradigmxyz/reth/pull/24568)); flush state provider metrics explicitly ([#24575](https://github.com/paradigmxyz/reth/pull/24575))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019e6972-b35a-74be-8d5e-6b63f6feb614
- **Bumped reth git rev** from `aec6ba0` to `40692d9` across all `reth-*` workspace dependencies in `Cargo.toml`.
- **`CachedStateProvider` no longer has a `PREWARM` const generic** — removed the `<const PREWARM: bool = false>` type parameter; `FixedCacheDb` in the TIP-20 bench is now a single non-generic alias.
- **`CachedStateProvider::new` metrics parameter is now `Option<CachedStateMetrics>`** — updated call sites in the TIP-20 bench and payload builder to wrap the metrics in `Some(...)`.
- **`CachedStateProvider::new_prewarm` no longer takes a metrics argument** — removed the `CachedStateMetrics::default()` / `metrics.clone()` argument from prewarming call sites in the bench and `crates/payload/builder/src/prewarming.rs` (also dropped the now-unused `CachedStateMetrics` import).
- **`reth_codecs::DecompressError` moved to `reth_codecs::compress::DecompressError`** — updated the `Decompress` impl for `TempoHeader` to use the new path.
- **Precompile macro now clones the full `cfg`** instead of destructuring `spec` and `enable_amsterdam_eip8037` separately, reading `cfg.spec` / `cfg.enable_amsterdam_eip8037` inside the closure (likely to accommodate an upstream field/shape change on the cfg type).
- **Added a clarifying comment in `TempoEvm`** noting that TIP-1016 stores absolute state-gas values charged verbatim by upstream revm — no behavior change, documenting an invariant after the upstream bump.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/26511283486)
