### PR TITLE
Downgrade tempo-alloy changelog to patch

### DIFF
--- a/.changelog/jolly-rats-dry.md
+++ b/.changelog/jolly-rats-dry.md
@@ -1,5 +1,5 @@
 ---
-tempo-alloy: minor
+tempo-alloy: patch
 ---
 
 Added sponsored transaction support via a new `RelayTransport` that routes `eth_sendRawTransaction` requests through a sponsor service.


### PR DESCRIPTION
## Summary
- Downgrade .changelog/jolly-rats-dry.md from minor to patch for tempo-alloy

## Testing
- Not run; changelog-only change