### PR TITLE
Use BLAKE2 for precompile storage hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,6 +2174,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13053,6 +13062,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
+ "blake2",
  "codspeed-criterion-compat",
  "commonware-codec",
  "commonware-cryptography",
@@ -13081,6 +13091,7 @@ name = "tempo-precompiles-macros"
 version = "1.7.0"
 dependencies = [
  "alloy",
+ "blake2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,6 +251,7 @@ async-trait = "0.1"
 auto_impl = "1"
 axum = "0.8.8"
 base64 = { version = "0.22", features = ["alloc"], default-features = false }
+blake2 = "0.10.6"
 bytes = "1.11.1"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 coins-bip32 = "0.12"

--- a/crates/precompiles-macros/Cargo.toml
+++ b/crates/precompiles-macros/Cargo.toml
@@ -19,6 +19,7 @@ syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
 alloy = { workspace = true }
+blake2.workspace = true
 
 [dev-dependencies]
 alloy = { workspace = true }

--- a/crates/precompiles-macros/src/utils.rs
+++ b/crates/precompiles-macros/src/utils.rs
@@ -1,6 +1,7 @@
 //! Utility functions for the contract macro implementation.
 
-use alloy::primitives::{U256, keccak256};
+use alloy::primitives::U256;
+use blake2::{Blake2s256, Digest};
 use syn::{Attribute, Lit, Type};
 
 /// Return type for [`extract_attributes`]: (slot, base_slot)
@@ -10,7 +11,7 @@ type ExtractedAttributes = (Option<U256>, Option<U256>);
 ///
 /// Supports:
 /// - Integer literals: decimal (`42`) or hexadecimal (`0x2a`)
-/// - String literals: computes keccak256 hash of the string
+/// - String literals: computes blake2s256 hash of the string
 fn parse_slot_value(value: &Lit) -> syn::Result<U256> {
     match value {
         Lit::Int(int) => {
@@ -23,12 +24,17 @@ fn parse_slot_value(value: &Lit) -> syn::Result<U256> {
             .map_err(|_| syn::Error::new_spanned(int, "Invalid slot number"))?;
             Ok(slot)
         }
-        Lit::Str(lit) => Ok(keccak256(lit.value().as_bytes()).into()),
+        Lit::Str(lit) => Ok(blake2s256_u256(lit.value().as_bytes())),
         _ => Err(syn::Error::new_spanned(
             value,
             "slot attribute must be an integer or a string literal",
         )),
     }
+}
+
+fn blake2s256_u256(data: impl AsRef<[u8]>) -> U256 {
+    let digest = Blake2s256::digest(data.as_ref());
+    U256::from_be_slice(&digest)
 }
 
 /// Converts a string from CamelCase or snake_case to snake_case.

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -20,6 +20,7 @@ alloy = { workspace = true, features = ["sol-types", "consensus"] }
 alloy-evm = { workspace = true, features = ["std"] }
 revm.workspace = true
 
+blake2.workspace = true
 commonware-cryptography.workspace = true
 commonware-codec.workspace = true
 

--- a/crates/precompiles/src/storage/types/array.rs
+++ b/crates/precompiles/src/storage/types/array.rs
@@ -3,7 +3,7 @@
 //! # Storage Layout
 //!
 //! Fixed-size arrays `[T; N]` use Solidity-compatible array storage:
-//! - **Base slot**: Arrays start directly at `base_slot` (not at keccak256)
+//! - **Base slot**: Arrays start directly at `base_slot` (not hash-derived)
 //! - **Data slots**: Elements are stored sequentially, either packed or unpacked
 //!
 //! ## Packing Strategy
@@ -31,7 +31,7 @@ tempo_precompiles_macros::storable_nested_arrays!();
 /// Type-safe handler for accessing fixed-size arrays `[T; N]` in storage.
 ///
 /// Unlike `VecHandler`, arrays have a fixed compile-time size and store elements
-/// directly at the base slot (not at `keccak256(base_slot)`).
+/// directly at the base slot (not at a hash-derived tail slot).
 ///
 /// # Element Access
 ///

--- a/crates/precompiles/src/storage/types/bytes_like.rs
+++ b/crates/precompiles/src/storage/types/bytes_like.rs
@@ -2,20 +2,20 @@
 //!
 //! # Storage Layout
 //!
-//! Bytes-like types use Solidity-compatible:
+//! Bytes-like types use Solidity-compatible inline encoding and BLAKE2-derived tail slots:
 //! **Short strings (≤31 bytes)** are stored inline in a single slot:
 //! - Bytes 0..len: UTF-8 string data (left-aligned)
 //! - Byte 31 (LSB): length * 2 (bit 0 = 0 indicates short string)
 //!
-//! **Long strings (≥32 bytes)** use keccak256-based storage:
+//! **Long strings (≥32 bytes)** use blake2s256-based storage:
 //! - Base slot: stores `length * 2 + 1` (bit 0 = 1 indicates long string)
-//! - Data slots: stored at `keccak256(main_slot) + i` for each 32-byte chunk
+//! - Data slots: stored at `blake2s256(main_slot) + i` for each 32-byte chunk
 
 use crate::{
     error::{Result, TempoPrecompileError},
     storage::{StorageCtx, StorageOps, types::*},
 };
-use alloy::primitives::{Address, Bytes, U256, keccak256};
+use alloy::primitives::{Address, Bytes, U256};
 use std::marker::PhantomData;
 
 impl StorableType for Bytes {
@@ -126,7 +126,7 @@ impl Storable for Bytes {
         store_bytes_like(self.as_ref(), storage, slot, ctx)
     }
 
-    /// Custom delete for bytes-like types: clears keccak256-addressed data slots for long values.
+    /// Custom delete for bytes-like types: clears blake2s256-addressed data slots for long values.
     #[inline]
     fn delete<S: StorageOps>(storage: &mut S, slot: U256, ctx: LayoutCtx) -> Result<()> {
         debug_assert!(ctx.is_full(), "Bytes cannot be packed");
@@ -151,7 +151,7 @@ impl Storable for String {
         store_bytes_like(self.as_bytes(), storage, slot, ctx)
     }
 
-    /// Custom delete for bytes-like types: clears keccak256-addressed data slots for long values.
+    /// Custom delete for bytes-like types: clears blake2s256-addressed data slots for long values.
     #[inline]
     fn delete<S: StorageOps>(storage: &mut S, slot: U256, ctx: LayoutCtx) -> Result<()> {
         debug_assert!(ctx.is_full(), "String cannot be packed");
@@ -173,7 +173,7 @@ where
     let length = calc_string_length(base_value, is_long)?;
 
     if is_long {
-        // Long string: read data from keccak256(base_slot) + i
+        // Long string: read data from blake2s256(base_slot) + i
         let slot_start = calc_data_slot(base_slot);
         let chunks = calc_chunks(length);
         let mut data = Vec::new();
@@ -235,7 +235,7 @@ fn store_bytes_like<S: StorageOps>(
     } else {
         storage.store(base_slot, encode_long_string_length(new_len))?;
 
-        // Store data in chunks at keccak256(base_slot) + i
+        // Store data in chunks at blake2s256(base_slot) + i
         let slot_start = data_slot.unwrap_or_else(|| calc_data_slot(base_slot));
         let chunks = calc_chunks(new_len);
         for i in 0..chunks {
@@ -257,7 +257,7 @@ fn store_bytes_like<S: StorageOps>(
 
 /// Generic delete implementation for byte-like types (String, Bytes) using Solidity's encoding.
 ///
-/// Clears both the main slot and any keccak256-addressed data slots for long strings.
+/// Clears both the main slot and any blake2s256-addressed data slots for long strings.
 #[inline]
 fn delete_bytes_like<S: StorageOps>(storage: &mut S, base_slot: U256) -> Result<()> {
     let base_value = storage.load(base_slot)?;
@@ -282,10 +282,10 @@ fn delete_bytes_like<S: StorageOps>(storage: &mut S, base_slot: U256) -> Result<
 
 /// Compute the storage slot where long string data begins.
 ///
-/// For long strings (≥32 bytes), data is stored starting at `keccak256(base_slot)`.
+/// For long strings (≥32 bytes), data is stored starting at `blake2s256(base_slot)`.
 #[inline]
 fn calc_data_slot(base_slot: U256) -> U256 {
-    U256::from_be_bytes(keccak256(base_slot.to_be_bytes::<32>()).0)
+    blake2s256_u256(base_slot.to_be_bytes::<32>())
 }
 
 /// Check if a storage slot value represents a long string.
@@ -415,16 +415,16 @@ mod tests {
     // -- UNIT TESTS FOR HELPER FUNCTIONS (NO STORAGE) ------------------------
 
     #[test]
-    fn test_calc_data_slot_matches_manual_keccak() {
+    fn test_calc_data_slot_matches_manual_blake2() {
         let base_slot = U256::random();
         let data_slot = calc_data_slot(base_slot);
 
         // Manual computation
-        let expected = U256::from_be_bytes(keccak256(base_slot.to_be_bytes::<32>()).0);
+        let expected = blake2s256_u256(base_slot.to_be_bytes::<32>());
 
         assert_eq!(
             data_slot, expected,
-            "calc_data_slot should match manual keccak256 computation"
+            "calc_data_slot should match manual blake2s256 computation"
         );
     }
 
@@ -672,12 +672,12 @@ mod tests {
                 // Calculate how many data slots were used
                 let chunks = calc_chunks(s.len());
 
-                // Verify delete works (clears both main slot and keccak256-addressed data)
+                // Verify delete works (clears both main slot and blake2s256-addressed data)
                 slot.delete().unwrap();
                 let after_delete = slot.read().unwrap();
                 prop_assert_eq!(after_delete, String::new(), "Long string not empty after delete");
 
-                // Verify all keccak256-addressed data slots are actually zero
+                // Verify all blake2s256-addressed data slots are actually zero
                 let data_slot_start = calc_data_slot(base_slot);
                 for i in 0..chunks {
                     let slot = Slot::<U256>::new_at_offset(data_slot_start, i, address);
@@ -746,12 +746,12 @@ mod tests {
                 // Calculate how many data slots were used
                 let chunks = calc_chunks(b.len());
 
-                // Verify delete works (clears both main slot and keccak256-addressed data)
+                // Verify delete works (clears both main slot and blake2s256-addressed data)
                 slot.delete().unwrap();
                 let after_delete = slot.read().unwrap();
                 prop_assert_eq!(after_delete, Bytes::new(), "Long bytes not empty after delete");
 
-                // Verify all keccak256-addressed data slots are actually zero
+                // Verify all blake2s256-addressed data slots are actually zero
                 let data_slot_start = calc_data_slot(base_slot);
                 for i in 0..chunks {
                     let slot = Slot::<U256>::new_at_offset(data_slot_start, i, address);

--- a/crates/precompiles/src/storage/types/mapping.rs
+++ b/crates/precompiles/src/storage/types/mapping.rs
@@ -11,7 +11,7 @@ use crate::storage::{Layout, LayoutCtx, StorableType, StorageKey, types::Handler
 /// Type-safe access wrapper for EVM storage mappings (hash-based key-value storage).
 ///
 /// This struct does not store data itself. Instead, it provides a zero-cost abstraction
-/// for accessing mapping storage slots using Solidity's hash-based layout. It wraps a
+/// for accessing mapping storage slots using BLAKE2-based layout. It wraps a
 /// base slot number and provides methods to compute the actual storage slots for keys.
 ///
 /// # Type Parameters
@@ -20,14 +20,14 @@ use crate::storage::{Layout, LayoutCtx, StorableType, StorageKey, types::Handler
 /// - `V`: Value type (must implement `StorableType`)
 ///
 /// `Mapping<K, V>` is essentially a slot computation helper. The `[key]` method
-/// performs the keccak256 hash to compute the actual storage slot and returns a
+/// performs the BLAKE2 hash to compute the actual storage slot and returns a
 /// `Handler` that can be used for read/write operations.
 ///
 /// # Storage Layout
 ///
-/// Mappings use a Solidity-equivalent storage layout:
+/// Mappings use a BLAKE2-derived storage layout:
 /// - Base slot: stored in `base_slot` field (never accessed directly)
-/// - Actual slot for key `k`: `keccak256(k || base_slot)`
+/// - Actual slot for key `k`: `blake2s256(k || base_slot)`
 ///
 /// # Usage Pattern
 ///
@@ -157,15 +157,14 @@ where
 mod tests {
     use super::*;
     use crate::storage::StorageKey;
-    use alloy::primitives::{Address, B256, keccak256};
+    use alloy::primitives::{Address, B256};
 
-    // Backward compatibility helper to verify the trait impl.
-    fn old_mapping_slot<K: AsRef<[u8]>>(key: K, slot: U256) -> U256 {
+    fn manual_mapping_slot<K: AsRef<[u8]>>(key: K, slot: U256) -> U256 {
         let key = key.as_ref();
         let mut buf = [0u8; 64];
         buf[32 - key.len()..32].copy_from_slice(key);
         buf[32..].copy_from_slice(&slot.to_be_bytes::<32>());
-        U256::from_be_bytes(keccak256(buf).0)
+        crate::storage::types::blake2s256_u256(buf)
     }
 
     #[test]
@@ -180,32 +179,32 @@ mod tests {
         // Slot in big-endian
         buf[32..].copy_from_slice(&base_slot.to_be_bytes::<32>());
 
-        let expected = U256::from_be_bytes(keccak256(buf).0);
+        let expected = crate::storage::types::blake2s256_u256(buf);
         let computed = key.mapping_slot(base_slot);
 
         assert_eq!(computed, expected, "mapping_slot encoding mismatch");
     }
 
     #[test]
-    fn test_mapping_slot_matches_old_impl() {
+    fn test_mapping_slot_matches_manual_impl() {
         let slot = U256::random();
 
         let addr = Address::random();
         assert_eq!(
             addr.mapping_slot(slot),
-            old_mapping_slot(addr.as_slice(), slot),
+            manual_mapping_slot(addr.as_slice(), slot),
         );
 
         let b256 = B256::random();
         assert_eq!(
             b256.mapping_slot(slot),
-            old_mapping_slot(b256.as_slice(), slot),
+            manual_mapping_slot(b256.as_slice(), slot),
         );
 
         let u256 = U256::random();
         assert_eq!(
             u256.mapping_slot(slot),
-            old_mapping_slot(u256.to_be_bytes::<32>(), slot),
+            manual_mapping_slot(u256.to_be_bytes::<32>(), slot),
         );
     }
 

--- a/crates/precompiles/src/storage/types/mod.rs
+++ b/crates/precompiles/src/storage/types/mod.rs
@@ -22,7 +22,8 @@ use crate::{
     error::Result,
     storage::{StorageOps, packing},
 };
-use alloy::primitives::{Address, U256, keccak256};
+use alloy::primitives::{Address, U256};
+use blake2::{Blake2s256, Digest};
 use std::{cell::RefCell, collections::HashMap, hash::Hash};
 
 /// Describes how a type is laid out in EVM storage.
@@ -177,7 +178,7 @@ pub trait StorableType {
 
     /// Whether this type stores it's data in its base slot or not.
     ///
-    /// Dynamic types (`Bytes`, `String`, `Vec`) store data at keccak256-addressed
+    /// Dynamic types (`Bytes`, `String`, `Vec`) store data at blake2s256-addressed
     /// slots and need special cleanup. Non-dynamic types just zero their slots.
     const IS_DYNAMIC: bool = false;
 
@@ -323,7 +324,7 @@ impl<T: Packable> Storable for T {
 
 /// Trait for types that can be used as storage mapping keys.
 ///
-/// Keys are hashed using keccak256 along with the mapping's base slot
+/// Keys are hashed using blake2s256 along with the mapping's base slot
 /// to determine the final storage location. This trait provides the
 /// byte representation used in that hash.
 ///
@@ -335,7 +336,7 @@ impl<T: Packable> Storable for T {
 ///
 /// # Encoding
 ///
-/// Mapping slots are computed as `keccak256(bytes32(key) | bytes32(slot))`, where the
+/// Mapping slots are computed as `blake2s256(bytes32(key) | bytes32(slot))`, where the
 /// key's raw bytes are left-padded to 32 bytes and the slot is appended in big-endian.
 ///
 /// This differs from Solidity's `keccak256(abi.encode(key, slot))`, where signed integers
@@ -365,8 +366,14 @@ pub trait StorageKey: sealed::OnlyPrimitives {
         buf[32 - key_bytes.len()..32].copy_from_slice(key_bytes);
         buf[32..].copy_from_slice(&slot.to_be_bytes::<32>());
 
-        U256::from_be_bytes(keccak256(buf).0)
+        blake2s256_u256(buf)
     }
+}
+
+#[inline]
+pub(crate) fn blake2s256_u256(data: impl AsRef<[u8]>) -> U256 {
+    let digest = Blake2s256::digest(data.as_ref());
+    U256::from_be_slice(&digest)
 }
 
 /// Cache for computed handlers with stable references.

--- a/crates/precompiles/src/storage/types/set.rs
+++ b/crates/precompiles/src/storage/types/set.rs
@@ -4,7 +4,7 @@
 //! # Storage Layout
 //!
 //! EnumerableSet uses two storage structures:
-//! - **Values Vec**: A `Vec<T>` storing all set elements at `keccak256(base_slot)`
+//! - **Values Vec**: A `Vec<T>` storing all set elements at `blake2s256(base_slot)`
 //! - **Positions Mapping**: A `Mapping<T, u32>` at `base_slot + 1` storing 1-indexed positions
 //!   - Position 0 means the value is not in the set
 //!   - Position N means the value is at index N-1 in the values array
@@ -190,7 +190,7 @@ where
 
 /// Set occupies 2 slots:
 ///
-/// - Slot 0: `Vec` length slot, with data at `keccak256(slot)`
+/// - Slot 0: `Vec` length slot, with data at `blake2s256(slot)`
 /// - Slot 1: `Mapping` base slot for positions
 impl<T> StorableType for Set<T>
 where

--- a/crates/precompiles/src/storage/types/vec.rs
+++ b/crates/precompiles/src/storage/types/vec.rs
@@ -2,9 +2,9 @@
 //!
 //! # Storage Layout
 //!
-//! Vec uses Solidity-compatible dynamic array storage:
+//! Vec uses BLAKE2-derived dynamic array storage:
 //! - **Base slot**: Stores the array length (number of elements)
-//! - **Data slots**: Start at `keccak256(len_slot)`, elements packed efficiently
+//! - **Data slots**: Start at `blake2s256(len_slot)`, elements packed efficiently
 //!
 //! ## Multi-Slot Support
 //!
@@ -19,7 +19,7 @@ use crate::{
     storage::{
         Handler, Layout, LayoutCtx, Storable, StorableType, StorageCtx, StorageOps,
         packing::{PackedSlot, calc_element_loc, calc_packed_slot_count},
-        types::{HandlerCache, Slot},
+        types::{HandlerCache, Slot, blake2s256_u256},
     },
 };
 
@@ -390,10 +390,10 @@ fn load_checked_len<S: StorageOps>(storage: &S, slot: U256) -> Result<usize> {
 
 /// Calculate the starting slot for dynamic array data.
 ///
-/// For Solidity compatibility, dynamic array data is stored at `keccak256(len_slot)`.
+/// Dynamic array data is stored at `blake2s256(len_slot)`.
 #[inline]
 pub(crate) fn calc_data_slot(len_slot: U256) -> U256 {
-    U256::from_be_bytes(alloy::primitives::keccak256(len_slot.to_be_bytes::<32>()).0)
+    blake2s256_u256(len_slot.to_be_bytes::<32>())
 }
 
 /// Clears storage occupied exclusively by `Vec` elements in the index range `[from, to)`.
@@ -617,14 +617,13 @@ mod tests {
     fn test_vec_data_slot_derivation() {
         let len_slot = U256::random();
 
-        // Verify data slot matches keccak256(len_slot)
+        // Verify data slot matches blake2s256(len_slot)
         let data_slot = calc_data_slot(len_slot);
-        let expected =
-            U256::from_be_bytes(alloy::primitives::keccak256(len_slot.to_be_bytes::<32>()).0);
+        let expected = blake2s256_u256(len_slot.to_be_bytes::<32>());
 
         assert_eq!(
             data_slot, expected,
-            "Data slot should be keccak256(len_slot)"
+            "Data slot should be blake2s256(len_slot)"
         );
     }
 
@@ -1319,7 +1318,7 @@ mod tests {
                 .unwrap();
             assert_eq!(length_value, U256::from(3), "Length slot incorrect");
 
-            // Verify data starts at keccak256(len_slot), not len_slot + 1
+            // Verify data starts at blake2s256(len_slot), not len_slot + 1
             let data_start = calc_data_slot(len_slot);
             assert_ne!(
                 data_start,

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -34,6 +34,7 @@ use alloy::{
     primitives::{Address, B256, U256, keccak256, uint},
     sol_types::SolValue,
 };
+use blake2::{Blake2s256, Digest};
 use std::sync::LazyLock;
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::{
@@ -114,18 +115,26 @@ pub struct TIP20Token {
     user_reward_info: Mapping<Address, UserRewardInfo>,
 }
 
-/// EIP-712 Permit typehash: keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")
+fn blake2s256(data: impl AsRef<[u8]>) -> B256 {
+    B256::from_slice(&Blake2s256::digest(data.as_ref()))
+}
+
+/// EIP-712 Permit typehash: blake2s256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")
 pub static PERMIT_TYPEHASH: LazyLock<B256> = LazyLock::new(|| {
-    keccak256(b"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")
+    blake2s256(
+        b"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)",
+    )
 });
 
 /// EIP-712 domain separator typehash
 pub static EIP712_DOMAIN_TYPEHASH: LazyLock<B256> = LazyLock::new(|| {
-    keccak256(b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
+    blake2s256(
+        b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)",
+    )
 });
 
-/// EIP-712 version hash: keccak256("1")
-pub static VERSION_HASH: LazyLock<B256> = LazyLock::new(|| keccak256(b"1"));
+/// EIP-712 version hash: blake2s256("1")
+pub static VERSION_HASH: LazyLock<B256> = LazyLock::new(|| blake2s256(b"1"));
 
 /// Role hash for pausing token transfers.
 pub static PAUSE_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"PAUSE_ROLE"));
@@ -676,7 +685,7 @@ impl TIP20Token {
     /// Returns the EIP-712 domain separator, computed dynamically from the token name and chain ID.
     pub fn domain_separator(&self) -> Result<B256> {
         let name = self.name()?;
-        let name_hash = self.storage.keccak256(name.as_bytes())?;
+        let name_hash = blake2s256(name.as_bytes());
         let chain_id = U256::from(self.storage.chain_id());
 
         let encoded = (
@@ -688,7 +697,7 @@ impl TIP20Token {
         )
             .abi_encode();
 
-        self.storage.keccak256(&encoded)
+        Ok(blake2s256(&encoded))
     }
 
     /// Sets allowance via a signed [EIP-2612] permit. Validates the ECDSA signature, checks the
@@ -707,8 +716,8 @@ impl TIP20Token {
 
         // 2. Construct EIP-712 struct hash
         let nonce = self.permit_nonces[call.owner].read()?;
-        let struct_hash = self.storage.keccak256(
-            &(
+        let struct_hash = blake2s256(
+            (
                 *PERMIT_TYPEHASH,
                 call.owner,
                 call.spender,
@@ -717,18 +726,18 @@ impl TIP20Token {
                 call.deadline,
             )
                 .abi_encode(),
-        )?;
+        );
 
         // 3. Construct EIP-712 digest
         let domain_separator = self.domain_separator()?;
-        let digest = self.storage.keccak256(
-            &[
+        let digest = blake2s256(
+            [
                 &[0x19, 0x01],
                 domain_separator.as_slice(),
                 struct_hash.as_slice(),
             ]
             .concat(),
-        )?;
+        );
 
         // 4. Validate ECDSA signature
         // Only v=27/28 is accepted; v=0/1 is intentionally NOT normalized (see TIP-1004 spec).
@@ -3208,7 +3217,7 @@ pub(crate) mod tests {
             deadline: U256,
         ) -> (u8, B256, B256) {
             let domain_separator = compute_domain_separator(token_name, token_address);
-            let struct_hash = keccak256(
+            let struct_hash = blake2s256(
                 (
                     *PERMIT_TYPEHASH,
                     signer.address(),
@@ -3219,7 +3228,7 @@ pub(crate) mod tests {
                 )
                     .abi_encode(),
             );
-            let digest = keccak256(
+            let digest = blake2s256(
                 [
                     &[0x19, 0x01],
                     domain_separator.as_slice(),
@@ -3236,10 +3245,10 @@ pub(crate) mod tests {
         }
 
         fn compute_domain_separator(token_name: &str, token_address: Address) -> B256 {
-            keccak256(
+            blake2s256(
                 (
                     *EIP712_DOMAIN_TYPEHASH,
-                    keccak256(token_name.as_bytes()),
+                    blake2s256(token_name.as_bytes()),
                     *VERSION_HASH,
                     U256::from(CHAIN_ID),
                     token_address,

--- a/crates/precompiles/tests/storage_tests/layouts.rs
+++ b/crates/precompiles/tests/storage_tests/layouts.rs
@@ -205,7 +205,7 @@ fn test_string_literal_slots() {
     #[contract]
     pub struct Layout {
         #[slot("id")]
-        pub field: U256, // slot: keccak256("id")
+        pub field: U256, // slot: blake2s256("id")
     }
 
     let (mut storage, address) = setup_storage();
@@ -219,7 +219,7 @@ fn test_string_literal_slots() {
         assert_eq!(layout.field.read().unwrap(), U256::ONE);
 
         // Verify slot assignment
-        let slot: U256 = keccak256("id").into();
+        let slot = blake2s256_u256("id");
         assert_eq!(layout.field.slot(), slot);
         assert_eq!(slots::FIELD, slot);
 

--- a/crates/precompiles/tests/storage_tests/mod.rs
+++ b/crates/precompiles/tests/storage_tests/mod.rs
@@ -5,6 +5,7 @@ use crate::storage::{
     packing::extract_from_word,
 };
 use alloy::primitives::{Address, U256, keccak256};
+use blake2::{Blake2s256, Digest};
 use proptest::prelude::*;
 use tempo_precompiles::error;
 use tempo_precompiles_macros::{Storable, contract};
@@ -73,9 +74,14 @@ pub(crate) fn test_address(byte: u8) -> Address {
 }
 
 /// Compute the i-th tail slot of a dynamic value (`String`/`Bytes`/`Vec`) whose
-/// base/length slot is `base_slot`. Solidity stores tail data at `keccak256(base_slot) + i`.
+/// base/length slot is `base_slot`. Tempo stores tail data at `blake2s256(base_slot) + i`.
 pub(crate) fn dyn_tail_slot(base_slot: U256, i: u64) -> U256 {
-    U256::from_be_bytes(keccak256(base_slot.to_be_bytes::<32>()).0) + U256::from(i)
+    blake2s256_u256(base_slot.to_be_bytes::<32>()) + U256::from(i)
+}
+
+pub(crate) fn blake2s256_u256(data: impl AsRef<[u8]>) -> U256 {
+    let digest = Blake2s256::digest(data.as_ref());
+    U256::from_be_slice(&digest)
 }
 
 /// Helper to test store + load roundtrip


### PR DESCRIPTION
## Summary
- add the blake2 crate to precompiles and precompiles-macros
- switch generated string-literal storage slots to BLAKE2s-256
- switch mapping slots, dynamic Vec tails, and long bytes/string tails to BLAKE2s-256
- keep TIP20 permit/domain hashing on BLAKE2s-256 and update tests/helpers accordingly

## Tests
- cargo fmt --all --check
- cargo test -p tempo-precompiles-macros
- cargo test -p tempo-precompiles permit_tests --features test-utils
- cargo test -p tempo-precompiles storage --features test-utils
- cargo clippy -p tempo-precompiles -p tempo-precompiles-macros --all-targets --all-features --locked