### PR TITLE
Use Arc for Tempo AA tx env

### DIFF
--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -9,6 +9,7 @@ use reth_rpc_convert::{
     FromConsensusHeader, SignTxRequestError, SignableTxRequest, TryIntoSimTx, TryIntoTxEnv,
 };
 use reth_rpc_eth_types::EthApiError;
+use std::sync::Arc;
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::TempoBlockEnv;
 use tempo_primitives::{
@@ -174,7 +175,7 @@ impl TryIntoTxEnv<TempoTxEnv, TempoHardfork, TempoBlockEnv> for TempoTransaction
                     return Err(EthApiError::InvalidParams("empty calls list".to_string()));
                 }
 
-                Some(Box::new(TempoBatchCallEnv {
+                Some(Arc::new(TempoBatchCallEnv {
                     aa_calls: calls,
                     signature: mock_signature,
                     tempo_authorization_list: tempo_authorization_list
@@ -385,9 +386,9 @@ mod tests {
 
         let evm_env = EvmEnv::default();
         let tx_env = req.try_into_tx_env(&evm_env).expect("try_into_tx_env");
-        let estimated_calls = tx_env.tempo_tx_env.expect("tempo_tx_env").aa_calls;
+        let estimated_calls = &tx_env.tempo_tx_env.as_ref().expect("tempo_tx_env").aa_calls;
 
-        assert_eq!(estimated_calls, built_calls);
+        assert_eq!(estimated_calls, &built_calls);
     }
 
     #[test]
@@ -565,10 +566,10 @@ mod tests {
 
         let evm_env = EvmEnv::default();
         let tx_env = req.try_into_tx_env(&evm_env).expect("try_into_tx_env");
-        let aa_calls = tx_env.tempo_tx_env.expect("tempo_tx_env").aa_calls;
+        let aa_calls = &tx_env.tempo_tx_env.as_ref().expect("tempo_tx_env").aa_calls;
 
         assert_eq!(
-            aa_calls, calls,
+            aa_calls, &calls,
             "roundtrip via try_into_tx_env must preserve exact call list"
         );
     }

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -512,7 +512,7 @@ where
         let (mut tx_env, recovered) = tx.into_parts();
         // Remove any prewarming-specific context that was added to the tx env.
         if let Some(tempo_tx_env) = tx_env.tempo_tx_env.as_mut() {
-            tempo_tx_env.expiring_nonce_idx = None;
+            std::sync::Arc::make_mut(tempo_tx_env).expiring_nonce_idx = None;
         }
         let next_section = self.validate_tx_pre_execution(recovered.tx())?;
 

--- a/crates/evm/src/engine.rs
+++ b/crates/evm/src/engine.rs
@@ -94,7 +94,7 @@ impl ToTxEnv<TempoTxEnv> for RecoveredInBlock {
     fn to_tx_env(&self) -> TempoTxEnv {
         let mut tx_env = TempoTxEnv::from_recovered_tx(self.tx(), *self.signer());
         if let Some(tempo_tx_env) = tx_env.tempo_tx_env.as_mut() {
-            tempo_tx_env.expiring_nonce_idx = self.expiring_nonce_idx;
+            std::sync::Arc::make_mut(tempo_tx_env).expiring_nonce_idx = self.expiring_nonce_idx;
         }
 
         tx_env

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -2284,7 +2284,7 @@ mod tests {
             configure_tx_env: impl FnOnce(&mut TempoTxEnv),
         ) -> Self {
             let mut tx_env = TempoTxEnv {
-                tempo_tx_env: Some(Box::new(aa_env)),
+                tempo_tx_env: Some(Arc::new(aa_env)),
                 ..Default::default()
             };
             configure_tx_env(&mut tx_env);
@@ -3458,7 +3458,7 @@ mod tests {
                             nonce,
                             ..Default::default()
                         },
-                        tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                        tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                             aa_calls: vec![Call {
                                 to: TxKind::Call(Address::random()),
                                 value: U256::ZERO,
@@ -3572,7 +3572,7 @@ mod tests {
                             nonce,
                             ..Default::default()
                         },
-                        tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                        tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                             aa_calls: vec![Call {
                                 to: TxKind::Call(Address::random()),
                                 value: U256::ZERO,
@@ -3639,7 +3639,7 @@ mod tests {
                 ..Default::default()
             },
             fee_token: Some(DEFAULT_FEE_TOKEN),
-            tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+            tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                 signature,
                 aa_calls: vec![Call {
                     to: TxKind::Call(target),
@@ -3755,7 +3755,7 @@ mod tests {
                 ..Default::default()
             },
             fee_token: Some(DEFAULT_FEE_TOKEN),
-            tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+            tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                 signature,
                 aa_calls: vec![Call {
                     to: TxKind::Call(target),
@@ -3856,7 +3856,7 @@ mod tests {
                 gas_limit: 1_000_000,
                 ..Default::default()
             },
-            tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+            tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                 signature,
                 aa_calls: vec![],
                 signature_hash: B256::ZERO,
@@ -4253,7 +4253,7 @@ mod tests {
 
             let tx_env = TempoTxEnv {
                 inner: revm::context::TxEnv::default(),
-                tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                     aa_calls: calls,
                     signature: secp256k1_sig(),
                     signature_hash: B256::ZERO,
@@ -4275,7 +4275,7 @@ mod tests {
         fn proptest_first_call_empty_aa(_dummy in 0u8..1) {
             let tx_env = TempoTxEnv {
                 inner: revm::context::TxEnv::default(),
-                tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                     aa_calls: vec![],
                     signature: secp256k1_sig(),
                     signature_hash: B256::ZERO,
@@ -4459,7 +4459,7 @@ mod tests {
                         nonce,
                         ..Default::default()
                     },
-                    tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                    tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                         aa_calls: vec![Call {
                             to: TxKind::Call(TEST_TARGET),
                             value: U256::ZERO,
@@ -4552,7 +4552,7 @@ mod tests {
                         nonce,
                         ..Default::default()
                     },
-                    tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                    tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                         aa_calls: vec![Call {
                             to: TxKind::Call(TEST_TARGET),
                             value: U256::ZERO,
@@ -4659,7 +4659,7 @@ mod tests {
                     ..Default::default()
                 },
                 fee_token: Some(DEFAULT_FEE_TOKEN),
-                tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                     signature: sig,
                     aa_calls: vec![Call {
                         to: TxKind::Call(Address::ZERO),
@@ -4762,7 +4762,8 @@ mod tests {
 
                 if !spec.is_t1c()
                     && let Some(aa_env) = evm.tx.tempo_tx_env.as_mut()
-                    && let TempoSignature::Keychain(keychain_sig) = &mut aa_env.signature
+                    && let TempoSignature::Keychain(keychain_sig) =
+                        &mut Arc::make_mut(aa_env).signature
                 {
                     // Overwrite the signature version pre-T1C to bypass the version check.
                     keychain_sig.version = KeychainVersion::V1;
@@ -5257,7 +5258,7 @@ mod tests {
                 kind: TxKind::Call(Address::random()),
                 ..Default::default()
             },
-            tempo_tx_env: Some(Box::new(aa_env)),
+            tempo_tx_env: Some(Arc::new(aa_env)),
             ..Default::default()
         };
 
@@ -5319,7 +5320,7 @@ mod tests {
                 kind: TxKind::Call(Address::random()),
                 ..Default::default()
             },
-            tempo_tx_env: Some(Box::new(aa_env)),
+            tempo_tx_env: Some(Arc::new(aa_env)),
             ..Default::default()
         };
 

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -11,6 +11,7 @@ use revm::context::{
         AccessList, AccessListItem, RecoveredAuthority, RecoveredAuthorization, SignedAuthorization,
     },
 };
+use std::sync::Arc;
 use tempo_primitives::{
     AASigned, TempoSignature, TempoTransaction, TempoTxEnvelope,
     transaction::{
@@ -90,8 +91,8 @@ pub struct TempoTxEnv {
     /// - None corresponds to a transaction without a fee payer
     pub fee_payer: Option<Option<Address>>,
 
-    /// AA-specific transaction environment (boxed to keep TempoTxEnv lean for non-AA tx)
-    pub tempo_tx_env: Option<Box<TempoBatchCallEnv>>,
+    /// AA-specific transaction environment (shared to keep cloned TempoTxEnv lean for AA tx)
+    pub tempo_tx_env: Option<Arc<TempoBatchCallEnv>>,
 }
 
 impl TempoTxEnv {
@@ -348,7 +349,7 @@ impl FromRecoveredTx<AASigned> for TempoTxEnv {
                 secp256k1::recover_signer(&sig, tx.fee_payer_signature_hash(caller)).ok()
             }),
             // Bundle AA-specific fields into TempoBatchCallEnv
-            tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+            tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                 signature: signature.clone(),
                 valid_before: valid_before.map(NonZeroU64::get),
                 valid_after: valid_after.map(NonZeroU64::get),
@@ -425,6 +426,7 @@ mod tests {
     use core::num::NonZeroU64;
     use proptest::prelude::*;
     use revm::context::{Transaction, TxEnv, result::InvalidTransaction};
+    use std::sync::Arc;
     use tempo_primitives::{
         TempoTxEnvelope,
         transaction::{
@@ -814,7 +816,7 @@ mod tests {
         let input2 = Bytes::from(vec![0xCC, 0xDD]);
 
         let tx_env = super::TempoTxEnv {
-            tempo_tx_env: Some(Box::new(super::TempoBatchCallEnv {
+            tempo_tx_env: Some(Arc::new(super::TempoBatchCallEnv {
                 aa_calls: vec![
                     Call {
                         to: TxKind::Call(addr1),
@@ -843,7 +845,7 @@ mod tests {
     fn test_first_call_with_empty_aa_calls() {
         // Test with tempo_tx_env but empty calls list
         let tx_env = super::TempoTxEnv {
-            tempo_tx_env: Some(Box::new(super::TempoBatchCallEnv {
+            tempo_tx_env: Some(Arc::new(super::TempoBatchCallEnv {
                 aa_calls: vec![],
                 ..Default::default()
             })),
@@ -881,7 +883,7 @@ mod tests {
 
         // AA transaction with multiple calls
         let aa_tx = super::TempoTxEnv {
-            tempo_tx_env: Some(Box::new(super::TempoBatchCallEnv {
+            tempo_tx_env: Some(Arc::new(super::TempoBatchCallEnv {
                 aa_calls: vec![
                     Call {
                         to: TxKind::Call(addr1),
@@ -914,7 +916,7 @@ mod tests {
 
         // AA transaction with empty calls list
         let empty_aa_tx = super::TempoTxEnv {
-            tempo_tx_env: Some(Box::new(super::TempoBatchCallEnv {
+            tempo_tx_env: Some(Arc::new(super::TempoBatchCallEnv {
                 aa_calls: vec![],
                 ..Default::default()
             })),
@@ -1045,7 +1047,7 @@ mod tests {
         #[test]
         fn proptest_calls_count_aa_tx(num_calls in 0usize..20) {
             let aa_tx = super::TempoTxEnv {
-                tempo_tx_env: Some(Box::new(super::TempoBatchCallEnv {
+                tempo_tx_env: Some(Arc::new(super::TempoBatchCallEnv {
                     aa_calls: (0..num_calls)
                         .map(|_| Call {
                             to: TxKind::Call(alloy_primitives::Address::ZERO),


### PR DESCRIPTION
## Summary
- change TempoTxEnv::tempo_tx_env from Option<Box<TempoBatchCallEnv>> to Option<Arc<TempoBatchCallEnv>>
- update AA tx env construction sites to use Arc::new
- use Arc::make_mut at the few expiring_nonce_idx mutation points

## Tests
- cargo test -p tempo-revm tx:: --lib
- cargo test -p tempo-evm --lib
- cargo fmt --check
- git diff --check