### PR TITLE
docs(tips): update TIP-1028 guard reserve invariant

### DIFF
--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -217,12 +217,12 @@ The aggregate blocked balance for each TIP-20 token sits in that token's `balanc
 
 The following restrictions apply:
 
-- A TIP-20 transfer or mint with `to == RECEIVE_POLICY_GUARD_ADDRESS` MUST revert with `AddressReserved()`. This applies to `transfer`, `transferFrom`, `transferWithMemo`, `transferFromWithMemo`, `systemTransferFrom`, `mint`, and `mintWithMemo`.
+- A TIP-20 transfer or mint with `to == RECEIVE_POLICY_GUARD_ADDRESS` MUST revert with `AddressReserved()`, except for the TIP-20 initializer mint described below. This applies to `transfer`, `transferFrom`, `transferWithMemo`, `transferFromWithMemo`, `systemTransferFrom`, `mint`, and `mintWithMemo`.
 - A reroute claim with `to == RECEIVE_POLICY_GUARD_ADDRESS` MUST revert.
 - `setReceivePolicy(...)` MUST reject `account == RECEIVE_POLICY_GUARD_ADDRESS`.
 - The TIP-20 `burnBlocked` function MUST revert when `from == RECEIVE_POLICY_GUARD_ADDRESS`. Funds leave `ReceivePolicyGuard` only by claiming or burning a specific receipt. Burning the aggregate `RECEIVE_POLICY_GUARD_ADDRESS` balance directly would leave receipts pointing at money that no longer exists.
 
-Without intervention, the first blocked transfer or mint for a token would pay an unexpected cold-sstore surcharge (~250,000 gas) for the zero-to-nonzero write to `balances[RECEIVE_POLICY_GUARD_ADDRESS]`, charged to whichever user happens to trigger the first block. To avoid this, the TIP-20 initializer MUST charge the deployer a one-time fee equivalent to a cold sstore on the token's `balances[RECEIVE_POLICY_GUARD_ADDRESS]` slot, and every subsequent write to `balances[RECEIVE_POLICY_GUARD_ADDRESS]` for that token MUST be priced as a warm sstore. No tokens are minted to `ReceivePolicyGuard` at deployment and no implementation-private reserve is required; the cold cost is paid exactly once, at deploy time, by the issuer.
+Without intervention, the first blocked transfer or mint for a token would pay an unexpected cold-sstore surcharge (~250,000 gas) for the zero-to-nonzero write to `balances[RECEIVE_POLICY_GUARD_ADDRESS]`, charged to whichever user happens to trigger the first block. To avoid this, the TIP-20 initializer MUST mint exactly 1 token unit to `RECEIVE_POLICY_GUARD_ADDRESS` at deployment, so the token's `balances[RECEIVE_POLICY_GUARD_ADDRESS]` slot is nonzero before any blocked receipt is created. This initializer mint is implementation-private guard reserve and MUST NOT create a blocked receipt, be claimable through `ReceivePolicyGuard`, or be counted in `blockedReceiptAmount`.
 
 ### Blocked Transfer Model
 
@@ -537,4 +537,4 @@ While these would be conceptually simpler, they raise several issues. For exampl
 
 ## Invariants
 
-- For every TIP-20 token, `balances[RECEIVE_POLICY_GUARD_ADDRESS]` equals exactly the sum of `blockedReceiptAmount[receiptKey]` over all open receipts for that token.
+- For every TIP-20 token, `balances[RECEIVE_POLICY_GUARD_ADDRESS]` is greater than or equal to the sum of `blockedReceiptAmount[receiptKey]` over all open receipts for that token.


### PR DESCRIPTION
Updates TIP-1028 to reflect the guard reserve approach discussed in Slack.\n\nChanges:\n- allow the TIP-20 initializer exception for minting to RECEIVE_POLICY_GUARD_ADDRESS\n- require minting exactly 1 token unit to the guard address at deployment\n- change the guard balance invariant from exact equality to greater-than-or-equal versus open blocked receipts