### PR TITLE
refactor(tip-1028): use receipt terminology

### DIFF
--- a/crates/contracts/src/precompiles/receive_policy_guard.rs
+++ b/crates/contracts/src/precompiles/receive_policy_guard.rs
@@ -14,11 +14,11 @@ crate::sol! {
             MINT
         }
 
-        /// @notice Claim proof for one blocked inbound transfer or mint.
+        /// @notice Claim receipt for one blocked inbound transfer or mint.
         /// @dev `recipient` is the addressed `to` value and may be virtual. The corresponding
         ///      `receiver` emitted in events is the resolved account/master where funds settle.
-        struct ClaimProofV1 {
-            /// @notice Proof layout version. Must equal `1` for this struct.
+        struct ClaimReceiptV1 {
+            /// @notice Receipt layout version. Must equal `1` for this struct.
             uint8 version;
             /// @notice TIP-20 token whose blocked funds are held by the guard.
             address token;
@@ -40,14 +40,14 @@ crate::sol! {
             bytes32 memo;
         }
 
-        function balanceOf(bytes calldata proof) external view returns (uint256 amount);
-        function claim(address to, bytes calldata proof) external;
+        function balanceOf(bytes calldata receipt) external view returns (uint256 amount);
+        function claim(address to, bytes calldata receipt) external;
 
         /// @notice Emitted when an inbound TIP-20 transfer or mint is blocked and funds are redirected.
         /// @param token TIP-20 token whose funds are held by the guard.
         /// @param from Original sender/originator of the blocked operation.
         /// @param receiver Resolved account where funds would settle; for virtual recipients its their master.
-        /// @param proofVersion Claim proof layout version.
+        /// @param receiptVersion Claim receipt layout version.
         /// @param blockedNonce Guard nonce assigned to the blocked operation.
         /// @param blockedAt Block timestamp when the operation was blocked.
         /// @param recipient Addressed recipient from the inbound operation; may be virtual.
@@ -55,30 +55,30 @@ crate::sol! {
         /// @param blockedReason TIP-403 blocked reason encoded as a `BlockedReason` discriminant.
         /// @param recoveryAuthority Claim authority: originator, receiver, or third-party address.
         /// @param memo Application memo copied from the blocked inbound operation.
-        event TransferBlocked(address indexed token, address indexed from, address indexed receiver, uint8 proofVersion, uint64 blockedNonce, uint64 blockedAt, address recipient, uint256 amount, uint8 blockedReason, address recoveryAuthority, bytes32 memo);
+        event TransferBlocked(address indexed token, address indexed from, address indexed receiver, uint8 receiptVersion, uint64 blockedNonce, uint64 blockedAt, address recipient, uint256 amount, uint8 blockedReason, address recoveryAuthority, bytes32 memo);
 
-        /// @notice Emitted when blocked funds are claimed with a valid proof.
+        /// @notice Emitted when blocked funds are claimed with a valid receipt.
         /// @param token TIP-20 token released by the guard.
         /// @param receiver Resolved account where funds would settle; for virtual recipients its their master.
-        /// @param proofVersion Claim proof layout version.
-        /// @param blockedNonce Guard nonce from the claimed proof.
-        /// @param blockedAt Block timestamp from the claimed proof.
-        /// @param originator Original sender/originator from the claimed proof.
-        /// @param recipient Addressed recipient from the claimed proof; may be virtual.
-        /// @param recoveryAuthority Claim authority from the claimed proof.
+        /// @param receiptVersion Claim receipt layout version.
+        /// @param blockedNonce Guard nonce from the claimed receipt.
+        /// @param blockedAt Block timestamp from the claimed receipt.
+        /// @param originator Original sender/originator from the claimed receipt.
+        /// @param recipient Addressed recipient from the claimed receipt; may be virtual.
+        /// @param recoveryAuthority Claim authority from the claimed receipt.
         /// @param caller Account that submitted the claim.
         /// @param to Address where released funds were sent.
         /// @param amount Amount of funds released.
-        event ProofClaimed(address indexed token, address indexed receiver, uint8 proofVersion, uint64 indexed blockedNonce, uint64 blockedAt, address originator, address recipient, address recoveryAuthority, address caller, address to, uint256 amount);
+        event ReceiptClaimed(address indexed token, address indexed receiver, uint8 receiptVersion, uint64 indexed blockedNonce, uint64 blockedAt, address originator, address recipient, address recoveryAuthority, address caller, address to, uint256 amount);
 
-        error InvalidProof();
+        error InvalidReceipt();
         error InvalidClaimAddress();
         error UnauthorizedClaimer();
         error AddressReserved();
     }
 }
 
-impl IReceivePolicyGuard::ClaimProofV1 {
+impl IReceivePolicyGuard::ClaimReceiptV1 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         token: Address,
@@ -112,11 +112,11 @@ impl IReceivePolicyGuard::ClaimProofV1 {
         to: Address,
         amount: U256,
     ) -> ReceivePolicyGuardEvent {
-        ReceivePolicyGuardEvent::ProofClaimed(IReceivePolicyGuard::ProofClaimed {
+        ReceivePolicyGuardEvent::ReceiptClaimed(IReceivePolicyGuard::ReceiptClaimed {
             token: self.token,
             originator: self.originator,
             receiver,
-            proofVersion: self.version,
+            receiptVersion: self.version,
             blockedNonce: self.blockedNonce,
             blockedAt: self.blockedAt,
             recipient: self.recipient,
@@ -132,7 +132,7 @@ impl IReceivePolicyGuard::ClaimProofV1 {
             token: self.token,
             from: self.originator,
             receiver,
-            proofVersion: self.version,
+            receiptVersion: self.version,
             blockedNonce: self.blockedNonce,
             blockedAt: self.blockedAt,
             recipient: self.recipient,
@@ -144,10 +144,10 @@ impl IReceivePolicyGuard::ClaimProofV1 {
     }
 }
 
-impl TryFrom<alloy_primitives::Bytes> for IReceivePolicyGuard::ClaimProofV1 {
+impl TryFrom<alloy_primitives::Bytes> for IReceivePolicyGuard::ClaimReceiptV1 {
     type Error = ReceivePolicyGuardError;
 
-    fn try_from(proof: alloy_primitives::Bytes) -> Result<Self, Self::Error> {
-        Self::abi_decode(&proof).map_err(|_| ReceivePolicyGuardError::invalid_proof())
+    fn try_from(receipt: alloy_primitives::Bytes) -> Result<Self, Self::Error> {
+        Self::abi_decode(&receipt).map_err(|_| ReceivePolicyGuardError::invalid_receipt())
     }
 }

--- a/crates/e2e/src/tests/blocked_transfers.rs
+++ b/crates/e2e/src/tests/blocked_transfers.rs
@@ -19,7 +19,7 @@ use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
 use tempo_precompiles::{
     PATH_USD_ADDRESS, RECEIVE_POLICY_GUARD_ADDRESS, TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS,
     receive_policy_guard::{
-        BLOCKED_PROOF_VERSION,
+        BLOCKED_RECEIPT_VERSION,
         IReceivePolicyGuard::{self, IReceivePolicyGuardErrors as ReceivePolicyGuardError},
         InboundKind,
     },
@@ -36,7 +36,7 @@ const GAS_PRICE: u128 = TEMPO_T1_BASE_FEE as u128;
 struct BlockedTransfer {
     token: Address,
     receiver: Address,
-    proof: Bytes,
+    receipt: Bytes,
 }
 
 #[test_traced]
@@ -60,7 +60,11 @@ fn test_blocked_transfer_claim_no_recovery() {
             .wallet(other_wallet)
             .connect_http(http_url.clone());
         let other_guard = IReceivePolicyGuard::new(RECEIVE_POLICY_GUARD_ADDRESS, other_provider);
-        let Err(result) = other_guard.claim(other, blocked.proof.clone()).call().await else {
+        let Err(result) = other_guard
+            .claim(other, blocked.receipt.clone())
+            .call()
+            .await
+        else {
             panic!("expected recovery claim without recovery address to fail");
         };
         assert_eq!(
@@ -82,7 +86,7 @@ fn test_blocked_transfer_claim_no_recovery() {
         let receiver_guard =
             IReceivePolicyGuard::new(RECEIVE_POLICY_GUARD_ADDRESS, receiver_provider);
         let claim = receiver_guard
-            .claim(blocked.receiver, blocked.proof.clone())
+            .claim(blocked.receiver, blocked.receipt.clone())
             .gas(GAS)
             .gas_price(GAS_PRICE)
             .send()
@@ -124,7 +128,7 @@ fn test_receive_policy_guard_claim_with_recovery() {
         let recovery_tip1028 =
             IReceivePolicyGuard::new(RECEIVE_POLICY_GUARD_ADDRESS, recovery_provider);
         let claim = recovery_tip1028
-            .claim(destination, blocked.proof)
+            .claim(destination, blocked.receipt)
             .gas(GAS)
             .gas_price(GAS_PRICE)
             .send()
@@ -244,8 +248,8 @@ async fn create_blocked_transfer(
         ITIP403Registry::BlockedReason::RECEIVE_POLICY as u8
     );
 
-    let proof: Bytes = IReceivePolicyGuard::ClaimProofV1 {
-        version: BLOCKED_PROOF_VERSION,
+    let receipt: Bytes = IReceivePolicyGuard::ClaimReceiptV1 {
+        version: BLOCKED_RECEIPT_VERSION,
         token,
         recoveryAuthority: recovery,
         originator: blocked.from,
@@ -264,7 +268,7 @@ async fn create_blocked_transfer(
         ProviderBuilder::new().connect_http(http_url.clone()),
     );
     assert_eq!(
-        guard.balanceOf(proof.clone()).call().await?,
+        guard.balanceOf(receipt.clone()).call().await?,
         amount,
         "blocked event: {blocked:#?}"
     );
@@ -283,7 +287,7 @@ async fn create_blocked_transfer(
     let blocked = BlockedTransfer {
         token,
         receiver,
-        proof,
+        receipt,
     };
 
     Ok(blocked)

--- a/crates/node/tests/it/gas/receive_policy_guard.rs
+++ b/crates/node/tests/it/gas/receive_policy_guard.rs
@@ -11,7 +11,7 @@ use tempo_contracts::precompiles::{
 };
 use tempo_precompiles::{
     PATH_USD_ADDRESS, RECEIVE_POLICY_GUARD_ADDRESS, TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS,
-    receive_policy_guard::{BLOCKED_PROOF_VERSION, InboundKind, RECOVERY_ORIGINATOR},
+    receive_policy_guard::{BLOCKED_RECEIPT_VERSION, InboundKind, RECOVERY_ORIGINATOR},
     tip20::ISSUER_ROLE,
     tip403_registry::{ALLOW_ALL_POLICY_ID, REJECT_ALL_POLICY_ID},
 };
@@ -21,7 +21,7 @@ use crate::utils::TestNodeBuilder;
 
 struct BlockedTransfer {
     receiver: Address,
-    proof: Bytes,
+    receipt: Bytes,
     gas_used: u64,
 }
 
@@ -105,13 +105,13 @@ async fn create_blocked_transfer<P: Provider + Clone>(
     assert_eq!(blocked.recipient, receiver);
     assert_eq!(blocked.recoveryAuthority, recovery);
     assert_eq!(blocked.amount, amount);
-    assert_eq!(blocked.proofVersion, BLOCKED_PROOF_VERSION);
+    assert_eq!(blocked.receiptVersion, BLOCKED_RECEIPT_VERSION);
     assert_eq!(
         blocked.blockedReason,
         ITIP403Registry::BlockedReason::RECEIVE_POLICY as u8
     );
 
-    let proof_bytes: Bytes = IReceivePolicyGuard::ClaimProofV1 {
+    let receipt_bytes: Bytes = IReceivePolicyGuard::ClaimReceiptV1 {
         version: 1,
         token: *token.address(),
         recoveryAuthority: recovery,
@@ -128,7 +128,7 @@ async fn create_blocked_transfer<P: Provider + Clone>(
 
     Ok(BlockedTransfer {
         receiver,
-        proof: proof_bytes,
+        receipt: receipt_bytes,
         gas_used: receipt.gas_used,
     })
 }
@@ -160,7 +160,7 @@ async fn claim_blocked<P: Provider + Clone>(
     blocked: &BlockedTransfer,
 ) -> eyre::Result<u64> {
     let receipt = guard
-        .claim(to, blocked.proof.clone())
+        .claim(to, blocked.receipt.clone())
         .gas(GAS_LIMIT)
         .send()
         .await?

--- a/crates/precompiles/src/receive_policy_guard/dispatch.rs
+++ b/crates/precompiles/src/receive_policy_guard/dispatch.rs
@@ -20,10 +20,10 @@ impl Precompile for ReceivePolicyGuard {
             IReceivePolicyGuardCalls::abi_decode,
             |call| match call {
                 IReceivePolicyGuardCalls::balanceOf(call) => {
-                    view(call, |c| self.balance_of(c.proof))
+                    view(call, |c| self.balance_of(c.receipt))
                 }
                 IReceivePolicyGuardCalls::claim(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.claim(s, c.to, c.proof))
+                    mutate_void(call, msg_sender, |s, c| self.claim(s, c.to, c.receipt))
                 }
             },
         )

--- a/crates/precompiles/src/receive_policy_guard/mod.rs
+++ b/crates/precompiles/src/receive_policy_guard/mod.rs
@@ -4,7 +4,7 @@ pub mod dispatch;
 
 pub use tempo_contracts::precompiles::IReceivePolicyGuard::{self, InboundKind};
 use tempo_contracts::precompiles::{
-    IReceivePolicyGuard::ClaimProofV1, ITIP403Registry::BlockedReason, ReceivePolicyGuardError,
+    IReceivePolicyGuard::ClaimReceiptV1, ITIP403Registry::BlockedReason, ReceivePolicyGuardError,
 };
 
 use crate::{
@@ -21,8 +21,8 @@ use alloy::{
 use tempo_precompiles_macros::{Storable, contract};
 use tempo_primitives::TempoAddressExt;
 
-/// Version tag for the v1 [`IReceivePolicyGuard::ClaimProofV1`] layout.
-pub const BLOCKED_PROOF_VERSION: u8 = 1;
+/// Version tag for the v1 [`IReceivePolicyGuard::ClaimReceiptV1`] layout.
+pub const BLOCKED_RECEIPT_VERSION: u8 = 1;
 
 /// Recovery-authority sentinel: originator/sender is authorized to claim (`address(0)`).
 pub const RECOVERY_ORIGINATOR: Address = Address::ZERO;
@@ -62,14 +62,14 @@ impl ReceivePolicyGuard {
         self.__initialize()
     }
 
-    /// Returns the unclaimed amount for a proof, or zero if unknown or already claimed.
-    pub fn balance_of(&self, proof: Bytes) -> Result<U256> {
-        let proof = ClaimProofV1::try_from(proof)?;
-        self.balances[self.proof_key(&proof)?].read()
+    /// Returns the unclaimed amount for a receipt, or zero if unknown or already claimed.
+    pub fn balance_of(&self, receipt: Bytes) -> Result<U256> {
+        let receipt = ClaimReceiptV1::try_from(receipt)?;
+        self.balances[self.receipt_key(&receipt)?].read()
     }
 
     /// Records a blocked inbound transfer or mint and emits `TransferBlocked` event.
-    /// Caller must send the funds into this address, which are claimable with a valid proof.
+    /// Caller must send the funds into this address, which are claimable with a valid receipt.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn store_blocked(
         &mut self,
@@ -92,15 +92,15 @@ impl ReceivePolicyGuard {
             BlockedReason::NONE | BlockedReason::__Invalid => true,
         };
         if is_invalid_reason || matches!(kind, InboundKind::__Invalid) {
-            return Err(ReceivePolicyGuardError::invalid_proof().into());
+            return Err(ReceivePolicyGuardError::invalid_receipt().into());
         }
 
         let receiver = to.target;
         let recipient = to.virtual_addr.unwrap_or(to.target);
 
-        let blocked_nonce = self.next_proof_nonce()?;
+        let blocked_nonce = self.next_receipt_nonce()?;
         let blocked_at = self.storage.timestamp().saturating_to::<u64>();
-        let proof = IReceivePolicyGuard::ClaimProofV1::new(
+        let receipt = IReceivePolicyGuard::ClaimReceiptV1::new(
             token,
             recovery_address,
             originator,
@@ -111,32 +111,35 @@ impl ReceivePolicyGuard {
             kind,
             memo,
         );
-        let key = self.proof_key(&proof)?;
+        let key = self.receipt_key(&receipt)?;
         self.balances[key].write(amount)?;
 
-        self.emit_event(proof.blocked_event(receiver, amount))?;
+        self.emit_event(receipt.blocked_event(receiver, amount))?;
         Ok((blocked_nonce, blocked_at))
     }
 
-    /// Given a valid proof, releases blocked funds to the authorized receiver.
-    pub fn claim(&mut self, msg_sender: Address, to: Address, proof: Bytes) -> Result<()> {
+    /// Given a valid receipt, releases blocked funds to the authorized receiver.
+    pub fn claim(&mut self, msg_sender: Address, to: Address, receipt: Bytes) -> Result<()> {
         if to == RECEIVE_POLICY_GUARD_ADDRESS {
             return Err(ReceivePolicyGuardError::invalid_claim_address().into());
         }
 
-        let proof = ClaimProofV1::try_from(proof)?;
+        let receipt = ClaimReceiptV1::try_from(receipt)?;
         let receiver = AddressRegistry::new()
-            .resolve_receiver(proof.recipient)
+            .resolve_receiver(receipt.recipient)
             .map_err(|_| ReceivePolicyGuardError::invalid_claim_address())?;
 
-        let recovery_authority =
-            RecoveryAuthority::from_address(proof.recoveryAuthority, receiver, proof.originator);
+        let recovery_authority = RecoveryAuthority::from_address(
+            receipt.recoveryAuthority,
+            receiver,
+            receipt.originator,
+        );
         recovery_authority.validate_auth(msg_sender)?;
 
-        let key = self.proof_key(&proof)?;
+        let key = self.receipt_key(&receipt)?;
         let amount = self.balances[key].read()?;
         if amount.is_zero() {
-            return Err(ReceivePolicyGuardError::invalid_proof().into());
+            return Err(ReceivePolicyGuardError::invalid_receipt().into());
         }
 
         self.balances[key].write(U256::ZERO)?;
@@ -149,19 +152,19 @@ impl ReceivePolicyGuard {
             RecoveryAuthority::Receiver(addr) | RecoveryAuthority::Originator(addr) => Some(addr),
             RecoveryAuthority::Contract(_) => None,
         };
-        TIP20Token::from_address(proof.token)?.release_blocked_funds(
-            proof.originator,
+        TIP20Token::from_address(receipt.token)?.release_blocked_funds(
+            receipt.originator,
             to,
             amount,
             reroute,
             recovery_addr,
         )?;
 
-        self.emit_event(proof.claimed_event(receiver, msg_sender, to, amount))
+        self.emit_event(receipt.claimed_event(receiver, msg_sender, to, amount))
     }
 
-    /// Allocates the next nonzero proof nonce.
-    fn next_proof_nonce(&mut self) -> Result<u64> {
+    /// Allocates the next nonzero receipt nonce.
+    fn next_receipt_nonce(&mut self) -> Result<u64> {
         let nonce = self.nonce.read()?.max(1);
         self.nonce.write(
             nonce
@@ -171,9 +174,9 @@ impl ReceivePolicyGuard {
         Ok(nonce)
     }
 
-    /// Content hash over every proof field. Any mutation yields a different empty slot.
-    fn proof_key(&self, proof: &IReceivePolicyGuard::ClaimProofV1) -> Result<B256> {
-        self.storage.keccak256(proof.abi_encode().as_ref())
+    /// Content hash over every receipt field. Any mutation yields a different empty slot.
+    fn receipt_key(&self, receipt: &IReceivePolicyGuard::ClaimReceiptV1) -> Result<B256> {
+        self.storage.keccak256(receipt.abi_encode().as_ref())
     }
 }
 
@@ -254,10 +257,10 @@ mod tests {
         )
     }
 
-    fn assert_invalid_proof(result: Result<()>) {
+    fn assert_invalid_receipt(result: Result<()>) {
         assert_eq!(
             result.unwrap_err(),
-            ReceivePolicyGuardError::invalid_proof().into()
+            ReceivePolicyGuardError::invalid_receipt().into()
         );
     }
 
@@ -303,7 +306,7 @@ mod tests {
                     let mut token = setup.apply()?;
                     block_all_senders(receiver, recovery_auth.address())?;
 
-                    let unknown = ClaimProofV1::new(
+                    let unknown = ClaimReceiptV1::new(
                         token.address(),
                         recovery_auth.address(),
                         originator,
@@ -358,7 +361,7 @@ mod tests {
                             token: token.address(),
                             from: originator,
                             receiver,
-                            proofVersion: BLOCKED_PROOF_VERSION,
+                            receiptVersion: BLOCKED_RECEIPT_VERSION,
                             blockedNonce: 1,
                             blockedAt: blocked_at,
                             recipient: receiver,
@@ -369,7 +372,7 @@ mod tests {
                         },
                     )]);
 
-                    let proof = ClaimProofV1::new(
+                    let receipt = ClaimReceiptV1::new(
                         token.address(),
                         recovery_auth.address(),
                         originator,
@@ -380,20 +383,20 @@ mod tests {
                         kind,
                         B256::ZERO,
                     );
-                    assert_eq!(guard.balance_of(proof.abi_encode().into())?, amount);
+                    assert_eq!(guard.balance_of(receipt.abi_encode().into())?, amount);
 
                     if let RecoveryAuthority::Contract(recovery) = recovery_auth {
                         assert_unauthorized(guard.claim(
                             receiver,
                             receiver,
-                            proof.abi_encode().into(),
+                            receipt.abi_encode().into(),
                         ));
                         assert_unauthorized(guard.claim(
                             Address::random(),
                             receiver,
-                            proof.abi_encode().into(),
+                            receipt.abi_encode().into(),
                         ));
-                        assert_eq!(guard.balance_of(proof.abi_encode().into())?, amount);
+                        assert_eq!(guard.balance_of(receipt.abi_encode().into())?, amount);
                         assert_eq!(recovery_auth.claimer(), recovery);
                     }
 
@@ -401,13 +404,13 @@ mod tests {
                     guard.claim(
                         recovery_auth.claimer(),
                         destination,
-                        proof.abi_encode().into(),
+                        receipt.abi_encode().into(),
                     )?;
-                    guard.assert_emitted_events(vec![ReceivePolicyGuardEvent::ProofClaimed(
-                        IReceivePolicyGuard::ProofClaimed {
+                    guard.assert_emitted_events(vec![ReceivePolicyGuardEvent::ReceiptClaimed(
+                        IReceivePolicyGuard::ReceiptClaimed {
                             token: token.address(),
                             receiver,
-                            proofVersion: BLOCKED_PROOF_VERSION,
+                            receiptVersion: BLOCKED_RECEIPT_VERSION,
                             blockedNonce: 1,
                             blockedAt: blocked_at,
                             originator,
@@ -419,7 +422,7 @@ mod tests {
                         },
                     )]);
 
-                    assert_eq!(guard.balance_of(proof.abi_encode().into())?, U256::ZERO);
+                    assert_eq!(guard.balance_of(receipt.abi_encode().into())?, U256::ZERO);
                     assert_eq!(
                         token.balance_of(ITIP20::balanceOfCall {
                             account: RECEIVE_POLICY_GUARD_ADDRESS
@@ -469,7 +472,7 @@ mod tests {
             )?;
             token.pause(admin, ITIP20::pauseCall {})?;
 
-            let proof = ClaimProofV1::new(
+            let receipt = ClaimReceiptV1::new(
                 token.address(),
                 receiver,
                 originator,
@@ -481,7 +484,7 @@ mod tests {
                 B256::ZERO,
             );
             let mut guard = ReceivePolicyGuard::new();
-            let result = guard.claim(receiver, receiver, proof.abi_encode().into());
+            let result = guard.claim(receiver, receiver, receipt.abi_encode().into());
             assert_eq!(result.unwrap_err(), TIP20Error::contract_paused().into());
 
             Ok(())
@@ -489,7 +492,7 @@ mod tests {
     }
 
     #[test]
-    fn test_receive_policy_guard_balance_matches_open_proofs() -> eyre::Result<()> {
+    fn test_receive_policy_guard_balance_matches_open_receipts() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
         storage.set_timestamp(U256::from(1_728_001u64));
 
@@ -539,7 +542,7 @@ mod tests {
                 },
             )?;
 
-            let proof_a = ClaimProofV1::new(
+            let receipt_a = ClaimReceiptV1::new(
                 token_a.address(),
                 receiver_a,
                 originator,
@@ -550,7 +553,7 @@ mod tests {
                 InboundKind::TRANSFER,
                 B256::ZERO,
             );
-            let proof_b = ClaimProofV1::new(
+            let receipt_b = ClaimReceiptV1::new(
                 token_a.address(),
                 recovery,
                 originator,
@@ -561,7 +564,7 @@ mod tests {
                 InboundKind::TRANSFER,
                 B256::ZERO,
             );
-            let proof_c = ClaimProofV1::new(
+            let receipt_c = ClaimReceiptV1::new(
                 token_b.address(),
                 receiver_c,
                 originator,
@@ -578,31 +581,31 @@ mod tests {
                 token_a.balance_of(ITIP20::balanceOfCall {
                     account: RECEIVE_POLICY_GUARD_ADDRESS
                 })?,
-                guard.balance_of(proof_a.abi_encode().into())?
-                    + guard.balance_of(proof_b.abi_encode().into())?
+                guard.balance_of(receipt_a.abi_encode().into())?
+                    + guard.balance_of(receipt_b.abi_encode().into())?
             );
             assert_eq!(
                 token_b.balance_of(ITIP20::balanceOfCall {
                     account: RECEIVE_POLICY_GUARD_ADDRESS
                 })?,
-                guard.balance_of(proof_c.abi_encode().into())?
+                guard.balance_of(receipt_c.abi_encode().into())?
             );
 
-            guard.claim(receiver_a, receiver_a, proof_a.abi_encode().into())?;
+            guard.claim(receiver_a, receiver_a, receipt_a.abi_encode().into())?;
             assert_eq!(
                 token_a.balance_of(ITIP20::balanceOfCall {
                     account: RECEIVE_POLICY_GUARD_ADDRESS
                 })?,
-                guard.balance_of(proof_b.abi_encode().into())?
+                guard.balance_of(receipt_b.abi_encode().into())?
             );
             assert_eq!(
                 token_b.balance_of(ITIP20::balanceOfCall {
                     account: RECEIVE_POLICY_GUARD_ADDRESS
                 })?,
-                guard.balance_of(proof_c.abi_encode().into())?
+                guard.balance_of(receipt_c.abi_encode().into())?
             );
 
-            guard.claim(recovery, receiver_b, proof_b.abi_encode().into())?;
+            guard.claim(recovery, receiver_b, receipt_b.abi_encode().into())?;
             assert_eq!(
                 token_a.balance_of(ITIP20::balanceOfCall {
                     account: RECEIVE_POLICY_GUARD_ADDRESS
@@ -613,7 +616,7 @@ mod tests {
                 token_b.balance_of(ITIP20::balanceOfCall {
                     account: RECEIVE_POLICY_GUARD_ADDRESS
                 })?,
-                guard.balance_of(proof_c.abi_encode().into())?
+                guard.balance_of(receipt_c.abi_encode().into())?
             );
 
             Ok(())
@@ -621,7 +624,7 @@ mod tests {
     }
 
     #[test]
-    fn test_proof_rejects_bad_encoding() -> eyre::Result<()> {
+    fn test_receipt_rejects_bad_encoding() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
 
         StorageCtx::enter(&mut storage, || {
@@ -629,7 +632,7 @@ mod tests {
             let result = guard.balance_of(vec![0xde, 0xad, 0xbe, 0xef].into());
             assert!(matches!(
                 result,
-                Err(e) if e == ReceivePolicyGuardError::invalid_proof().into()
+                Err(e) if e == ReceivePolicyGuardError::invalid_receipt().into()
             ));
 
             Ok(())
@@ -662,7 +665,7 @@ mod tests {
                 );
                 assert!(matches!(
                     result,
-                    Err(e) if e == ReceivePolicyGuardError::invalid_proof().into()
+                    Err(e) if e == ReceivePolicyGuardError::invalid_receipt().into()
                 ));
             }
 
@@ -671,7 +674,7 @@ mod tests {
     }
 
     #[test]
-    fn test_proof_key_binds_proof_fields() -> eyre::Result<()> {
+    fn test_receipt_key_binds_receipt_fields() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
         storage.set_timestamp(U256::from(1_728_002u64));
 
@@ -710,7 +713,7 @@ mod tests {
                 B256::repeat_byte(0x22),
             )?;
 
-            let proof_a = ClaimProofV1::new(
+            let receipt_a = ClaimReceiptV1::new(
                 token_a.address(),
                 recovery,
                 originator_a,
@@ -721,7 +724,7 @@ mod tests {
                 InboundKind::TRANSFER,
                 memo,
             );
-            let proof_b = ClaimProofV1::new(
+            let receipt_b = ClaimReceiptV1::new(
                 token_b.address(),
                 recovery,
                 originator_b,
@@ -733,11 +736,11 @@ mod tests {
                 B256::repeat_byte(0x22),
             );
 
-            assert_eq!(guard.balance_of(proof_a.abi_encode().into())?, amount_a);
-            assert_eq!(guard.balance_of(proof_b.abi_encode().into())?, amount_b);
+            assert_eq!(guard.balance_of(receipt_a.abi_encode().into())?, amount_a);
+            assert_eq!(guard.balance_of(receipt_b.abi_encode().into())?, amount_b);
 
-            let mutated_proofs = [
-                ClaimProofV1::new(
+            let mutated_receipts = [
+                ClaimReceiptV1::new(
                     token_a.address(),
                     recovery,
                     Address::random(),
@@ -748,7 +751,7 @@ mod tests {
                     InboundKind::TRANSFER,
                     memo,
                 ),
-                ClaimProofV1::new(
+                ClaimReceiptV1::new(
                     token_a.address(),
                     recovery,
                     originator_a,
@@ -759,7 +762,7 @@ mod tests {
                     InboundKind::TRANSFER,
                     memo,
                 ),
-                ClaimProofV1::new(
+                ClaimReceiptV1::new(
                     token_a.address(),
                     recovery,
                     originator_a,
@@ -770,7 +773,7 @@ mod tests {
                     InboundKind::TRANSFER,
                     memo,
                 ),
-                ClaimProofV1::new(
+                ClaimReceiptV1::new(
                     token_a.address(),
                     recovery,
                     originator_a,
@@ -781,7 +784,7 @@ mod tests {
                     InboundKind::TRANSFER,
                     memo,
                 ),
-                ClaimProofV1::new(
+                ClaimReceiptV1::new(
                     token_a.address(),
                     recovery,
                     originator_a,
@@ -792,7 +795,7 @@ mod tests {
                     InboundKind::TRANSFER,
                     memo,
                 ),
-                ClaimProofV1::new(
+                ClaimReceiptV1::new(
                     token_a.address(),
                     recovery,
                     originator_a,
@@ -803,7 +806,7 @@ mod tests {
                     InboundKind::MINT,
                     memo,
                 ),
-                ClaimProofV1::new(
+                ClaimReceiptV1::new(
                     token_a.address(),
                     recovery,
                     originator_a,
@@ -816,18 +819,18 @@ mod tests {
                 ),
             ];
 
-            for mutated in mutated_proofs {
+            for mutated in mutated_receipts {
                 assert_eq!(guard.balance_of(mutated.abi_encode().into())?, U256::ZERO);
             }
-            assert_eq!(guard.balance_of(proof_a.abi_encode().into())?, amount_a);
-            assert_eq!(guard.balance_of(proof_b.abi_encode().into())?, amount_b);
+            assert_eq!(guard.balance_of(receipt_a.abi_encode().into())?, amount_a);
+            assert_eq!(guard.balance_of(receipt_b.abi_encode().into())?, amount_b);
 
             Ok(())
         })
     }
 
     #[test]
-    fn test_claim_rejects_missing_proof() -> eyre::Result<()> {
+    fn test_claim_rejects_missing_receipt() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
         storage.set_timestamp(U256::from(1_728_003u64));
 
@@ -841,7 +844,7 @@ mod tests {
                 .with_mint(originator, amount)
                 .apply()?;
 
-            let proof = ClaimProofV1::new(
+            let receipt = ClaimReceiptV1::new(
                 token.address(),
                 receiver,
                 originator,
@@ -854,7 +857,7 @@ mod tests {
             );
 
             let mut guard = ReceivePolicyGuard::new();
-            assert_invalid_proof(guard.claim(receiver, receiver, proof.abi_encode().into()));
+            assert_invalid_receipt(guard.claim(receiver, receiver, receipt.abi_encode().into()));
 
             block_all_senders(receiver, receiver)?;
             token.transfer(
@@ -864,8 +867,8 @@ mod tests {
                     amount,
                 },
             )?;
-            guard.claim(receiver, receiver, proof.abi_encode().into())?;
-            assert_invalid_proof(guard.claim(receiver, receiver, proof.abi_encode().into()));
+            guard.claim(receiver, receiver, receipt.abi_encode().into())?;
+            assert_invalid_receipt(guard.claim(receiver, receiver, receipt.abi_encode().into()));
 
             Ok(())
         })
@@ -907,7 +910,7 @@ mod tests {
                 },
             )?;
 
-            let self_proof = ClaimProofV1::new(
+            let self_receipt = ClaimReceiptV1::new(
                 token.address(),
                 receiver,
                 originator,
@@ -918,7 +921,7 @@ mod tests {
                 InboundKind::TRANSFER,
                 B256::ZERO,
             );
-            let recovery_proof = ClaimProofV1::new(
+            let recovery_receipt = ClaimReceiptV1::new(
                 token.address(),
                 recovery,
                 originator,
@@ -931,17 +934,17 @@ mod tests {
             );
 
             let mut guard = ReceivePolicyGuard::new();
-            assert_unauthorized(guard.claim(stranger, receiver, self_proof.abi_encode().into()));
+            assert_unauthorized(guard.claim(stranger, receiver, self_receipt.abi_encode().into()));
             for caller in [recovery_receiver, stranger] {
                 assert_unauthorized(guard.claim(
                     caller,
                     recovery_receiver,
-                    recovery_proof.abi_encode().into(),
+                    recovery_receipt.abi_encode().into(),
                 ));
             }
-            assert_eq!(guard.balance_of(self_proof.abi_encode().into())?, amount);
+            assert_eq!(guard.balance_of(self_receipt.abi_encode().into())?, amount);
             assert_eq!(
-                guard.balance_of(recovery_proof.abi_encode().into())?,
+                guard.balance_of(recovery_receipt.abi_encode().into())?,
                 amount
             );
 
@@ -975,7 +978,7 @@ mod tests {
                 },
             )?;
 
-            let proof = ClaimProofV1::new(
+            let receipt = ClaimReceiptV1::new(
                 token.address(),
                 VIRTUAL_MASTER,
                 originator,
@@ -991,7 +994,7 @@ mod tests {
                     token: token.address(),
                     from: originator,
                     receiver: VIRTUAL_MASTER,
-                    proofVersion: BLOCKED_PROOF_VERSION,
+                    receiptVersion: BLOCKED_RECEIPT_VERSION,
                     blockedNonce: 1,
                     blockedAt: 1_728_009,
                     recipient: virtual_addr,
@@ -1002,13 +1005,13 @@ mod tests {
                 },
             )]);
             guard.clear_emitted_events();
-            guard.claim(VIRTUAL_MASTER, VIRTUAL_MASTER, proof.abi_encode().into())?;
+            guard.claim(VIRTUAL_MASTER, VIRTUAL_MASTER, receipt.abi_encode().into())?;
 
-            guard.assert_emitted_events(vec![ReceivePolicyGuardEvent::ProofClaimed(
-                IReceivePolicyGuard::ProofClaimed {
+            guard.assert_emitted_events(vec![ReceivePolicyGuardEvent::ReceiptClaimed(
+                IReceivePolicyGuard::ReceiptClaimed {
                     token: token.address(),
                     receiver: VIRTUAL_MASTER,
-                    proofVersion: BLOCKED_PROOF_VERSION,
+                    receiptVersion: BLOCKED_RECEIPT_VERSION,
                     blockedNonce: 1,
                     blockedAt: 1_728_009,
                     originator,

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1183,7 +1183,7 @@ impl TIP20Token {
     }
 
     /// Validates the receive policy of `to.target`. If blocked, moves the funds into the guard
-    /// account and stores a claim proof; returns `true`. Returns `false` when the inbound is
+    /// account and stores a claim receipt; returns `true`. Returns `false` when the inbound is
     /// authorized and the caller should proceed with the normal transfer or mint.
     pub(crate) fn validate_inbound_or_block(
         &mut self,
@@ -1215,7 +1215,7 @@ impl TIP20Token {
                 self.emit_event(TIP20Event::mint(guard.target, amount))?;
             }
             InboundKind::__Invalid => {
-                return Err(ReceivePolicyGuardError::invalid_proof().into());
+                return Err(ReceivePolicyGuardError::invalid_receipt().into());
             }
         }
         ReceivePolicyGuard::new()
@@ -1640,7 +1640,7 @@ pub(crate) mod tests {
     mod tip1028_tests {
         use super::*;
         use crate::{
-            receive_policy_guard::BLOCKED_PROOF_VERSION,
+            receive_policy_guard::BLOCKED_RECEIPT_VERSION,
             tip403_registry::{ALLOW_ALL_POLICY_ID, REJECT_ALL_POLICY_ID},
         };
 
@@ -1701,7 +1701,7 @@ pub(crate) mod tests {
                     amount,
                 })]);
 
-                let proof = IReceivePolicyGuard::ClaimProofV1::new(
+                let receipt = IReceivePolicyGuard::ClaimReceiptV1::new(
                     token.address,
                     Address::ZERO,
                     sender,
@@ -1713,13 +1713,13 @@ pub(crate) mod tests {
                     B256::ZERO,
                 );
                 let guard = ReceivePolicyGuard::new();
-                assert_eq!(guard.balance_of(proof.abi_encode().into())?, amount);
+                assert_eq!(guard.balance_of(receipt.abi_encode().into())?, amount);
                 guard.assert_emitted_events(vec![ReceivePolicyGuardEvent::TransferBlocked(
                     IReceivePolicyGuard::TransferBlocked {
                         token: token.address,
                         from: sender,
                         receiver,
-                        proofVersion: BLOCKED_PROOF_VERSION,
+                        receiptVersion: BLOCKED_RECEIPT_VERSION,
                         blockedNonce: 1,
                         blockedAt: BLOCKED_AT,
                         recipient: receiver,
@@ -1763,7 +1763,7 @@ pub(crate) mod tests {
                     },
                 )?;
 
-                let proof = IReceivePolicyGuard::ClaimProofV1::new(
+                let receipt = IReceivePolicyGuard::ClaimReceiptV1::new(
                     token.address,
                     Address::ZERO,
                     sender,
@@ -1775,13 +1775,13 @@ pub(crate) mod tests {
                     B256::ZERO,
                 );
                 let guard = ReceivePolicyGuard::new();
-                assert_eq!(guard.balance_of(proof.abi_encode().into())?, amount);
+                assert_eq!(guard.balance_of(receipt.abi_encode().into())?, amount);
                 guard.assert_emitted_events(vec![ReceivePolicyGuardEvent::TransferBlocked(
                     IReceivePolicyGuard::TransferBlocked {
                         token: token.address,
                         from: sender,
                         receiver,
-                        proofVersion: BLOCKED_PROOF_VERSION,
+                        receiptVersion: BLOCKED_RECEIPT_VERSION,
                         blockedNonce: 1,
                         blockedAt: BLOCKED_AT,
                         recipient: receiver,
@@ -1865,7 +1865,7 @@ pub(crate) mod tests {
                     to: receiver,
                     amount,
                 })]);
-                let proof = IReceivePolicyGuard::ClaimProofV1::new(
+                let receipt = IReceivePolicyGuard::ClaimReceiptV1::new(
                     token.address,
                     Address::ZERO,
                     sender,
@@ -1877,7 +1877,7 @@ pub(crate) mod tests {
                     B256::ZERO,
                 );
                 assert_eq!(
-                    ReceivePolicyGuard::new().balance_of(proof.abi_encode().into())?,
+                    ReceivePolicyGuard::new().balance_of(receipt.abi_encode().into())?,
                     U256::ZERO
                 );
 
@@ -1967,7 +1967,7 @@ pub(crate) mod tests {
                     to: RECEIVE_POLICY_GUARD_ADDRESS,
                     amount,
                 })]);
-                let proof = IReceivePolicyGuard::ClaimProofV1::new(
+                let receipt = IReceivePolicyGuard::ClaimReceiptV1::new(
                     token.address,
                     Address::ZERO,
                     sender,
@@ -1979,7 +1979,7 @@ pub(crate) mod tests {
                     memo,
                 );
                 assert_eq!(
-                    ReceivePolicyGuard::new().balance_of(proof.abi_encode().into())?,
+                    ReceivePolicyGuard::new().balance_of(receipt.abi_encode().into())?,
                     amount
                 );
 
@@ -2029,7 +2029,7 @@ pub(crate) mod tests {
                         token: token.address,
                         from: admin,
                         receiver,
-                        proofVersion: BLOCKED_PROOF_VERSION,
+                        receiptVersion: BLOCKED_RECEIPT_VERSION,
                         blockedNonce: 1,
                         blockedAt: BLOCKED_AT,
                         recipient: receiver,
@@ -2040,7 +2040,7 @@ pub(crate) mod tests {
                     },
                 )]);
 
-                let proof = IReceivePolicyGuard::ClaimProofV1::new(
+                let receipt = IReceivePolicyGuard::ClaimReceiptV1::new(
                     token.address,
                     Address::ZERO,
                     admin,
@@ -2051,7 +2051,7 @@ pub(crate) mod tests {
                     InboundKind::MINT,
                     B256::ZERO,
                 );
-                assert_eq!(guard.balance_of(proof.abi_encode().into())?, amount);
+                assert_eq!(guard.balance_of(receipt.abi_encode().into())?, amount);
 
                 Ok(())
             })


### PR DESCRIPTION
Renames TIP-1028 implementation terminology from proof to receipt to align with the updated spec.\n\nValidation:\n- cargo fmt --check\n- cargo test -p tempo-precompiles receive_policy_guard --lib