### PR TITLE
docs(tip-1028): use receipt terminology

### DIFF
--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -668,7 +668,7 @@ TIP-20 delivery helpers MUST return whether the inbound credited the intended re
 
 ### 5.6 Integration Consequence
 
-After TIP-1028, `transfer`, `transferFrom`, `mint`, `mintWithMemo`, DEX wallet payouts, and FeeManager or TIPFeeAMM wallet payouts may succeed either because the intended receiver was credited or because the inbound was escrowed. Contracts and offchain systems that must distinguish those outcomes MUST inspect `TransferBlocked` or `MintBlocked` or use wrapper logic. Higher-level Tempo precompile events MUST NOT be interpreted as proof that the intended wallet was credited unless the call surface explicitly exposes the delivery outcome.
+After TIP-1028, `transfer`, `transferFrom`, `mint`, `mintWithMemo`, DEX wallet payouts, and FeeManager or TIPFeeAMM wallet payouts may succeed either because the intended receiver was credited or because the inbound was escrowed. Contracts and offchain systems that must distinguish those outcomes MUST inspect `TransferBlocked` or `MintBlocked` or use wrapper logic. Higher-level Tempo precompile events MUST NOT be interpreted as a receipt that the intended wallet was credited unless the call surface explicitly exposes the delivery outcome.
 
 ## 6. Gas and Storage Analysis
 


### PR DESCRIPTION
Updates TIP-1028 wording from proof terminology back to receipt terminology for blocked-funds delivery outcomes.