### PR TITLE
refactor(transaction-pool): use alloy primitive maps in maintenance

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,8 @@ jobs:
           components: clippy
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        with:
+          version: v0.15.0
       - name: Run clippy
         run: cargo clippy --all-targets --all-features --locked
         env:
@@ -70,6 +72,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        with:
+          version: v0.15.0
       - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
         with:
           tool: cargo-hack
@@ -91,6 +95,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        with:
+          version: v0.15.0
       - name: Build documentation
         run: cargo doc --workspace --all-features --no-deps --document-private-items
         env:
@@ -151,6 +157,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        with:
+          version: v0.15.0
       - uses: taiki-e/cache-cargo-install-action@f9eed3e4680f27610dc6d8c67be1b88593f7dade # v3.0.6
         with:
           tool: zepter
@@ -172,6 +180,8 @@ jobs:
         with:
           target: riscv32imac-unknown-none-elf
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        with:
+          version: v0.15.0
       - name: Run no_std checks
         run: .github/scripts/check_no_std.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        with:
+          version: v0.15.0
       - name: Generate genesis
         run: |
           cargo xtask generate-genesis \
@@ -102,6 +104,8 @@ jobs:
           components: ${{ needs.check-precompiles.outputs.coverage == 'true' && 'llvm-tools-preview' || '' }}
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        with:
+          version: v0.15.0
       - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
         with:
           tool: nextest@0.9.124
@@ -165,6 +169,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        with:
+          version: v0.15.0
       - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
         with:
           tool: nextest@0.9.124
@@ -189,6 +195,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        with:
+          version: v0.15.0
       - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
         with:
           tool: nextest@0.9.124
@@ -210,6 +218,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        with:
+          version: v0.15.0
       - name: Build tempo
         run: cargo build --bin tempo
       - name: Run CLI tests
@@ -230,6 +240,8 @@ jobs:
           toolchain: "1.93" # MSRV
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        with:
+          version: v0.15.0
       - name: Build with MSRV
         run: cargo build --bin tempo
         env:

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use alloy_consensus::transaction::TxHashRef;
 use alloy_primitives::{
-    Address, B256, TxHash,
-    map::{AddressMap, HashMap, HashSet},
+    Address, TxHash,
+    map::{AddressMap, AddressSet, B256Map, B256Set},
 };
 use alloy_sol_types::SolEvent;
 use futures::StreamExt;
@@ -61,7 +61,7 @@ pub struct TempoPoolUpdates {
     /// resolve to a different token at execution time, causing fee payment failures.
     /// Uses a set since a user can emit multiple events in the same block; we only need to
     /// process each user once. No cleanup needed as this is ephemeral per-block data.
-    pub user_token_changes: HashSet<Address>,
+    pub user_token_changes: AddressSet,
     /// TIP403 blacklist additions: (policy_id, account).
     pub blacklist_additions: Vec<(u64, Address)>,
     /// TIP403 whitelist removals: (policy_id, account).
@@ -71,16 +71,16 @@ pub struct TempoPoolUpdates {
     /// Tokens whose transfer policy was changed via `changeTransferPolicyId()`.
     /// Pending transactions using these tokens as fee tokens need to be re-validated
     /// because the new policy may forbid the fee payer or fee manager.
-    pub transfer_policy_updates: HashSet<Address>,
+    pub transfer_policy_updates: AddressSet,
     /// Tokens whose `quoteToken` was updated via `completeQuoteTokenUpdate()`.
     /// Pending transactions paying in these tokens need to be re-validated because the new
     /// quote token may invalidate the old route.
-    pub quote_token_updates: HashSet<Address>,
+    pub quote_token_updates: AddressSet,
     /// Fee token balance changes keyed by token.
     ///
     /// We only track the debited `from` account from TIP20 `Transfer` logs because credits to the
     /// `to` account cannot make an already-admitted transaction newly invalid.
-    pub fee_balance_changes: AddressMap<HashSet<Address>>,
+    pub fee_balance_changes: AddressMap<AddressSet>,
     /// Spending-limit spends emitted by the account keychain during execution.
     ///
     /// We record the exact `(account, key_id, token)` triples emitted by `AccessKeySpend`
@@ -93,7 +93,7 @@ pub struct TempoPoolUpdates {
     ///
     /// Pending AA transactions carrying the same `(account, witness)` key authorization are no
     /// longer executable once the account explicitly burns that witness.
-    pub key_authorization_witness_burns: AddressMap<HashSet<B256>>,
+    pub key_authorization_witness_burns: AddressMap<B256Set>,
 }
 
 impl TempoPoolUpdates {
@@ -233,7 +233,7 @@ struct TempoPoolState {
     /// Maps timestamp to transactions that are going to be invalidated at that time (due to `valid_after` or keychain-related expiry).
     expiry_map: BTreeMap<u64, Vec<TxHash>>,
     /// Reverse mapping: tx_hash -> valid_before timestamp (for cleanup during drain).
-    tx_to_expiry: HashMap<TxHash, u64>,
+    tx_to_expiry: B256Map<u64>,
     /// Pool for transactions whose fee token is temporarily paused.
     paused_pool: PausedFeeTokenPool,
     /// Tracks pending transaction staleness for DoS mitigation.
@@ -299,7 +299,7 @@ const DEFAULT_PENDING_STALENESS_INTERVAL: u64 = 30 * 60;
 #[derive(Debug)]
 struct PendingStalenessTracker {
     /// Previous snapshot of pending transaction hashes.
-    previous_pending: HashSet<TxHash>,
+    previous_pending: B256Set,
     /// Timestamp of the last snapshot.
     last_snapshot_time: Option<u64>,
     /// Interval in seconds between staleness checks.
@@ -310,7 +310,7 @@ impl PendingStalenessTracker {
     /// Creates a new tracker with the given check interval.
     fn new(interval_secs: u64) -> Self {
         Self {
-            previous_pending: HashSet::default(),
+            previous_pending: B256Set::default(),
             last_snapshot_time: None,
             interval_secs,
         }
@@ -328,13 +328,13 @@ impl PendingStalenessTracker {
     /// (i.e., pending for at least one full interval).
     ///
     /// Call `should_check` first to avoid collecting the pending set on every block.
-    fn check_and_update(&mut self, current_pending: HashSet<TxHash>, now: u64) -> Vec<TxHash> {
+    fn check_and_update(&mut self, current_pending: B256Set, now: u64) -> Vec<TxHash> {
         let previous_pending = std::mem::take(&mut self.previous_pending);
 
         // Split the current snapshot into stale transactions to evict and fresh
         // transactions to track. A transaction is stale if it appears in both
         // the previous and current pending snapshots.
-        let (stale, next_pending): (Vec<TxHash>, HashSet<TxHash>) =
+        let (stale, next_pending): (Vec<TxHash>, B256Set) =
             current_pending.into_iter().partition_map(|hash| {
                 if previous_pending.contains(&hash) {
                     Either::Left(hash)
@@ -700,7 +700,7 @@ where
                 // Only runs once per interval (~30 min) to avoid overhead on every block.
                 // Transactions pending across two consecutive snapshots are considered stale.
                 if state.pending_staleness.should_check(tip_timestamp) {
-                    let current_pending: HashSet<TxHash> =
+                    let current_pending: B256Set =
                         pool.pending_transactions().iter().map(|tx| *tx.hash()).collect();
                     let stale_to_evict =
                         state.pending_staleness.check_and_update(current_pending, tip_timestamp);
@@ -731,7 +731,7 @@ where
 mod tests {
     use super::*;
     use crate::test_utils::TxBuilder;
-    use alloy_primitives::{Address, TxHash};
+    use alloy_primitives::{Address, B256, TxHash};
     use reth_primitives_traits::RecoveredBlock;
     use std::sync::Arc;
     use tempo_primitives::{Block, BlockBody, TempoHeader, TempoTxEnvelope};

--- a/crates/transaction-pool/src/paused.rs
+++ b/crates/transaction-pool/src/paused.rs
@@ -7,8 +7,8 @@
 
 use crate::{RevokedKeys, SpendingLimitUpdates, transaction::TempoPooledTransaction};
 use alloy_primitives::{
-    Address, B256, TxHash,
-    map::{AddressMap, HashMap, HashSet},
+    Address, TxHash,
+    map::{AddressMap, B256Set},
 };
 use reth_transaction_pool::{PoolTransaction, ValidPoolTransaction};
 use std::{sync::Arc, time::Instant};
@@ -50,7 +50,7 @@ struct PausedTokenMeta {
 #[derive(Debug, Default)]
 pub struct PausedFeeTokenPool {
     /// Fee token -> metadata including pause time and entries
-    by_token: HashMap<Address, PausedTokenMeta>,
+    by_token: AddressMap<PausedTokenMeta>,
 }
 
 impl PausedFeeTokenPool {
@@ -206,7 +206,7 @@ impl PausedFeeTokenPool {
         revoked_keys: &RevokedKeys,
         spending_limit_updates: &SpendingLimitUpdates,
         spending_limit_spends: &SpendingLimitUpdates,
-        key_authorization_witness_burns: &AddressMap<HashSet<B256>>,
+        key_authorization_witness_burns: &AddressMap<B256Set>,
     ) -> usize {
         if revoked_keys.is_empty()
             && spending_limit_updates.is_empty()
@@ -281,6 +281,7 @@ impl PausedFeeTokenPool {
 mod tests {
     use super::*;
     use crate::test_utils::{TxBuilder, wrap_valid_tx};
+    use alloy_primitives::B256;
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use reth_primitives_traits::Recovered;
@@ -608,7 +609,7 @@ mod tests {
         let mut burned = AddressMap::default();
         burned
             .entry(user_address)
-            .or_insert_with(HashSet::default)
+            .or_insert_with(B256Set::default)
             .insert(burned_witness);
 
         let evicted = pool.evict_invalidated(


### PR DESCRIPTION
Uses Alloy's fixed-byte `Address` and `B256` map/set aliases for transaction-pool maintenance tracking. This keeps address and transaction-hash membership/lookup paths on the specialized hasher while preserving the existing maintenance behavior.