### PR TITLE
perf(transaction-pool): inline fee token cost

### DIFF
--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -91,6 +91,7 @@ impl TempoPooledTransaction {
     }
 
     /// Get the cost of the transaction in the fee token.
+    #[inline]
     pub fn fee_token_cost(&self) -> U256 {
         self.inner.cost - self.inner.value()
     }


### PR DESCRIPTION
Marks `TempoPooledTransaction::fee_token_cost` as inline so repeated transaction-pool balance checks can avoid function call overhead.