### PR TITLE
TIP-1065: T6 Hardfork Meta TIP

### DIFF
--- a/tips/tip-1065.md
+++ b/tips/tip-1065.md
@@ -24,7 +24,7 @@ T6 includes reward-accounting optimizations for TIP-20 transfers. Because these 
 
 ## 1. Improve TIP-20 reward handling
 
-**PR**: [#4142](https://github.com/tempoxyz/tempo/pull/4142) · **Author**: @0xrusowsky
+**PR**: [#4161](https://github.com/tempoxyz/tempo/pull/4161) · **Author**: @0xrusowsky
 
 TIP-20 transfers currently perform redundant reward-accounting storage reads and writes while updating sender and recipient balances. T6+ reuses already-loaded balances and global reward-per-token values during transfer reward handling, and only writes a holder's reward-per-token checkpoint when the global value has changed.
 

--- a/tips/tip-1065.md
+++ b/tips/tip-1065.md
@@ -1,0 +1,31 @@
+---
+id: TIP-1065
+title: T6 Hardfork Meta TIP
+description: Meta TIP collecting performance improvements and protocol changes gated behind the T6 hardfork.
+authors: Marc Martinez (@0xrusowsky)
+status: Draft
+related: https://github.com/tempoxyz/tempo/pull/4142
+protocolVersion: T6
+---
+
+# TIP-1065: T6 Hardfork Meta TIP
+
+## Abstract
+
+This meta TIP collects performance improvements and protocol changes that activate at T6. Each item is small in isolation, but together they define the complete in-scope T6 optimization bundle.
+
+## Motivation
+
+T6 includes reward-accounting optimizations for TIP-20 transfers. Because these changes alter gas costs and hardfork-gated execution behavior, they are grouped here as one coordinated rollout under T6.
+
+---
+
+# Changes
+
+## 1. Improve TIP-20 reward handling
+
+**PR**: [#4142](https://github.com/tempoxyz/tempo/pull/4142) · **Author**: @0xrusowsky
+
+TIP-20 transfers currently perform redundant reward-accounting storage reads and writes while updating sender and recipient balances. T6+ reuses already-loaded balances and global reward-per-token values during transfer reward handling, and only writes a holder's reward-per-token checkpoint when the global value has changed.
+
+This avoids useless SLOAD and SSTORE operations in common TIP-20 transfer paths while preserving legacy behavior before T6.

--- a/tips/tip-1065.md
+++ b/tips/tip-1065.md
@@ -2,9 +2,9 @@
 id: TIP-1065
 title: T6 Hardfork Meta TIP
 description: Meta TIP collecting performance improvements and protocol changes gated behind the T6 hardfork.
-authors: Marc Martinez (@0xrusowsky)
+authors: Marc Martinez (@0xrusowsky), Jennifer (@jenpaff)
 status: Draft
-related: https://github.com/tempoxyz/tempo/pull/4142
+related: N/A
 protocolVersion: T6
 ---
 


### PR DESCRIPTION
Meta TIP collecting all protocol changes included in the T6 network upgrade.

| PR | Title |
|----|-------|
| [#4161](https://github.com/tempoxyz/tempo/pull/4161) | perf(tip20): better reward handling |
