### PR TITLE
fix state hook precompile original info

### DIFF
--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -191,19 +191,20 @@ where
         &mut self,
         address: Address,
     ) -> Result<(), BlockExecutionError> {
-        let info = self
+        let original_info = self
             .inner
             .evm
             .db_mut()
             .basic(address)
             .map_err(BlockExecutionError::other)?
             .unwrap_or_default();
-        if info.is_empty_code_hash() {
+        if original_info.is_empty_code_hash() {
             let code = Bytecode::new_legacy([0xef].into());
-            let mut new_info = info;
+            let mut new_info = original_info.clone();
             new_info.code_hash = code.hash_slow();
             new_info.code = Some(code);
             let mut account: Account = new_info.into();
+            account.original_info = Box::new(original_info);
             account.mark_touch();
             let state = EvmState::from_iter([(address, account)]);
             self.inner.system_caller.on_state(
@@ -702,7 +703,7 @@ mod tests {
     use alloy_rlp::Encodable;
     use commonware_cryptography::{Signer, ed25519::PrivateKey};
     use reth_chainspec::EthChainSpec;
-    use reth_revm::State;
+    use reth_revm::{State, state::AccountInfo};
     use revm::{
         context::result::{ExecutionResult, ResultGas},
         database::EmptyDB,
@@ -1732,6 +1733,51 @@ mod tests {
         assert!(
             calls[0].1.contains_key(&addr),
             "state hook should contain the deployed address"
+        );
+        assert_eq!(
+            *calls[0].1[&addr].original_info,
+            Default::default(),
+            "state hook account should preserve original_info"
+        );
+    }
+
+    #[test]
+    fn test_deploy_precompile_at_boundary_preserves_existing_original_info() {
+        use std::sync::{Arc, Mutex};
+
+        let chainspec = test_chainspec();
+        let mut db = State::builder().with_bundle_update().build();
+        let addr = Address::with_last_byte(0xfe);
+        let original_info = AccountInfo {
+            balance: U256::from(42),
+            nonce: 7,
+            ..Default::default()
+        };
+        db.insert_account(addr, original_info.clone().into());
+
+        let mut executor = TestExecutorBuilder::default()
+            .with_parent_beacon_block_root(B256::ZERO)
+            .build(&mut db, &chainspec);
+
+        let hook_calls: Arc<Mutex<Vec<(StateChangeSource, EvmState)>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        let hook_calls_clone = hook_calls.clone();
+        executor.set_state_hook(Some(Box::new(
+            move |source: StateChangeSource, state: &EvmState| {
+                hook_calls_clone
+                    .lock()
+                    .unwrap()
+                    .push((source, state.clone()));
+            },
+        )));
+
+        executor.deploy_precompile_at_boundary(addr).unwrap();
+
+        let calls = hook_calls.lock().unwrap();
+        assert_eq!(calls.len(), 1, "state hook should be called exactly once");
+        assert_eq!(
+            *calls[0].1[&addr].original_info, original_info,
+            "state hook account should preserve existing original_info"
         );
     }
 

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -1753,7 +1753,7 @@ mod tests {
             nonce: 7,
             ..Default::default()
         };
-        db.insert_account(addr, original_info.clone().into());
+        db.insert_account(addr, original_info.clone());
 
         let mut executor = TestExecutorBuilder::default()
             .with_parent_beacon_block_root(B256::ZERO)


### PR DESCRIPTION
## Summary
- Preserve loaded pre-state as original_info for synthetic precompile boundary account updates before dispatching to the state hook
- Add regression coverage for empty and existing accounts

## Tests
- cargo fmt --check
- cargo test -p tempo-evm deploy_precompile_at_boundary