### PR TITLE
docs: remove TIP-1047 from T5 meta TIP

### DIFF
--- a/tips/tip-1057.md
+++ b/tips/tip-1057.md
@@ -4,7 +4,7 @@ title: T5 Hardfork Meta TIP
 description: Meta TIP collecting bug fixes, security hardening, and infrastructure changes gated behind the T5 hardfork.
 authors: Marc Martinez (@0xrusowsky)
 status: Draft
-related: TIP-1026, TIP-1030, TIP-1033, TIP-1034, TIP-1035, TIP-1045, TIP-1047, TIP-1053, TIP-1056
+related: TIP-1026, TIP-1030, TIP-1033, TIP-1034, TIP-1035, TIP-1045, TIP-1053, TIP-1056
 protocolVersion: T5
 ---
 
@@ -12,7 +12,7 @@ protocolVersion: T5
 
 ## Abstract
 
-This meta TIP collects bug fixes, security hardening, and infrastructure changes that activate at T5. Each item is small in isolation, but together they define the complete in-scope T5 bug-fix and infrastructure bundle. Feature changes already specified by standalone TIPs (TIP-1026, TIP-1030, TIP-1033, TIP-1034, TIP-1035, TIP-1045, TIP-1047, TIP-1053, TIP-1056) are intentionally excluded from this meta TIP.
+This meta TIP collects bug fixes, security hardening, and infrastructure changes that activate at T5. Each item is small in isolation, but together they define the complete in-scope T5 bug-fix and infrastructure bundle. Feature changes already specified by standalone TIPs (TIP-1026, TIP-1030, TIP-1033, TIP-1034, TIP-1035, TIP-1045, TIP-1053, TIP-1056) are intentionally excluded from this meta TIP.
 
 ## Motivation
 


### PR DESCRIPTION
## Summary
- remove TIP-1047 from the T5 meta TIP related list
- remove TIP-1047 from the abstract's list of standalone T5 TIPs

## Context
PR #3992 moved TIP-1047's protocol version from T5 to tbd, so TIP-1057 should no longer list it as part of the T5 bundle.

## Testing
- not run; documentation-only change