### PR TITLE
feat(tip-1028): impl latest spec changes

### DIFF
--- a/crates/contracts/src/precompiles/receive_policy_guard.rs
+++ b/crates/contracts/src/precompiles/receive_policy_guard.rs
@@ -72,6 +72,19 @@ crate::sol! {
         /// @param amount Amount of funds released.
         event ReceiptClaimed(address indexed token, address indexed receiver, uint8 receiptVersion, uint64 indexed blockedNonce, uint64 blockedAt, address originator, address recipient, address recoveryAuthority, address caller, address to, uint256 amount);
 
+        /// @notice Emitted when blocked funds are burned with a valid receipt.
+        /// @param token TIP-20 token burned by the guard.
+        /// @param receiver Resolved account where funds would settle; for virtual recipients its their master.
+        /// @param receiptVersion Claim receipt layout version.
+        /// @param blockedNonce Guard nonce from the burned receipt.
+        /// @param blockedAt Block timestamp from the burned receipt.
+        /// @param originator Original sender/originator from the burned receipt.
+        /// @param recipient Addressed recipient from the burned receipt; may be virtual.
+        /// @param recoveryAuthority Claim authority from the burned receipt.
+        /// @param caller Account that submitted the burn.
+        /// @param amount Amount of funds burned.
+        event ReceiptBurned(address indexed token, address indexed receiver, uint8 receiptVersion, uint64 indexed blockedNonce, uint64 blockedAt, address originator, address recipient, address recoveryAuthority, address caller, uint256 amount);
+
         error InvalidReceipt();
         error InvalidClaimAddress();
         error UnauthorizedClaimer();
@@ -148,6 +161,26 @@ impl IReceivePolicyGuard::ClaimReceiptV1 {
             blockedReason: self.blockedReason,
             recoveryAuthority: self.recoveryAuthority,
             memo: self.memo,
+        })
+    }
+
+    pub fn burned_event(
+        &self,
+        receiver: Address,
+        caller: Address,
+        amount: U256,
+    ) -> ReceivePolicyGuardEvent {
+        ReceivePolicyGuardEvent::ReceiptBurned(IReceivePolicyGuard::ReceiptBurned {
+            token: self.token,
+            receiver,
+            receiptVersion: self.version,
+            blockedNonce: self.blockedNonce,
+            blockedAt: self.blockedAt,
+            originator: self.originator,
+            recipient: self.recipient,
+            recoveryAuthority: self.recoveryAuthority,
+            caller,
+            amount,
         })
     }
 }

--- a/crates/contracts/src/precompiles/receive_policy_guard.rs
+++ b/crates/contracts/src/precompiles/receive_policy_guard.rs
@@ -83,7 +83,7 @@ impl IReceivePolicyGuard::ClaimProofV1 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         token: Address,
-        recovery_auth: Address,
+        recovery_address: Address,
         originator: Address,
         recipient: Address,
         at: u64,
@@ -92,6 +92,13 @@ impl IReceivePolicyGuard::ClaimProofV1 {
         kind: IReceivePolicyGuard::InboundKind,
         memo: B256,
     ) -> Self {
+        // Ensure proof doesn't use the `address(0)` sentinel
+        let recovery_auth = if recovery_address.is_zero() {
+            originator
+        } else {
+            recovery_address
+        };
+
         Self {
             version: 1,
             token,

--- a/crates/contracts/src/precompiles/receive_policy_guard.rs
+++ b/crates/contracts/src/precompiles/receive_policy_guard.rs
@@ -22,7 +22,7 @@ crate::sol! {
             uint8 version;
             /// @notice TIP-20 token whose blocked funds are held by the guard.
             address token;
-            /// @notice Claim authority: originator sentinel, receiver sentinel, or third-party address.
+            /// @notice Address with the authority to claim the blocked funds.
             address recoveryAuthority;
             /// @notice Original sender/originator of the blocked transfer or mint.
             address originator;
@@ -42,6 +42,7 @@ crate::sol! {
 
         function balanceOf(bytes calldata proof) external view returns (uint256 amount);
         function claim(address to, bytes calldata proof) external;
+        function burnBlockedProof(bytes calldata proof) external;
 
         /// @notice Emitted when an inbound TIP-20 transfer or mint is blocked and funds are redirected.
         /// @param token TIP-20 token whose funds are held by the guard.

--- a/crates/node/tests/it/gas/receive_policy_guard.rs
+++ b/crates/node/tests/it/gas/receive_policy_guard.rs
@@ -87,7 +87,7 @@ async fn set_receive_policy<P: Provider + Clone>(
 async fn create_blocked_transfer<P: Provider + Clone>(
     token: &ITIP20::ITIP20Instance<P>,
     receiver: Address,
-    recovery: Address,
+    expected_recovery_authority: Address,
     amount: U256,
 ) -> eyre::Result<BlockedTransfer> {
     let receipt = token
@@ -103,7 +103,7 @@ async fn create_blocked_transfer<P: Provider + Clone>(
     assert_eq!(blocked.token, *token.address());
     assert_eq!(blocked.receiver, receiver);
     assert_eq!(blocked.recipient, receiver);
-    assert_eq!(blocked.recoveryAuthority, recovery);
+    assert_eq!(blocked.recoveryAuthority, expected_recovery_authority);
     assert_eq!(blocked.amount, amount);
     assert_eq!(blocked.proofVersion, BLOCKED_PROOF_VERSION);
     assert_eq!(
@@ -114,7 +114,7 @@ async fn create_blocked_transfer<P: Provider + Clone>(
     let proof_bytes: Bytes = IReceivePolicyGuard::ClaimProofV1 {
         version: 1,
         token: *token.address(),
-        recoveryAuthority: recovery,
+        recoveryAuthority: expected_recovery_authority,
         originator: blocked.from,
         recipient: blocked.recipient,
         blockedAt: blocked.blockedAt,
@@ -272,7 +272,7 @@ async fn test_receive_policy_guard_gas_snapshots() -> eyre::Result<()> {
     let originator_blocked = create_blocked_transfer(
         &originator_token,
         originator_recovery_receiver.address(),
-        RECOVERY_ORIGINATOR,
+        originator.address(),
         U256::from(1_000),
     )
     .await?;

--- a/crates/node/tests/it/gas/snapshots/it__gas__receive_policy_guard__receive_policy_guard_gas_snapshots.snap
+++ b/crates/node/tests/it/gas/snapshots/it__gas__receive_policy_guard__receive_policy_guard_gas_snapshots.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/node/tests/it/gas/receive_policy_guard.rs
-assertion_line: 353
+assertion_line: 351
 expression: gas
 ---
-claim_originator_recovery_to_destination: 308129
-claim_receiver_recovery_to_receiver: 303853
+claim_originator_recovery_to_destination: 308369
+claim_receiver_recovery_to_receiver: 304081
 claim_third_party_recovery_to_destination: 306281
 set_receive_policy_allowed_third_party_recovery: 778029
 set_receive_policy_originator_recovery: 527777
-set_receive_policy_receiver_recovery: 527789
+set_receive_policy_receiver_recovery: 528017
 set_receive_policy_third_party_recovery: 778017
 transfer_allowed_third_party_receive_policy: 301858
 transfer_blocked_originator_recovery: 1060259

--- a/crates/precompiles/src/receive_policy_guard/dispatch.rs
+++ b/crates/precompiles/src/receive_policy_guard/dispatch.rs
@@ -25,6 +25,9 @@ impl Precompile for ReceivePolicyGuard {
                 IReceivePolicyGuardCalls::claim(call) => {
                     mutate_void(call, msg_sender, |s, c| self.claim(s, c.to, c.proof))
                 }
+                IReceivePolicyGuardCalls::burnBlockedProof(call) => {
+                    mutate_void(call, msg_sender, |s, c| self.burn_blocked_proof(s, c.proof))
+                }
             },
         )
     }

--- a/crates/precompiles/src/receive_policy_guard/mod.rs
+++ b/crates/precompiles/src/receive_policy_guard/mod.rs
@@ -75,11 +75,13 @@ impl RecoveryMode {
         }
     }
 
-    /// Returns whether claiming to `to` redirects funds away from the receiver.
+    /// Returns whether a claim is a reroute under TIP-1028.
+    /// Originator-authorized claims are always reroutes; non-originator recovery claims resume
+    /// only when claiming to the receiver.
     pub(crate) fn is_reroute(self, to: Address, receiver: Address) -> bool {
         match self {
-            Self::Receiver => to != receiver,
-            Self::Originator | Self::ThirdParty => true,
+            Self::Originator => true,
+            Self::Receiver | Self::ThirdParty => to != receiver,
         }
     }
 

--- a/crates/precompiles/src/receive_policy_guard/mod.rs
+++ b/crates/precompiles/src/receive_policy_guard/mod.rs
@@ -138,11 +138,7 @@ impl ReceivePolicyGuard {
         let blocked_at = self.storage.timestamp().saturating_to::<u64>();
         let proof = IReceivePolicyGuard::ClaimProofV1::new(
             token,
-            if recovery_address.is_zero() {
-                originator
-            } else {
-                recovery_address
-            },
+            recovery_address,
             originator,
             recipient,
             blocked_at,

--- a/crates/precompiles/src/receive_policy_guard/mod.rs
+++ b/crates/precompiles/src/receive_policy_guard/mod.rs
@@ -197,7 +197,9 @@ impl ReceivePolicyGuard {
         // Burn from the account with ownership of the funds.
         let owner = recovery_mode.policy_subject(receipt.originator, receiver);
         TIP20Token::from_address(receipt.token)?.burn_blocked(msg_sender, owner, amount, true)?;
-        self.balances[key].write(U256::ZERO)
+        self.balances[key].write(U256::ZERO)?;
+
+        self.emit_event(receipt.burned_event(receiver, msg_sender, amount))
     }
 
     /// Allocates the next nonzero receipt nonce.
@@ -235,7 +237,7 @@ mod tests {
         error::TempoPrecompileError,
         storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{TIP20Setup, VIRTUAL_MASTER, register_virtual_master},
-        tip20::ITIP20,
+        tip20::{BURN_BLOCKED_ROLE, ITIP20},
         tip403_registry::{ALLOW_ALL_POLICY_ID, REJECT_ALL_POLICY_ID, TIP403Registry},
     };
     use alloy::sol_types::SolValue;
@@ -432,6 +434,94 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn test_burn_blocked_receipt_emits_receipt_burned() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        let blocked_at = 1_728_010u64;
+        storage.set_timestamp(U256::from(blocked_at));
+
+        let admin = Address::random();
+        let burner = Address::random();
+        let originator = Address::random();
+        let receiver = Address::random();
+        let amount = U256::from(100u64);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::create("T", "T", admin)
+                .with_issuer(admin)
+                .with_role(burner, *BURN_BLOCKED_ROLE)
+                .with_mint(originator, amount)
+                .apply()?;
+            block_all_senders(receiver, receiver)?;
+
+            token.transfer(
+                originator,
+                ITIP20::transferCall {
+                    to: receiver,
+                    amount,
+                },
+            )?;
+
+            let receipt = ClaimReceiptV1::new(
+                token.address(),
+                receiver,
+                originator,
+                receiver,
+                blocked_at,
+                1,
+                BlockedReason::RECEIVE_POLICY as u8,
+                InboundKind::TRANSFER,
+                B256::ZERO,
+            );
+
+            let mut registry = TIP403Registry::new();
+            let policy_id = registry.create_policy(
+                admin,
+                ITIP403Registry::createPolicyCall {
+                    admin,
+                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                },
+            )?;
+            registry.modify_policy_blacklist(
+                admin,
+                ITIP403Registry::modifyPolicyBlacklistCall {
+                    policyId: policy_id,
+                    account: receiver,
+                    restricted: true,
+                },
+            )?;
+            token.change_transfer_policy_id(
+                admin,
+                ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: policy_id,
+                },
+            )?;
+
+            let mut guard = ReceivePolicyGuard::new();
+            guard.clear_emitted_events();
+
+            guard.burn_blocked_receipt(burner, receipt.abi_encode().into())?;
+
+            guard.assert_emitted_events(vec![ReceivePolicyGuardEvent::ReceiptBurned(
+                IReceivePolicyGuard::ReceiptBurned {
+                    token: token.address(),
+                    receiver,
+                    receiptVersion: BLOCKED_RECEIPT_VERSION,
+                    blockedNonce: 1,
+                    blockedAt: blocked_at,
+                    originator,
+                    recipient: receiver,
+                    recoveryAuthority: receiver,
+                    caller: burner,
+                    amount,
+                },
+            )]);
+            assert_eq!(guard.balance_of(receipt.abi_encode().into())?, U256::ZERO);
+
+            Ok(())
+        })
     }
 
     #[test]

--- a/crates/precompiles/src/receive_policy_guard/mod.rs
+++ b/crates/precompiles/src/receive_policy_guard/mod.rs
@@ -35,7 +35,7 @@ pub struct ReceivePolicyGuard {
 }
 
 /// Recovery authority for blocked inbound funds.
-#[derive(Debug, Clone, Copy, Default, Storable)]
+#[derive(Debug, Clone, Copy, Default, Storable, PartialEq)]
 #[repr(u8)]
 pub(crate) enum RecoveryMode {
     #[default]
@@ -45,6 +45,7 @@ pub(crate) enum RecoveryMode {
 }
 
 impl RecoveryMode {
+    /// Encodes a configured recovery authority into a mode and stored authority value.
     pub(crate) fn encode(authority: Address, msg_sender: Address) -> (Self, Address) {
         if authority == RECOVERY_ORIGINATOR {
             (Self::Originator, Address::ZERO)
@@ -52,6 +53,41 @@ impl RecoveryMode {
             (Self::Receiver, Address::ZERO)
         } else {
             (Self::ThirdParty, authority)
+        }
+    }
+
+    /// Resolves the recovery mode for a proof and resolved receiver.
+    pub(crate) fn from(proof: &ClaimProofV1, receiver: Address) -> Self {
+        if proof.recoveryAuthority == proof.originator {
+            Self::Originator
+        } else if proof.recoveryAuthority == receiver {
+            Self::Receiver
+        } else {
+            Self::ThirdParty
+        }
+    }
+
+    /// Returns the address of the account who has effective ownership of the blocked funds.
+    pub(crate) fn policy_subject(self, originator: Address, receiver: Address) -> Address {
+        match self {
+            Self::Originator => originator,
+            Self::Receiver | Self::ThirdParty => receiver,
+        }
+    }
+
+    /// Returns whether claiming to `to` redirects funds away from the receiver.
+    pub(crate) fn is_reroute(self, to: Address, receiver: Address) -> bool {
+        match self {
+            Self::Receiver => to != receiver,
+            Self::Originator | Self::ThirdParty => true,
+        }
+    }
+
+    /// Returns the account charged for access-key spending limits, if any.
+    pub(crate) fn spending_account(self, recovery_authority: Address) -> Option<Address> {
+        match self {
+            Self::Originator | Self::Receiver => Some(recovery_authority),
+            Self::ThirdParty => None,
         }
     }
 }
@@ -102,7 +138,11 @@ impl ReceivePolicyGuard {
         let blocked_at = self.storage.timestamp().saturating_to::<u64>();
         let proof = IReceivePolicyGuard::ClaimProofV1::new(
             token,
-            recovery_address,
+            if recovery_address.is_zero() {
+                originator
+            } else {
+                recovery_address
+            },
             originator,
             recipient,
             blocked_at,
@@ -124,14 +164,10 @@ impl ReceivePolicyGuard {
             return Err(ReceivePolicyGuardError::invalid_claim_address().into());
         }
 
-        let proof = ClaimProofV1::try_from(proof)?;
-        let receiver = AddressRegistry::new()
-            .resolve_receiver(proof.recipient)
-            .map_err(|_| ReceivePolicyGuardError::invalid_claim_address())?;
-
-        let recovery_authority =
-            RecoveryAuthority::from_address(proof.recoveryAuthority, receiver, proof.originator);
-        recovery_authority.validate_auth(msg_sender)?;
+        let (proof, receiver, recovery_mode) = resolve_proof(proof)?;
+        if proof.recoveryAuthority != msg_sender {
+            return Err(ReceivePolicyGuardError::unauthorized_claimer().into());
+        };
 
         let key = self.proof_key(&proof)?;
         let amount = self.balances[key].read()?;
@@ -141,23 +177,31 @@ impl ReceivePolicyGuard {
 
         self.balances[key].write(U256::ZERO)?;
 
-        let reroute = match recovery_authority {
-            RecoveryAuthority::Originator(_) => true,
-            RecoveryAuthority::Receiver(_) | RecoveryAuthority::Contract(_) => to != receiver,
-        };
-        let recovery_addr = match recovery_authority {
-            RecoveryAuthority::Receiver(addr) | RecoveryAuthority::Originator(addr) => Some(addr),
-            RecoveryAuthority::Contract(_) => None,
-        };
         TIP20Token::from_address(proof.token)?.release_blocked_funds(
             proof.originator,
+            receiver,
             to,
             amount,
-            reroute,
-            recovery_addr,
+            recovery_mode,
+            proof.recoveryAuthority,
         )?;
 
         self.emit_event(proof.claimed_event(receiver, msg_sender, to, amount))
+    }
+
+    pub fn burn_blocked_proof(&mut self, msg_sender: Address, proof: Bytes) -> Result<()> {
+        let (proof, receiver, recovery_mode) = resolve_proof(proof)?;
+
+        let key = self.proof_key(&proof)?;
+        let amount = self.balances[key].read()?;
+        if amount.is_zero() {
+            return Err(ReceivePolicyGuardError::invalid_proof().into());
+        }
+
+        // Burn from the account with ownership of the funds.
+        let owner = recovery_mode.policy_subject(proof.originator, receiver);
+        TIP20Token::from_address(proof.token)?.burn_blocked(msg_sender, owner, amount, true)?;
+        self.balances[key].write(U256::ZERO)
     }
 
     /// Allocates the next nonzero proof nonce.
@@ -177,35 +221,14 @@ impl ReceivePolicyGuard {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum RecoveryAuthority {
-    Originator(Address),
-    Receiver(Address),
-    Contract(Address),
-}
+fn resolve_proof(bytes: Bytes) -> Result<(ClaimProofV1, Address, RecoveryMode)> {
+    let proof = ClaimProofV1::try_from(bytes)?;
+    let receiver = AddressRegistry::new()
+        .resolve_receiver(proof.recipient)
+        .map_err(|_| ReceivePolicyGuardError::invalid_claim_address())?;
+    let recovery_mode = RecoveryMode::from(&proof, receiver);
 
-impl RecoveryAuthority {
-    fn from_address(address: Address, receiver: Address, originator: Address) -> Self {
-        if address == RECOVERY_ORIGINATOR {
-            Self::Originator(originator)
-        } else if address == receiver {
-            Self::Receiver(receiver)
-        } else {
-            Self::Contract(address)
-        }
-    }
-
-    fn validate_auth(self, msg_sender: Address) -> Result<()> {
-        let authorized_claimer = match self {
-            Self::Receiver(claimer) | Self::Originator(claimer) | Self::Contract(claimer) => {
-                claimer
-            }
-        };
-        if msg_sender != authorized_claimer {
-            return Err(ReceivePolicyGuardError::unauthorized_claimer().into());
-        }
-        Ok(())
-    }
+    Ok((proof, receiver, recovery_mode))
 }
 
 #[cfg(test)]
@@ -224,24 +247,6 @@ mod tests {
     use tempo_contracts::precompiles::{
         ITIP403Registry, ReceivePolicyGuardEvent, TIP20Error, TIP20Event,
     };
-
-    impl RecoveryAuthority {
-        fn claimer(&self) -> Address {
-            match self {
-                Self::Originator(addr) => *addr,
-                Self::Receiver(addr) => *addr,
-                Self::Contract(addr) => *addr,
-            }
-        }
-
-        fn address(&self) -> Address {
-            match self {
-                Self::Originator(_) => RECOVERY_ORIGINATOR,
-                Self::Receiver(addr) => *addr,
-                Self::Contract(addr) => *addr,
-            }
-        }
-    }
 
     fn block_all_senders(receiver: Address, recovery_authority: Address) -> Result<()> {
         TIP403Registry::new().set_receive_policy(
@@ -283,15 +288,12 @@ mod tests {
                 InboundKind::__Invalid => unreachable!(),
             };
 
-            for recovery_auth in [
-                RecoveryAuthority::Originator(originator),
-                RecoveryAuthority::Receiver(receiver),
-                RecoveryAuthority::Contract(Address::random()),
+            let third_party = Address::random();
+            for (configured_authority, claimer, destination, is_third_party) in [
+                (RECOVERY_ORIGINATOR, originator, originator, false),
+                (receiver, receiver, receiver, false),
+                (third_party, third_party, Address::random(), true),
             ] {
-                let destination = match recovery_auth {
-                    RecoveryAuthority::Originator(addr) | RecoveryAuthority::Receiver(addr) => addr,
-                    RecoveryAuthority::Contract(_) => Address::random(),
-                };
                 let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
                 storage.set_timestamp(U256::from(blocked_at));
 
@@ -301,11 +303,11 @@ mod tests {
                         setup = setup.with_mint(originator, amount);
                     }
                     let mut token = setup.apply()?;
-                    block_all_senders(receiver, recovery_auth.address())?;
+                    block_all_senders(receiver, configured_authority)?;
 
                     let unknown = ClaimProofV1::new(
                         token.address(),
-                        recovery_auth.address(),
+                        claimer,
                         originator,
                         receiver,
                         blocked_at,
@@ -364,14 +366,14 @@ mod tests {
                             recipient: receiver,
                             amount,
                             blockedReason: BlockedReason::RECEIVE_POLICY as u8,
-                            recoveryAuthority: recovery_auth.address(),
+                            recoveryAuthority: claimer,
                             memo: B256::ZERO,
                         },
                     )]);
 
                     let proof = ClaimProofV1::new(
                         token.address(),
-                        recovery_auth.address(),
+                        claimer,
                         originator,
                         receiver,
                         blocked_at,
@@ -382,7 +384,7 @@ mod tests {
                     );
                     assert_eq!(guard.balance_of(proof.abi_encode().into())?, amount);
 
-                    if let RecoveryAuthority::Contract(recovery) = recovery_auth {
+                    if is_third_party {
                         assert_unauthorized(guard.claim(
                             receiver,
                             receiver,
@@ -394,15 +396,10 @@ mod tests {
                             proof.abi_encode().into(),
                         ));
                         assert_eq!(guard.balance_of(proof.abi_encode().into())?, amount);
-                        assert_eq!(recovery_auth.claimer(), recovery);
                     }
 
                     guard.clear_emitted_events();
-                    guard.claim(
-                        recovery_auth.claimer(),
-                        destination,
-                        proof.abi_encode().into(),
-                    )?;
+                    guard.claim(claimer, destination, proof.abi_encode().into())?;
                     guard.assert_emitted_events(vec![ReceivePolicyGuardEvent::ProofClaimed(
                         IReceivePolicyGuard::ProofClaimed {
                             token: token.address(),
@@ -412,8 +409,8 @@ mod tests {
                             blockedAt: blocked_at,
                             originator,
                             recipient: receiver,
-                            recoveryAuthority: recovery_auth.address(),
-                            caller: recovery_auth.claimer(),
+                            recoveryAuthority: claimer,
+                            caller: claimer,
                             to: destination,
                             amount,
                         },
@@ -602,7 +599,7 @@ mod tests {
                 guard.balance_of(proof_c.abi_encode().into())?
             );
 
-            guard.claim(recovery, receiver_b, proof_b.abi_encode().into())?;
+            guard.claim(recovery, recovery, proof_b.abi_encode().into())?;
             assert_eq!(
                 token_a.balance_of(ITIP20::balanceOfCall {
                     account: RECEIVE_POLICY_GUARD_ADDRESS

--- a/crates/precompiles/src/tip20/dispatch.rs
+++ b/crates/precompiles/src/tip20/dispatch.rs
@@ -170,7 +170,9 @@ impl Precompile for TIP20Token {
                     mutate_void(call, msg_sender, |s, c| self.burn_with_memo(s, c))
                 }
                 TIP20Call::TIP20(ITIP20Calls::burnBlocked(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.burn_blocked(s, c))
+                    mutate_void(call, msg_sender, |s, c| {
+                        self.burn_blocked(s, c.from, c.amount, false)
+                    })
                 }
                 TIP20Call::TIP20(ITIP20Calls::transferWithMemo(call)) => {
                     mutate_void(call, msg_sender, |s, c| self.transfer_with_memo(s, c))

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1251,14 +1251,11 @@ impl TIP20Token {
         self.check_not_paused()?;
         let destination = Recipient::resolve(to)?;
         destination.validate()?;
-        self.ensure_transfer_authorized(
-            recovery_mode.policy_subject(originator, receiver),
-            destination.target,
-        )?;
-
         if recovery_mode.is_reroute(to, receiver) {
+            let policy_subject = recovery_mode.policy_subject(originator, receiver);
+            self.ensure_transfer_authorized(policy_subject, destination.target)?;
             if TIP403Registry::new()
-                .validate_receive_policy(self.address, originator, destination.target)?
+                .validate_receive_policy(self.address, policy_subject, destination.target)?
                 .is_some()
             {
                 return Err(TIP20Error::policy_forbids().into());
@@ -1266,6 +1263,8 @@ impl TIP20Token {
             if let Some(addr) = recovery_mode.spending_account(recovery_auth) {
                 self.check_and_update_spending_limit(addr, amount)?;
             }
+        } else {
+            self.ensure_authorized_as(destination.target, AuthRole::recipient())?;
         }
 
         self._transfer(RECEIVE_POLICY_GUARD_ADDRESS, &destination, amount)?;
@@ -1810,6 +1809,55 @@ pub(crate) mod tests {
                     Ok::<(), TempoPrecompileError>(())
                 })?;
             }
+
+            let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+            StorageCtx::enter(&mut storage, || {
+                let mut registry = TIP403Registry::new();
+                let recipient_policy = registry.create_policy_with_accounts(
+                    admin,
+                    ITIP403Registry::createPolicyWithAccountsCall {
+                        admin,
+                        policyType: ITIP403Registry::PolicyType::WHITELIST,
+                        accounts: vec![receiver],
+                    },
+                )?;
+                let transfer_policy = registry.create_compound_policy(
+                    admin,
+                    ITIP403Registry::createCompoundPolicyCall {
+                        senderPolicyId: REJECT_ALL_POLICY_ID,
+                        recipientPolicyId: recipient_policy,
+                        mintRecipientPolicyId: ALLOW_ALL_POLICY_ID,
+                    },
+                )?;
+
+                let mut token = TIP20Setup::create("Test", "TST", admin)
+                    .with_issuer(admin)
+                    .apply()?;
+                token.change_transfer_policy_id(
+                    admin,
+                    ITIP20::changeTransferPolicyIdCall {
+                        newPolicyId: transfer_policy,
+                    },
+                )?;
+                token.set_balance(RECEIVE_POLICY_GUARD_ADDRESS, amount)?;
+
+                // A third-party claim back to the receiver is a resume. It requires the receiver
+                // to be authorized as recipient, but must not require the receiver/policy subject
+                // to be authorized as sender.
+                token.release_blocked_funds(
+                    originator,
+                    receiver,
+                    receiver,
+                    amount,
+                    RecoveryMode::ThirdParty,
+                    third_party,
+                )?;
+
+                assert_eq!(token.get_balance(RECEIVE_POLICY_GUARD_ADDRESS)?, U256::ZERO);
+                assert_eq!(token.get_balance(receiver)?, amount);
+
+                Ok::<(), TempoPrecompileError>(())
+            })?;
 
             Ok(())
         }

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1743,6 +1743,76 @@ pub(crate) mod tests {
         }
 
         #[test]
+        fn test_release_blocked_funds_receive_policy_paths() -> eyre::Result<()> {
+            let admin = Address::random();
+            let originator = Address::random();
+            let receiver = Address::random();
+            let third_party = Address::random();
+            let open_destination = Address::random();
+            let blocked_destination = Address::random();
+            let amount = U256::from(10u64);
+
+            for (mode, recovery_auth, destination, destination_policy_blocks, should_succeed) in [
+                // Receiver recovery back to the receiver is a resume: it skips receive-policy
+                // validation, so the original blocking policy does not deadlock the claim.
+                (RecoveryMode::Receiver, receiver, receiver, true, true),
+                // Receiver and originator reroutes re-check the destination receive policy.
+                (RecoveryMode::Receiver, receiver, blocked_destination, true, false),
+                (RecoveryMode::Originator, originator, blocked_destination, true, false),
+                (RecoveryMode::Originator, originator, originator, false, true),
+                // Third-party recovery is always a reroute, including claims back to receiver.
+                (RecoveryMode::ThirdParty, third_party, receiver, true, false),
+                (RecoveryMode::ThirdParty, third_party, open_destination, false, true),
+            ] {
+                let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+                StorageCtx::enter(&mut storage, || {
+                    let mut token = TIP20Setup::create("Test", "TST", admin)
+                        .with_issuer(admin)
+                        .apply()?;
+                    token.set_balance(RECEIVE_POLICY_GUARD_ADDRESS, amount)?;
+
+                    set_receive_policy(
+                        receiver,
+                        REJECT_ALL_POLICY_ID,
+                        ALLOW_ALL_POLICY_ID,
+                        Address::ZERO,
+                    )?;
+                    if destination_policy_blocks && destination != receiver {
+                        set_receive_policy(
+                            destination,
+                            REJECT_ALL_POLICY_ID,
+                            ALLOW_ALL_POLICY_ID,
+                            Address::ZERO,
+                        )?;
+                    }
+
+                    let result = token.release_blocked_funds(
+                        originator,
+                        receiver,
+                        destination,
+                        amount,
+                        mode,
+                        recovery_auth,
+                    );
+
+                    if should_succeed {
+                        result?;
+                        assert_eq!(token.get_balance(RECEIVE_POLICY_GUARD_ADDRESS)?, U256::ZERO);
+                        assert_eq!(token.get_balance(destination)?, amount);
+                    } else {
+                        assert_eq!(result.unwrap_err(), TIP20Error::policy_forbids().into());
+                        assert_eq!(token.get_balance(RECEIVE_POLICY_GUARD_ADDRESS)?, amount);
+                        assert_eq!(token.get_balance(destination)?, U256::ZERO);
+                    }
+
+                    Ok::<(), TempoPrecompileError>(())
+                })?;
+            }
+
+            Ok(())
+        }
+
+        #[test]
         fn test_transfer_blocked_by_token_filter_records_reason() -> eyre::Result<()> {
             let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
             storage.set_timestamp(U256::from(BLOCKED_AT));

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1743,6 +1743,7 @@ pub(crate) mod tests {
         }
 
         #[test]
+        #[rustfmt::skip]
         fn test_release_blocked_funds_receive_policy_paths() -> eyre::Result<()> {
             let admin = Address::random();
             let originator = Address::random();

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1251,12 +1251,12 @@ impl TIP20Token {
         self.check_not_paused()?;
         let destination = Recipient::resolve(to)?;
         destination.validate()?;
+        self.ensure_transfer_authorized(
+            recovery_mode.policy_subject(originator, receiver),
+            destination.target,
+        )?;
 
         if recovery_mode.is_reroute(to, receiver) {
-            self.ensure_transfer_authorized(
-                recovery_mode.policy_subject(originator, receiver),
-                destination.target,
-            )?;
             if TIP403Registry::new()
                 .validate_receive_policy(self.address, originator, destination.target)?
                 .is_some()

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     account_keychain::AccountKeychain,
     address_registry::AddressRegistry,
     error::{Result, TempoPrecompileError},
-    receive_policy_guard::{InboundKind, ReceivePolicyGuard},
+    receive_policy_guard::{InboundKind, ReceivePolicyGuard, RecoveryMode},
     storage::{Handler, Mapping},
     tip20::{rewards::UserRewardInfo, roles::DEFAULT_ADMIN_ROLE},
     tip20_factory::TIP20Factory,
@@ -587,7 +587,8 @@ impl TIP20Token {
         self.emit_event(TIP20Event::burn(msg_sender, call.amount))
     }
 
-    /// Burns tokens from addresses blocked by [`TIP403Registry`] policy.
+    /// Burns tokens from addresses blocked by [`TIP403Registry`] policy. Where `owner` refers to
+    /// the account with ownership of the funds, either directly, or via the `ReceivePolicyGuard`.
     ///
     /// # Errors
     /// - `ContractPaused` — (+T3) token is paused
@@ -597,7 +598,9 @@ impl TIP20Token {
     pub fn burn_blocked(
         &mut self,
         msg_sender: Address,
-        call: ITIP20::burnBlockedCall,
+        owner: Address,
+        amount: U256,
+        policed_by_guard: bool,
     ) -> Result<()> {
         let hardfork = self.storage.spec();
 
@@ -608,35 +611,40 @@ impl TIP20Token {
         self.check_role(msg_sender, *BURN_BLOCKED_ROLE)?;
 
         // Prevent burning from system custody addresses to protect accounting invariants.
-        let hardfork = self.storage.spec();
-        if PROTECTED
-            .iter()
-            .any(|(fork, addrs)| hardfork >= *fork && addrs.contains(&call.from))
+        if !policed_by_guard
+            && PROTECTED
+                .iter()
+                .any(|(fork, addrs)| hardfork >= *fork && addrs.contains(&owner))
         {
             return Err(TIP20Error::protected_address().into());
         }
 
         // Check if the address is blocked from transferring (sender authorization)
         let policy_id = self.transfer_policy_id()?;
-        if TIP403Registry::new().is_authorized_as(policy_id, call.from, AuthRole::sender())? {
+        if TIP403Registry::new().is_authorized_as(policy_id, owner, AuthRole::sender())? {
             // Only allow burning from addresses that are blocked from transferring
             return Err(TIP20Error::policy_forbids().into());
         }
 
-        self._transfer(call.from, &Recipient::direct(Address::ZERO), call.amount)?;
+        let burn_from = if policed_by_guard {
+            RECEIVE_POLICY_GUARD_ADDRESS
+        } else {
+            owner
+        };
+        self._transfer(burn_from, &Recipient::direct(Address::ZERO), amount)?;
 
         let total_supply = self.total_supply()?;
         let new_supply =
             total_supply
-                .checked_sub(call.amount)
+                .checked_sub(amount)
                 .ok_or(TIP20Error::insufficient_balance(
                     total_supply,
-                    call.amount,
+                    amount,
                     self.address,
                 ))?;
         self.set_total_supply(new_supply)?;
 
-        self.emit_event(TIP20Event::burn_blocked(call.from, call.amount))
+        self.emit_event(TIP20Event::burn_blocked(owner, amount))
     }
 
     fn _burn(&mut self, msg_sender: Address, amount: U256) -> Result<()> {
@@ -1229,10 +1237,11 @@ impl TIP20Token {
     pub(crate) fn release_blocked_funds(
         &mut self,
         originator: Address,
+        receiver: Address,
         to: Address,
         amount: U256,
-        reroute: bool,
-        recovery_addr: Option<Address>,
+        recovery_mode: RecoveryMode,
+        recovery_auth: Address,
     ) -> Result<()> {
         debug_assert!(
             to != RECEIVE_POLICY_GUARD_ADDRESS,
@@ -1243,19 +1252,18 @@ impl TIP20Token {
         let destination = Recipient::resolve(to)?;
         destination.validate()?;
 
-        if reroute {
-            let registry = TIP403Registry::new();
-            let policy_id = self.transfer_policy_id()?;
-            if !registry.is_authorized_as(policy_id, destination.target, AuthRole::recipient())? {
-                return Err(TIP20Error::policy_forbids().into());
-            }
-            if registry
+        if recovery_mode.is_reroute(to, receiver) {
+            self.ensure_transfer_authorized(
+                recovery_mode.policy_subject(originator, receiver),
+                destination.target,
+            )?;
+            if TIP403Registry::new()
                 .validate_receive_policy(self.address, originator, destination.target)?
                 .is_some()
             {
                 return Err(TIP20Error::policy_forbids().into());
             }
-            if let Some(addr) = recovery_addr {
+            if let Some(addr) = recovery_mode.spending_account(recovery_auth) {
                 self.check_and_update_spending_limit(addr, amount)?;
             }
         }
@@ -1703,7 +1711,7 @@ pub(crate) mod tests {
 
                 let proof = IReceivePolicyGuard::ClaimProofV1::new(
                     token.address,
-                    Address::ZERO,
+                    sender,
                     sender,
                     receiver,
                     BLOCKED_AT,
@@ -1725,7 +1733,7 @@ pub(crate) mod tests {
                         recipient: receiver,
                         amount,
                         blockedReason: ITIP403Registry::BlockedReason::RECEIVE_POLICY as u8,
-                        recoveryAuthority: Address::ZERO,
+                        recoveryAuthority: sender,
                         memo: B256::ZERO,
                     },
                 )]);
@@ -1765,7 +1773,7 @@ pub(crate) mod tests {
 
                 let proof = IReceivePolicyGuard::ClaimProofV1::new(
                     token.address,
-                    Address::ZERO,
+                    sender,
                     sender,
                     receiver,
                     BLOCKED_AT,
@@ -1787,7 +1795,7 @@ pub(crate) mod tests {
                         recipient: receiver,
                         amount,
                         blockedReason: ITIP403Registry::BlockedReason::TOKEN_FILTER as u8,
-                        recoveryAuthority: Address::ZERO,
+                        recoveryAuthority: sender,
                         memo: B256::ZERO,
                     },
                 )]);
@@ -1867,7 +1875,7 @@ pub(crate) mod tests {
                 })]);
                 let proof = IReceivePolicyGuard::ClaimProofV1::new(
                     token.address,
-                    Address::ZERO,
+                    sender,
                     sender,
                     receiver,
                     BLOCKED_AT,
@@ -1969,7 +1977,7 @@ pub(crate) mod tests {
                 })]);
                 let proof = IReceivePolicyGuard::ClaimProofV1::new(
                     token.address,
-                    Address::ZERO,
+                    sender,
                     sender,
                     receiver,
                     BLOCKED_AT,
@@ -2035,14 +2043,14 @@ pub(crate) mod tests {
                         recipient: receiver,
                         amount,
                         blockedReason: ITIP403Registry::BlockedReason::RECEIVE_POLICY as u8,
-                        recoveryAuthority: Address::ZERO,
+                        recoveryAuthority: admin,
                         memo: B256::ZERO,
                     },
                 )]);
 
                 let proof = IReceivePolicyGuard::ClaimProofV1::new(
                     token.address,
-                    Address::ZERO,
+                    admin,
                     admin,
                     receiver,
                     BLOCKED_AT,
@@ -3167,13 +3175,7 @@ pub(crate) mod tests {
                 RECEIVE_POLICY_GUARD_ADDRESS,
                 TIP20_CHANNEL_RESERVE_ADDRESS,
             ] {
-                let result = token.burn_blocked(
-                    burner,
-                    ITIP20::burnBlockedCall {
-                        from: protected,
-                        amount: burn_amount,
-                    },
-                );
+                let result = token.burn_blocked(burner, protected, burn_amount, false);
                 assert_eq!(result.unwrap_err(), TIP20Error::protected_address().into());
             }
 
@@ -3199,13 +3201,7 @@ pub(crate) mod tests {
                 STABLECOIN_DEX_ADDRESS,
                 TIP20_CHANNEL_RESERVE_ADDRESS,
             ] {
-                let result = token.burn_blocked(
-                    burner,
-                    ITIP20::burnBlockedCall {
-                        from: protected,
-                        amount: burn_amount,
-                    },
-                );
+                let result = token.burn_blocked(burner, protected, burn_amount, false);
                 assert_eq!(result.unwrap_err(), TIP20Error::protected_address().into());
             }
 
@@ -3218,13 +3214,7 @@ pub(crate) mod tests {
             token.set_balance(RECEIVE_POLICY_GUARD_ADDRESS, amount)?;
             token.set_total_supply(token.total_supply()? + amount)?;
 
-            token.burn_blocked(
-                burner,
-                ITIP20::burnBlockedCall {
-                    from: RECEIVE_POLICY_GUARD_ADDRESS,
-                    amount: burn_amount,
-                },
-            )?;
+            token.burn_blocked(burner, RECEIVE_POLICY_GUARD_ADDRESS, burn_amount, false)?;
 
             let balance = token.balance_of(ITIP20::balanceOfCall {
                 account: RECEIVE_POLICY_GUARD_ADDRESS,
@@ -3251,13 +3241,7 @@ pub(crate) mod tests {
                 },
             )?;
 
-            token.burn_blocked(
-                burner,
-                ITIP20::burnBlockedCall {
-                    from: TIP20_CHANNEL_RESERVE_ADDRESS,
-                    amount: burn_amount,
-                },
-            )?;
+            token.burn_blocked(burner, TIP20_CHANNEL_RESERVE_ADDRESS, burn_amount, false)?;
 
             let balance = token.balance_of(ITIP20::balanceOfCall {
                 account: TIP20_CHANNEL_RESERVE_ADDRESS,
@@ -4504,13 +4488,7 @@ pub(crate) mod tests {
                 // Pause the token
                 token.pause(admin, ITIP20::pauseCall {})?;
 
-                let result = token.burn_blocked(
-                    admin,
-                    ITIP20::burnBlockedCall {
-                        from: blocked,
-                        amount,
-                    },
-                );
+                let result = token.burn_blocked(admin, blocked, amount, false);
 
                 if hardfork.is_t3() {
                     assert_eq!(

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1761,8 +1761,9 @@ pub(crate) mod tests {
                 (RecoveryMode::Receiver, receiver, blocked_destination, true, false),
                 (RecoveryMode::Originator, originator, blocked_destination, true, false),
                 (RecoveryMode::Originator, originator, originator, false, true),
-                // Third-party recovery is always a reroute, including claims back to receiver.
-                (RecoveryMode::ThirdParty, third_party, receiver, true, false),
+                // Third-party recovery back to the receiver is also a resume: the receiver selected
+                // that authority, so the claim skips receive-policy validation like receiver recovery.
+                (RecoveryMode::ThirdParty, third_party, receiver, true, true),
                 (RecoveryMode::ThirdParty, third_party, open_destination, false, true),
             ] {
                 let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -23,6 +23,7 @@ use crate::{
     storage::{Handler, Mapping},
 };
 use alloy::primitives::Address;
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_primitives::TempoAddressExt;
 
 /// Built-in policy ID that always rejects authorization.
@@ -30,6 +31,10 @@ pub const REJECT_ALL_POLICY_ID: u64 = 0;
 
 /// Built-in policy ID that always allows authorization.
 pub const ALLOW_ALL_POLICY_ID: u64 = 1;
+
+/// System addresses that cannot be policed.
+pub const ALWAYS_AUTHORIZED: &[(TempoHardfork, &[Address])] =
+    &[(TempoHardfork::T6, &[RECEIVE_POLICY_GUARD_ADDRESS])];
 
 /// Registry for [TIP-403] transfer policies. TIP20 tokens reference an ID from this registry
 /// to police transfers between sender and receiver addresses.
@@ -657,7 +662,8 @@ impl TIP403Registry {
 
     /// Core role-based authorization check ([TIP-1015]). Resolves built-in policies (0 = reject,
     /// 1 = allow) immediately, delegates compound policies to their sub-policies, and evaluates
-    /// simple policies via `is_simple`.
+    /// simple policies via `is_simple`. (T6+) introduces protocol addresses that can't be policed.
+    ///
     ///
     /// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
     ///
@@ -666,6 +672,16 @@ impl TIP403Registry {
     /// - `InvalidPolicyType` — stored type cannot be decoded
     /// - `IncompatiblePolicyType` — a compound policy was passed where a simple one is required
     pub fn is_authorized_as(&self, policy_id: u64, user: Address, role: AuthRole) -> Result<bool> {
+        let hardfork = self.storage.spec();
+
+        // (spec: +T6) some protocol addresses can't be policed and are always authorized.
+        if ALWAYS_AUTHORIZED
+            .iter()
+            .any(|(fork, addrs)| hardfork >= *fork && addrs.contains(&user))
+        {
+            return Ok(true);
+        }
+
         if let Some(auth) = self.builtin_authorization(policy_id) {
             return Ok(auth);
         }
@@ -685,7 +701,7 @@ impl TIP403Registry {
                 AuthRole::Transfer => {
                     // (spec: +T2) short-circuit and skip recipient check if sender fails
                     let sender_auth = self.is_authorized_simple(compound.sender_policy_id, user)?;
-                    if self.storage.spec().is_t2() && !sender_auth {
+                    if hardfork.is_t2() && !sender_auth {
                         return Ok(false);
                     }
                     let recipient_auth =
@@ -895,7 +911,6 @@ mod tests {
         sol_types::SolEvent,
     };
     use rand_08::Rng;
-    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{PATH_USD_ADDRESS, TIP403_REGISTRY_ADDRESS};
     use tempo_primitives::{MasterId, TempoAddressExt, UserTag};
 
@@ -943,6 +958,82 @@ mod tests {
 
             // Policy 1 should always allow
             assert!(registry.is_authorized_as(1, user, AuthRole::Transfer)?);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_always_authorized_t6_bypasses_policy_variants() -> eyre::Result<()> {
+        const ROLES: &[AuthRole] = &[
+            AuthRole::Transfer,
+            AuthRole::Sender,
+            AuthRole::Recipient,
+            AuthRole::MintRecipient,
+        ];
+        let admin = Address::random();
+
+        // pre-T6 the address is NOT protected
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T2);
+        StorageCtx::enter(&mut storage, || {
+            let registry = TIP403Registry::new();
+            assert!(!registry.is_authorized_as(
+                REJECT_ALL_POLICY_ID,
+                RECEIVE_POLICY_GUARD_ADDRESS,
+                AuthRole::Transfer,
+            )?);
+            Ok::<(), TempoPrecompileError>(())
+        })?;
+
+        // T6+ the address is protected
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = TIP403Registry::new();
+            let whitelist_id = registry.create_policy(
+                admin,
+                ITIP403Registry::createPolicyCall {
+                    admin,
+                    policyType: ITIP403Registry::PolicyType::WHITELIST,
+                },
+            )?;
+            let blacklist_id = registry.create_policy(
+                admin,
+                ITIP403Registry::createPolicyCall {
+                    admin,
+                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                },
+            )?;
+            let compound_id = registry.create_compound_policy(
+                admin,
+                ITIP403Registry::createCompoundPolicyCall {
+                    senderPolicyId: REJECT_ALL_POLICY_ID,
+                    recipientPolicyId: REJECT_ALL_POLICY_ID,
+                    mintRecipientPolicyId: REJECT_ALL_POLICY_ID,
+                },
+            )?;
+
+            registry.modify_policy_blacklist(
+                admin,
+                ITIP403Registry::modifyPolicyBlacklistCall {
+                    policyId: blacklist_id,
+                    account: RECEIVE_POLICY_GUARD_ADDRESS,
+                    restricted: true,
+                },
+            )?;
+            for (policy_id, roles) in [
+                (REJECT_ALL_POLICY_ID, ROLES),
+                (whitelist_id, &[AuthRole::Transfer][..]),
+                (blacklist_id, &[AuthRole::Transfer][..]),
+                (compound_id, ROLES),
+            ] {
+                for role in roles {
+                    assert!(registry.is_authorized_as(
+                        policy_id,
+                        RECEIVE_POLICY_GUARD_ADDRESS,
+                        *role,
+                    )?);
+                }
+            }
+
             Ok(())
         })
     }


### PR DESCRIPTION
this PR implements the latest changes in the spec, mainly around:
- `burnBlockedProof`
- `releaseBlockedFunds`

it also gets rid of the impl/internal `enum recoveryAuthority` as it became overlapping/redundant now that we have `RecoveryMode` which is stored.