### PR TITLE
Update cost implications for blocked transfers in TIP-20

### DIFF
--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -222,8 +222,6 @@ The following restrictions apply:
 - `setReceivePolicy(...)` MUST reject `account == RECEIVE_POLICY_GUARD_ADDRESS`.
 - The TIP-20 `burnBlocked` function MUST revert when `from == RECEIVE_POLICY_GUARD_ADDRESS`. Funds leave `ReceivePolicyGuard` only by claiming or burning a specific receipt. Burning the aggregate `RECEIVE_POLICY_GUARD_ADDRESS` balance directly would leave receipts pointing at money that no longer exists.
 
-Without intervention, the first blocked transfer or mint for a token would pay an unexpected cold-sstore surcharge (~250,000 gas) for the zero-to-nonzero write to `balances[RECEIVE_POLICY_GUARD_ADDRESS]`, charged to whichever user happens to trigger the first block. To avoid this, the TIP-20 initializer MUST charge the deployer a one-time fee equivalent to a cold sstore on the token's `balances[RECEIVE_POLICY_GUARD_ADDRESS]` slot, and every subsequent write to `balances[RECEIVE_POLICY_GUARD_ADDRESS]` for that token MUST be priced as a warm sstore. No tokens are minted to `ReceivePolicyGuard` at deployment and no implementation-private reserve is required; the cold cost is paid exactly once, at deploy time, by the issuer.
-
 ### Blocked Transfer Model
 
 When a transfer or mint is blocked, the funds are credited to `RECEIVE_POLICY_GUARD_ADDRESS` instead of the receiver. `ReceivePolicyGuard` records one receipt per blocked transfer or mint. Each receipt captures the full context of the blocked operation, including the original sender, the requested recipient, whether it was a transfer or mint, the memo, and the reason for blocking. This gives the authorized claimer enough information to decide whether and how to claim.


### PR DESCRIPTION
Clarified the cost implications of blocked transfers and minting in the context of the `RECEIVE_POLICY_GUARD_ADDRESS`. Specified the one-time fee for the deployer and the pricing for subsequent writes.