### PR TITLE
perf(pool): clone cached tx env for payload building

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -570,7 +570,7 @@ where
                 .unwrap_or_default();
 
             let tx_execution_start = Instant::now();
-            let tx_with_env = pool_tx.transaction.clone().into_with_tx_env();
+            let tx_with_env = pool_tx.transaction.clone_into_with_tx_env();
             let execution_result =
                 builder.execute_transaction_with_result_closure(tx_with_env, |result| {
                     cumulative_gas_used += result.block_gas_used();

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -206,8 +206,7 @@ impl BestTransactionsPrewarming {
                     return;
                 }
 
-                if let Err(err) = evm.transact_raw(tx.transaction.clone().into_with_tx_env().tx_env)
-                {
+                if let Err(err) = evm.transact_raw(tx.transaction.clone_tx_env()) {
                     trace!(
                         target: "payload_builder",
                         %err,

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -205,6 +205,26 @@ impl TempoPooledTransaction {
         self.tx_env.get_or_init(|| self.tx_env_slow())
     }
 
+    /// Returns a cloned [`TempoTxEnv`] for this transaction.
+    ///
+    /// This uses the cached value prepared by [`Self::tx_env`] when available,
+    /// and computes it on-demand otherwise.
+    pub fn clone_tx_env(&self) -> TempoTxEnv {
+        self.tx_env().clone()
+    }
+
+    /// Returns a [`WithTxEnv`] wrapper by cloning the cached [`TempoTxEnv`] and
+    /// recovered transaction.
+    ///
+    /// This avoids cloning the full pooled transaction when the caller only
+    /// needs an owned executable transaction.
+    pub fn clone_into_with_tx_env(&self) -> WithTxEnv<TempoTxEnv, Recovered<TempoTxEnvelope>> {
+        WithTxEnv {
+            tx_env: self.clone_tx_env(),
+            tx: Arc::new(self.inner.transaction.clone()),
+        }
+    }
+
     /// Returns a [`WithTxEnv`] wrapper containing the cached [`TempoTxEnv`].
     ///
     /// If the [`TempoTxEnv`] was pre-computed via [`Self::tx_env`], the cached


### PR DESCRIPTION
Adds `clone_tx_env()` to `TempoPooledTransaction` so payload execution and prewarming can reuse the cached transaction environment without cloning the pooled transaction first.

This keeps prewarming to an env clone only and narrows payload execution to the transaction ownership required by the block builder.