### PR TITLE
chore: reset main version to 1.7.0

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -77,8 +77,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          # tmp: mablr/bump_alloy_2.0.5
-          ref: 08bf6fcdc3765a421f2239c0bf78cdcc9267104d
+          # tmp: rus/bump-tempo-v1.7
+          ref: 2a70688470dd684e00d54b4ac1a9b165162960be
           path: foundry
           persist-credentials: false
 
@@ -220,8 +220,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          # tmp: mablr/bump_alloy_2.0.5
-          ref: 08bf6fcdc3765a421f2239c0bf78cdcc9267104d
+          # tmp: rus/bump-tempo-v1.7
+          ref: 2a70688470dd684e00d54b4ac1a9b165162960be
           path: foundry
           persist-credentials: false
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12541,7 +12541,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -12680,7 +12680,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12739,7 +12739,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node-config"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -12752,7 +12752,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12783,7 +12783,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12797,7 +12797,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12848,7 +12848,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -12886,7 +12886,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "clap",
  "dirs-next",
@@ -12905,7 +12905,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "eyre",
  "indenter",
@@ -12913,7 +12913,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -12926,7 +12926,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "alloy-eips 2.0.5",
@@ -12994,7 +12994,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13027,7 +13027,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -13045,7 +13045,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13077,7 +13077,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13125,7 +13125,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -13159,7 +13159,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "clap",
@@ -13184,7 +13184,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "eyre",
  "jiff",
@@ -13193,7 +13193,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -13232,7 +13232,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13244,7 +13244,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.7.1"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "alloy-json-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.7.1"
+version = "1.7.0"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Resets the workspace package version on main back to 1.7.0 which was bumped by accident. The v1.7.1 version should live only on the release branch until the release is tagged.