### PR TITLE
ci: reenable Foundry lint on build

### DIFF
--- a/tips/verify/foundry.toml
+++ b/tips/verify/foundry.toml
@@ -21,9 +21,6 @@ invariant = { runs = 10, depth = 50, fail_on_revert = true, show_solidity = true
 [profile.fuzz500]
 invariant = { runs = 500, depth = 500, fail_on_revert = true, show_solidity = true }
 
-[lint]
-lint_on_build = false
-
 [fmt]
 line_length = 100
 sort_imports = true


### PR DESCRIPTION
## Summary
- remove the `tips/verify` Foundry `[lint]` section entirely
- this re-enables Foundry lint-on-build using Foundry defaults

## Testing
- uv run --with tomli python -c "import tomli; tomli.load(open('tips/verify/foundry.toml','rb')); print('foundry.toml: valid TOML')"

Note: follow-up work will handle test lint noise and the stale `foundry.lock` dependency warning separately.