### PR TITLE
feat(ci): collect codspeed pre-bench artifacts

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - bare-metal-dual-schelk

--- a/.github/workflows/codspeed-microbench.yml
+++ b/.github/workflows/codspeed-microbench.yml
@@ -91,7 +91,7 @@ jobs:
           command -v bench
       - name: Collect block artifacts
         run: |
-          nu bench-e2e.nu codspeed-fixtures \
+          nu codspeed-prebench.nu collect \
             --preset "$CODSPEED_PRE_BENCH_PRESET" \
             --bloat "$CODSPEED_PRE_BENCH_BLOAT" \
             --duration "$CODSPEED_PRE_BENCH_DURATION" \

--- a/.github/workflows/codspeed-microbench.yml
+++ b/.github/workflows/codspeed-microbench.yml
@@ -32,6 +32,11 @@ on:
         required: true
         default: "simulation"
         type: string
+      pre_bench_txgen_ref:
+        description: "Optional ref to pin in tempoxyz/txgen for the pre-bench artifact collection"
+        required: false
+        default: "mediocregopher/bench-send-bal-output"
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -43,8 +48,73 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
+  pre-bench:
+    name: Collect CodSpeed pre-bench artifacts
+    runs-on: [self-hosted, Linux, X64, bare-metal-dual-schelk]
+    timeout-minutes: 120
+    env:
+      CODSPEED_PRE_BENCH_PRESET: tip20
+      CODSPEED_PRE_BENCH_DURATION: "300"
+      CODSPEED_PRE_BENCH_BLOAT: "100"
+      CODSPEED_PRE_BENCH_TPS: "20000"
+      CODSPEED_PRE_BENCH_ACCOUNTS: "1000"
+      CODSPEED_PRE_BENCH_MAX_CONCURRENT_REQUESTS: "100"
+      CODSPEED_PRE_BENCH_GAS_LIMIT: "1000000000"
+      CODSPEED_PRE_BENCH_FEATURES: "jemalloc,asm-keccak,keccak-cache-global"
+      CODSPEED_PRE_BENCH_TXGEN_REF: ${{ inputs.pre_bench_txgen_ref || 'mediocregopher/bench-send-bal-output' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        continue-on-error: true
+      - name: Install txgen
+        env:
+          TXGEN_GIT_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
+        run: |
+          CARGO_BIN_DIR="${CARGO_HOME:-$HOME/.cargo}/bin"
+          echo "$CARGO_BIN_DIR" >> "$GITHUB_PATH"
+          export PATH="$CARGO_BIN_DIR:$PATH"
+
+          TXGEN_GIT_URL="https://x-access-token:${TXGEN_GIT_TOKEN}@github.com/tempoxyz/txgen"
+          install_args=(--git "$TXGEN_GIT_URL" --locked)
+          if [ -n "$CODSPEED_PRE_BENCH_TXGEN_REF" ]; then
+            TXGEN_REV="$(git ls-remote "$TXGEN_GIT_URL" "$CODSPEED_PRE_BENCH_TXGEN_REF" "refs/heads/$CODSPEED_PRE_BENCH_TXGEN_REF" "refs/tags/$CODSPEED_PRE_BENCH_TXGEN_REF" | awk 'BEGIN { rev = "" } /\^\{\}$/ { rev = $1; exit } rev == "" { rev = $1 } END { if (rev != "") print rev }')"
+            install_args+=(--rev "${TXGEN_REV:-$CODSPEED_PRE_BENCH_TXGEN_REF}")
+          fi
+
+          cargo install "${install_args[@]}" txgen-tempo bench-cli
+          echo "TXGEN_TEMPO_BIN=$CARGO_BIN_DIR/txgen-tempo" >> "$GITHUB_ENV"
+          echo "TXGEN_BENCH_BIN=$CARGO_BIN_DIR/bench" >> "$GITHUB_ENV"
+          command -v txgen-tempo
+          command -v bench
+      - name: Collect block artifacts
+        run: |
+          nu bench-e2e.nu codspeed-fixtures \
+            --preset "$CODSPEED_PRE_BENCH_PRESET" \
+            --bloat "$CODSPEED_PRE_BENCH_BLOAT" \
+            --duration "$CODSPEED_PRE_BENCH_DURATION" \
+            --tps "$CODSPEED_PRE_BENCH_TPS" \
+            --accounts "$CODSPEED_PRE_BENCH_ACCOUNTS" \
+            --max-concurrent-requests "$CODSPEED_PRE_BENCH_MAX_CONCURRENT_REQUESTS" \
+            --gas-limit "$CODSPEED_PRE_BENCH_GAS_LIMIT" \
+            --no-default-features \
+            --features "$CODSPEED_PRE_BENCH_FEATURES" \
+            --tune \
+            --output-dir codspeed-prebench
+      - name: Upload pre-bench artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: codspeed-prebench-tip20
+          path: codspeed-prebench/
+          if-no-files-found: error
+          retention-days: 7
+
   codspeed:
     name: CodSpeed microbenchmarks
+    needs: pre-bench
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -54,6 +124,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - name: Download pre-bench artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: codspeed-prebench-tip20
+          path: codspeed-prebench
+      - name: Export pre-bench artifact paths
+        run: |
+          {
+            echo "TEMPO_CODSPEED_BLOCK_ACCESS_LISTS=$PWD/codspeed-prebench/block-access-lists.ndjson.gz"
+            echo "TEMPO_CODSPEED_TRIE_WITNESSES=$PWD/codspeed-prebench/trie-witnesses.ndjson.gz"
+            echo "TEMPO_CODSPEED_PREBENCH_MANIFEST=$PWD/codspeed-prebench/manifest.json"
+          } >> "$GITHUB_ENV"
       - name: Install cargo-codspeed
         run: |
           cargo install cargo-codspeed \

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -719,8 +719,6 @@ def bench-update-pr-status [status: string] {
 
 def run-local-e2e-phase [run: record, ctx: record] {
     let phase = $run.phase
-    let block_access_list_output = ($run | get -o block_access_list_output | default "")
-    let trie_witness_output = ($run | get -o trie_witness_output | default "")
     print $"=== Starting local e2e phase: ($phase) ==="
     let run_type = if ($phase | str starts-with "baseline") { "baseline" } else { "feature" }
     let genesis = ($run | get -o genesis | default $ctx.genesis)
@@ -763,17 +761,14 @@ def run-local-e2e-phase [run: record, ctx: record] {
         mkdir $dir
     }
 
-    let stale_paths = ([
+    for stale in [
         $"($ctx.results_dir)/report-($phase).json"
         $"($ctx.results_dir)/profile-($phase)-a.json.gz"
         $"($ctx.results_dir)/profile-($phase)-b.json.gz"
         $"($ctx.results_dir)/tracy-profile-($phase).tracy"
         $"($ctx.results_dir)/logs-($phase)-a"
         $"($ctx.results_dir)/logs-($phase)-b"
-    ]
-        | append (if $block_access_list_output != "" { [$block_access_list_output] } else { [] })
-        | append (if $trie_witness_output != "" { [$trie_witness_output] } else { [] }))
-    for stale in $stale_paths {
+    ] {
         if ($stale | path exists) { rm -rf $stale }
     }
     if ("report.json" | path exists) { rm report.json }
@@ -880,8 +875,6 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --scenario $scenario
                 --victoriametrics-url $ctx.victoriametrics_url
                 --clickhouse-url $phase_clickhouse_url
-                --block-access-list-output $block_access_list_output
-                --trie-witness-output $trie_witness_output
                 --skip-funding=($ctx.bloat > 0))
             if not $bench_result.ok {
                 $bench_result.exit_code
@@ -1330,256 +1323,4 @@ def "main e2e" [
     if $e2e_exit != 0 {
         exit $e2e_exit
     }
-}
-
-# Collect one TIP20 e2e run's block artifacts for CodSpeed benchmarks.
-def "main codspeed-fixtures" [
-    --preset: string = "tip20"                         # Txgen preset name
-    --tps: int = 20000                                  # Target TPS
-    --duration: int = 300                               # Duration in seconds
-    --accounts: int = 1000                              # Number of accounts
-    --max-concurrent-requests: int = 100                # Max concurrent requests
-    --bloat: int = $E2E_DEFAULT_BLOAT                   # State bloat snapshot size in GiB: 1, 10, or 100
-    --gas-limit: string = $E2E_GAS_LIMIT                # Builder gas limit
-    --profile: string = $DEFAULT_PROFILE                # Cargo build profile
-    --features: string = $DEFAULT_FEATURES              # Cargo features
-    --no-default-features                               # Disable Cargo default features
-    --force-bloat                                       # Regenerate and promote both local e2e snapshots
-    --bench-args: string = ""                           # Additional txgen generate arguments
-    --bench-env: string = ""                            # Environment vars for the sender process
-    --node-args: string = ""                            # Additional node args for the fixture run
-    --node-env: string = ""                             # Environment vars for the fixture node processes
-    --output-dir: string = "codspeed-prebench"          # Directory for fixture artifacts
-    --tune                                              # Apply system tuning
-    --loud                                              # Show node debug logs
-] {
-    let preset_path = (txgen-preset-path $preset)
-    let bloat_mib = (e2e-bloat-gib-to-mib $bloat)
-    let validator_list = (
-        $E2E_VALIDATORS
-        | split row ","
-        | each { |v| $v | str trim }
-        | where { |v| $v != "" }
-    )
-    if ($validator_list | length) != 2 {
-        print "Error: E2E_VALIDATORS must contain exactly two comma-separated consensus addresses ordered as a,b"
-        exit 1
-    }
-
-    let a_validator = ($validator_list | get 0)
-    let b_validator = ($validator_list | get 1)
-    let a_ip = ($a_validator | split row ":" | get 0)
-    let a_consensus_port = ($a_validator | split row ":" | get 1 | into int)
-    let b_ip = ($b_validator | split row ":" | get 0)
-    let b_consensus_port = ($b_validator | split row ":" | get 1 | into int)
-    let a_db = $"($E2E_A_MOUNT)/tempo_e2e_($bloat_mib)mb"
-    let b_db = $"($E2E_B_MOUNT)/tempo_e2e_($bloat_mib)mb"
-    let a_identity = $a_db
-    let b_identity = $b_db
-    let genesis_path = $"($a_db)/($BENCH_META_SUBDIR)/genesis.json"
-    let a_trusted_peers_path = $"($a_db)/($BENCH_META_SUBDIR)/trusted-peers.txt"
-    let gas_limit_args = if $gas_limit != "" { ["--gas-limit" $gas_limit] } else { [] }
-    let snapshot_state_hardfork = (latest-tempo-hardfork)
-    let snapshot_hardfork_args = (hardfork-to-genesis-args $snapshot_state_hardfork)
-
-    let run_started_at = (date now)
-    let timestamp = ($run_started_at | format date "%Y%m%d-%H%M%S-%3f")
-    let current_sha = (git rev-parse HEAD | str trim)
-    let benchmark_id = if (($env | get --optional GITHUB_RUN_ID) != null) {
-        $"codspeed-prebench-($env.GITHUB_RUN_ID)"
-    } else {
-        $"codspeed-prebench-($timestamp)"
-    }
-    let reference_epoch = (($run_started_at | into int) / 1_000_000_000 | into int)
-    let artifact_dir = ($output_dir | path expand)
-    if ($artifact_dir | path exists) { rm -rf $artifact_dir }
-    mkdir $artifact_dir
-    let block_access_list_output = $"($artifact_dir)/block-access-lists.ndjson.gz"
-    let trie_witness_output = $"($artifact_dir)/trie-witnesses.ndjson.gz"
-
-    validate-schelk-state $E2E_A_STATE_PATH $E2E_B_STATE_PATH
-    cleanup-local-e2e-processes
-
-    build-tempo --no-default-features=$no_default_features ["tempo"] $profile $features
-    let tempo_bin = if $profile == "dev" { "./target/debug/tempo" } else { $"./target/($profile)/tempo" }
-    let txgen = txgen-resolve-binaries
-
-    bench-restore-at $E2E_A_STATE_PATH $E2E_A_MOUNT $a_db
-    bench-restore-at $E2E_B_STATE_PATH $E2E_B_MOUNT $b_db
-
-    let snapshots_ready = (e2e-snapshots-ready $a_db $b_db)
-    let should_init_snapshots = $force_bloat or (not $snapshots_ready)
-    if (not $snapshots_ready) and (not $force_bloat) {
-        print $"Local e2e snapshot ($bloat) is missing required files; initializing it once."
-        let missing_a = (e2e-snapshot-missing-files $a_db)
-        let missing_b = (e2e-snapshot-missing-files $b_db)
-        if ($missing_a | length) > 0 {
-            print $"  Missing from a: ($missing_a | str join ', ')"
-        }
-        if ($missing_b | length) > 0 {
-            print $"  Missing from b: ($missing_b | str join ', ')"
-        }
-    }
-
-    if $should_init_snapshots {
-        let init_dir = $"($LOCALNET_DIR)/e2e-local-init"
-        let generated_genesis = $"($init_dir)/genesis.json"
-        let bloat_file = $"($E2E_BLOAT_TMP_DIR)/state_bloat.bin"
-        mark-schelk-dirty-at $E2E_A_STATE_PATH
-        mark-schelk-dirty-at $E2E_B_STATE_PATH
-        if ($init_dir | path exists) { rm -rf $init_dir }
-        mkdir $init_dir
-        if ($E2E_BLOAT_TMP_DIR | path exists) { rm -rf $E2E_BLOAT_TMP_DIR }
-        mkdir $E2E_BLOAT_TMP_DIR
-
-        let genesis_accounts = ([$accounts 3] | math max) + 1
-        print $"Generating local e2e localnet config for validators: ($E2E_VALIDATORS)"
-        cargo run -p tempo-xtask --profile $profile -- generate-localnet -o $init_dir --accounts $genesis_accounts --validators $E2E_VALIDATORS --seed $E2E_SEED --force ...$gas_limit_args ...$snapshot_hardfork_args
-
-        let trusted_peers = (trusted-peers-from-localnet $init_dir)
-        if $trusted_peers == "" {
-            print "Error: generated localnet did not produce trusted peers"
-            exit 1
-        }
-        if $bloat_mib > 0 {
-            ensure-bloat-space $bloat_mib
-            print $"Generating local e2e state bloat \(($bloat_mib) MiB\)..."
-            let token_args = ($TIP20_TOKEN_IDS | each { |id| ["--token" $"($id)"] } | flatten)
-            cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat_mib --out $bloat_file ...$token_args
-        }
-
-        let marker = {
-            bloat_mib: $bloat_mib
-            bloat: $bloat
-            accounts: $genesis_accounts
-            validators: $E2E_VALIDATORS
-            seed: $E2E_SEED
-            gas_limit: $gas_limit
-            dkg_in_genesis: true
-            topology: "single-runner"
-            state_hardfork: $snapshot_state_hardfork
-        }
-        init-local-e2e-side a $E2E_A_STATE_PATH $E2E_A_MOUNT $a_db $a_identity $"($init_dir)/($a_validator)" $generated_genesis $trusted_peers $bloat_mib $bloat_file $tempo_bin ($marker | insert bench_datadir $a_db | insert node_dir $a_identity | insert validator_addr $a_validator)
-        init-local-e2e-side b $E2E_B_STATE_PATH $E2E_B_MOUNT $b_db $b_identity $"($init_dir)/($b_validator)" $generated_genesis $trusted_peers $bloat_mib $bloat_file $tempo_bin ($marker | insert bench_datadir $b_db | insert node_dir $b_identity | insert validator_addr $b_validator)
-        if ($E2E_BLOAT_TMP_DIR | path exists) {
-            rm -rf $E2E_BLOAT_TMP_DIR
-        }
-        bench-promote-at $E2E_A_STATE_PATH $a_db
-        bench-promote-at $E2E_B_STATE_PATH $b_db
-        bench-restore-at $E2E_A_STATE_PATH $E2E_A_MOUNT $a_db
-        bench-restore-at $E2E_B_STATE_PATH $E2E_B_MOUNT $b_db
-    }
-
-    let trusted_peers = if ($a_trusted_peers_path | path exists) {
-        open $a_trusted_peers_path | str trim
-    } else {
-        let b_trusted_peers_path = $"($b_db)/($BENCH_META_SUBDIR)/trusted-peers.txt"
-        if ($b_trusted_peers_path | path exists) {
-            open $b_trusted_peers_path | str trim
-        } else {
-            print $"Error: trusted peers file not found in ($a_trusted_peers_path) or ($b_trusted_peers_path)"
-            exit 1
-        }
-    }
-
-    let ctx = {
-        genesis: $genesis_path
-        trusted_peers: $trusted_peers
-        a: {
-            state_path: $E2E_A_STATE_PATH
-            mount: $E2E_A_MOUNT
-            datadir: $a_db
-            node_dir: $a_identity
-            ip: $a_ip
-            consensus_port: $a_consensus_port
-            cpus: $E2E_A_CPUS
-            memory: $E2E_A_MEMORY
-        }
-        b: {
-            state_path: $E2E_B_STATE_PATH
-            mount: $E2E_B_MOUNT
-            datadir: $b_db
-            node_dir: $b_identity
-            ip: $b_ip
-            consensus_port: $b_consensus_port
-            cpus: $E2E_B_CPUS
-            memory: $E2E_B_MEMORY
-        }
-        preset: $preset
-        preset_path: $preset_path
-        tps: $tps
-        duration: $duration
-        accounts: $accounts
-        max_concurrent_requests: $max_concurrent_requests
-        bloat: $bloat_mib
-        txgen: $txgen
-        results_dir: $artifact_dir
-        profile: $profile
-        samply: false
-        samply_args: []
-        tracy: "off"
-        tracy_filter: "debug"
-        tracy_seconds: 0
-        tracy_offset: 0
-        baseline_args: ""
-        feature_args: $node_args
-        bench_args: $bench_args
-        baseline_env: ""
-        feature_env: $node_env
-        bench_env: $bench_env
-        victoriametrics_url: ""
-        clickhouse_url: ""
-        clickhouse_run: ""
-        run_type: "codspeed-prebench"
-        benchmark_id: $benchmark_id
-        reference_epoch: $reference_epoch
-        tune: $tune
-        loud: $loud
-        gas_limit: $gas_limit
-        tracing_otlp: ""
-    }
-    let run = {
-        phase: "codspeed-prebench"
-        ref: $current_sha
-        ref_label: "codspeed-prebench"
-        tempo: $tempo_bin
-        genesis: $genesis_path
-        hardfork: ""
-        block_access_list_output: $block_access_list_output
-        trie_witness_output: $trie_witness_output
-    }
-
-    let phase_exit = (run-local-e2e-phase $run $ctx)
-    cleanup-local-e2e-processes
-    bench-restore-at $E2E_A_STATE_PATH $E2E_A_MOUNT $a_db
-    bench-restore-at $E2E_B_STATE_PATH $E2E_B_MOUNT $b_db
-    if $phase_exit != 0 {
-        exit $phase_exit
-    }
-
-    let report_path = $"($artifact_dir)/report-codspeed-prebench.json"
-    for required in [$block_access_list_output $trie_witness_output $report_path] {
-        if not ($required | path exists) {
-            print $"Error: expected CodSpeed fixture artifact was not written: ($required)"
-            exit 1
-        }
-    }
-
-    {
-        preset: $preset
-        duration_secs: $duration
-        tps: $tps
-        accounts: $accounts
-        max_concurrent_requests: $max_concurrent_requests
-        bloat_gib: $bloat
-        gas_limit: $gas_limit
-        git_ref: $current_sha
-        benchmark_id: $benchmark_id
-        block_access_lists: "block-access-lists.ndjson.gz"
-        trie_witnesses: "trie-witnesses.ndjson.gz"
-        report: "report-codspeed-prebench.json"
-        format: "gzip_ndjson"
-    } | to json | save -f $"($artifact_dir)/manifest.json"
-
-    print $"CodSpeed pre-bench fixtures written to ($artifact_dir)"
 }

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -719,6 +719,8 @@ def bench-update-pr-status [status: string] {
 
 def run-local-e2e-phase [run: record, ctx: record] {
     let phase = $run.phase
+    let block_access_list_output = ($run | get -o block_access_list_output | default "")
+    let trie_witness_output = ($run | get -o trie_witness_output | default "")
     print $"=== Starting local e2e phase: ($phase) ==="
     let run_type = if ($phase | str starts-with "baseline") { "baseline" } else { "feature" }
     let genesis = ($run | get -o genesis | default $ctx.genesis)
@@ -761,14 +763,17 @@ def run-local-e2e-phase [run: record, ctx: record] {
         mkdir $dir
     }
 
-    for stale in [
+    let stale_paths = ([
         $"($ctx.results_dir)/report-($phase).json"
         $"($ctx.results_dir)/profile-($phase)-a.json.gz"
         $"($ctx.results_dir)/profile-($phase)-b.json.gz"
         $"($ctx.results_dir)/tracy-profile-($phase).tracy"
         $"($ctx.results_dir)/logs-($phase)-a"
         $"($ctx.results_dir)/logs-($phase)-b"
-    ] {
+    ]
+        | append (if $block_access_list_output != "" { [$block_access_list_output] } else { [] })
+        | append (if $trie_witness_output != "" { [$trie_witness_output] } else { [] }))
+    for stale in $stale_paths {
         if ($stale | path exists) { rm -rf $stale }
     }
     if ("report.json" | path exists) { rm report.json }
@@ -875,6 +880,8 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --scenario $scenario
                 --victoriametrics-url $ctx.victoriametrics_url
                 --clickhouse-url $phase_clickhouse_url
+                --block-access-list-output $block_access_list_output
+                --trie-witness-output $trie_witness_output
                 --skip-funding=($ctx.bloat > 0))
             if not $bench_result.ok {
                 $bench_result.exit_code
@@ -1323,4 +1330,256 @@ def "main e2e" [
     if $e2e_exit != 0 {
         exit $e2e_exit
     }
+}
+
+# Collect one TIP20 e2e run's block artifacts for CodSpeed benchmarks.
+def "main codspeed-fixtures" [
+    --preset: string = "tip20"                         # Txgen preset name
+    --tps: int = 20000                                  # Target TPS
+    --duration: int = 300                               # Duration in seconds
+    --accounts: int = 1000                              # Number of accounts
+    --max-concurrent-requests: int = 100                # Max concurrent requests
+    --bloat: int = $E2E_DEFAULT_BLOAT                   # State bloat snapshot size in GiB: 1, 10, or 100
+    --gas-limit: string = $E2E_GAS_LIMIT                # Builder gas limit
+    --profile: string = $DEFAULT_PROFILE                # Cargo build profile
+    --features: string = $DEFAULT_FEATURES              # Cargo features
+    --no-default-features                               # Disable Cargo default features
+    --force-bloat                                       # Regenerate and promote both local e2e snapshots
+    --bench-args: string = ""                           # Additional txgen generate arguments
+    --bench-env: string = ""                            # Environment vars for the sender process
+    --node-args: string = ""                            # Additional node args for the fixture run
+    --node-env: string = ""                             # Environment vars for the fixture node processes
+    --output-dir: string = "codspeed-prebench"          # Directory for fixture artifacts
+    --tune                                              # Apply system tuning
+    --loud                                              # Show node debug logs
+] {
+    let preset_path = (txgen-preset-path $preset)
+    let bloat_mib = (e2e-bloat-gib-to-mib $bloat)
+    let validator_list = (
+        $E2E_VALIDATORS
+        | split row ","
+        | each { |v| $v | str trim }
+        | where { |v| $v != "" }
+    )
+    if ($validator_list | length) != 2 {
+        print "Error: E2E_VALIDATORS must contain exactly two comma-separated consensus addresses ordered as a,b"
+        exit 1
+    }
+
+    let a_validator = ($validator_list | get 0)
+    let b_validator = ($validator_list | get 1)
+    let a_ip = ($a_validator | split row ":" | get 0)
+    let a_consensus_port = ($a_validator | split row ":" | get 1 | into int)
+    let b_ip = ($b_validator | split row ":" | get 0)
+    let b_consensus_port = ($b_validator | split row ":" | get 1 | into int)
+    let a_db = $"($E2E_A_MOUNT)/tempo_e2e_($bloat_mib)mb"
+    let b_db = $"($E2E_B_MOUNT)/tempo_e2e_($bloat_mib)mb"
+    let a_identity = $a_db
+    let b_identity = $b_db
+    let genesis_path = $"($a_db)/($BENCH_META_SUBDIR)/genesis.json"
+    let a_trusted_peers_path = $"($a_db)/($BENCH_META_SUBDIR)/trusted-peers.txt"
+    let gas_limit_args = if $gas_limit != "" { ["--gas-limit" $gas_limit] } else { [] }
+    let snapshot_state_hardfork = (latest-tempo-hardfork)
+    let snapshot_hardfork_args = (hardfork-to-genesis-args $snapshot_state_hardfork)
+
+    let run_started_at = (date now)
+    let timestamp = ($run_started_at | format date "%Y%m%d-%H%M%S-%3f")
+    let current_sha = (git rev-parse HEAD | str trim)
+    let benchmark_id = if (($env | get --optional GITHUB_RUN_ID) != null) {
+        $"codspeed-prebench-($env.GITHUB_RUN_ID)"
+    } else {
+        $"codspeed-prebench-($timestamp)"
+    }
+    let reference_epoch = (($run_started_at | into int) / 1_000_000_000 | into int)
+    let artifact_dir = ($output_dir | path expand)
+    if ($artifact_dir | path exists) { rm -rf $artifact_dir }
+    mkdir $artifact_dir
+    let block_access_list_output = $"($artifact_dir)/block-access-lists.ndjson.gz"
+    let trie_witness_output = $"($artifact_dir)/trie-witnesses.ndjson.gz"
+
+    validate-schelk-state $E2E_A_STATE_PATH $E2E_B_STATE_PATH
+    cleanup-local-e2e-processes
+
+    build-tempo --no-default-features=$no_default_features ["tempo"] $profile $features
+    let tempo_bin = if $profile == "dev" { "./target/debug/tempo" } else { $"./target/($profile)/tempo" }
+    let txgen = txgen-resolve-binaries
+
+    bench-restore-at $E2E_A_STATE_PATH $E2E_A_MOUNT $a_db
+    bench-restore-at $E2E_B_STATE_PATH $E2E_B_MOUNT $b_db
+
+    let snapshots_ready = (e2e-snapshots-ready $a_db $b_db)
+    let should_init_snapshots = $force_bloat or (not $snapshots_ready)
+    if (not $snapshots_ready) and (not $force_bloat) {
+        print $"Local e2e snapshot ($bloat) is missing required files; initializing it once."
+        let missing_a = (e2e-snapshot-missing-files $a_db)
+        let missing_b = (e2e-snapshot-missing-files $b_db)
+        if ($missing_a | length) > 0 {
+            print $"  Missing from a: ($missing_a | str join ', ')"
+        }
+        if ($missing_b | length) > 0 {
+            print $"  Missing from b: ($missing_b | str join ', ')"
+        }
+    }
+
+    if $should_init_snapshots {
+        let init_dir = $"($LOCALNET_DIR)/e2e-local-init"
+        let generated_genesis = $"($init_dir)/genesis.json"
+        let bloat_file = $"($E2E_BLOAT_TMP_DIR)/state_bloat.bin"
+        mark-schelk-dirty-at $E2E_A_STATE_PATH
+        mark-schelk-dirty-at $E2E_B_STATE_PATH
+        if ($init_dir | path exists) { rm -rf $init_dir }
+        mkdir $init_dir
+        if ($E2E_BLOAT_TMP_DIR | path exists) { rm -rf $E2E_BLOAT_TMP_DIR }
+        mkdir $E2E_BLOAT_TMP_DIR
+
+        let genesis_accounts = ([$accounts 3] | math max) + 1
+        print $"Generating local e2e localnet config for validators: ($E2E_VALIDATORS)"
+        cargo run -p tempo-xtask --profile $profile -- generate-localnet -o $init_dir --accounts $genesis_accounts --validators $E2E_VALIDATORS --seed $E2E_SEED --force ...$gas_limit_args ...$snapshot_hardfork_args
+
+        let trusted_peers = (trusted-peers-from-localnet $init_dir)
+        if $trusted_peers == "" {
+            print "Error: generated localnet did not produce trusted peers"
+            exit 1
+        }
+        if $bloat_mib > 0 {
+            ensure-bloat-space $bloat_mib
+            print $"Generating local e2e state bloat \(($bloat_mib) MiB\)..."
+            let token_args = ($TIP20_TOKEN_IDS | each { |id| ["--token" $"($id)"] } | flatten)
+            cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat_mib --out $bloat_file ...$token_args
+        }
+
+        let marker = {
+            bloat_mib: $bloat_mib
+            bloat: $bloat
+            accounts: $genesis_accounts
+            validators: $E2E_VALIDATORS
+            seed: $E2E_SEED
+            gas_limit: $gas_limit
+            dkg_in_genesis: true
+            topology: "single-runner"
+            state_hardfork: $snapshot_state_hardfork
+        }
+        init-local-e2e-side a $E2E_A_STATE_PATH $E2E_A_MOUNT $a_db $a_identity $"($init_dir)/($a_validator)" $generated_genesis $trusted_peers $bloat_mib $bloat_file $tempo_bin ($marker | insert bench_datadir $a_db | insert node_dir $a_identity | insert validator_addr $a_validator)
+        init-local-e2e-side b $E2E_B_STATE_PATH $E2E_B_MOUNT $b_db $b_identity $"($init_dir)/($b_validator)" $generated_genesis $trusted_peers $bloat_mib $bloat_file $tempo_bin ($marker | insert bench_datadir $b_db | insert node_dir $b_identity | insert validator_addr $b_validator)
+        if ($E2E_BLOAT_TMP_DIR | path exists) {
+            rm -rf $E2E_BLOAT_TMP_DIR
+        }
+        bench-promote-at $E2E_A_STATE_PATH $a_db
+        bench-promote-at $E2E_B_STATE_PATH $b_db
+        bench-restore-at $E2E_A_STATE_PATH $E2E_A_MOUNT $a_db
+        bench-restore-at $E2E_B_STATE_PATH $E2E_B_MOUNT $b_db
+    }
+
+    let trusted_peers = if ($a_trusted_peers_path | path exists) {
+        open $a_trusted_peers_path | str trim
+    } else {
+        let b_trusted_peers_path = $"($b_db)/($BENCH_META_SUBDIR)/trusted-peers.txt"
+        if ($b_trusted_peers_path | path exists) {
+            open $b_trusted_peers_path | str trim
+        } else {
+            print $"Error: trusted peers file not found in ($a_trusted_peers_path) or ($b_trusted_peers_path)"
+            exit 1
+        }
+    }
+
+    let ctx = {
+        genesis: $genesis_path
+        trusted_peers: $trusted_peers
+        a: {
+            state_path: $E2E_A_STATE_PATH
+            mount: $E2E_A_MOUNT
+            datadir: $a_db
+            node_dir: $a_identity
+            ip: $a_ip
+            consensus_port: $a_consensus_port
+            cpus: $E2E_A_CPUS
+            memory: $E2E_A_MEMORY
+        }
+        b: {
+            state_path: $E2E_B_STATE_PATH
+            mount: $E2E_B_MOUNT
+            datadir: $b_db
+            node_dir: $b_identity
+            ip: $b_ip
+            consensus_port: $b_consensus_port
+            cpus: $E2E_B_CPUS
+            memory: $E2E_B_MEMORY
+        }
+        preset: $preset
+        preset_path: $preset_path
+        tps: $tps
+        duration: $duration
+        accounts: $accounts
+        max_concurrent_requests: $max_concurrent_requests
+        bloat: $bloat_mib
+        txgen: $txgen
+        results_dir: $artifact_dir
+        profile: $profile
+        samply: false
+        samply_args: []
+        tracy: "off"
+        tracy_filter: "debug"
+        tracy_seconds: 0
+        tracy_offset: 0
+        baseline_args: ""
+        feature_args: $node_args
+        bench_args: $bench_args
+        baseline_env: ""
+        feature_env: $node_env
+        bench_env: $bench_env
+        victoriametrics_url: ""
+        clickhouse_url: ""
+        clickhouse_run: ""
+        run_type: "codspeed-prebench"
+        benchmark_id: $benchmark_id
+        reference_epoch: $reference_epoch
+        tune: $tune
+        loud: $loud
+        gas_limit: $gas_limit
+        tracing_otlp: ""
+    }
+    let run = {
+        phase: "codspeed-prebench"
+        ref: $current_sha
+        ref_label: "codspeed-prebench"
+        tempo: $tempo_bin
+        genesis: $genesis_path
+        hardfork: ""
+        block_access_list_output: $block_access_list_output
+        trie_witness_output: $trie_witness_output
+    }
+
+    let phase_exit = (run-local-e2e-phase $run $ctx)
+    cleanup-local-e2e-processes
+    bench-restore-at $E2E_A_STATE_PATH $E2E_A_MOUNT $a_db
+    bench-restore-at $E2E_B_STATE_PATH $E2E_B_MOUNT $b_db
+    if $phase_exit != 0 {
+        exit $phase_exit
+    }
+
+    let report_path = $"($artifact_dir)/report-codspeed-prebench.json"
+    for required in [$block_access_list_output $trie_witness_output $report_path] {
+        if not ($required | path exists) {
+            print $"Error: expected CodSpeed fixture artifact was not written: ($required)"
+            exit 1
+        }
+    }
+
+    {
+        preset: $preset
+        duration_secs: $duration
+        tps: $tps
+        accounts: $accounts
+        max_concurrent_requests: $max_concurrent_requests
+        bloat_gib: $bloat
+        gas_limit: $gas_limit
+        git_ref: $current_sha
+        benchmark_id: $benchmark_id
+        block_access_lists: "block-access-lists.ndjson.gz"
+        trie_witnesses: "trie-witnesses.ndjson.gz"
+        report: "report-codspeed-prebench.json"
+        format: "gzip_ndjson"
+    } | to json | save -f $"($artifact_dir)/manifest.json"
+
+    print $"CodSpeed pre-bench fixtures written to ($artifact_dir)"
 }

--- a/codspeed-prebench.nu
+++ b/codspeed-prebench.nu
@@ -1,0 +1,372 @@
+#!/usr/bin/env nu
+
+# CodSpeed pre-bench fixture collection.
+#
+# Restores one existing large benchmark snapshot, starts a single dev-mode Tempo
+# node, runs txgen + bench for the TIP20 profile, and writes the block artifacts
+# that Criterion benchmarks consume later in the CodSpeed job.
+
+source tempo.nu
+
+const PREBENCH_STATE_PATH = "/var/lib/schelk/a.json"
+const PREBENCH_MOUNT = "/reth-bench-a"
+const PREBENCH_SCHELK_SCRIPT = "bench-schelk.nu"
+const PREBENCH_FREE_MARGIN_MIB = 51200
+
+def run-prebench-schelk [...args: string] {
+    let result = (nu $PREBENCH_SCHELK_SCRIPT ...$args | complete)
+    if $result.stdout != "" { print $result.stdout }
+    if $result.stderr != "" { print $result.stderr }
+    if $result.exit_code != 0 {
+        error make { msg: $"bench-schelk failed: ($args | str join ' ')" }
+    }
+}
+
+def has-prebench-schelk [] {
+    (has-schelk) and ($PREBENCH_STATE_PATH | path exists)
+}
+
+def prebench-bloat-gib-to-mib [bloat: int] {
+    if $bloat in [1 10 100] {
+        return ($bloat * 1000)
+    }
+
+    print "Error: --bloat must be one of: 1, 10, 100"
+    exit 1
+}
+
+def prebench-datadir [bloat_mib: int, configured: string] {
+    if $configured != "" {
+        return ($configured | path expand)
+    }
+
+    if (has-prebench-schelk) {
+        return $"($PREBENCH_MOUNT)/tempo_e2e_($bloat_mib)mb"
+    }
+
+    $"($LOCALNET_DIR | path expand)/codspeed-prebench-reth"
+}
+
+def prebench-generated-datadir [bloat_mib: int] {
+    if (has-prebench-schelk) {
+        return $"($PREBENCH_MOUNT)/tempo_codspeed_($bloat_mib)mb"
+    }
+
+    $"($LOCALNET_DIR | path expand)/codspeed-prebench-reth"
+}
+
+def restore-prebench-snapshot [datadir: string] {
+    if (has-prebench-schelk) {
+        print $"Restoring pre-bench snapshot at ($PREBENCH_MOUNT)..."
+        run-prebench-schelk "restore" $PREBENCH_STATE_PATH $PREBENCH_MOUNT
+        return
+    }
+
+    if ($"($datadir).virgin" | path exists) {
+        print $"Restoring snapshot from ($datadir).virgin..."
+        rm -rf $datadir
+        ^cp -a $"($datadir).virgin" $datadir
+    }
+}
+
+def promote-prebench-snapshot [datadir: string] {
+    if (has-prebench-schelk) {
+        print $"Promoting pre-bench snapshot at ($PREBENCH_MOUNT)..."
+        run-prebench-schelk "promote" $PREBENCH_STATE_PATH
+        return
+    }
+
+    print $"Saving snapshot to ($datadir).virgin..."
+    rm -rf $"($datadir).virgin"
+    ^cp -a $datadir $"($datadir).virgin"
+}
+
+def df-available-mib [path: string] {
+    let row = (^df -Pm $path | lines | skip 1 | first | split row --regex '\s+')
+    $row | get 3 | into int
+}
+
+def ensure-prebench-space [mount: string, bloat_mib: int] {
+    if $bloat_mib <= 0 or not ($mount | path exists) {
+        return
+    }
+
+    let required_mib = $bloat_mib + $PREBENCH_FREE_MARGIN_MIB
+    let available_mib = (df-available-mib $mount)
+    if $available_mib < $required_mib {
+        print $"Error: ($mount) has ($available_mib) MiB free, needs at least ($required_mib) MiB for ($bloat_mib) MiB bloat plus margin"
+        exit 1
+    }
+}
+
+def prebench-meta-dir [datadir: string] {
+    $"($datadir)/($BENCH_META_SUBDIR)"
+}
+
+def prebench-genesis-path [datadir: string] {
+    $"(prebench-meta-dir $datadir)/genesis.json"
+}
+
+def prebench-snapshot-required-files [datadir: string] {
+    [
+        (prebench-genesis-path $datadir)
+        $"(prebench-meta-dir $datadir)/marker.json"
+        $"($datadir)/db"
+        $"($datadir)/static_files"
+    ]
+}
+
+def prebench-snapshot-ready [datadir: string] {
+    (prebench-snapshot-required-files $datadir | where { |path| not ($path | path exists) } | length) == 0
+}
+
+def save-prebench-meta [datadir: string, genesis_path: string, marker: record] {
+    let meta_dir = (prebench-meta-dir $datadir)
+    mkdir $meta_dir
+    cp $genesis_path $"($meta_dir)/genesis.json"
+    $marker | insert initialized_at (date now | format date "%Y-%m-%dT%H:%M:%SZ") | to json | save -f $"($meta_dir)/marker.json"
+}
+
+def init-prebench-snapshot [
+    tempo_bin: string,
+    datadir: string,
+    bloat_mib: int,
+    accounts: int,
+    gas_limit: string,
+    profile: string,
+] {
+    let init_dir = $"($LOCALNET_DIR)/codspeed-prebench-init"
+    let bloat_file = $"($init_dir)/state_bloat.bin"
+    let genesis_accounts = ([$accounts 3] | math max) + 1
+    let gas_limit_args = if $gas_limit != "" { ["--gas-limit" $gas_limit] } else { [] }
+
+    if ($init_dir | path exists) { rm -rf $init_dir }
+    mkdir $init_dir
+
+    ensure-prebench-space (if (has-prebench-schelk) { $PREBENCH_MOUNT } else { "." }) $bloat_mib
+
+    print $"Generating CodSpeed pre-bench genesis with ($genesis_accounts) accounts..."
+    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $init_dir -a $genesis_accounts --mnemonic (txgen-account-mnemonic) --no-dkg-in-genesis ...$gas_limit_args
+
+    if $bloat_mib > 0 {
+        print $"Generating CodSpeed pre-bench state bloat \(($bloat_mib) MiB\)..."
+        let token_args = ($TIP20_TOKEN_IDS | each { |id| ["--token" $"($id)"] } | flatten)
+        cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat_mib --out $bloat_file ...$token_args
+    }
+
+    bench-clean-datadir $datadir
+    mkdir $datadir
+    bench-init-db $tempo_bin $"($init_dir)/genesis.json" $datadir $bloat_mib $bloat_file
+    save-prebench-meta $datadir $"($init_dir)/genesis.json" {
+        bloat_mib: $bloat_mib
+        accounts: $genesis_accounts
+        gas_limit: $gas_limit
+        topology: "single-node"
+        txgen_mnemonic: (txgen-account-mnemonic)
+    }
+    promote-prebench-snapshot $datadir
+    restore-prebench-snapshot $datadir
+}
+
+def stop-prebench-node [] {
+    let pids = (find-tempo-pids)
+    if ($pids | length) > 0 {
+        print $"Stopping tempo process\(es): ($pids | str join ', ')"
+    }
+    for pid in $pids {
+        kill -s 2 $pid
+    }
+    for pid in $pids {
+        mut waited = 0
+        while $waited < 30 {
+            if (ps | where pid == $pid | length) == 0 { break }
+            sleep 1sec
+            $waited = $waited + 1
+        }
+        if $waited >= 30 {
+            print $"  Warning: PID ($pid) did not exit, sending SIGKILL"
+            kill -s 9 $pid
+            sleep 1sec
+        }
+    }
+}
+
+def start-prebench-node [
+    tempo_bin: string,
+    genesis_path: string,
+    datadir: string,
+    output_dir: string,
+    node_args: string,
+    node_env: string,
+    bloat_mib: int,
+    loud: bool,
+] {
+    let log_dir = $"($output_dir)/logs-node"
+    if ($log_dir | path exists) { rm -rf $log_dir }
+    mkdir $log_dir
+
+    let extra_args = if $node_args == "" { [] } else { $node_args | split row " " }
+    let base_args = (build-base-args $genesis_path $datadir $log_dir "0.0.0.0" 8545 9001)
+        | append (build-dev-args)
+        | append [
+            "--disable-discovery"
+            "--builder.max-tasks" "1"
+            "--engine.share-sparse-trie-with-payload-builder"
+        ]
+        | append (log-filter-args $loud)
+    let args = (dedup-args $base_args $extra_args)
+    let node_cmd = (txgen-shell-join [$tempo_bin ...$args])
+    let env_prefix = if $node_env != "" { $"($node_env) " } else { "" }
+
+    print $"Starting single-node CodSpeed pre-bench node: ($tempo_bin | path basename)"
+    job spawn {
+        bash -lc $"set -euo pipefail; ($env_prefix)($node_cmd) 2>&1"
+        | lines
+        | each { |line| print $"[codspeed-prebench-node] ($line)" }
+    }
+
+    sleep 2sec
+    let rpc_timeout = if $bloat_mib > 0 { 600 } else { 120 }
+    wait-for-rpc "http://localhost:8545" $rpc_timeout
+}
+
+def "main collect" [
+    --preset: string = "tip20"                         # Txgen preset name
+    --tps: int = 20000                                  # Target TPS
+    --duration: int = 300                               # Duration in seconds
+    --accounts: int = 1000                              # Number of accounts
+    --max-concurrent-requests: int = 100                # Max concurrent requests
+    --bloat: int = 100                                  # State bloat snapshot size in GiB: 1, 10, or 100
+    --gas-limit: string = "1000000000"                  # Builder gas limit
+    --profile: string = $DEFAULT_PROFILE                # Cargo build profile
+    --features: string = $DEFAULT_FEATURES              # Cargo features
+    --no-default-features                               # Disable Cargo default features
+    --force-bloat                                       # Regenerate and promote the local snapshot
+    --bench-args: string = ""                           # Additional txgen generate arguments
+    --bench-env: string = ""                            # Environment vars for the sender process
+    --node-args: string = ""                            # Additional node args
+    --node-env: string = ""                             # Environment vars for the node process
+    --bench-datadir: string = ""                        # Node database directory
+    --output-dir: string = "codspeed-prebench"          # Directory for fixture artifacts
+    --tune                                              # Apply system tuning
+    --loud                                              # Show node debug logs
+] {
+    let preset_path = (txgen-preset-path $preset)
+    let txgen = (txgen-resolve-binaries)
+    let bloat_mib = (prebench-bloat-gib-to-mib $bloat)
+    let restore_datadir = (prebench-datadir $bloat_mib $bench_datadir)
+    let artifact_dir = ($output_dir | path expand)
+    let current_sha = (git rev-parse HEAD | str trim)
+    let timestamp = (date now | format date "%Y%m%d-%H%M%S-%3f")
+    let benchmark_id = if (($env | get --optional GITHUB_RUN_ID) != null) {
+        $"codspeed-prebench-($env.GITHUB_RUN_ID)"
+    } else {
+        $"codspeed-prebench-($timestamp)"
+    }
+    let block_access_list_output = $"($artifact_dir)/block-access-lists.ndjson.gz"
+    let trie_witness_output = $"($artifact_dir)/trie-witnesses.ndjson.gz"
+    let report_path = $"($artifact_dir)/report-codspeed-prebench.json"
+
+    if ($artifact_dir | path exists) { rm -rf $artifact_dir }
+    mkdir $artifact_dir
+
+    stop-prebench-node
+    build-tempo --no-default-features=$no_default_features ["tempo"] $profile $features
+    let tempo_bin = if $profile == "dev" { "./target/debug/tempo" } else { $"./target/($profile)/tempo" }
+
+    restore-prebench-snapshot $restore_datadir
+
+    let e2e_datadir = $"($PREBENCH_MOUNT)/tempo_e2e_($bloat_mib)mb"
+    let datadir = if $bench_datadir != "" {
+        $restore_datadir
+    } else if (has-prebench-schelk) and (not $force_bloat) and (prebench-snapshot-ready $e2e_datadir) {
+        print $"Using existing large e2e snapshot: ($e2e_datadir)"
+        $e2e_datadir
+    } else {
+        prebench-generated-datadir $bloat_mib
+    }
+
+    if $force_bloat or not (prebench-snapshot-ready $datadir) {
+        if not $force_bloat {
+            print $"CodSpeed pre-bench snapshot is missing required files; initializing ($datadir)."
+        }
+        init-prebench-snapshot $tempo_bin $datadir $bloat_mib $accounts $gas_limit $profile
+    }
+
+    let genesis_path = (prebench-genesis-path $datadir)
+    if not ($genesis_path | path exists) {
+        print $"Error: genesis file not found: ($genesis_path)"
+        exit 1
+    }
+
+    let tuning_state = if $tune { apply-system-tuning } else { { tuned: false } }
+    start-prebench-node $tempo_bin $genesis_path $datadir $artifact_dir $node_args $node_env $bloat_mib $loud
+
+    let run_result = (try {
+        let result = (txgen-run-preset-pipeline
+            --txgen-tempo-bin ($txgen.txgen_tempo_bin)
+            --txgen-bench-bin ($txgen.txgen_bench_bin)
+            --preset-path $preset_path
+            --generate-rpc-url "http://localhost:8545"
+            --submit-rpc-url "http://localhost:8545"
+            --metrics-url ["http://127.0.0.1:9001/metrics"]
+            --report-path $report_path
+            --tps $tps
+            --duration $duration
+            --accounts $accounts
+            --max-concurrent-requests $max_concurrent_requests
+            --bench-args $bench_args
+            --bench-env $bench_env
+            --git-ref $current_sha
+            --git-ref-label "codspeed-prebench"
+            --build-profile $profile
+            --benchmark-mode "codspeed-prebench"
+            --benchmark-id $benchmark_id
+            --benchmark-run "codspeed-prebench"
+            --run-type "codspeed-prebench"
+            --platform "tempo"
+            --scenario $"($preset)-($tps // 1000)k"
+            --block-access-list-output $block_access_list_output
+            --trie-witness-output $trie_witness_output
+            --skip-funding=($bloat_mib > 0))
+        $result
+    } catch { |e|
+        print $"Error: CodSpeed pre-bench txgen run failed: ($e.msg)"
+        { ok: false, exit_code: 1, report_path: $report_path }
+    })
+
+    stop-prebench-node
+    restore-system-tuning $tuning_state
+    restore-prebench-snapshot $datadir
+
+    if not $run_result.ok {
+        exit $run_result.exit_code
+    }
+
+    for required in [$block_access_list_output $trie_witness_output $report_path] {
+        if not ($required | path exists) {
+            print $"Error: expected CodSpeed fixture artifact was not written: ($required)"
+            exit 1
+        }
+    }
+
+    {
+        preset: $preset
+        duration_secs: $duration
+        tps: $tps
+        accounts: $accounts
+        max_concurrent_requests: $max_concurrent_requests
+        bloat_gib: $bloat
+        bloat_mib: $bloat_mib
+        datadir: $datadir
+        gas_limit: $gas_limit
+        git_ref: $current_sha
+        benchmark_id: $benchmark_id
+        block_access_lists: "block-access-lists.ndjson.gz"
+        trie_witnesses: "trie-witnesses.ndjson.gz"
+        report: "report-codspeed-prebench.json"
+        format: "gzip_ndjson"
+    } | to json | save -f $"($artifact_dir)/manifest.json"
+
+    print $"CodSpeed pre-bench fixtures written to ($artifact_dir)"
+}

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -188,6 +188,8 @@ def txgen-run-preset-pipeline [
     --scenario: string = ""
     --victoriametrics-url: string = ""
     --clickhouse-url: string = ""
+    --block-access-list-output: string = ""
+    --trie-witness-output: string = ""
     --skip-funding                                   # Skip faucet funding (accounts already funded at genesis via state bloat)
 ] {
     let chain_id = (txgen-fetch-chain-id $generate_rpc_url)
@@ -223,6 +225,8 @@ def txgen-run-preset-pipeline [
         "--drain-timeout" $TXGEN_HELPER_DRAIN_TIMEOUT_SECS
     ]
         | append (if $victoriametrics_url != "" and $benchmark_start > 0 { ["--metrics-align" $"($benchmark_start)"] } else { [] })
+        | append (if $block_access_list_output != "" { ["--block-access-list-output" $block_access_list_output] } else { [] })
+        | append (if $trie_witness_output != "" { ["--trie-witness-output" $trie_witness_output] } else { [] })
     let report_args = ["--report" $"json:($report_path)"]
         | append (if $victoriametrics_url != "" { ["--report" $"victoriametrics:($victoriametrics_url)"] } else { [] })
         | append (if $clickhouse_url != "" { ["--report" $"clickhouse:($clickhouse_url)"] } else { [] })


### PR DESCRIPTION
Depends on tempoxyz/txgen#111.

Adds a CodSpeed pre-bench job that runs the tip20 txgen bench once against a single local Tempo node backed by the existing large snapshot and uploads block access list and trie witness artifacts. The CodSpeed job downloads those fixtures and exposes their paths via env vars for follow-up Criterion benchmark consumption.

The fixture collection lives in `codspeed-prebench.nu` instead of the e2e harness.