### PR TITLE
Use BLAKE2 for TIP20 storage slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,6 +2174,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13053,6 +13062,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
+ "blake2",
  "codspeed-criterion-compat",
  "commonware-codec",
  "commonware-cryptography",
@@ -13081,6 +13091,7 @@ name = "tempo-precompiles-macros"
 version = "1.7.0"
 dependencies = [
  "alloy",
+ "blake2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13250,6 +13261,7 @@ dependencies = [
  "alloy",
  "alloy-json-abi",
  "alloy-primitives",
+ "blake2",
  "clap",
  "coins-bip32",
  "commonware-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,6 +251,7 @@ async-trait = "0.1"
 auto_impl = "1"
 axum = "0.8.8"
 base64 = { version = "0.22", features = ["alloc"], default-features = false }
+blake2 = { version = "0.10", default-features = false }
 bytes = "1.11.1"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 coins-bip32 = "0.12"

--- a/crates/precompiles-macros/Cargo.toml
+++ b/crates/precompiles-macros/Cargo.toml
@@ -19,6 +19,7 @@ syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
 alloy = { workspace = true }
+blake2.workspace = true
 
 [dev-dependencies]
 alloy = { workspace = true }

--- a/crates/precompiles-macros/src/utils.rs
+++ b/crates/precompiles-macros/src/utils.rs
@@ -1,6 +1,7 @@
 //! Utility functions for the contract macro implementation.
 
-use alloy::primitives::{U256, keccak256};
+use alloy::primitives::U256;
+use blake2::{Blake2s256, Digest};
 use syn::{Attribute, Lit, Type};
 
 /// Return type for [`extract_attributes`]: (slot, base_slot)
@@ -10,7 +11,7 @@ type ExtractedAttributes = (Option<U256>, Option<U256>);
 ///
 /// Supports:
 /// - Integer literals: decimal (`42`) or hexadecimal (`0x2a`)
-/// - String literals: computes keccak256 hash of the string
+/// - String literals: computes BLAKE2s-256 hash of the string
 fn parse_slot_value(value: &Lit) -> syn::Result<U256> {
     match value {
         Lit::Int(int) => {
@@ -23,7 +24,9 @@ fn parse_slot_value(value: &Lit) -> syn::Result<U256> {
             .map_err(|_| syn::Error::new_spanned(int, "Invalid slot number"))?;
             Ok(slot)
         }
-        Lit::Str(lit) => Ok(keccak256(lit.value().as_bytes()).into()),
+        Lit::Str(lit) => Ok(U256::from_be_bytes(
+            Blake2s256::digest(lit.value().as_bytes()).into(),
+        )),
         _ => Err(syn::Error::new_spanned(
             value,
             "slot attribute must be an integer or a string literal",

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -18,6 +18,7 @@ tempo-primitives.workspace = true
 tempo-precompiles-macros.workspace = true
 alloy = { workspace = true, features = ["sol-types", "consensus"] }
 alloy-evm = { workspace = true, features = ["std"] }
+blake2.workspace = true
 revm.workspace = true
 
 commonware-cryptography.workspace = true

--- a/crates/precompiles/src/storage/types/mapping.rs
+++ b/crates/precompiles/src/storage/types/mapping.rs
@@ -11,7 +11,7 @@ use crate::storage::{Layout, LayoutCtx, StorableType, StorageKey, types::Handler
 /// Type-safe access wrapper for EVM storage mappings (hash-based key-value storage).
 ///
 /// This struct does not store data itself. Instead, it provides a zero-cost abstraction
-/// for accessing mapping storage slots using Solidity's hash-based layout. It wraps a
+/// for accessing mapping storage slots using hash-based layout. It wraps a
 /// base slot number and provides methods to compute the actual storage slots for keys.
 ///
 /// # Type Parameters
@@ -20,14 +20,14 @@ use crate::storage::{Layout, LayoutCtx, StorableType, StorageKey, types::Handler
 /// - `V`: Value type (must implement `StorableType`)
 ///
 /// `Mapping<K, V>` is essentially a slot computation helper. The `[key]` method
-/// performs the keccak256 hash to compute the actual storage slot and returns a
+/// performs the BLAKE2s-256 hash to compute the actual storage slot and returns a
 /// `Handler` that can be used for read/write operations.
 ///
 /// # Storage Layout
 ///
-/// Mappings use a Solidity-equivalent storage layout:
+/// Mappings use a BLAKE2s-256 storage layout:
 /// - Base slot: stored in `base_slot` field (never accessed directly)
-/// - Actual slot for key `k`: `keccak256(k || base_slot)`
+/// - Actual slot for key `k`: `blake2s256(k || base_slot)`
 ///
 /// # Usage Pattern
 ///
@@ -157,15 +157,15 @@ where
 mod tests {
     use super::*;
     use crate::storage::StorageKey;
-    use alloy::primitives::{Address, B256, keccak256};
+    use alloy::primitives::{Address, B256};
+    use blake2::{Blake2s256, Digest};
 
-    // Backward compatibility helper to verify the trait impl.
-    fn old_mapping_slot<K: AsRef<[u8]>>(key: K, slot: U256) -> U256 {
+    fn expected_mapping_slot<K: AsRef<[u8]>>(key: K, slot: U256) -> U256 {
         let key = key.as_ref();
         let mut buf = [0u8; 64];
         buf[32 - key.len()..32].copy_from_slice(key);
         buf[32..].copy_from_slice(&slot.to_be_bytes::<32>());
-        U256::from_be_bytes(keccak256(buf).0)
+        U256::from_be_bytes(Blake2s256::digest(buf).into())
     }
 
     #[test]
@@ -180,32 +180,32 @@ mod tests {
         // Slot in big-endian
         buf[32..].copy_from_slice(&base_slot.to_be_bytes::<32>());
 
-        let expected = U256::from_be_bytes(keccak256(buf).0);
+        let expected = U256::from_be_bytes(Blake2s256::digest(buf).into());
         let computed = key.mapping_slot(base_slot);
 
         assert_eq!(computed, expected, "mapping_slot encoding mismatch");
     }
 
     #[test]
-    fn test_mapping_slot_matches_old_impl() {
+    fn test_mapping_slot_matches_expected_impl() {
         let slot = U256::random();
 
         let addr = Address::random();
         assert_eq!(
             addr.mapping_slot(slot),
-            old_mapping_slot(addr.as_slice(), slot),
+            expected_mapping_slot(addr.as_slice(), slot),
         );
 
         let b256 = B256::random();
         assert_eq!(
             b256.mapping_slot(slot),
-            old_mapping_slot(b256.as_slice(), slot),
+            expected_mapping_slot(b256.as_slice(), slot),
         );
 
         let u256 = U256::random();
         assert_eq!(
             u256.mapping_slot(slot),
-            old_mapping_slot(u256.to_be_bytes::<32>(), slot),
+            expected_mapping_slot(u256.to_be_bytes::<32>(), slot),
         );
     }
 

--- a/crates/precompiles/src/storage/types/mod.rs
+++ b/crates/precompiles/src/storage/types/mod.rs
@@ -22,7 +22,8 @@ use crate::{
     error::Result,
     storage::{StorageOps, packing},
 };
-use alloy::primitives::{Address, U256, keccak256};
+use alloy::primitives::{Address, U256};
+use blake2::{Blake2s256, Digest};
 use std::{cell::RefCell, collections::HashMap, hash::Hash};
 
 /// Describes how a type is laid out in EVM storage.
@@ -323,7 +324,7 @@ impl<T: Packable> Storable for T {
 
 /// Trait for types that can be used as storage mapping keys.
 ///
-/// Keys are hashed using keccak256 along with the mapping's base slot
+/// Keys are hashed using BLAKE2s-256 along with the mapping's base slot
 /// to determine the final storage location. This trait provides the
 /// byte representation used in that hash.
 ///
@@ -335,7 +336,7 @@ impl<T: Packable> Storable for T {
 ///
 /// # Encoding
 ///
-/// Mapping slots are computed as `keccak256(bytes32(key) | bytes32(slot))`, where the
+/// Mapping slots are computed as `blake2s256(bytes32(key) | bytes32(slot))`, where the
 /// key's raw bytes are left-padded to 32 bytes and the slot is appended in big-endian.
 ///
 /// This differs from Solidity's `keccak256(abi.encode(key, slot))`, where signed integers
@@ -365,7 +366,7 @@ pub trait StorageKey: sealed::OnlyPrimitives {
         buf[32 - key_bytes.len()..32].copy_from_slice(key_bytes);
         buf[32..].copy_from_slice(&slot.to_be_bytes::<32>());
 
-        U256::from_be_bytes(keccak256(buf).0)
+        U256::from_be_bytes(Blake2s256::digest(buf).into())
     }
 }
 

--- a/crates/precompiles/tests/storage_tests/layouts.rs
+++ b/crates/precompiles/tests/storage_tests/layouts.rs
@@ -4,6 +4,7 @@
 //! including auto-assignment, explicit slots, base_slot, and string literal slots.
 
 use super::*;
+use blake2::{Blake2s256, Digest};
 use tempo_precompiles::storage::Mapping;
 
 #[test]
@@ -205,7 +206,7 @@ fn test_string_literal_slots() {
     #[contract]
     pub struct Layout {
         #[slot("id")]
-        pub field: U256, // slot: keccak256("id")
+        pub field: U256, // slot: blake2s256("id")
     }
 
     let (mut storage, address) = setup_storage();
@@ -219,7 +220,7 @@ fn test_string_literal_slots() {
         assert_eq!(layout.field.read().unwrap(), U256::ONE);
 
         // Verify slot assignment
-        let slot: U256 = keccak256("id").into();
+        let slot = U256::from_be_bytes(Blake2s256::digest("id").into());
         assert_eq!(layout.field.slot(), slot);
         assert_eq!(slots::FIELD, slot);
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -35,6 +35,7 @@ alloy = { workspace = true, features = [
 ] }
 alloy-json-abi.workspace = true
 alloy-primitives = { workspace = true, features = ["asm-keccak"] }
+blake2.workspace = true
 coins-bip32.workspace = true
 clap = { workspace = true, features = ["derive"] }
 commonware-codec.workspace = true

--- a/xtask/src/generate_state_bloat.rs
+++ b/xtask/src/generate_state_bloat.rs
@@ -12,6 +12,7 @@ use alloy::{
         utils::secret_key_to_address,
     },
 };
+use blake2::{Blake2s256, Digest};
 use coins_bip32::prelude::*;
 use eyre::{Context as _, ensure};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -265,14 +266,14 @@ fn derive_parent_key(mnemonic_phrase: &str) -> eyre::Result<XPriv> {
     Ok(master)
 }
 
-/// Compute a Solidity mapping slot: keccak256(pad32(key) || pad32(base_slot))
+/// Compute a TIP20 mapping slot: blake2s256(pad32(key) || pad32(base_slot))
 fn compute_mapping_slot(key: Address, base_slot: U256) -> U256 {
     let mut buf = [0u8; 64];
     // Left-pad address to 32 bytes
     buf[12..32].copy_from_slice(key.as_slice());
     // Base slot as big-endian 32 bytes
     buf[32..].copy_from_slice(&base_slot.to_be_bytes::<32>());
-    U256::from_be_bytes(keccak256(buf).0)
+    U256::from_be_bytes(Blake2s256::digest(buf).into())
 }
 
 /// Write a block header to the output.
@@ -311,7 +312,7 @@ mod tests {
 
     #[test]
     fn test_compute_mapping_slot() {
-        // Verify the slot computation matches Solidity's keccak256(abi.encode(key, slot))
+        // Verify the slot computation is deterministic for TIP20's BLAKE2s-256 layout.
         let addr: Address = "0x1234567890123456789012345678901234567890"
             .parse()
             .unwrap();


### PR DESCRIPTION
## Summary
- switch storage mapping slot hashing from keccak256 to BLAKE2s-256 for generated precompile storage access
- switch string literal slot attributes to BLAKE2s-256
- update TIP20 state-bloat slot generation and storage tests for the new layout

## Tests
- cargo fmt --check
- cargo test -p tempo-precompiles storage::types::mapping --features test-utils
- cargo test -p tempo-precompiles --test storage --features test-utils
- cargo check -p tempo-xtask