### PR TITLE
bench: TIP-20 rewards

### DIFF
--- a/.github/workflows/codspeed-microbench.yml
+++ b/.github/workflows/codspeed-microbench.yml
@@ -25,7 +25,7 @@ on:
       filters:
         description: "Optional benchmark name filter passed to cargo codspeed run"
         required: false
-        default: ""
+        default: "tip20_"
         type: string
       measurement_modes:
         description: "CodSpeed measurement mode(s), separated by commas"
@@ -65,7 +65,7 @@ jobs:
         env:
           INPUT_PACKAGES: ${{ inputs.packages || 'tempo-evm' }}
           INPUT_BENCHMARKS: ${{ inputs.benchmarks || 'tip20_execution' }}
-          INPUT_FILTERS: ${{ inputs.filters || '' }}
+          INPUT_FILTERS: ${{ inputs.filters || 'tip20_' }}
           INPUT_MEASUREMENT_MODES: ${{ inputs.measurement_modes || 'simulation' }}
         run: |
           set -euo pipefail

--- a/crates/evm/benches/tip20_execution.rs
+++ b/crates/evm/benches/tip20_execution.rs
@@ -67,9 +67,12 @@ const TXGEN_MNEMONIC: &str = "test test test test test test test test test test 
 const DEFAULT_ACCOUNT_COUNT: usize = 1_024;
 const DEFAULT_TX_COUNT: usize = 4_096;
 const DEFAULT_BLOCK_TIMESTAMP: u64 = 1_700_000_000;
-const TXGEN_GAS_LIMIT: u64 = 300_000;
+const TXGEN_GAS_LIMIT: u64 = 2_000_000;
 const TXGEN_FEE_PER_GAS: u128 = 100_000_000_000;
 const PARTICIPANT_MINT_AMOUNT: u128 = 1_000_000_000_000_000_000;
+const REWARD_BENCH_TX_COUNT: usize = 1_024;
+const REWARD_DISTRIBUTION_AMOUNT: u128 = 1_000_000_000_000;
+const REWARD_TRANSFER_AMOUNT: u128 = 1_000_000;
 const EXECUTION_CACHE_BYTES: usize = 64 * 1024 * 1024;
 
 #[derive(Clone)]
@@ -77,6 +80,35 @@ struct Workload {
     transactions: Vec<Recovered<TempoTxEnvelope>>,
     participants: Vec<Address>,
     block_timestamp: u64,
+}
+
+#[derive(Clone, Copy)]
+enum RewardSeedMode {
+    None,
+    SelfRecipient,
+    SharedDelegate,
+    DistinctDelegate,
+}
+
+#[derive(Clone, Copy)]
+enum RewardBenchKind {
+    Transfer {
+        sender: RewardSeedMode,
+        recipient: RewardSeedMode,
+        reward_delta: bool,
+    },
+    ClaimRewards,
+    DistributeReward {
+        opted_in_accounts: usize,
+    },
+}
+
+struct RewardBenchWorkload {
+    name: &'static str,
+    transactions: Vec<Recovered<TempoTxEnvelope>>,
+    participants: Vec<Address>,
+    delegates: Vec<Address>,
+    kind: RewardBenchKind,
 }
 
 #[derive(Default)]
@@ -268,7 +300,11 @@ fn bench_env(block_timestamp: u64) -> EvmEnv<TempoHardfork, TempoBlockEnv> {
     }
 }
 
-fn seed_in_memory_cache_db(participants: &[Address], block_timestamp: u64) -> CacheDB<EmptyDB> {
+fn seed_in_memory_cache_db(
+    participants: &[Address],
+    block_timestamp: u64,
+    reward_seed: Option<(&[Address], RewardBenchKind)>,
+) -> CacheDB<EmptyDB> {
     // This setup database only materializes the benchmark fixture in memory. The measured
     // execution path below uses Reth's fixed-cache execution provider, not CacheDB.
     let mut evm = TempoEvmFactory::default()
@@ -308,6 +344,10 @@ fn seed_in_memory_cache_db(participants: &[Address], block_timestamp: u64) -> Ca
                 )?;
             }
 
+            if let Some((delegates, kind)) = reward_seed {
+                seed_reward_bench_state(&mut token, admin, participants, delegates, kind)?;
+            }
+
             TipFeeManager::new().initialize()?;
             NonceManager::new().initialize()?;
             Ok::<(), TempoPrecompileError>(())
@@ -320,8 +360,12 @@ fn seed_in_memory_cache_db(participants: &[Address], block_timestamp: u64) -> Ca
     evm.finish().0
 }
 
-fn setup_fixed_cache_state(participants: &[Address], block_timestamp: u64) -> ExecutionFixture {
-    let seeded = seed_in_memory_cache_db(participants, block_timestamp);
+fn setup_fixed_cache_state(
+    participants: &[Address],
+    block_timestamp: u64,
+    reward_seed: Option<(&[Address], RewardBenchKind)>,
+) -> ExecutionFixture {
+    let seeded = seed_in_memory_cache_db(participants, block_timestamp, reward_seed);
     let state_cache = seeded.cache;
     let execution_cache = ExecutionCache::new(EXECUTION_CACHE_BYTES);
 
@@ -389,6 +433,87 @@ fn insert_account(
     accounts.insert(address, account);
 }
 
+fn seed_reward_bench_state(
+    token: &mut TIP20Token,
+    admin: Address,
+    participants: &[Address],
+    delegates: &[Address],
+    kind: RewardBenchKind,
+) -> Result<(), TempoPrecompileError> {
+    match kind {
+        RewardBenchKind::Transfer {
+            sender,
+            recipient,
+            reward_delta,
+        } => {
+            for chunk in participants.chunks(2) {
+                if let Some(sender_addr) = chunk.first().copied() {
+                    apply_seed_reward_mode(token, sender_addr, sender, delegates)?;
+                }
+                if let Some(recipient_addr) = chunk.get(1).copied() {
+                    apply_seed_reward_mode(token, recipient_addr, recipient, delegates)?;
+                }
+            }
+            if reward_delta {
+                token.distribute_reward(
+                    admin,
+                    ITIP20::distributeRewardCall {
+                        amount: U256::from(REWARD_DISTRIBUTION_AMOUNT),
+                    },
+                )?;
+            }
+        }
+        RewardBenchKind::ClaimRewards => {
+            for participant in participants {
+                token.set_reward_recipient(
+                    *participant,
+                    ITIP20::setRewardRecipientCall {
+                        recipient: *participant,
+                    },
+                )?;
+            }
+            token.distribute_reward(
+                admin,
+                ITIP20::distributeRewardCall {
+                    amount: U256::from(REWARD_DISTRIBUTION_AMOUNT),
+                },
+            )?;
+            for participant in participants {
+                token.update_rewards(*participant)?;
+            }
+        }
+        RewardBenchKind::DistributeReward { opted_in_accounts } => {
+            for participant in participants.iter().take(opted_in_accounts) {
+                token.set_reward_recipient(
+                    *participant,
+                    ITIP20::setRewardRecipientCall {
+                        recipient: *participant,
+                    },
+                )?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn apply_seed_reward_mode(
+    token: &mut TIP20Token,
+    account: Address,
+    mode: RewardSeedMode,
+    delegates: &[Address],
+) -> Result<(), TempoPrecompileError> {
+    let recipient = match mode {
+        RewardSeedMode::None => return Ok(()),
+        RewardSeedMode::SelfRecipient => account,
+        RewardSeedMode::SharedDelegate => delegates[0],
+        RewardSeedMode::DistinctDelegate => {
+            delegates[account.as_slice()[19] as usize % delegates.len()]
+        }
+    };
+    token.set_reward_recipient(account, ITIP20::setRewardRecipientCall { recipient })?;
+    Ok(())
+}
+
 fn txgen_signers(account_count: usize) -> Vec<PrivateKeySigner> {
     (0..account_count)
         .map(|idx| {
@@ -406,10 +531,19 @@ fn sign_tip20_transfer(
     recipient: Address,
     amount: U256,
 ) -> Recovered<TempoTxEnvelope> {
-    let call = ITIP20::transferCall {
-        to: recipient,
-        amount,
-    };
+    sign_tip20_call(
+        signer,
+        Bytes::from(
+            ITIP20::transferCall {
+                to: recipient,
+                amount,
+            }
+            .abi_encode(),
+        ),
+    )
+}
+
+fn sign_tip20_call(signer: &PrivateKeySigner, input: Bytes) -> Recovered<TempoTxEnvelope> {
     let tx = TempoTransaction {
         chain_id: CHAIN_ID,
         fee_token: Some(PATH_USD_ADDRESS),
@@ -419,7 +553,7 @@ fn sign_tip20_transfer(
         calls: vec![Call {
             to: TxKind::Call(PATH_USD_ADDRESS),
             value: U256::ZERO,
-            input: Bytes::from(call.abi_encode()),
+            input,
         }],
         access_list: Default::default(),
         nonce_key: TEMPO_EXPIRING_NONCE_KEY,
@@ -440,7 +574,7 @@ fn sign_tip20_transfer(
 
     TempoTxEnvelope::from(signed)
         .try_into_recovered()
-        .expect("generated TIP20 transaction should recover")
+        .expect("generated TIP20 benchmark transaction should recover")
 }
 
 fn generated_workload() -> Workload {
@@ -460,6 +594,132 @@ fn generated_workload() -> Workload {
         transactions,
         participants,
         block_timestamp: DEFAULT_BLOCK_TIMESTAMP,
+    }
+}
+
+fn reward_bench_workloads() -> Vec<RewardBenchWorkload> {
+    let signers = txgen_signers(DEFAULT_ACCOUNT_COUNT);
+    let participants: Vec<_> = signers.iter().map(|signer| signer.address()).collect();
+    let delegates = vec![Address::repeat_byte(0xa1), Address::repeat_byte(0xa2)];
+
+    vec![
+        transfer_reward_workload(
+            "tip20_transfer_rewards_opted_out",
+            &signers,
+            RewardSeedMode::None,
+            RewardSeedMode::None,
+            false,
+            &delegates,
+        ),
+        transfer_reward_workload(
+            "tip20_transfer_rewards_self_no_delta",
+            &signers,
+            RewardSeedMode::SelfRecipient,
+            RewardSeedMode::SelfRecipient,
+            false,
+            &delegates,
+        ),
+        transfer_reward_workload(
+            "tip20_transfer_rewards_self_with_delta",
+            &signers,
+            RewardSeedMode::SelfRecipient,
+            RewardSeedMode::SelfRecipient,
+            true,
+            &delegates,
+        ),
+        transfer_reward_workload(
+            "tip20_transfer_rewards_delegate_no_delta",
+            &signers,
+            RewardSeedMode::SharedDelegate,
+            RewardSeedMode::SharedDelegate,
+            false,
+            &delegates,
+        ),
+        transfer_reward_workload(
+            "tip20_transfer_rewards_delegate_with_delta",
+            &signers,
+            RewardSeedMode::SharedDelegate,
+            RewardSeedMode::SharedDelegate,
+            true,
+            &delegates,
+        ),
+        transfer_reward_workload(
+            "tip20_transfer_mixed_sender_recipient",
+            &signers,
+            RewardSeedMode::DistinctDelegate,
+            RewardSeedMode::SelfRecipient,
+            true,
+            &delegates,
+        ),
+        RewardBenchWorkload {
+            name: "tip20_claim_rewards",
+            transactions: signers
+                .iter()
+                .take(REWARD_BENCH_TX_COUNT)
+                .map(|signer| {
+                    sign_tip20_call(
+                        signer,
+                        Bytes::from(ITIP20::claimRewardsCall {}.abi_encode()),
+                    )
+                })
+                .collect(),
+            participants: participants.clone(),
+            delegates: delegates.clone(),
+            kind: RewardBenchKind::ClaimRewards,
+        },
+        RewardBenchWorkload {
+            name: "tip20_distribute_reward",
+            transactions: signers
+                .iter()
+                .take(REWARD_BENCH_TX_COUNT)
+                .map(|signer| {
+                    sign_tip20_call(
+                        signer,
+                        Bytes::from(
+                            ITIP20::distributeRewardCall {
+                                amount: U256::from(REWARD_DISTRIBUTION_AMOUNT / 1_000),
+                            }
+                            .abi_encode(),
+                        ),
+                    )
+                })
+                .collect(),
+            participants,
+            delegates,
+            kind: RewardBenchKind::DistributeReward {
+                opted_in_accounts: DEFAULT_ACCOUNT_COUNT,
+            },
+        },
+    ]
+}
+
+fn transfer_reward_workload(
+    name: &'static str,
+    signers: &[PrivateKeySigner],
+    sender: RewardSeedMode,
+    recipient: RewardSeedMode,
+    reward_delta: bool,
+    delegates: &[Address],
+) -> RewardBenchWorkload {
+    let participants: Vec<_> = signers.iter().map(|signer| signer.address()).collect();
+    let transactions = (0..REWARD_BENCH_TX_COUNT)
+        .map(|idx| {
+            let signer = &signers[idx % signers.len()];
+            let recipient = participants[(idx.wrapping_mul(17) + 1) % participants.len()];
+            sign_tip20_transfer(signer, recipient, U256::from(REWARD_TRANSFER_AMOUNT))
+        })
+        .collect();
+
+    RewardBenchWorkload {
+        name,
+        transactions,
+        participants,
+        delegates: delegates.to_vec(),
+        kind: RewardBenchKind::Transfer {
+            sender,
+            recipient,
+            reward_delta,
+        },
     }
 }
 
@@ -596,7 +856,7 @@ where
 fn tip20_execution(c: &mut Criterion) {
     let workload = workload();
     let config = TempoEvmConfig::new(Arc::new(TempoChainSpec::moderato()));
-    let fixture = setup_fixed_cache_state(&workload.participants, workload.block_timestamp);
+    let fixture = setup_fixed_cache_state(&workload.participants, workload.block_timestamp, None);
     execute_txs(
         &config,
         fixture.prewarm_state_db(),
@@ -622,6 +882,42 @@ fn tip20_execution(c: &mut Criterion) {
         )
     });
     group.finish();
+
+    let reward_workloads = reward_bench_workloads();
+    for reward_workload in reward_workloads {
+        let fixture = setup_fixed_cache_state(
+            &reward_workload.participants,
+            DEFAULT_BLOCK_TIMESTAMP,
+            Some((&reward_workload.delegates, reward_workload.kind)),
+        );
+        execute_txs(
+            &config,
+            fixture.prewarm_state_db(),
+            &reward_workload.transactions,
+            DEFAULT_BLOCK_TIMESTAMP,
+        );
+
+        let mut group = c.benchmark_group("tip20_rewards");
+        group.throughput(Throughput::Elements(
+            reward_workload.transactions.len() as u64
+        ));
+        group.bench_function(reward_workload.name, |b| {
+            b.iter_batched(
+                || fixture.state_db(),
+                |db| {
+                    let stats = execute_txs(
+                        &config,
+                        db,
+                        &reward_workload.transactions,
+                        DEFAULT_BLOCK_TIMESTAMP,
+                    );
+                    black_box(stats.gas_used);
+                },
+                BatchSize::SmallInput,
+            )
+        });
+        group.finish();
+    }
 }
 
 criterion_group!(benches, tip20_execution);


### PR DESCRIPTION
## Summary
- add reward-state seeding to the pure TIP20 execution Criterion bench
- add transfer reward benchmarks for opted-out, self-recipient, delegated, mixed, and accrued-delta paths
- add claimRewards and distributeReward pure execution benchmarks

## Validation
- cargo fmt --check
- cargo bench -p tempo-evm --bench tip20_execution --no-run
- cargo bench -p tempo-evm --bench tip20_execution -- --sample-size 10 --warm-up-time 1 --measurement-time 1