### PR TITLE
refactor(node): use empty body storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12968,6 +12968,7 @@ dependencies = [
  "reth-rpc-builder",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
+ "reth-storage-api",
  "reth-tracing",
  "reth-transaction-pool",
  "serde",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -42,6 +42,7 @@ reth-rpc-builder.workspace = true
 reth-node-api.workspace = true
 reth-rpc-eth-types.workspace = true
 reth-node-ethereum.workspace = true
+reth-storage-api.workspace = true
 
 alloy-serde.workspace = true
 alloy-eips.workspace = true

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -26,12 +26,13 @@ use reth_node_builder::{
 };
 use reth_node_ethereum::EthereumNetworkBuilder;
 use reth_primitives_traits::SealedHeader;
-use reth_provider::{EthStorage, providers::ProviderFactoryBuilder};
+use reth_provider::providers::ProviderFactoryBuilder;
 use reth_rpc_builder::{Identity, RethRpcModule};
 use reth_rpc_eth_api::{
     RpcNodeCore,
     helpers::config::{EthConfigApiServer, EthConfigHandler},
 };
+use reth_storage_api::EmptyBodyStorage;
 use reth_tracing::tracing::{debug, info};
 use reth_transaction_pool::{TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore};
 use std::default::Default;
@@ -148,7 +149,7 @@ impl TempoNode {
 impl NodeTypes for TempoNode {
     type Primitives = TempoPrimitives;
     type ChainSpec = TempoChainSpec;
-    type Storage = EthStorage<TempoTxEnvelope, TempoHeader>;
+    type Storage = EmptyBodyStorage<TempoTxEnvelope, TempoHeader>;
     type Payload = TempoPayloadTypes;
 }
 


### PR DESCRIPTION
Uses Reth's `EmptyBodyStorage` for Tempo node body storage.

Tempo blocks do not persist ommers or withdrawals, so block body reads can synthesize empty extras instead of using Ethereum body tables.