### PR TITLE
perf(transaction-pool): defer mined aa transaction drops

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -820,7 +820,7 @@ where
                 // 6. Update 2D nonce pool (also removes included expiring nonce txs
                 // via slot changes on the nonce precompile)
                 let nonce_pool_start = Instant::now();
-                pool.notify_aa_pool_on_state_updates(bundle_state);
+                let _mined_aa_txs = pool.notify_aa_pool_on_state_updates(bundle_state);
                 metrics.nonce_pool_update_duration_seconds.record(nonce_pool_start.elapsed());
 
                 // 7. Update AMM liquidity cache (must happen before validator token eviction)

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -90,7 +90,7 @@ where
 
     /// Updates the 2d nonce pool with the given state changes.
     ///
-    /// Returns mined AA transactions so the caller controls where their drop cost is paid.
+    /// Returns mined AA transactions.
     pub(crate) fn notify_aa_pool_on_state_updates(
         &self,
         state: &AddressMap<BundleAccount>,

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -89,12 +89,18 @@ where
     }
 
     /// Updates the 2d nonce pool with the given state changes.
-    pub(crate) fn notify_aa_pool_on_state_updates(&self, state: &AddressMap<BundleAccount>) {
-        let (promoted, _mined) = self.aa_2d_pool.write().on_state_updates(state);
+    ///
+    /// Returns mined AA transactions so the caller controls where their drop cost is paid.
+    pub(crate) fn notify_aa_pool_on_state_updates(
+        &self,
+        state: &AddressMap<BundleAccount>,
+    ) -> Vec<Arc<ValidPoolTransaction<TempoPooledTransaction>>> {
+        let (promoted, mined) = self.aa_2d_pool.write().on_state_updates(state);
         // Note: mined transactions are notified via the vanilla pool updates
         self.protocol_pool
             .inner()
             .notify_on_transaction_updates(promoted, Vec::new());
+        mined
     }
 
     /// Evicts transactions that are no longer valid due to on-chain events.


### PR DESCRIPTION
Returns mined AA transactions from `notify_aa_pool_on_state_updates` and keeps them bound at the maintenance callsite.

This lets the vector drop naturally at the end of the maintenance scope instead of paying the destructor cost inside the nonce-pool update timing window.