### PR TITLE
ci(bench): enable prewarming in e2e bench

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -27,6 +27,7 @@ const E2E_LOCAL_RETH_ARGS = [
     "--tempo.bootnodes-endpoint" "none"
     "--builder.max-tasks" "1"
     "--engine.share-sparse-trie-with-payload-builder"
+    "--builder.enable-prewarming"
 ]
 
 def run-bench-schelk [...args: string] {


### PR DESCRIPTION
## Summary
- enable `--builder.enable-prewarming` in `E2E_LOCAL_RETH_ARGS` for bench-e2e runs

## Testing
- not run; config-only change