### PR TITLE
perf(revm): cache tempo gas param overrides

### DIFF
--- a/crates/revm/src/gas_params.rs
+++ b/crates/revm/src/gas_params.rs
@@ -1,5 +1,8 @@
 use auto_impl::auto_impl;
-use revm::context_interface::cfg::{GasId, GasParams};
+use revm::{
+    context_interface::cfg::{GasId, GasParams},
+    primitives::OnceLock,
+};
 use tempo_chainspec::hardfork::TempoHardfork;
 
 /// Extending [`GasParams`] for Tempo use case.
@@ -55,73 +58,86 @@ const T4_SSTORE_SET_REFUND: u64 = T4_SSTORE_SET_STATE + 17_800; // 230,000 + 17,
 /// Tempo gas params override.
 ///
 /// `amsterdam_eip8037_enabled` mirrors `CfgEnv::enable_amsterdam_eip8037` and gates the
-/// TIP-1016 regular/state gas split. When `false`, TIP-1000 (T1) costs are used regardless
-/// of the spec, so TIP-1016 can be deferred independently of the T4 hardfork activation.
+/// TIP-1016 regular/state gas split. When `false` on T1+, TIP-1000 (T1) costs are used,
+/// so TIP-1016 can be deferred independently of the T4 hardfork activation.
 #[inline]
 pub fn tempo_gas_params_with_amsterdam(
     spec: TempoHardfork,
     amsterdam_eip8037_enabled: bool,
 ) -> GasParams {
-    let mut gas_params = GasParams::new_spec(spec.into());
-    let mut overrides = vec![];
     if amsterdam_eip8037_enabled {
-        // TIP-1016: Split storage creation costs into regular gas + state gas.
-        // Regular gas (computational overhead) = at least pre-TIP-1000 EVM cost.
-        // State gas (permanent storage burden) = total - regular.
-        overrides.extend([
-            // SSTORE (zero → non-zero): 20k regular + 230k state
-            (GasId::sstore_set_without_load_cost(), T4_SSTORE_SET_REGULAR),
-            (GasId::sstore_set_state_gas(), T4_SSTORE_SET_STATE),
-            (GasId::sstore_set_refund(), T4_SSTORE_SET_REFUND),
-            // Contract metadata (CREATE base): 32k regular + 468k state
-            (GasId::tx_create_cost(), T4_CREATE_REGULAR),
-            (GasId::create(), T4_CREATE_REGULAR),
-            (GasId::create_state_gas(), T4_CREATE_STATE),
-            // Account creation: 25k regular + 225k state
-            (GasId::new_account_cost(), T4_NEW_ACCOUNT_REGULAR),
-            (GasId::new_account_state_gas(), T4_NEW_ACCOUNT_STATE),
-            (
-                GasId::new_account_cost_for_selfdestruct(),
-                T4_NEW_ACCOUNT_REGULAR,
-            ),
-            // Code deposit: 200 regular + 2,300 state per byte
-            (GasId::code_deposit_cost(), T4_CODE_DEPOSIT_REGULAR),
-            (GasId::code_deposit_state_gas(), T4_CODE_DEPOSIT_STATE),
-            // EIP-7702 delegation: 25k regular + 225k state = 250k per auth
-            (
-                GasId::tx_eip7702_per_empty_account_cost(),
-                T4_EIP7702_PER_AUTH_TOTAL,
-            ),
-            (
-                GasId::tx_eip7702_per_auth_state_gas(),
-                T4_NEW_ACCOUNT_STATE, // 225,000
-            ),
-            // Auth refund is zeroed by apply_eip7702_auth_list override (TIP-1000:
-            // "no refund if the account already exists"), but set the value for
-            // upstream split_eip7702_refund correctness if the override is bypassed.
-            (GasId::tx_eip7702_auth_refund(), 0),
-            // Auth account creation (keychain): same split as account creation
-            (GasId::new(255), T4_NEW_ACCOUNT_REGULAR),
-            (GasId::new(254), T4_NEW_ACCOUNT_STATE),
-        ]);
-    } else if spec.is_t1() {
-        // TIP-1000: All storage creation costs in regular gas (no state gas split).
-        overrides.extend([
-            (GasId::sstore_set_without_load_cost(), SSTORE_SET_COST),
-            (GasId::tx_create_cost(), CREATE_COST),
-            (GasId::create(), CREATE_COST),
-            (GasId::new_account_cost(), NEW_ACCOUNT_COST),
-            (GasId::new_account_cost_for_selfdestruct(), NEW_ACCOUNT_COST),
-            (GasId::code_deposit_cost(), CODE_DEPOSIT_COST_T1),
-            (
-                GasId::tx_eip7702_per_empty_account_cost(),
-                EIP7702_PER_EMPTY_ACCOUNT_COST_T1,
-            ),
-            (GasId::new(255), AUTH_ACCOUNT_CREATION_COST),
-        ]);
+        static TABLE: OnceLock<GasParams> = OnceLock::new();
+        return TABLE.get_or_init(amsterdam_gas_params).clone();
     }
 
-    gas_params.override_gas(overrides);
+    if spec.is_t1() {
+        static TABLE: OnceLock<GasParams> = OnceLock::new();
+        return TABLE.get_or_init(t1_gas_params).clone();
+    }
+
+    GasParams::new_spec(spec.into())
+}
+
+fn amsterdam_gas_params() -> GasParams {
+    let mut gas_params = GasParams::new_spec(TempoHardfork::T4.into());
+    // TIP-1016: Split storage creation costs into regular gas + state gas.
+    // Regular gas (computational overhead) = at least pre-TIP-1000 EVM cost.
+    // State gas (permanent storage burden) = total - regular.
+    gas_params.override_gas([
+        // SSTORE (zero -> non-zero): 20k regular + 230k state
+        (GasId::sstore_set_without_load_cost(), T4_SSTORE_SET_REGULAR),
+        (GasId::sstore_set_state_gas(), T4_SSTORE_SET_STATE),
+        (GasId::sstore_set_refund(), T4_SSTORE_SET_REFUND),
+        // Contract metadata (CREATE base): 32k regular + 468k state
+        (GasId::tx_create_cost(), T4_CREATE_REGULAR),
+        (GasId::create(), T4_CREATE_REGULAR),
+        (GasId::create_state_gas(), T4_CREATE_STATE),
+        // Account creation: 25k regular + 225k state
+        (GasId::new_account_cost(), T4_NEW_ACCOUNT_REGULAR),
+        (GasId::new_account_state_gas(), T4_NEW_ACCOUNT_STATE),
+        (
+            GasId::new_account_cost_for_selfdestruct(),
+            T4_NEW_ACCOUNT_REGULAR,
+        ),
+        // Code deposit: 200 regular + 2,300 state per byte
+        (GasId::code_deposit_cost(), T4_CODE_DEPOSIT_REGULAR),
+        (GasId::code_deposit_state_gas(), T4_CODE_DEPOSIT_STATE),
+        // EIP-7702 delegation: 25k regular + 225k state = 250k per auth
+        (
+            GasId::tx_eip7702_per_empty_account_cost(),
+            T4_EIP7702_PER_AUTH_TOTAL,
+        ),
+        (
+            GasId::tx_eip7702_per_auth_state_gas(),
+            T4_NEW_ACCOUNT_STATE, // 225,000
+        ),
+        // Auth refund is zeroed by apply_eip7702_auth_list override (TIP-1000:
+        // "no refund if the account already exists"), but set the value for
+        // upstream split_eip7702_refund correctness if the override is bypassed.
+        (GasId::tx_eip7702_auth_refund(), 0),
+        // Auth account creation (keychain): same split as account creation
+        (GasId::new(255), T4_NEW_ACCOUNT_REGULAR),
+        (GasId::new(254), T4_NEW_ACCOUNT_STATE),
+    ]);
+    gas_params
+}
+
+fn t1_gas_params() -> GasParams {
+    let mut gas_params = GasParams::new_spec(TempoHardfork::T1.into());
+    // TIP-1000: All storage creation costs in regular gas (no state gas split).
+    gas_params.override_gas([
+        (GasId::sstore_set_without_load_cost(), SSTORE_SET_COST),
+        (GasId::tx_create_cost(), CREATE_COST),
+        (GasId::create(), CREATE_COST),
+        (GasId::new_account_cost(), NEW_ACCOUNT_COST),
+        (GasId::new_account_cost_for_selfdestruct(), NEW_ACCOUNT_COST),
+        (GasId::code_deposit_cost(), CODE_DEPOSIT_COST_T1),
+        (
+            GasId::tx_eip7702_per_empty_account_cost(),
+            EIP7702_PER_EMPTY_ACCOUNT_COST_T1,
+        ),
+        (GasId::new(255), AUTH_ACCOUNT_CREATION_COST),
+    ]);
     gas_params
 }
 
@@ -137,6 +153,23 @@ pub fn tempo_gas_params(spec: TempoHardfork) -> GasParams {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_tempo_override_gas_params_are_cached() {
+        let t1 = tempo_gas_params_with_amsterdam(TempoHardfork::T1, false);
+        let t5 = tempo_gas_params_with_amsterdam(TempoHardfork::T5, false);
+        assert!(
+            std::ptr::eq(t1.table(), t5.table()),
+            "T1+ TIP-1000 gas params should share the cached table"
+        );
+
+        let amsterdam_t4 = tempo_gas_params_with_amsterdam(TempoHardfork::T4, true);
+        let amsterdam_t5 = tempo_gas_params_with_amsterdam(TempoHardfork::T5, true);
+        assert!(
+            std::ptr::eq(amsterdam_t4.table(), amsterdam_t5.table()),
+            "Amsterdam gas params should share the cached table"
+        );
+    }
 
     #[test]
     fn test_t1_gas_params_no_state_gas_split() {

--- a/crates/revm/src/gas_params.rs
+++ b/crates/revm/src/gas_params.rs
@@ -78,7 +78,7 @@ pub fn tempo_gas_params_with_amsterdam(
     GasParams::new_spec(spec.into())
 }
 
-/// Builds the cached Amsterdam gas table with the TIP-1016 regular/state split.
+/// Builds the Amsterdam gas table with the TIP-1016 regular/state split.
 fn amsterdam_gas_params() -> GasParams {
     let mut gas_params = GasParams::new_spec(TempoHardfork::T4.into());
     // TIP-1016: Split storage creation costs into regular gas + state gas.
@@ -123,7 +123,7 @@ fn amsterdam_gas_params() -> GasParams {
     gas_params
 }
 
-/// Builds the cached T1+ gas table with TIP-1000 costs and no state gas split.
+/// Builds the T1+ gas table with TIP-1000 costs and no state gas split.
 fn t1_gas_params() -> GasParams {
     let mut gas_params = GasParams::new_spec(TempoHardfork::T1.into());
     // TIP-1000: All storage creation costs in regular gas (no state gas split).

--- a/crates/revm/src/gas_params.rs
+++ b/crates/revm/src/gas_params.rs
@@ -78,6 +78,7 @@ pub fn tempo_gas_params_with_amsterdam(
     GasParams::new_spec(spec.into())
 }
 
+/// Builds the cached Amsterdam gas table with the TIP-1016 regular/state split.
 fn amsterdam_gas_params() -> GasParams {
     let mut gas_params = GasParams::new_spec(TempoHardfork::T4.into());
     // TIP-1016: Split storage creation costs into regular gas + state gas.
@@ -122,6 +123,7 @@ fn amsterdam_gas_params() -> GasParams {
     gas_params
 }
 
+/// Builds the cached T1+ gas table with TIP-1000 costs and no state gas split.
 fn t1_gas_params() -> GasParams {
     let mut gas_params = GasParams::new_spec(TempoHardfork::T1.into());
     // TIP-1000: All storage creation costs in regular gas (no state gas split).


### PR DESCRIPTION
Caches the Tempo gas parameter override tables behind `OnceLock` so `tempo_gas_params_with_amsterdam` only pays the `override_gas` table copy once per override mode. Repeated calls now clone the cached `GasParams` handle, matching revm's `GasParams::new_spec` pattern while keeping pre-T1 specs on the upstream cached table.