### PR TITLE
Make CodSpeed workflow manual only

### DIFF
--- a/.github/workflows/codspeed-microbench.yml
+++ b/.github/workflows/codspeed-microbench.yml
@@ -5,9 +5,6 @@ permissions:
   id-token: write
 
 on:
-  push:
-    branches: [main]
-  pull_request:
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- remove automatic push and pull_request triggers from the CodSpeed microbenchmark workflow
- leave workflow_dispatch inputs intact so benchmarks can still be run manually

## Verification
- checked the workflow file no longer contains push or pull_request triggers
