### PR TITLE
perf(bench): stream summary metric extraction

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -91,10 +91,10 @@ on:
         required: true
         default: "100"
       txgen-ref:
-        description: Optional ref to pin in tempoxyz/txgen.
+        description: Ref to pin in tempoxyz/txgen.
         type: string
         required: false
-        default: ""
+        default: "f30c01574b5cc0afbf88e90b5100e1b683459698"
       profiling:
         description: Profiling.
         type: choice
@@ -225,7 +225,7 @@ on:
       txgen-ref:
         type: string
         required: false
-        default: ""
+        default: "f30c01574b5cc0afbf88e90b5100e1b683459698"
       baseline-name:
         type: string
         required: false

--- a/contrib/bench/extract-metric-samples.py
+++ b/contrib/bench/extract-metric-samples.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Extract the benchmark metric samples needed by tempo.nu summaries.
+
+The txgen samples sidecar can contain millions of full Prometheus samples. The
+summary only needs a small fixed allowlist, so this script streams NDJSON (plain
+or gzip), parses only matching metric-name lines, and emits compact JSON for
+Nushell to consume.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import math
+import sys
+from pathlib import Path
+from typing import BinaryIO, Iterator, Optional
+
+SUMMARY_METRICS = {
+    "reth_tempo_payload_builder_payload_build_duration_seconds",
+    "reth_tempo_payload_builder_payload_finalization_duration_seconds",
+    "reth_tempo_payload_builder_total_normal_included_transaction_execution_duration_seconds",
+    "reth_tempo_payload_builder_total_normal_invalid_transaction_execution_duration_seconds",
+    "reth_tempo_payload_builder_invalid_pool_transaction_execution_attempts",
+    "reth_tempo_payload_builder_pool_transactions_skipped_total",
+    "reth_tempo_payload_builder_normal_transaction_fill_overhead_duration_seconds",
+    "reth_tempo_payload_builder_normal_transaction_fill_idle_duration_seconds",
+    "reth_consensus_engine_beacon_new_payload_latency",
+    "reth_tempo_payload_builder_gas_per_second_last",
+    "reth_consensus_engine_beacon_new_payload_gas_per_second_last",
+}
+SUMMARY_METRICS_BYTES = {name.encode() for name in SUMMARY_METRICS}
+ALLOWED_QUANTILES = {"", "0.5", "0.9", "0.99"}
+NAME_MARKER = b'"name":"'
+
+
+def open_samples(path: Path) -> BinaryIO:
+    if path.suffix == ".gz":
+        return gzip.open(path, "rb")
+    return path.open("rb")
+
+
+def fast_metric_name(line: bytes) -> Optional[bytes]:
+    """Return the metric name without parsing JSON, when possible.
+
+    txgen writes samples with `name` first, but searching for the marker keeps
+    this tolerant of field-order changes. Metric names do not contain escaped
+    quotes, so a byte scan is enough for the prefilter.
+    """
+
+    start = line.find(NAME_MARKER)
+    if start < 0:
+        return None
+    start += len(NAME_MARKER)
+    end = line.find(b'"', start)
+    if end < 0:
+        return None
+    return line[start:end]
+
+
+def iter_summary_samples(path: Path) -> Iterator[dict]:
+    with open_samples(path) as samples:
+        for line in samples:
+            if not line.strip():
+                continue
+
+            name_bytes = fast_metric_name(line)
+            if name_bytes not in SUMMARY_METRICS_BYTES:
+                continue
+
+            sample = json.loads(line)
+            name = sample.get("name")
+            if name not in SUMMARY_METRICS:
+                continue
+
+            labels = sample.get("labels") or {}
+            quantile = labels.get("quantile", "")
+            if quantile not in ALLOWED_QUANTILES:
+                continue
+
+            value = sample.get("value")
+            if not isinstance(value, (int, float)) or not math.isfinite(value):
+                continue
+
+            summary_labels = {}
+            if quantile:
+                summary_labels["quantile"] = quantile
+            reason = labels.get("reason")
+            if reason is not None:
+                summary_labels["reason"] = reason
+
+            yield {"name": name, "labels": summary_labels, "value": value}
+
+
+def write_json_array(samples: Iterator[dict]) -> None:
+    sys.stdout.write("[")
+    first = True
+    for sample in samples:
+        if not first:
+            sys.stdout.write(",")
+        first = False
+        sys.stdout.write(json.dumps(sample, separators=(",", ":")))
+    sys.stdout.write("]\n")
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: extract-metric-samples.py <samples.ndjson[.gz]>", file=sys.stderr)
+        return 2
+
+    path = Path(sys.argv[1])
+    if not path.exists():
+        print(f"samples file not found: {path}", file=sys.stderr)
+        return 1
+
+    write_json_array(iter_summary_samples(path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tempo.nu
+++ b/tempo.nu
@@ -785,6 +785,38 @@ def grafana-performance-url [benchmark_id: string, from_ms: int, to_ms: int] {
     $"https://tempoxyz.grafana.net/d/performance/performance?orgId=1&from=($from)&to=($to)&timezone=browser&var-datasource=efk1hcn87dnnkd&var-filter_label=benchmark_id&var-filter_value=($benchmark_id)&var-group_by=benchmark_run"
 }
 
+# Extract only the metric samples used by the PR summary. The full txgen
+# sidecars can contain millions of samples, so leave the streaming/filtering to
+# Python instead of loading and JSON-parsing the whole file in Nushell.
+def extract-summary-metric-samples [samples_path: string] {
+    let extractor = $"($BENCH_DIR)/extract-metric-samples.py"
+    if not ($extractor | path exists) {
+        print $"Warning: metric sample extractor not found: ($extractor)"
+        return []
+    }
+    if ((which python3 | length) == 0) {
+        print "Warning: python3 not found; skipping metric sample extraction"
+        return []
+    }
+
+    let result = (^python3 $extractor $samples_path | complete)
+    if $result.exit_code != 0 {
+        print $"Warning: metric sample extraction failed for ($samples_path)"
+        if $result.stderr != "" { print $result.stderr }
+        return []
+    }
+
+    let output = ($result.stdout | str trim)
+    if $output == "" {
+        return []
+    }
+
+    try { $output | from json } catch { |e|
+        print $"Warning: failed to parse metric sample extractor output for ($samples_path): ($e.msg)"
+        []
+    }
+}
+
 
 def generate-summary [results_dir: string, baseline_ref: string, feature_ref: string, bloat: int, preset: string, tps: int, duration: int, --benchmark-id: string = "", --reference-epoch: int = 0] {
     let run_order_path = $"($results_dir)/run-order.txt"
@@ -853,33 +885,13 @@ def generate-summary [results_dir: string, baseline_ref: string, feature_ref: st
         let report = (open $report_path)
         let samples_path = $"($results_dir)/report-($label).samples.ndjson"
         let samples_gz_path = $"($samples_path).gz"
-        let samples_raw = if ($samples_path | path exists) {
-            open --raw $samples_path
+        let samples_source_path = if ($samples_path | path exists) {
+            $samples_path
         } else if ($samples_gz_path | path exists) {
-            gzip -dc $samples_gz_path
+            $samples_gz_path
         } else { "" }
-        let metric_samples = if $samples_raw != "" {
-            $samples_raw
-                | lines
-                | where { |line| ($line | str trim) != "" }
-                | each { |line| $line | from json }
-                | where { |sample| $sample.name in [
-                    "reth_tempo_payload_builder_payload_build_duration_seconds"
-                    "reth_tempo_payload_builder_payload_finalization_duration_seconds"
-                    "reth_tempo_payload_builder_total_normal_included_transaction_execution_duration_seconds"
-                    "reth_tempo_payload_builder_total_normal_invalid_transaction_execution_duration_seconds"
-                    "reth_tempo_payload_builder_invalid_pool_transaction_execution_attempts"
-                    "reth_tempo_payload_builder_pool_transactions_skipped_total"
-                    "reth_tempo_payload_builder_normal_transaction_fill_overhead_duration_seconds"
-                    "reth_tempo_payload_builder_normal_transaction_fill_idle_duration_seconds"
-                    "reth_consensus_engine_beacon_new_payload_latency"
-                    "reth_tempo_payload_builder_gas_per_second_last"
-                    "reth_consensus_engine_beacon_new_payload_gas_per_second_last"
-                ] }
-                | where { |sample|
-                    let quantile = ($sample.labels | get -o quantile | default "")
-                    ($quantile in ["0.5" "0.9" "0.99"]) or ($quantile == "")
-                }
+        let metric_samples = if $samples_source_path != "" {
+            extract-summary-metric-samples $samples_source_path
         } else { [] }
         let builder_samples = ($metric_samples | where name == "reth_tempo_payload_builder_payload_build_duration_seconds")
         let builder_finish_samples = ($metric_samples | where name == "reth_tempo_payload_builder_payload_finalization_duration_seconds")


### PR DESCRIPTION
Moves benchmark summary sample filtering into a small streaming Python helper. This avoids loading and JSON-parsing full txgen sample sidecars in Nushell when only the PR summary metric allowlist is needed.

Also includes a patch to txgen that makes sample archive streaming into the reporters a lot faster.