### PR TITLE
ci: shell-quote e2e bench node command

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -417,6 +417,14 @@ def taskset-command [cmd: list<string>, cpus: string] {
     }
 }
 
+def shell-quote [arg: string] {
+    $arg | to json --raw
+}
+
+def shell-command [cmd: list<string>] {
+    $cmd | each { |arg| shell-quote $arg } | str join " "
+}
+
 def start-e2e-local-node [
     role: string,
     phase: string,
@@ -437,7 +445,7 @@ def start-e2e-local-node [
     } else { [] }
     let pinned_cmd = taskset-command [$tempo_bin ...$args] $cpus
     let node_cmd = wrap-samply $pinned_cmd $samply $full_samply_args
-    let node_cmd_str = ($node_cmd | str join " ")
+    let node_cmd_str = (shell-command $node_cmd)
     let script = $"($env_prefix)($otel_attrs)($tracy_env_prefix)($node_cmd_str) 2>&1"
     let unit_phase = ($phase | str replace -a "_" "-" | str replace -a "." "-")
     let runner = (systemd-scope-command $"tempo-e2e-($role)-($unit_phase)" $cpus $memory $script)


### PR DESCRIPTION
## Summary
- Shell-quote the local e2e benchmark node argv before embedding it in the `bash -lc` script passed through `systemd-run`.
- This keeps extra node args such as `--builder.enable-prewarming --consensus.time-to-prepare-proposal-transactions=400ms` from breaking shell parsing when the dispatch input or rendered argv includes quoting/spaces.

## Failure window
- The provided run URL did not resolve through the GitHub Actions API for `tempoxyz/tempo`.
- The first recent accessible `bench-e2e` failure on `main` was [run 26172699473](https://github.com/tempoxyz/tempo/actions/runs/26172699473), started 2026-05-20 15:30:24 UTC on `01f1ec340`.
- That run failed before producing benchmark summaries: artifacts only contained `run-order.txt`, and the log showed both validators exited before readiness in `baseline-1`.
- Earlier same-SHA run [26171157092](https://github.com/tempoxyz/tempo/actions/runs/26171157092) succeeded, and later runs on main succeeded, so this looked like a dispatch/input-sensitive bench harness failure rather than a deterministic code perf regression.

## Profile
- No usable perf profile was produced by the failing run because the validators exited during startup.
- The failure log showed the generated `bash -lc` command ending with unescaped node args before `2>&1`, so the shell wrapper was the immediate brittle point.

## Verification
- Inspected failing run/job logs and artifacts for [run 26172699473](https://github.com/tempoxyz/tempo/actions/runs/26172699473).
- Inspected adjacent successful benchmark [run 26176044414](https://github.com/tempoxyz/tempo/actions/runs/26176044414), which produced `summary.json` and completed successfully.
- Not run locally: `nu` is not installed in this sandbox, and the actual e2e harness requires the self-hosted bare-metal schelk runner.


## Follow-up validation
- First PR validation run [26211515205](https://github.com/tempoxyz/tempo/actions/runs/26211515205) caught a Nushell parser error in the initial helper implementation; fixed in amended commit `c11591996`.
- Second validation run [26211559608](https://github.com/tempoxyz/tempo/actions/runs/26211559608) is in progress and has passed the early parser/setup phase.