### PR TITLE
chore: set workspace version to 1.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12541,7 +12541,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -12680,7 +12680,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12739,7 +12739,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node-config"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -12752,7 +12752,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12783,7 +12783,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12797,7 +12797,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12848,7 +12848,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -12886,7 +12886,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "clap",
  "dirs-next",
@@ -12905,7 +12905,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "eyre",
  "indenter",
@@ -12913,7 +12913,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -12926,7 +12926,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy",
  "alloy-eips 2.0.5",
@@ -12995,7 +12995,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13029,7 +13029,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -13047,7 +13047,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13079,7 +13079,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13127,7 +13127,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -13161,7 +13161,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy",
  "clap",
@@ -13186,7 +13186,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "eyre",
  "jiff",
@@ -13195,7 +13195,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -13234,7 +13234,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13246,7 +13246,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "alloy",
  "alloy-json-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.7.0"
+version = "1.7.1"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Sets the workspace package version in Cargo.toml to 1.7.1 on main and updates Cargo.lock with the matching Tempo workspace package versions.