### PR TITLE
feat(payload-builder): add BAL builder flag

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -69,8 +69,13 @@ pub struct TempoNodeArgs {
     #[arg(long = "builder.enable-prewarming", default_value_t = false)]
     pub builder_enable_prewarming: bool,
 
-    /// Enable EIP-7928 block access list collection in the payload builder.
-    #[arg(long = "builder.enable-bal", default_value_t = false)]
+    /// Experimental: enable EIP-7928 block access list collection in the payload builder.
+    #[arg(
+        long = "builder.enable-bal",
+        default_value_t = false,
+        hide = true,
+        help = "EXPERIMENTAL: Enable EIP-7928 block access list collection in the payload builder."
+    )]
     pub builder_enable_bal: bool,
 }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -68,6 +68,10 @@ pub struct TempoNodeArgs {
     /// Enable prewarming for the payload builder.
     #[arg(long = "builder.enable-prewarming", default_value_t = false)]
     pub builder_enable_prewarming: bool,
+
+    /// Enable EIP-7928 block access list collection in the payload builder.
+    #[arg(long = "builder.enable-bal", default_value_t = false)]
+    pub builder_enable_bal: bool,
 }
 
 impl TempoNodeArgs {
@@ -84,6 +88,7 @@ impl TempoNodeArgs {
         TempoPayloadBuilderBuilder {
             state_provider_metrics: self.builder_state_provider_metrics,
             enable_prewarming: self.builder_enable_prewarming,
+            enable_bal: self.builder_enable_bal,
         }
     }
 }
@@ -491,6 +496,8 @@ pub struct TempoPayloadBuilderBuilder {
     pub state_provider_metrics: bool,
     /// Enable prewarming for the payload builder.
     pub enable_prewarming: bool,
+    /// Enable EIP-7928 block access list collection in the payload builder.
+    pub enable_bal: bool,
 }
 
 impl<Node> PayloadBuilderBuilder<Node, TempoTransactionPool<Node::Provider>, TempoEvmConfig>
@@ -514,6 +521,7 @@ where
             ctx.is_dev(),
             self.state_provider_metrics,
             self.enable_prewarming,
+            self.enable_bal,
         ))
     }
 }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -32,8 +32,10 @@ use reth_evm::{
 use reth_execution_types::BlockExecutionOutput;
 use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError};
 use reth_payload_primitives::{BuiltPayload, BuiltPayloadExecutedBlock};
-use reth_primitives_traits::{Recovered, transaction::error::InvalidTransactionError};
-use reth_revm::{State, context::Block, database::StateProviderDatabase};
+use reth_primitives_traits::{
+    Recovered, RecoveredBlock, transaction::error::InvalidTransactionError,
+};
+use reth_revm::{State, context::Block as _, database::StateProviderDatabase};
 use reth_storage_api::StateProviderFactory;
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{
@@ -52,7 +54,7 @@ use tempo_evm::{TempoEvmConfig, TempoNextBlockEnvAttributes, TempoStateAccess, e
 use tempo_payload_types::{TempoBuiltPayload, TempoPayloadAttributes};
 use tempo_precompiles::validator_config_v2::ValidatorConfigV2;
 use tempo_primitives::{
-    RecoveredSubBlock, SubBlockMetadata, TempoHeader, TempoTxEnvelope,
+    Block as TempoBlock, RecoveredSubBlock, SubBlockMetadata, TempoHeader, TempoTxEnvelope,
     subblock::PartialValidatorKey,
     transaction::envelope::{TEMPO_SYSTEM_TX_SENDER, TEMPO_SYSTEM_TX_SIGNATURE},
 };
@@ -97,6 +99,8 @@ pub struct TempoPayloadBuilder<Provider> {
     state_provider_metrics: bool,
     /// Whether to enable prewarming of best transactions.
     enable_prewarming: bool,
+    /// Whether to collect EIP-7928 block access lists while building payloads.
+    enable_bal: bool,
 }
 
 impl<Provider> TempoPayloadBuilder<Provider> {
@@ -108,6 +112,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
         is_dev: bool,
         state_provider_metrics: bool,
         enable_prewarming: bool,
+        enable_bal: bool,
     ) -> Self {
         Self {
             pool,
@@ -120,6 +125,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             is_dev,
             state_provider_metrics,
             enable_prewarming,
+            enable_bal,
         }
     }
 }
@@ -298,6 +304,7 @@ where
         let mut db = State::builder()
             .with_database(Box::new(state) as Box<dyn Database<Error = ProviderError>>)
             .with_bundle_update()
+            .with_bal_builder_if(self.enable_bal)
             .build();
         drop(_state_setup_span);
         self.metrics
@@ -728,7 +735,7 @@ where
             block,
             hashed_state,
             trie_updates,
-            ..
+            block_access_list,
         } = if let Some(mut handle) = trie_handle {
             // Dropping the hook signals that execution is complete and the sparse trie task can
             // finalize the state root it has been updating incrementally.
@@ -763,6 +770,8 @@ where
         } else {
             builder.finish(finish_provider(), None)?
         };
+        let block_access_list = block_access_list.map(|bal| alloy_rlp::encode(&bal).into());
+        let block = clear_block_access_list_hash(block);
         drop(_finish_span);
         let builder_finish_elapsed = builder_finish_start.elapsed();
         self.metrics
@@ -874,7 +883,8 @@ where
             "Built payload"
         );
 
-        let eth_payload = EthBuiltPayload::new(sealed_block, total_fees, requests, None);
+        let eth_payload =
+            EthBuiltPayload::new(sealed_block, total_fees, requests, block_access_list);
 
         let execution_output = BlockExecutionOutput {
             result: execution_result,
@@ -900,6 +910,12 @@ where
             })
         }
     }
+}
+
+fn clear_block_access_list_hash(block: RecoveredBlock<TempoBlock>) -> RecoveredBlock<TempoBlock> {
+    let (mut block, senders) = block.split();
+    block.header.inner.block_access_list_hash = None;
+    RecoveredBlock::new_unhashed(block, senders)
 }
 
 pub fn is_more_subblocks(
@@ -1135,5 +1151,24 @@ mod tests {
         // No valid_before → NOT expired
         let subblock_no_expiry = RecoveredSubBlock::with_valid_before(None);
         assert!(!has_expired_transactions(&subblock_no_expiry, 1000));
+    }
+
+    #[test]
+    fn test_clear_block_access_list_hash() {
+        let mut header = TempoHeader::default();
+        header.inner.block_access_list_hash = Some(B256::random());
+        let block = Block {
+            header,
+            body: BlockBody {
+                transactions: vec![],
+                ommers: vec![],
+                withdrawals: None,
+            },
+        };
+
+        let recovered = RecoveredBlock::new_unhashed(block, vec![]);
+        let cleared = clear_block_access_list_hash(recovered);
+
+        assert_eq!(cleared.header().inner.block_access_list_hash, None);
     }
 }

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -5,12 +5,11 @@
 
 mod attrs;
 
-use alloy_primitives::B256;
+use alloy_primitives::{B256, Bytes, U256};
 pub use attrs::{InterruptHandle, TempoPayloadAttributes};
 use std::sync::Arc;
 
 use alloy_eips::eip7685::Requests;
-use alloy_primitives::U256;
 use alloy_rpc_types_eth::Withdrawal;
 use reth_ethereum_engine_primitives::EthBuiltPayload;
 use reth_node_api::{BlockBody, ExecutionPayload, PayloadTypes};
@@ -68,12 +67,59 @@ impl BuiltPayload for TempoBuiltPayload {
         self.inner.fees()
     }
 
+    fn block_access_list(&self) -> Option<&Bytes> {
+        self.inner.block_access_list()
+    }
+
     fn executed_block(&self) -> Option<BuiltPayloadExecutedBlock<Self::Primitives>> {
         self.executed_block.clone()
     }
 
     fn requests(&self) -> Option<Requests> {
         self.inner.requests()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempo_primitives::TempoHeader;
+
+    fn empty_sealed_block() -> Arc<SealedBlock<Block>> {
+        let block = Block {
+            header: TempoHeader::default(),
+            body: Default::default(),
+        };
+
+        Arc::new(SealedBlock::seal_slow(block))
+    }
+
+    #[test]
+    fn built_payload_exposes_block_access_list() {
+        let block_access_list = Bytes::from_static(&[0xc0]);
+        let eth_payload = EthBuiltPayload::new(
+            empty_sealed_block(),
+            U256::ZERO,
+            None,
+            Some(block_access_list.clone()),
+        );
+        let payload = TempoBuiltPayload::new(eth_payload, None);
+
+        assert_eq!(payload.block_access_list(), Some(&block_access_list));
+    }
+
+    #[test]
+    fn execution_data_does_not_carry_block_access_list() {
+        let eth_payload = EthBuiltPayload::new(
+            empty_sealed_block(),
+            U256::ZERO,
+            None,
+            Some(Bytes::from_static(&[0xc0])),
+        );
+        let payload = TempoBuiltPayload::new(eth_payload, None);
+        let execution_data = payload.into_execution_data();
+
+        assert_eq!(execution_data.block_access_list(), None);
     }
 }
 


### PR DESCRIPTION
Adds a hidden experimental --builder.enable-bal flag to collect EIP-7928 block access lists during local payload construction and expose them on TempoBuiltPayload events. The built block header is normalized so block_access_list_hash remains unset even when BAL collection is enabled.