### PR TITLE
fix(transaction-pool): prefilter invalid timestamp txs

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -37,7 +37,7 @@ use reth_revm::{State, context::Block, database::StateProviderDatabase};
 use reth_storage_api::StateProviderFactory;
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{
-    BestTransactions, BestTransactionsAttributes, TransactionPool, ValidPoolTransaction,
+    BestTransactions, BestTransactionsAttributes, ValidPoolTransaction,
     error::InvalidPoolTransactionError,
 };
 use std::{
@@ -186,7 +186,10 @@ where
     ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
         self.build_payload(
             args,
-            |attributes| self.pool.best_transactions_with_attributes(attributes),
+            |attributes, block_timestamp| {
+                self.pool
+                    .best_transactions_with_block_timestamp(attributes, block_timestamp)
+            },
             false,
         )
     }
@@ -211,7 +214,7 @@ where
                 Default::default(),
                 Default::default(),
             ),
-            |_| core::iter::empty(),
+            |_, _| core::iter::empty(),
             true,
         )?
         .into_payload()
@@ -235,7 +238,7 @@ where
     fn build_payload<Txs>(
         &self,
         args: BuildArguments<TempoPayloadAttributes, TempoBuiltPayload>,
-        best_txs: impl FnOnce(BestTransactionsAttributes) -> Txs,
+        best_txs: impl FnOnce(BestTransactionsAttributes, Option<u64>) -> Txs,
         empty: bool,
     ) -> Result<BuildOutcome<TempoBuiltPayload>, PayloadBuilderError>
     where
@@ -438,14 +441,17 @@ where
 
         let base_fee = builder.evm_mut().block().basefee;
         let pool_fetch_start = Instant::now();
-        let best_txs = best_txs(BestTransactionsAttributes::new(
-            base_fee,
-            builder
-                .evm_mut()
-                .block()
-                .blob_gasprice()
-                .map(|gasprice| gasprice as u64),
-        ));
+        let best_txs = best_txs(
+            BestTransactionsAttributes::new(
+                base_fee,
+                builder
+                    .evm_mut()
+                    .block()
+                    .blob_gasprice()
+                    .map(|gasprice| gasprice as u64),
+            ),
+            Some(attributes.timestamp),
+        );
         // Wrap best transactions into state-aware wrapper to skip transactions that
         // get invalidated by already-executed ones.
         let mut best_txs = StateAwareBestTransactions::new(if self.enable_prewarming {

--- a/crates/transaction-pool/src/best.rs
+++ b/crates/transaction-pool/src/best.rs
@@ -1,6 +1,9 @@
 //! An iterator over the best transactions in the tempo pool.
 
-use crate::{transaction::TempoPooledTransaction, tt_2d_pool::BestAA2dTransactions};
+use crate::{
+    transaction::{TempoPoolTransactionError, TempoPooledTransaction},
+    tt_2d_pool::BestAA2dTransactions,
+};
 use alloy_primitives::{Address, U256, map::HashMap};
 use reth_evm::block::TxResult;
 use reth_primitives_traits::transaction::error::InvalidTransactionError;
@@ -23,6 +26,7 @@ pub struct MergeBestTransactions {
     aa_2d_pool: BestAA2dTransactions,
     next_protocol_pool: Option<BestTransactionWithPriority>,
     next_aa_2d_pool: Option<BestTransactionWithPriority>,
+    block_timestamp: Option<u64>,
 }
 
 impl MergeBestTransactions {
@@ -31,11 +35,21 @@ impl MergeBestTransactions {
         protocol_pool: BestProtocolTransactions<TxOrdering>,
         aa_2d_pool: BestAA2dTransactions,
     ) -> Self {
+        Self::new_with_block_timestamp(protocol_pool, aa_2d_pool, None)
+    }
+
+    /// Creates a new iterator over the given iterators with optional block timestamp filtering.
+    pub(crate) fn new_with_block_timestamp(
+        protocol_pool: BestProtocolTransactions<TxOrdering>,
+        aa_2d_pool: BestAA2dTransactions,
+        block_timestamp: Option<u64>,
+    ) -> Self {
         Self {
             protocol_pool,
             aa_2d_pool,
             next_protocol_pool: None,
             next_aa_2d_pool: None,
+            block_timestamp,
         }
     }
 }
@@ -78,13 +92,34 @@ impl MergeBestTransactions {
             }
         }
     }
+
+    /// Returns the invalid block timestamp error for a transaction, if the timestamp is known.
+    fn invalid_block_timestamp_error(
+        &self,
+        transaction: &BestTransaction,
+    ) -> Option<InvalidPoolTransactionError> {
+        let block_timestamp = self.block_timestamp?;
+        transaction
+            .transaction
+            .ensure_valid_block_timestamp(block_timestamp)
+            .err()
+            .map(|err| InvalidPoolTransactionError::other(TempoPoolTransactionError::Evm(err)))
+    }
 }
 
 impl Iterator for MergeBestTransactions {
     type Item = BestTransaction;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.next_best().map(|(tx, _)| tx)
+        loop {
+            let (tx, _) = self.next_best()?;
+            if let Some(err) = self.invalid_block_timestamp_error(&tx) {
+                self.mark_invalid(&tx, err);
+                continue;
+            }
+
+            return Some(tx);
+        }
     }
 }
 
@@ -220,15 +255,32 @@ mod tests {
     type TestTx = Arc<ValidPoolTransaction<TempoPooledTransaction>>;
 
     fn tx_with_nonce_key(nonce_key: U256, sender: Address, nonce: u64, priority: u128) -> TestTx {
-        Arc::new(wrap_valid_tx(
-            TxBuilder::aa(sender)
-                .nonce_key(nonce_key)
-                .nonce(nonce)
-                .max_priority_fee(priority)
-                .max_fee(u128::from(TempoHardfork::T1.base_fee()) + priority)
-                .build(),
-            TransactionOrigin::External,
-        ))
+        tx_with_nonce_key_and_time_bounds(nonce_key, sender, nonce, priority, None, None)
+    }
+
+    fn tx_with_nonce_key_and_time_bounds(
+        nonce_key: U256,
+        sender: Address,
+        nonce: u64,
+        priority: u128,
+        valid_after: Option<u64>,
+        valid_before: Option<u64>,
+    ) -> TestTx {
+        let mut builder = TxBuilder::aa(sender)
+            .nonce_key(nonce_key)
+            .nonce(nonce)
+            .max_priority_fee(priority)
+            .max_fee(u128::from(TempoHardfork::T1.base_fee()) + priority);
+
+        if let Some(valid_after) = valid_after {
+            builder = builder.valid_after(valid_after);
+        }
+
+        if let Some(valid_before) = valid_before {
+            builder = builder.valid_before(valid_before);
+        }
+
+        Arc::new(wrap_valid_tx(builder.build(), TransactionOrigin::External))
     }
 
     fn protocol_tx(nonce: u64, priority: u128) -> TestTx {
@@ -299,6 +351,18 @@ mod tests {
         MergeBestTransactions::new(
             protocol_best_transactions(protocol_txs),
             aa_2d_best_transactions(aa_2d_txs),
+        )
+    }
+
+    fn merged_best_transactions_at(
+        protocol_txs: Vec<TestTx>,
+        aa_2d_txs: Vec<TestTx>,
+        block_timestamp: u64,
+    ) -> MergeBestTransactions {
+        MergeBestTransactions::new_with_block_timestamp(
+            protocol_best_transactions(protocol_txs),
+            aa_2d_best_transactions(aa_2d_txs),
+            Some(block_timestamp),
         )
     }
 
@@ -424,6 +488,68 @@ mod tests {
         assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*r2.hash())); // 6
         assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*l3.hash())); // 5
         assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*r3.hash())); // 4
+        assert!(merged.next().is_none());
+    }
+
+    #[test]
+    fn test_block_timestamp_prefilter_skips_expired_valid_before() {
+        let block_timestamp = 1_000;
+        let expired = tx_with_nonce_key_and_time_bounds(
+            U256::ZERO,
+            Address::random(),
+            0,
+            10,
+            None,
+            Some(block_timestamp),
+        );
+        let valid = tx_with_nonce_key_and_time_bounds(
+            U256::ZERO,
+            Address::random(),
+            0,
+            5,
+            None,
+            Some(block_timestamp + 1),
+        );
+        let mut merged =
+            merged_best_transactions_at(vec![expired, valid.clone()], vec![], block_timestamp);
+
+        assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*valid.hash()));
+        assert!(merged.next().is_none());
+    }
+
+    #[test]
+    fn test_block_timestamp_prefilter_skips_future_valid_after() {
+        let block_timestamp = 1_000;
+        let future = tx_with_nonce_key_and_time_bounds(
+            U256::from(1),
+            Address::random(),
+            0,
+            10,
+            Some(block_timestamp + 1),
+            None,
+        );
+        let valid = aa_2d_tx(0, 5);
+        let mut merged =
+            merged_best_transactions_at(vec![], vec![future, valid.clone()], block_timestamp);
+
+        assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*valid.hash()));
+        assert!(merged.next().is_none());
+    }
+
+    #[test]
+    fn test_block_timestamp_prefilter_is_disabled_without_timestamp() {
+        let block_timestamp = 1_000;
+        let future = tx_with_nonce_key_and_time_bounds(
+            U256::from(1),
+            Address::random(),
+            0,
+            10,
+            Some(block_timestamp + 1),
+            None,
+        );
+        let mut merged = merged_best_transactions(vec![], vec![future.clone()]);
+
+        assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*future.hash()));
         assert!(merged.next().is_none());
     }
 

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -75,6 +75,30 @@ impl<Client> TempoTransactionPool<Client>
 where
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = TempoChainSpec> + 'static,
 {
+    fn best_transactions_at_block_timestamp(
+        &self,
+        block_timestamp: Option<u64>,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<TempoPooledTransaction>>>> {
+        let left = self.protocol_pool.inner().best_transactions();
+        let right = self.aa_2d_pool.read().best_transactions();
+        let best = match block_timestamp {
+            Some(block_timestamp) => {
+                MergeBestTransactions::new_with_block_timestamp(left, right, Some(block_timestamp))
+            }
+            None => MergeBestTransactions::new(left, right),
+        };
+        Box::new(best)
+    }
+
+    /// Returns best transactions with Tempo block-timestamp pre-filtering when available.
+    pub fn best_transactions_with_block_timestamp(
+        &self,
+        _attributes: BestTransactionsAttributes,
+        block_timestamp: Option<u64>,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<TempoPooledTransaction>>>> {
+        self.best_transactions_at_block_timestamp(block_timestamp)
+    }
+
     /// Obtains a clone of the shared [`AmmLiquidityCache`].
     pub fn amm_liquidity_cache(&self) -> AmmLiquidityCache {
         self.protocol_pool
@@ -810,16 +834,14 @@ where
     fn best_transactions(
         &self,
     ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
-        let left = self.protocol_pool.inner().best_transactions();
-        let right = self.aa_2d_pool.read().best_transactions();
-        Box::new(MergeBestTransactions::new(left, right))
+        self.best_transactions_at_block_timestamp(None)
     }
 
     fn best_transactions_with_attributes(
         &self,
-        _attributes: BestTransactionsAttributes,
+        attributes: BestTransactionsAttributes,
     ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
-        self.best_transactions()
+        self.best_transactions_with_block_timestamp(attributes, None)
     }
 
     fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -140,6 +140,42 @@ impl TempoPooledTransaction {
         self.expiring_nonce_hash.is_some()
     }
 
+    /// Checks whether this transaction can be included in a block with `block_timestamp`.
+    ///
+    /// Non-AA transactions do not carry Tempo timestamp bounds and always pass. AA transactions
+    /// pass when `block_timestamp` is greater than or equal to `valid_after`, if set, and strictly
+    /// less than `valid_before`, if set. Returns the corresponding `TempoInvalidTransaction`
+    /// rejection when either timestamp bound excludes the block timestamp.
+    pub(crate) fn ensure_valid_block_timestamp(
+        &self,
+        block_timestamp: u64,
+    ) -> Result<(), TempoInvalidTransaction> {
+        let Some(aa_tx) = self.inner().as_aa() else {
+            return Ok(());
+        };
+        let tx = aa_tx.tx();
+
+        if let Some(valid_after) = tx.valid_after
+            && block_timestamp < valid_after.get()
+        {
+            return Err(TempoInvalidTransaction::ValidAfter {
+                current: block_timestamp,
+                valid_after: valid_after.get(),
+            });
+        }
+
+        if let Some(valid_before) = tx.valid_before
+            && block_timestamp >= valid_before.get()
+        {
+            return Err(TempoInvalidTransaction::ValidBefore {
+                current: block_timestamp,
+                valid_before: valid_before.get(),
+            });
+        }
+
+        Ok(())
+    }
+
     /// Extracts the keychain subject (account, key_id, fee_token) from this transaction.
     ///
     /// Returns `None` if:


### PR DESCRIPTION
Prefilters Tempo AA transactions during best-transaction iteration when the payload block timestamp is available. Transactions outside their `valid_after`/`valid_before` window are marked invalid before execution selection.

Callers that cannot provide a block timestamp keep the existing behavior via `None`.