### PR TITLE
ci(bench): disable txgen send retries

### DIFF
--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -218,6 +218,7 @@ def txgen-run-preset-pipeline [
         "--rpc-url" $submit_rpc_url
         "--tps" $tps
         "--max-concurrent" $max_concurrent_requests
+        "--retries" 0
         ...$metrics_url_args
         "--scrape-interval-ms" $TXGEN_HELPER_SCRAPE_INTERVAL_MS
         "--drain-timeout" $TXGEN_HELPER_DRAIN_TIMEOUT_SECS


### PR DESCRIPTION
## Summary
- pass `--retries 0` to `bench send` in the txgen benchmark helper
- avoids retrying normal generated transactions while conditional retry behavior is deferred

## Testing
- Not run: `nu` is not installed in this sandbox
- Verified against tempoxyz/txgen#115 that `--retries 0` disables `bench send` retries