### PR TITLE
feat(builder): separate state root metrics from builder finish

### DIFF
--- a/contrib/bench/grafana/dashboards/tempo-benchmarking.json
+++ b/contrib/bench/grafana/dashboards/tempo-benchmarking.json
@@ -660,13 +660,13 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "label_replace(avg(reth_tempo_payload_builder_builder_finish_duration_seconds{namespace=\"$namespace\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
+          "expr": "label_replace(avg(reth_tempo_payload_builder_payload_finalization_duration_seconds{namespace=\"$namespace\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
           "legendFormat": "{{job}} p{{quantile}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "builder.finish() Latency",
+      "title": "Finalization (state root) Latency",
       "type": "timeseries"
     },
     {

--- a/contrib/bench/grafana/dashboards/tempo-benchmarking.json
+++ b/contrib/bench/grafana/dashboards/tempo-benchmarking.json
@@ -660,13 +660,13 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "label_replace(avg(reth_tempo_payload_builder_payload_finalization_duration_seconds{namespace=\"$namespace\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
+          "expr": "label_replace(avg(reth_tempo_payload_builder_builder_finish_duration_seconds{namespace=\"$namespace\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
           "legendFormat": "{{job}} p{{quantile}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Finalization (state root) Latency",
+      "title": "builder.finish() Latency",
       "type": "timeseries"
     },
     {

--- a/crates/e2e/src/tests/payload_builder.rs
+++ b/crates/e2e/src/tests/payload_builder.rs
@@ -15,6 +15,8 @@ use crate::{CONSENSUS_NODE_PREFIX, Setup, connect_execution_peers, setup_validat
 
 const PAYLOAD_FINALIZATION_COUNT_METRIC: &str =
     "reth_tempo_payload_builder_payload_finalization_duration_seconds_count";
+const BUILDER_FINISH_COUNT_METRIC: &str =
+    "reth_tempo_payload_builder_builder_finish_duration_seconds_count";
 const STATE_ROOT_WITH_UPDATES_COUNT_METRIC: &str =
     "reth_tempo_payload_builder_state_root_with_updates_duration_seconds_count";
 const POOL_TRANSACTIONS_YIELDED_COUNT_METRIC: &str =
@@ -39,6 +41,10 @@ fn shared_sparse_trie_single_validator_bypasses_sync_state_root() {
     assert!(
         deltas.finalization_count > 0,
         "expected payload builder finalization metrics to increase"
+    );
+    assert!(
+        deltas.builder_finish_count > 0,
+        "expected payload builder finish metrics to increase"
     );
     assert_pool_inclusion_metrics(&deltas);
     assert_eq!(
@@ -73,6 +79,8 @@ fn run_payload_builder_test(
     let metrics_recorder = install_prometheus_recorder();
     let initial_finalization_count =
         prometheus_histogram_count(metrics_recorder, PAYLOAD_FINALIZATION_COUNT_METRIC);
+    let initial_builder_finish_count =
+        prometheus_histogram_count(metrics_recorder, BUILDER_FINISH_COUNT_METRIC);
     let initial_state_root_count =
         prometheus_histogram_count(metrics_recorder, STATE_ROOT_WITH_UPDATES_COUNT_METRIC);
     let initial_pool_transactions_yielded_count =
@@ -115,6 +123,8 @@ fn run_payload_builder_test(
 
     let final_finalization_count =
         prometheus_histogram_count(metrics_recorder, PAYLOAD_FINALIZATION_COUNT_METRIC);
+    let final_builder_finish_count =
+        prometheus_histogram_count(metrics_recorder, BUILDER_FINISH_COUNT_METRIC);
     let final_state_root_count =
         prometheus_histogram_count(metrics_recorder, STATE_ROOT_WITH_UPDATES_COUNT_METRIC);
     let final_pool_transactions_yielded_count =
@@ -132,6 +142,7 @@ fn run_payload_builder_test(
 
     MetricDelta {
         finalization_count: final_finalization_count - initial_finalization_count,
+        builder_finish_count: final_builder_finish_count - initial_builder_finish_count,
         state_root_count: final_state_root_count - initial_state_root_count,
         pool_transactions_yielded_count: final_pool_transactions_yielded_count
             - initial_pool_transactions_yielded_count,
@@ -146,6 +157,7 @@ fn run_payload_builder_test(
 
 struct MetricDelta {
     finalization_count: u64,
+    builder_finish_count: u64,
     state_root_count: u64,
     pool_transactions_yielded_count: u64,
     pool_transactions_included_count: u64,

--- a/crates/e2e/src/tests/payload_builder.rs
+++ b/crates/e2e/src/tests/payload_builder.rs
@@ -17,6 +17,8 @@ const PAYLOAD_FINALIZATION_COUNT_METRIC: &str =
     "reth_tempo_payload_builder_payload_finalization_duration_seconds_count";
 const BUILDER_FINISH_COUNT_METRIC: &str =
     "reth_tempo_payload_builder_builder_finish_duration_seconds_count";
+const SPARSE_TRIE_STATE_ROOT_WAIT_COUNT_METRIC: &str =
+    "reth_tempo_payload_builder_sparse_trie_state_root_wait_duration_seconds_count";
 const STATE_ROOT_WITH_UPDATES_COUNT_METRIC: &str =
     "reth_tempo_payload_builder_state_root_with_updates_duration_seconds_count";
 const POOL_TRANSACTIONS_YIELDED_COUNT_METRIC: &str =
@@ -45,6 +47,10 @@ fn shared_sparse_trie_single_validator_bypasses_sync_state_root() {
     assert!(
         deltas.builder_finish_count > 0,
         "expected payload builder finish metrics to increase"
+    );
+    assert!(
+        deltas.sparse_trie_state_root_wait_count > 0,
+        "expected sparse trie state-root wait metrics to increase"
     );
     assert_pool_inclusion_metrics(&deltas);
     assert_eq!(
@@ -81,6 +87,8 @@ fn run_payload_builder_test(
         prometheus_histogram_count(metrics_recorder, PAYLOAD_FINALIZATION_COUNT_METRIC);
     let initial_builder_finish_count =
         prometheus_histogram_count(metrics_recorder, BUILDER_FINISH_COUNT_METRIC);
+    let initial_sparse_trie_state_root_wait_count =
+        prometheus_histogram_count(metrics_recorder, SPARSE_TRIE_STATE_ROOT_WAIT_COUNT_METRIC);
     let initial_state_root_count =
         prometheus_histogram_count(metrics_recorder, STATE_ROOT_WITH_UPDATES_COUNT_METRIC);
     let initial_pool_transactions_yielded_count =
@@ -125,6 +133,8 @@ fn run_payload_builder_test(
         prometheus_histogram_count(metrics_recorder, PAYLOAD_FINALIZATION_COUNT_METRIC);
     let final_builder_finish_count =
         prometheus_histogram_count(metrics_recorder, BUILDER_FINISH_COUNT_METRIC);
+    let final_sparse_trie_state_root_wait_count =
+        prometheus_histogram_count(metrics_recorder, SPARSE_TRIE_STATE_ROOT_WAIT_COUNT_METRIC);
     let final_state_root_count =
         prometheus_histogram_count(metrics_recorder, STATE_ROOT_WITH_UPDATES_COUNT_METRIC);
     let final_pool_transactions_yielded_count =
@@ -143,6 +153,8 @@ fn run_payload_builder_test(
     MetricDelta {
         finalization_count: final_finalization_count - initial_finalization_count,
         builder_finish_count: final_builder_finish_count - initial_builder_finish_count,
+        sparse_trie_state_root_wait_count: final_sparse_trie_state_root_wait_count
+            - initial_sparse_trie_state_root_wait_count,
         state_root_count: final_state_root_count - initial_state_root_count,
         pool_transactions_yielded_count: final_pool_transactions_yielded_count
             - initial_pool_transactions_yielded_count,
@@ -158,6 +170,7 @@ fn run_payload_builder_test(
 struct MetricDelta {
     finalization_count: u64,
     builder_finish_count: u64,
+    sparse_trie_state_root_wait_count: u64,
     state_root_count: u64,
     pool_transactions_yielded_count: u64,
     pool_transactions_included_count: u64,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -748,7 +748,7 @@ where
             .total_normal_included_transaction_execution_duration_seconds
             .record(total_included_transaction_execution_elapsed);
 
-        let builder_finish_start = Instant::now();
+        let payload_finalization_start = Instant::now();
         let _finish_span = debug_span!(target: "payload_builder", "finish_block").entered();
         let finish_provider = || InstrumentedFinishProvider {
             inner: &*state_provider,
@@ -757,18 +757,27 @@ where
 
         check_cancel!();
 
-        let BlockBuilderOutcome {
-            execution_result,
-            block,
-            hashed_state,
-            trie_updates,
-            ..
-        } = if let Some(mut handle) = trie_handle {
+        let (
+            BlockBuilderOutcome {
+                execution_result,
+                block,
+                hashed_state,
+                trie_updates,
+                ..
+            },
+            builder_finish_elapsed,
+        ) = if let Some(mut handle) = trie_handle {
             // Dropping the hook signals that execution is complete and the sparse trie task can
             // finalize the state root it has been updating incrementally.
             builder.executor_mut().set_state_hook(None);
 
-            match handle.state_root() {
+            let state_root_wait_start = Instant::now();
+            let state_root_outcome = handle.state_root();
+            self.metrics
+                .sparse_trie_state_root_wait_duration_seconds
+                .record(state_root_wait_start.elapsed());
+
+            match state_root_outcome {
                 Ok(outcome) => {
                     debug!(
                         target: "payload_builder",
@@ -776,13 +785,17 @@ where
                         state_root = ?outcome.state_root,
                         "received state root from sparse trie"
                     );
-                    builder.finish(
+                    let builder_finish_start = Instant::now();
+                    let result = builder.finish(
                         finish_provider(),
                         Some((
                             outcome.state_root,
                             Arc::unwrap_or_clone(outcome.trie_updates),
                         )),
-                    )?
+                    );
+                    let elapsed = builder_finish_start.elapsed();
+                    self.metrics.builder_finish_duration_seconds.record(elapsed);
+                    (result?, elapsed)
                 }
                 Err(err) => {
                     warn!(
@@ -791,20 +804,25 @@ where
                         %err,
                         "sparse trie failed, falling back to sync state root"
                     );
-                    builder.finish(finish_provider(), None)?
+                    let builder_finish_start = Instant::now();
+                    let result = builder.finish(finish_provider(), None);
+                    let elapsed = builder_finish_start.elapsed();
+                    self.metrics.builder_finish_duration_seconds.record(elapsed);
+                    (result?, elapsed)
                 }
             }
         } else {
-            builder.finish(finish_provider(), None)?
+            let builder_finish_start = Instant::now();
+            let result = builder.finish(finish_provider(), None);
+            let elapsed = builder_finish_start.elapsed();
+            self.metrics.builder_finish_duration_seconds.record(elapsed);
+            (result?, elapsed)
         };
         drop(_finish_span);
-        let builder_finish_elapsed = builder_finish_start.elapsed();
+        let payload_finalization_elapsed = payload_finalization_start.elapsed();
         self.metrics
             .payload_finalization_duration_seconds
-            .record(builder_finish_elapsed);
-        self.metrics
-            .builder_finish_duration_seconds
-            .record(builder_finish_elapsed);
+            .record(payload_finalization_elapsed);
 
         let total_transactions = block.transaction_count();
         self.metrics

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -757,45 +757,24 @@ where
 
         check_cancel!();
 
-        let (
-            BlockBuilderOutcome {
-                execution_result,
-                block,
-                hashed_state,
-                trie_updates,
-                ..
-            },
-            builder_finish_elapsed,
-        ) = if let Some(mut handle) = trie_handle {
+        let state_root_outcome = if let Some(mut handle) = trie_handle {
             // Dropping the hook signals that execution is complete and the sparse trie task can
             // finalize the state root it has been updating incrementally.
             builder.executor_mut().set_state_hook(None);
 
             let state_root_wait_start = Instant::now();
-            let state_root_outcome = handle.state_root();
-            self.metrics
-                .sparse_trie_state_root_wait_duration_seconds
-                .record(state_root_wait_start.elapsed());
-
-            match state_root_outcome {
+            match handle.state_root() {
                 Ok(outcome) => {
+                    self.metrics
+                        .sparse_trie_state_root_wait_duration_seconds
+                        .record(state_root_wait_start.elapsed());
                     debug!(
                         target: "payload_builder",
                         id = %payload_id,
                         state_root = ?outcome.state_root,
                         "received state root from sparse trie"
                     );
-                    let builder_finish_start = Instant::now();
-                    let result = builder.finish(
-                        finish_provider(),
-                        Some((
-                            outcome.state_root,
-                            Arc::unwrap_or_clone(outcome.trie_updates),
-                        )),
-                    );
-                    let elapsed = builder_finish_start.elapsed();
-                    self.metrics.builder_finish_duration_seconds.record(elapsed);
-                    (result?, elapsed)
+                    Some(outcome)
                 }
                 Err(err) => {
                     warn!(
@@ -804,20 +783,35 @@ where
                         %err,
                         "sparse trie failed, falling back to sync state root"
                     );
-                    let builder_finish_start = Instant::now();
-                    let result = builder.finish(finish_provider(), None);
-                    let elapsed = builder_finish_start.elapsed();
-                    self.metrics.builder_finish_duration_seconds.record(elapsed);
-                    (result?, elapsed)
+                    None
                 }
             }
         } else {
-            let builder_finish_start = Instant::now();
-            let result = builder.finish(finish_provider(), None);
-            let elapsed = builder_finish_start.elapsed();
-            self.metrics.builder_finish_duration_seconds.record(elapsed);
-            (result?, elapsed)
+            None
         };
+
+        let builder_finish_start = Instant::now();
+        let BlockBuilderOutcome {
+            execution_result,
+            block,
+            hashed_state,
+            trie_updates,
+            ..
+        } = if let Some(outcome) = state_root_outcome {
+            builder.finish(
+                finish_provider(),
+                Some((
+                    outcome.state_root,
+                    Arc::unwrap_or_clone(outcome.trie_updates),
+                )),
+            )
+        } else {
+            builder.finish(finish_provider(), None)
+        }?;
+        let builder_finish_elapsed = builder_finish_start.elapsed();
+        self.metrics
+            .builder_finish_duration_seconds
+            .record(builder_finish_elapsed);
         drop(_finish_span);
         let payload_finalization_elapsed = payload_finalization_start.elapsed();
         self.metrics

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -802,6 +802,9 @@ where
         self.metrics
             .payload_finalization_duration_seconds
             .record(builder_finish_elapsed);
+        self.metrics
+            .builder_finish_duration_seconds
+            .record(builder_finish_elapsed);
 
         let total_transactions = block.transaction_count();
         self.metrics

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -757,38 +757,41 @@ where
 
         check_cancel!();
 
-        let state_root_outcome = if let Some(mut handle) = trie_handle {
-            // Dropping the hook signals that execution is complete and the sparse trie task can
-            // finalize the state root it has been updating incrementally.
-            builder.executor_mut().set_state_hook(None);
+        let (state_root_outcome, sparse_trie_state_root_wait_elapsed) =
+            if let Some(mut handle) = trie_handle {
+                // Dropping the hook signals that execution is complete and the sparse trie task can
+                // finalize the state root it has been updating incrementally.
+                builder.executor_mut().set_state_hook(None);
 
-            let state_root_wait_start = Instant::now();
-            match handle.state_root() {
-                Ok(outcome) => {
-                    self.metrics
-                        .sparse_trie_state_root_wait_duration_seconds
-                        .record(state_root_wait_start.elapsed());
-                    debug!(
-                        target: "payload_builder",
-                        id = %payload_id,
-                        state_root = ?outcome.state_root,
-                        "received state root from sparse trie"
-                    );
-                    Some(outcome)
+                let state_root_wait_start = Instant::now();
+                match handle.state_root() {
+                    Ok(outcome) => {
+                        let elapsed = state_root_wait_start.elapsed();
+                        self.metrics
+                            .sparse_trie_state_root_wait_duration_seconds
+                            .record(elapsed);
+                        debug!(
+                            target: "payload_builder",
+                            id = %payload_id,
+                            state_root = ?outcome.state_root,
+                            "received state root from sparse trie"
+                        );
+                        Some((outcome, elapsed))
+                    }
+                    Err(err) => {
+                        warn!(
+                            target: "payload_builder",
+                            id = %payload_id,
+                            %err,
+                            "sparse trie failed, falling back to sync state root"
+                        );
+                        None
+                    }
                 }
-                Err(err) => {
-                    warn!(
-                        target: "payload_builder",
-                        id = %payload_id,
-                        %err,
-                        "sparse trie failed, falling back to sync state root"
-                    );
-                    None
-                }
+            } else {
+                None
             }
-        } else {
-            None
-        };
+            .unzip();
 
         let builder_finish_start = Instant::now();
         let BlockBuilderOutcome {
@@ -928,6 +931,7 @@ where
             ?normal_transaction_fill_idle_elapsed,
             ?normal_transaction_fill_overhead_elapsed,
             ?total_subblock_transaction_execution_elapsed,
+            ?sparse_trie_state_root_wait_elapsed,
             ?builder_finish_elapsed,
             "Built payload"
         );

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -97,6 +97,8 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) system_transactions_execution_duration_seconds: Histogram,
     /// The time it took to finalize the payload in seconds. Includes merging transitions and calculating the state root.
     pub(crate) payload_finalization_duration_seconds: Histogram,
+    /// Wall-clock time spent waiting for the shared sparse trie state root.
+    pub(crate) sparse_trie_state_root_wait_duration_seconds: Histogram,
     /// Wall-clock time spent in `builder.finish()`.
     pub(crate) builder_finish_duration_seconds: Histogram,
     /// Total time it took to build the payload in seconds.

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -97,6 +97,8 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) system_transactions_execution_duration_seconds: Histogram,
     /// The time it took to finalize the payload in seconds. Includes merging transitions and calculating the state root.
     pub(crate) payload_finalization_duration_seconds: Histogram,
+    /// Wall-clock time spent in `builder.finish()`.
+    pub(crate) builder_finish_duration_seconds: Histogram,
     /// Total time it took to build the payload in seconds.
     pub(crate) payload_build_duration_seconds: Histogram,
     /// Gas per second calculated as gas_used / payload_build_duration.


### PR DESCRIPTION
## Summary
- add an explicit `tempo_payload_builder_builder_finish_duration_seconds` histogram for wall-clock time spent in `builder.finish()`
- keep state-root timing in `tempo_payload_builder_state_root_with_updates_duration_seconds`
- update the payload-builder e2e metric smoke test and benchmarking Grafana panel to use the explicit builder.finish metric

## Test
- `cargo fmt`
- `git diff --check`
- `cargo test -p tempo-e2e payload_builder -- --nocapture`