### PR TITLE
perf(payload): use cached transaction lengths

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -37,8 +37,8 @@ use reth_revm::{State, context::Block, database::StateProviderDatabase};
 use reth_storage_api::StateProviderFactory;
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{
-    BestTransactions, BestTransactionsAttributes, TransactionPool, ValidPoolTransaction,
-    error::InvalidPoolTransactionError,
+    BestTransactions, BestTransactionsAttributes, PoolTransaction, TransactionPool,
+    ValidPoolTransaction, error::InvalidPoolTransactionError,
 };
 use std::{
     sync::{
@@ -549,7 +549,7 @@ where
                 payment_transactions += 1;
             }
 
-            let tx_rlp_length = pool_tx.transaction.inner().length();
+            let tx_rlp_length = pool_tx.transaction.encoded_length();
             let estimated_block_size_with_tx = block_size_used + tx_rlp_length;
 
             if is_osaka && estimated_block_size_with_tx > MAX_RLP_BLOCK_SIZE {


### PR DESCRIPTION
Uses `PoolTransaction::encoded_length()` for pooled transaction block-size accounting instead of re-encoding through `inner().length()`. Generated system transactions stay as consensus transactions because wrapping them as `TempoPooledTransaction` adds overhead without using an existing cached pool value.

The cached length is populated when the pooled transaction is created: https://github.com/tempoxyz/tempo/blob/c29124dd7ae0626e8cbaf4cf46d54f210a8a619e/crates/transaction-pool/src/transaction.rs#L72-L78