### PR TITLE
feat: share execution cache in benches

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -258,6 +258,7 @@ run_single() {
     --debug.startup-sync-state-idle
     --builder.max-tasks 1
     --engine.share-sparse-trie-with-payload-builder
+    --engine.share-execution-cache-with-payload-builder
   )
 
   # Per-label extra node args

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -27,6 +27,7 @@ const E2E_LOCAL_RETH_ARGS = [
     "--tempo.bootnodes-endpoint" "none"
     "--builder.max-tasks" "1"
     "--engine.share-sparse-trie-with-payload-builder"
+    "--engine.share-execution-cache-with-payload-builder"
     "--builder.enable-prewarming"
 ]
 


### PR DESCRIPTION
## Summary
- enable `--engine.share-execution-cache-with-payload-builder` for the tempo replay bench runner
- enable `--engine.share-execution-cache-with-payload-builder` for local `bench-e2e.nu` node defaults
- keep sparse trie sharing and prewarming enabled for local e2e bench defaults

## Testing
- not run; bench configuration change only