### PR TITLE
feat(txgen): add existing recipient TIP20 preset

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -58,6 +58,7 @@ on:
         options:
           - tip20
           - tip20_random_recipients
+          - tip20_existing_recipients
           - mpp
           - mix
       duration:

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -873,6 +873,8 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --benchmark-start $ctx.reference_epoch
                 --platform "tempo"
                 --scenario $scenario
+                --bloat-mib $ctx.bloat
+                --bloat-token-count ($TIP20_TOKEN_IDS | length)
                 --victoriametrics-url $ctx.victoriametrics_url
                 --clickhouse-url $phase_clickhouse_url
                 --skip-funding=($ctx.bloat > 0))

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -3,8 +3,8 @@
 source ../../tempo.nu
 
 const TXGEN_EXISTING_RECIPIENTS_PRESET = "tip20_existing_recipients"
-const TXGEN_EXISTING_RECIPIENTS_START = 50000
-const TXGEN_EXISTING_RECIPIENTS_END = 100000
+const TXGEN_EXISTING_RECIPIENTS_START = 10000
+const TXGEN_EXISTING_RECIPIENTS_END = 4000000
 
 def resolved-runtime-mode [mode: string] {
     if $mode == "e2e" {

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -2,6 +2,10 @@
 
 source ../../tempo.nu
 
+const TXGEN_EXISTING_RECIPIENTS_PRESET = "tip20_existing_recipients"
+const TXGEN_EXISTING_RECIPIENTS_START = 50000
+const TXGEN_EXISTING_RECIPIENTS_END = 100000
+
 def resolved-runtime-mode [mode: string] {
     if $mode == "e2e" {
         "dev"
@@ -21,6 +25,20 @@ def normalize-tracy-mode [value: any] {
         "full"
     } else {
         error make { msg: $"--tracy must be one of: off, on, full \(got ($value)\)" }
+    }
+}
+
+def txgen-genesis-accounts [preset: string, accounts: int] {
+    let signer_accounts = ([$accounts 3] | math max) + 1
+
+    if $preset == $TXGEN_EXISTING_RECIPIENTS_PRESET {
+        if $accounts > $TXGEN_EXISTING_RECIPIENTS_START {
+            error make { msg: $"preset ($preset) requires --accounts <= ($TXGEN_EXISTING_RECIPIENTS_START) so signer and recipient derivation ranges do not overlap" }
+        }
+
+        [$signer_accounts $TXGEN_EXISTING_RECIPIENTS_END] | math max
+    } else {
+        $signer_accounts
     }
 }
 
@@ -349,7 +367,7 @@ def "main run" [
         $"($abs_localnet)/reth"
     }
     let meta_dir = $"($datadir)/($BENCH_META_SUBDIR)"
-    let genesis_accounts = ([$accounts 3] | math max) + 1
+    let genesis_accounts = (txgen-genesis-accounts $preset $accounts)
     let gas_limit_args = if $gas_limit != "" { ["--gas-limit" $gas_limit] } else { [] }
     let txgen_mnemonic = (txgen-account-mnemonic)
     let txgen_genesis_args = ["--mnemonic" $txgen_mnemonic]

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -2,10 +2,6 @@
 
 source ../../tempo.nu
 
-const TXGEN_EXISTING_RECIPIENTS_PRESET = "tip20_existing_recipients"
-const TXGEN_EXISTING_RECIPIENTS_START = 10000
-const TXGEN_EXISTING_RECIPIENTS_END = 4000000
-
 def resolved-runtime-mode [mode: string] {
     if $mode == "e2e" {
         "dev"
@@ -25,20 +21,6 @@ def normalize-tracy-mode [value: any] {
         "full"
     } else {
         error make { msg: $"--tracy must be one of: off, on, full \(got ($value)\)" }
-    }
-}
-
-def txgen-genesis-accounts [preset: string, accounts: int] {
-    let signer_accounts = ([$accounts 3] | math max) + 1
-
-    if $preset == $TXGEN_EXISTING_RECIPIENTS_PRESET {
-        if $accounts > $TXGEN_EXISTING_RECIPIENTS_START {
-            error make { msg: $"preset ($preset) requires --accounts <= ($TXGEN_EXISTING_RECIPIENTS_START) so signer and recipient derivation ranges do not overlap" }
-        }
-
-        [$signer_accounts $TXGEN_EXISTING_RECIPIENTS_END] | math max
-    } else {
-        $signer_accounts
     }
 }
 
@@ -152,6 +134,8 @@ def run-txgen-bench-single [
         --git-ref-label $git_ref_label
         --platform $platform
         --scenario $scenario
+        --bloat-mib $bloat
+        --bloat-token-count ($TIP20_TOKEN_IDS | length)
         --skip-funding=($bloat > 0))
     if not $bench_result.ok {
         error make { msg: $"txgen benchmark run ($run_label) failed with exit code ($bench_result.exit_code)" }
@@ -367,7 +351,7 @@ def "main run" [
         $"($abs_localnet)/reth"
     }
     let meta_dir = $"($datadir)/($BENCH_META_SUBDIR)"
-    let genesis_accounts = (txgen-genesis-accounts $preset $accounts)
+    let genesis_accounts = ([$accounts 3] | math max) + 1
     let gas_limit_args = if $gas_limit != "" { ["--gas-limit" $gas_limit] } else { [] }
     let txgen_mnemonic = (txgen-account-mnemonic)
     let txgen_genesis_args = ["--mnemonic" $txgen_mnemonic]

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -4,6 +4,8 @@ const TXGEN_HELPER_SCRAPE_INTERVAL_MS = 500
 const TXGEN_HELPER_DRAIN_TIMEOUT_SECS = 300
 const TXGEN_HELPER_FUND_DRAIN_TIMEOUT_SECS = 120
 const TXGEN_HELPER_PRESETS_DIR = "contrib/bench/txgen/presets"
+const TXGEN_HELPER_EXISTING_RECIPIENTS_PRESET = "tip20_existing_recipients"
+const TXGEN_HELPER_EXISTING_RECIPIENTS_START = 10000
 
 def txgen-shell-quote [value: any] {
     let s = ($value | into string)
@@ -100,6 +102,44 @@ def txgen-account-mnemonic [] {
     $TXGEN_HELPER_ACCOUNT_MNEMONIC
 }
 
+def txgen-bloat-accounts-per-token [bloat_mib: int, token_count: int] {
+    if $bloat_mib <= 0 {
+        error make { msg: "bloat size must be greater than zero" }
+    }
+    if $token_count <= 0 {
+        error make { msg: "bloat token count must be greater than zero" }
+    }
+
+    let target_bytes = $bloat_mib * 1024 * 1024
+    let overhead_per_token = 40 + 64
+    let available_for_balances = $target_bytes - ($token_count * $overhead_per_token)
+    if $available_for_balances <= 0 {
+        error make { msg: $"bloat size ($bloat_mib) MiB is too small for ($token_count) token\(s\)" }
+    }
+
+    (($available_for_balances / 64) / $token_count) | into int
+}
+
+def txgen-configure-existing-recipients-env [preset_path: string, bloat_mib: int, token_count: int] {
+    let preset_name = ($preset_path | path basename | str replace --regex '\.yml$' '')
+    if $preset_name != $TXGEN_HELPER_EXISTING_RECIPIENTS_PRESET {
+        return
+    }
+
+    if $bloat_mib <= 0 {
+        error make { msg: $"preset ($preset_name) requires state bloat" }
+    }
+
+    let recipient_end = (txgen-bloat-accounts-per-token $bloat_mib $token_count)
+    if $recipient_end <= $TXGEN_HELPER_EXISTING_RECIPIENTS_START {
+        error make { msg: $"preset ($preset_name) requires state bloat with more than ($TXGEN_HELPER_EXISTING_RECIPIENTS_START) accounts per token" }
+    }
+
+    $env.TXGEN_EXISTING_RECIPIENTS_START = ($TXGEN_HELPER_EXISTING_RECIPIENTS_START | into string)
+    $env.TXGEN_EXISTING_RECIPIENTS_END = ($recipient_end | into string)
+    print $"  Using existing recipient range ($TXGEN_HELPER_EXISTING_RECIPIENTS_START)..($recipient_end) from ($bloat_mib) MiB state bloat"
+}
+
 def txgen-rpc-call [rpc_url: string, payload: string] {
     let result = (^curl -sf -X POST -H "Content-Type: application/json" -d $payload $rpc_url | complete)
     if $result.exit_code != 0 {
@@ -188,6 +228,8 @@ def txgen-run-preset-pipeline [
     --scenario: string = ""
     --victoriametrics-url: string = ""
     --clickhouse-url: string = ""
+    --bloat-mib: int = 0
+    --bloat-token-count: int = 4
     --skip-funding                                   # Skip faucet funding (accounts already funded at genesis via state bloat)
 ] {
     let chain_id = (txgen-fetch-chain-id $generate_rpc_url)
@@ -196,6 +238,7 @@ def txgen-run-preset-pipeline [
     if not ($spec_path | path exists) {
         error make { msg: $"txgen preset file not found: ($spec_path)" }
     }
+    txgen-configure-existing-recipients-env $spec_path $bloat_mib $bloat_token_count
     if not $skip_funding {
         txgen-fund-accounts $txgen_tempo_bin $spec_path $generate_rpc_url
     }

--- a/contrib/bench/txgen/presets/tip20_existing_recipients.yml
+++ b/contrib/bench/txgen/presets/tip20_existing_recipients.yml
@@ -16,8 +16,8 @@ address_pools:
   existing_recipients:
     mnemonic: "test test test test test test test test test test test junk"
     range:
-      - 50000
-      - 100000
+      - 10000
+      - 4000000
 
 artifacts:
   ERC20: ../erc20.abi.json

--- a/contrib/bench/txgen/presets/tip20_existing_recipients.yml
+++ b/contrib/bench/txgen/presets/tip20_existing_recipients.yml
@@ -12,12 +12,12 @@ accounts:
       - ${TXGEN_ACCOUNTS}
 
 address_pools:
-  # Keep this range in sync with TXGEN_EXISTING_RECIPIENTS_* in contrib/bench/bench-txgen.nu.
   existing_recipients:
-    mnemonic: "test test test test test test test test test test test junk"
-    range:
-      - 10000
-      - 4000000
+    fast:
+      seed: "test test test test test test test test test test test junk"
+      range:
+        - ${TXGEN_EXISTING_RECIPIENTS_START}
+        - ${TXGEN_EXISTING_RECIPIENTS_END}
 
 artifacts:
   ERC20: ../erc20.abi.json

--- a/contrib/bench/txgen/presets/tip20_existing_recipients.yml
+++ b/contrib/bench/txgen/presets/tip20_existing_recipients.yml
@@ -1,0 +1,49 @@
+chain_id: 1337
+
+gas:
+  max_fee_per_gas: 100000000000
+  max_priority_fee_per_gas: 100000000000
+
+accounts:
+  users:
+    mnemonic: "test test test test test test test test test test test junk"
+    range:
+      - 0
+      - ${TXGEN_ACCOUNTS}
+
+address_pools:
+  # Keep this range in sync with TXGEN_EXISTING_RECIPIENTS_* in contrib/bench/bench-txgen.nu.
+  existing_recipients:
+    mnemonic: "test test test test test test test test test test test junk"
+    range:
+      - 50000
+      - 100000
+
+artifacts:
+  ERC20: ../erc20.abi.json
+
+templates:
+  tip20_transfer:
+    type: tempo
+    from:
+      pool: users
+      select: random
+    gas_limit: 300000
+    max_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 100000000000
+    fee_token: "0x20c0000000000000000000000000000000000000"
+    expiring_nonce: true
+    valid_for_secs: 10
+    call:
+      to: "0x20c0000000000000000000000000000000000000"
+      abi: ERC20
+      function: transfer
+      args:
+        - address_pool:
+            pool: existing_recipients
+            select: random
+        - 1
+
+mix:
+  - template: tip20_transfer
+    weight: 100


### PR DESCRIPTION
Adds a TIP20 txgen preset that selects recipients from a destination-only fast address pool matching Tempo state-bloat address derivation. The txgen benchmark harness derives the recipient range from the configured bloat size so recipients exist in the bloat state without adding them to genesis.

Depends on tempoxyz/txgen#116.