### PR TITLE
perf(txpool): add best transaction size hints

### DIFF
--- a/crates/transaction-pool/src/best.rs
+++ b/crates/transaction-pool/src/best.rs
@@ -86,6 +86,19 @@ impl Iterator for MergeBestTransactions {
     fn next(&mut self) -> Option<Self::Item> {
         self.next_best().map(|(tx, _)| tx)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let cached = usize::from(self.next_protocol_pool.is_some())
+            .saturating_add(usize::from(self.next_aa_2d_pool.is_some()));
+        let (_, protocol_upper) = self.protocol_pool.size_hint();
+        let (_, aa_2d_upper) = self.aa_2d_pool.size_hint();
+        let upper = protocol_upper
+            .zip(aa_2d_upper)
+            .and_then(|(protocol, aa_2d)| protocol.checked_add(aa_2d))
+            .and_then(|upper| upper.checked_add(cached));
+
+        (0, upper)
+    }
 }
 
 impl BestTransactions for MergeBestTransactions {
@@ -180,6 +193,11 @@ where
 
             return Some(tx);
         }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.inner.size_hint();
+        (0, upper)
     }
 }
 
@@ -326,6 +344,31 @@ mod tests {
         assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*tx_c.hash())); // priority 3
         assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*tx_f.hash())); // priority 1
         assert!(merged.next().is_none());
+    }
+
+    #[test]
+    fn test_merge_best_transactions_size_hint() {
+        let tx_a = protocol_tx(0, 10);
+        let tx_b = aa_2d_tx(0, 8);
+        let mut merged = merged_best_transactions(vec![tx_a.clone()], vec![tx_b]);
+        merged.no_updates();
+
+        assert_eq!(merged.size_hint().0, 0);
+        assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*tx_a.hash()));
+        assert_eq!(merged.size_hint().0, 0);
+    }
+
+    #[test]
+    fn test_state_aware_best_transactions_size_hint() {
+        let tx_a = aa_2d_tx(0, 10);
+        let tx_b = aa_2d_tx(1, 5);
+        let mut best = StateAwareBestTransactions::new(
+            aa_2d_best_transactions(vec![tx_a, tx_b]).without_updates(),
+        );
+
+        assert_eq!(best.size_hint(), (0, Some(2)));
+        assert!(best.next().is_some());
+        assert_eq!(best.size_hint(), (0, Some(1)));
     }
 
     #[test]

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -1589,6 +1589,15 @@ pub(crate) struct BestAA2dTransactions {
 }
 
 impl BestAA2dTransactions {
+    fn remaining_len(&self) -> usize {
+        self.by_id.len().saturating_add(
+            self.independent
+                .iter()
+                .filter(|tx| tx.transaction.transaction.is_expiring_nonce())
+                .count(),
+        )
+    }
+
     /// Removes the best transaction from the set
     fn pop_best(&mut self) -> Option<(AA2dTransactionId, PendingTransaction<TxOrdering>)> {
         let tx = self.independent.pop_last()?;
@@ -1688,6 +1697,15 @@ impl Iterator for BestAA2dTransactions {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next_tx_and_priority().map(|(tx, _)| tx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            0,
+            self.new_transaction_receiver
+                .is_none()
+                .then_some(self.remaining_len()),
+        )
     }
 }
 
@@ -3662,6 +3680,58 @@ mod tests {
 
         let third = best.next();
         assert!(third.is_none());
+    }
+
+    #[test]
+    fn test_best_transactions_size_hint() {
+        let mut pool = AA2dPool::default();
+        let sender = Address::random();
+
+        for nonce in 0..3 {
+            let tx = TxBuilder::aa(sender)
+                .nonce_key(U256::ZERO)
+                .nonce(nonce)
+                .build();
+            pool.add_transaction(
+                Arc::new(wrap_valid_tx(tx, TransactionOrigin::Local)),
+                0,
+                TempoHardfork::T1,
+            )
+            .unwrap();
+        }
+
+        let mut best = pool.best_transactions();
+        assert_eq!(best.size_hint(), (0, None));
+
+        best.no_updates();
+        assert_eq!(best.size_hint(), (0, Some(3)));
+
+        assert!(best.next().is_some());
+        assert_eq!(best.size_hint(), (0, Some(2)));
+    }
+
+    #[test]
+    fn test_best_transactions_size_hint_includes_expiring_nonce() {
+        let mut pool = AA2dPool::default();
+        let sender = Address::random();
+
+        let regular = TxBuilder::aa(sender).nonce_key(U256::ZERO).build();
+        let expiring = TxBuilder::aa(sender).nonce_key(U256::MAX).build();
+        for tx in [regular, expiring] {
+            pool.add_transaction(
+                Arc::new(wrap_valid_tx(tx, TransactionOrigin::Local)),
+                0,
+                TempoHardfork::T1,
+            )
+            .unwrap();
+        }
+
+        let mut best = pool.best_transactions();
+        best.no_updates();
+        assert_eq!(best.size_hint(), (0, Some(2)));
+
+        assert!(best.next().is_some());
+        assert_eq!(best.size_hint(), (0, Some(1)));
     }
 
     #[test]


### PR DESCRIPTION
Adds `size_hint` implementations for Tempo's best-transaction iterators so callers can get bounded upper hints when updates are disabled.

The AA 2D iterator accounts for expiring nonce transactions separately, and the merge/state-aware wrappers forward conservative bounds from their inner iterators.