### PR TITLE
chore(precompiles): add `CheckedMath` trait to avoid err mapping

### DIFF
--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -5,6 +5,9 @@
 pub mod error;
 pub use error::{IntoPrecompileResult, Result};
 
+pub mod math;
+pub use math::CheckedMath;
+
 pub mod storage;
 
 pub(crate) mod ip_validation;

--- a/crates/precompiles/src/math.rs
+++ b/crates/precompiles/src/math.rs
@@ -1,15 +1,11 @@
-//! Checked arithmetic helpers for Tempo precompile code.
-
-use alloy::primitives::Uint;
+//! Checked arithmetic helpers for Tempo precompiles.
 
 use crate::error::{Result, TempoPrecompileError};
+use alloy::primitives::Uint;
 
 /// Checked arithmetic helpers that convert arithmetic failure into a Tempo precompile error.
 ///
-/// This trait is implemented for all Alloy unsigned integer types (`Uint<BITS, LIMBS>`),
-/// including aliases like `U256`, and for Rust primitive unsigned integers. It preserves the
-/// checked arithmetic semantics of `checked_add`, `checked_sub`, `checked_mul`, and `checked_div`,
-/// but returns the crate's [`Result`] so callers can use `?` directly.
+/// Implemented for all Alloy and Rust primitive unsigned integer types.
 pub trait CheckedMath<Rhs = Self>: Sized {
     /// Adds `rhs`, returning [`TempoPrecompileError::under_overflow`] on overflow.
     fn try_add(self, rhs: Rhs) -> Result<Self>;
@@ -77,5 +73,4 @@ macro_rules! impl_checked_math_for_unsigned_primitives {
         )+
     };
 }
-
 impl_checked_math_for_unsigned_primitives!(u8, u16, u32, u64, u128);

--- a/crates/precompiles/src/math.rs
+++ b/crates/precompiles/src/math.rs
@@ -1,0 +1,81 @@
+//! Checked arithmetic helpers for Tempo precompile code.
+
+use alloy::primitives::Uint;
+
+use crate::error::{Result, TempoPrecompileError};
+
+/// Checked arithmetic helpers that convert arithmetic failure into a Tempo precompile error.
+///
+/// This trait is implemented for all Alloy unsigned integer types (`Uint<BITS, LIMBS>`),
+/// including aliases like `U256`, and for Rust primitive unsigned integers. It preserves the
+/// checked arithmetic semantics of `checked_add`, `checked_sub`, `checked_mul`, and `checked_div`,
+/// but returns the crate's [`Result`] so callers can use `?` directly.
+pub trait CheckedMath<Rhs = Self>: Sized {
+    /// Adds `rhs`, returning [`TempoPrecompileError::under_overflow`] on overflow.
+    fn try_add(self, rhs: Rhs) -> Result<Self>;
+
+    /// Subtracts `rhs`, returning [`TempoPrecompileError::under_overflow`] on underflow.
+    fn try_sub(self, rhs: Rhs) -> Result<Self>;
+
+    /// Multiplies by `rhs`, returning [`TempoPrecompileError::under_overflow`] on overflow.
+    fn try_mul(self, rhs: Rhs) -> Result<Self>;
+
+    /// Divides by `rhs`, returning [`TempoPrecompileError::under_overflow`] on division by zero.
+    fn try_div(self, rhs: Rhs) -> Result<Self>;
+}
+
+impl<const BITS: usize, const LIMBS: usize> CheckedMath for Uint<BITS, LIMBS> {
+    #[inline]
+    fn try_add(self, rhs: Self) -> Result<Self> {
+        self.checked_add(rhs)
+            .ok_or_else(TempoPrecompileError::under_overflow)
+    }
+
+    #[inline]
+    fn try_sub(self, rhs: Self) -> Result<Self> {
+        self.checked_sub(rhs)
+            .ok_or_else(TempoPrecompileError::under_overflow)
+    }
+
+    #[inline]
+    fn try_mul(self, rhs: Self) -> Result<Self> {
+        self.checked_mul(rhs)
+            .ok_or_else(TempoPrecompileError::under_overflow)
+    }
+
+    #[inline]
+    fn try_div(self, rhs: Self) -> Result<Self> {
+        self.checked_div(rhs)
+            .ok_or_else(TempoPrecompileError::under_overflow)
+    }
+}
+
+macro_rules! impl_checked_math_for_unsigned_primitives {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl CheckedMath for $ty {
+                #[inline]
+                fn try_add(self, rhs: Self) -> Result<Self> {
+                    self.checked_add(rhs).ok_or_else(TempoPrecompileError::under_overflow)
+                }
+
+                #[inline]
+                fn try_sub(self, rhs: Self) -> Result<Self> {
+                    self.checked_sub(rhs).ok_or_else(TempoPrecompileError::under_overflow)
+                }
+
+                #[inline]
+                fn try_mul(self, rhs: Self) -> Result<Self> {
+                    self.checked_mul(rhs).ok_or_else(TempoPrecompileError::under_overflow)
+                }
+
+                #[inline]
+                fn try_div(self, rhs: Self) -> Result<Self> {
+                    self.checked_div(rhs).ok_or_else(TempoPrecompileError::under_overflow)
+                }
+            }
+        )+
+    };
+}
+
+impl_checked_math_for_unsigned_primitives!(u8, u16, u32, u64, u128);

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -19,8 +19,8 @@ use tempo_contracts::precompiles::PATH_USD_ADDRESS;
 pub use tempo_contracts::precompiles::{IStablecoinDEX, StablecoinDEXError, StablecoinDEXEvents};
 
 use crate::{
-    STABLECOIN_DEX_ADDRESS,
-    error::{Result, TempoPrecompileError},
+    CheckedMath, STABLECOIN_DEX_ADDRESS,
+    error::Result,
     stablecoin_dex::orderbook::{MAX_PRICE, MIN_PRICE, compute_book_key},
     storage::{Handler, Mapping},
     tip20::{ITIP20, TIP20Token, validate_usd_currency},
@@ -123,25 +123,13 @@ impl StablecoinDEX {
     /// Add to user's balance
     fn increment_balance(&mut self, user: Address, token: Address, amount: u128) -> Result<()> {
         let current = self.balance_of(user, token)?;
-        self.set_balance(
-            user,
-            token,
-            current
-                .checked_add(amount)
-                .ok_or(TempoPrecompileError::under_overflow())?,
-        )
+        self.set_balance(user, token, current.try_add(amount)?)
     }
 
     /// Subtract from user's balance.
     fn sub_balance(&mut self, user: Address, token: Address, amount: u128) -> Result<()> {
         let current = self.balance_of(user, token)?;
-        self.set_balance(
-            user,
-            token,
-            current
-                .checked_sub(amount)
-                .ok_or(TempoPrecompileError::under_overflow())?,
-        )
+        self.set_balance(user, token, current.try_sub(amount)?)
     }
 
     /// Emit the appropriate OrderFilled event
@@ -223,9 +211,7 @@ impl StablecoinDEX {
             }
             self.sub_balance(sender, token, amount)
         } else {
-            let remaining = amount
-                .checked_sub(user_balance)
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            let remaining = amount.try_sub(user_balance)?;
 
             self.transfer_from(token, sender, remaining)?;
             self.set_balance(sender, token, 0)
@@ -499,8 +485,7 @@ impl StablecoinDEX {
         // Calculate escrow amount and token based on order side
         let (escrow_token, escrow_amount, non_escrow_token) = if is_bid {
             // For bids, escrow quote tokens based on price
-            let quote_amount = base_to_quote(amount, tick, RoundingDirection::Up)
-                .ok_or(StablecoinDEXError::insufficient_balance())?;
+            let quote_amount = base_to_quote(amount, tick, RoundingDirection::Up)?;
             (quote_token, quote_amount, token)
         } else {
             // For asks, escrow base tokens
@@ -576,10 +561,7 @@ impl StablecoinDEX {
             level.tail = order.order_id();
         }
 
-        let new_liquidity = level
-            .total_liquidity
-            .checked_add(order.remaining())
-            .ok_or(TempoPrecompileError::under_overflow())?;
+        let new_liquidity = level.total_liquidity.try_add(order.remaining())?;
         level.total_liquidity = new_liquidity;
 
         self.books[order.book_key()]
@@ -666,8 +648,7 @@ impl StablecoinDEX {
         // Calculate escrow amount and token based on order side
         let (escrow_token, escrow_amount, non_escrow_token) = if is_bid {
             // For bids, escrow quote tokens based on price
-            let quote_amount = base_to_quote(amount, tick, RoundingDirection::Up)
-                .ok_or(StablecoinDEXError::insufficient_balance())?;
+            let quote_amount = base_to_quote(amount, tick, RoundingDirection::Up)?;
             (quote_token, quote_amount, token)
         } else {
             // For asks, escrow base tokens
@@ -755,8 +736,7 @@ impl StablecoinDEX {
         // Calculate escrow amount and token based on order side
         let (escrow_token, escrow_amount, non_escrow_token) = if flipped.is_bid {
             // For bids, escrow quote tokens based on price
-            let quote_amount = base_to_quote(flipped.amount, flipped.tick, RoundingDirection::Up)
-                .ok_or(StablecoinDEXError::insufficient_balance())?;
+            let quote_amount = base_to_quote(flipped.amount, flipped.tick, RoundingDirection::Up)?;
             (quote_token, quote_amount, base_token)
         } else {
             // For asks, escrow base tokens
@@ -828,8 +808,7 @@ impl StablecoinDEX {
             } else {
                 RoundingDirection::Up // Ask: maker receives quote, round UP to favor maker
             },
-        )
-        .ok_or(TempoPrecompileError::under_overflow())?;
+        )?;
 
         if order.is_bid() {
             // Bid order maker receives base tokens (exact amount)
@@ -847,10 +826,7 @@ impl StablecoinDEX {
         };
 
         // Update price level total liquidity
-        let new_liquidity = level
-            .total_liquidity
-            .checked_sub(fill_amount)
-            .ok_or(TempoPrecompileError::under_overflow())?;
+        let new_liquidity = level.total_liquidity.try_sub(fill_amount)?;
         level.total_liquidity = new_liquidity;
 
         self.books[order.book_key()]
@@ -885,12 +861,10 @@ impl StablecoinDEX {
             // Bid maker receives base tokens (exact amount)
             self.increment_balance(order.maker(), orderbook.base, fill_amount)?;
             // Taker receives quote tokens - round DOWN
-            base_to_quote(fill_amount, order.tick(), RoundingDirection::Down)
-                .ok_or(TempoPrecompileError::under_overflow())?
+            base_to_quote(fill_amount, order.tick(), RoundingDirection::Down)?
         } else {
             // Ask maker receives quote tokens - round UP to favor maker
-            let quote_amount = base_to_quote(fill_amount, order.tick(), RoundingDirection::Up)
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            let quote_amount = base_to_quote(fill_amount, order.tick(), RoundingDirection::Up)?;
 
             self.increment_balance(order.maker(), orderbook.quote, quote_amount)?;
 
@@ -977,10 +951,7 @@ impl StablecoinDEX {
             level.head = order.next();
             self.orders[order.next()].prev.delete()?;
 
-            let new_liquidity = level
-                .total_liquidity
-                .checked_sub(fill_amount)
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            let new_liquidity = level.total_liquidity.try_sub(fill_amount)?;
             level.total_liquidity = new_liquidity;
 
             self.books[book_key]
@@ -1013,48 +984,37 @@ impl StablecoinDEX {
             let (fill_amount, amount_in) = if bid {
                 // For bids: amount_out is quote, amount_in is base
                 // Round UP baseNeeded to ensure we collect enough base to cover exact output
-                let base_needed = quote_to_base(amount_out, tick, RoundingDirection::Up)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                let base_needed = quote_to_base(amount_out, tick, RoundingDirection::Up)?;
                 let fill_amount = base_needed.min(order.remaining());
                 (fill_amount, fill_amount)
             } else {
                 // For asks: amount_out is base, amount_in is quote
                 // Taker pays quote, maker receives quote - round UP (zero-sum with maker)
                 let fill_amount = amount_out.min(order.remaining());
-                let amount_in = base_to_quote(fill_amount, tick, RoundingDirection::Up)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                let amount_in = base_to_quote(fill_amount, tick, RoundingDirection::Up)?;
                 (fill_amount, amount_in)
             };
 
             if fill_amount < order.remaining() {
                 self.partial_fill_order(&mut order, &mut level, fill_amount, taker)?;
-                total_amount_in = total_amount_in
-                    .checked_add(amount_in)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                total_amount_in = total_amount_in.try_add(amount_in)?;
                 break;
             } else {
                 let (amount_out_received, next_order_info) =
                     self.fill_order(book_key, &mut order, level, taker)?;
-                total_amount_in = total_amount_in
-                    .checked_add(amount_in)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                total_amount_in = total_amount_in.try_add(amount_in)?;
 
                 // Update remaining amount_out
                 if bid {
                     // Round UP baseNeeded to match the initial calculation
-                    let base_needed = quote_to_base(amount_out, tick, RoundingDirection::Up)
-                        .ok_or(TempoPrecompileError::under_overflow())?;
+                    let base_needed = quote_to_base(amount_out, tick, RoundingDirection::Up)?;
                     if base_needed > order.remaining() {
-                        amount_out = amount_out
-                            .checked_sub(amount_out_received)
-                            .ok_or(TempoPrecompileError::under_overflow())?;
+                        amount_out = amount_out.try_sub(amount_out_received)?;
                     } else {
                         amount_out = 0;
                     }
                 } else if amount_out > order.remaining() {
-                    amount_out = amount_out
-                        .checked_sub(amount_out_received)
-                        .ok_or(TempoPrecompileError::under_overflow())?;
+                    amount_out = amount_out.try_sub(amount_out_received)?;
                 } else {
                     amount_out = 0;
                 }
@@ -1096,46 +1056,35 @@ impl StablecoinDEX {
             } else {
                 // For asks: amount_in is quote, convert to base
                 // Round down base_out (user receives less base, favors protocol)
-                let base_out = quote_to_base(amount_in, tick, RoundingDirection::Down)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                let base_out = quote_to_base(amount_in, tick, RoundingDirection::Down)?;
                 base_out.min(order.remaining())
             };
 
             if fill_amount < order.remaining() {
                 let amount_out =
                     self.partial_fill_order(&mut order, &mut level, fill_amount, taker)?;
-                total_amount_out = total_amount_out
-                    .checked_add(amount_out)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                total_amount_out = total_amount_out.try_add(amount_out)?;
                 break;
             } else {
                 let (amount_out, next_order_info) =
                     self.fill_order(book_key, &mut order, level, taker)?;
-                total_amount_out = total_amount_out
-                    .checked_add(amount_out)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                total_amount_out = total_amount_out.try_add(amount_out)?;
 
                 // Set to 0 to avoid rounding errors
                 if bid {
                     if amount_in > order.remaining() {
-                        amount_in = amount_in
-                            .checked_sub(order.remaining())
-                            .ok_or(TempoPrecompileError::under_overflow())?;
+                        amount_in = amount_in.try_sub(order.remaining())?;
                     } else {
                         amount_in = 0;
                     }
                 } else {
                     // For asks: taker pays quote, maker receives quote
-                    let base_out = quote_to_base(amount_in, tick, RoundingDirection::Down)
-                        .ok_or(TempoPrecompileError::under_overflow())?;
+                    let base_out = quote_to_base(amount_in, tick, RoundingDirection::Down)?;
                     if base_out > order.remaining() {
                         // Quote consumed = what maker receives - round UP (zero-sum with maker)
                         let quote_needed =
-                            base_to_quote(order.remaining(), tick, RoundingDirection::Up)
-                                .ok_or(TempoPrecompileError::under_overflow())?;
-                        amount_in = amount_in
-                            .checked_sub(quote_needed)
-                            .ok_or(TempoPrecompileError::under_overflow())?;
+                            base_to_quote(order.remaining(), tick, RoundingDirection::Up)?;
+                        amount_in = amount_in.try_sub(quote_needed)?;
                     } else {
                         amount_in = 0;
                     }
@@ -1221,10 +1170,7 @@ impl StablecoinDEX {
         }
 
         // Update level liquidity
-        let new_liquidity = level
-            .total_liquidity
-            .checked_sub(order.remaining())
-            .ok_or(TempoPrecompileError::under_overflow())?;
+        let new_liquidity = level.total_liquidity.try_sub(order.remaining())?;
         level.total_liquidity = new_liquidity;
 
         // If this was the last order at this tick, clear the bitmap bit
@@ -1263,8 +1209,7 @@ impl StablecoinDEX {
             // Bid orders escrowed quote tokens using RoundingDirection::Up,
             // so refund must also use Up to return the exact escrowed amount
             let quote_amount =
-                base_to_quote(order.remaining(), order.tick(), RoundingDirection::Up)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                base_to_quote(order.remaining(), order.tick(), RoundingDirection::Up)?;
 
             self.increment_balance(order.maker(), orderbook.quote, quote_amount)?;
         } else {
@@ -1383,8 +1328,8 @@ impl StablecoinDEX {
                 // Note: this quote iterates per-tick, but execution iterates per-order.
                 // If multiple orders exist at a tick, execution may charge slightly more
                 // due to ceiling accumulation across order boundaries.
-                let base_needed = quote_to_base(remaining_out, current_tick, RoundingDirection::Up)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                let base_needed =
+                    quote_to_base(remaining_out, current_tick, RoundingDirection::Up)?;
                 let fill_amount = if base_needed > level.total_liquidity {
                     level.total_liquidity
                 } else {
@@ -1399,8 +1344,7 @@ impl StablecoinDEX {
                 } else {
                     remaining_out
                 };
-                let quote_needed = base_to_quote(fill_amount, current_tick, RoundingDirection::Up)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                let quote_needed = base_to_quote(fill_amount, current_tick, RoundingDirection::Up)?;
                 (fill_amount, quote_needed)
             };
 
@@ -1408,17 +1352,14 @@ impl StablecoinDEX {
                 // Round down amount_out_tick (user receives less quote).
                 // Cap at remaining_out to avoid underflow from round-trip rounding:
                 // when tick > 0, base_to_quote(quote_to_base(x, Up), Down) can exceed x by 1.
-                base_to_quote(fill_amount, current_tick, RoundingDirection::Down)
-                    .ok_or(TempoPrecompileError::under_overflow())?
+                base_to_quote(fill_amount, current_tick, RoundingDirection::Down)?
                     .min(remaining_out)
             } else {
                 fill_amount
             };
 
             remaining_out = remaining_out.saturating_sub(amount_out_tick);
-            amount_in = amount_in
-                .checked_add(amount_in_tick)
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            amount_in = amount_in.try_add(amount_in_tick)?;
 
             // If we exhausted this level or filled our requirement, move to next tick
             if fill_amount == level.total_liquidity {
@@ -1600,27 +1541,20 @@ impl StablecoinDEX {
                 // For bids: remaining_in is base, amount_out is quote
                 let fill = remaining_in.min(level.total_liquidity);
                 // Round down quote_out (user receives less quote)
-                let quote_out = base_to_quote(fill, current_tick, RoundingDirection::Down)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                let quote_out = base_to_quote(fill, current_tick, RoundingDirection::Down)?;
                 (fill, quote_out, fill)
             } else {
                 // For asks: remaining_in is quote, amount_out is base
                 // Taker pays quote, maker receives quote - round UP (zero-sum with maker)
                 let base_to_get =
-                    quote_to_base(remaining_in, current_tick, RoundingDirection::Down)
-                        .ok_or(TempoPrecompileError::under_overflow())?;
+                    quote_to_base(remaining_in, current_tick, RoundingDirection::Down)?;
                 let fill = base_to_get.min(level.total_liquidity);
-                let quote_consumed = base_to_quote(fill, current_tick, RoundingDirection::Up)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                let quote_consumed = base_to_quote(fill, current_tick, RoundingDirection::Up)?;
                 (fill, fill, quote_consumed)
             };
 
-            remaining_in = remaining_in
-                .checked_sub(amount_consumed)
-                .ok_or(TempoPrecompileError::under_overflow())?;
-            amount_out = amount_out
-                .checked_add(amount_out_tick)
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            remaining_in = remaining_in.try_sub(amount_consumed)?;
+            amount_out = amount_out.try_add(amount_out_tick)?;
 
             // If we exhausted this level, move to next tick
             if fill_amount == level.total_liquidity {
@@ -4233,8 +4167,8 @@ mod tests {
             // Test is_bid == true: base -> quote
             let quoted_out_bid = exchange.quote_exact_in(book_key, amount, true)?;
             let expected_quote_out = amount
-                .checked_mul(u128::from(price))
-                .and_then(|v| v.checked_div(u128::from(orderbook::PRICE_SCALE)))
+                .try_mul(u128::from(price))
+                .and_then(|v| v.try_div(u128::from(orderbook::PRICE_SCALE)))
                 .expect("calculation");
             assert_eq!(
                 quoted_out_bid, expected_quote_out,
@@ -4248,8 +4182,8 @@ mod tests {
             let quote_in = (amount * u128::from(price)) / u128::from(orderbook::PRICE_SCALE);
             let quoted_out_ask = exchange.quote_exact_in(book_key, quote_in, false)?;
             let expected_base_out = quote_in
-                .checked_mul(u128::from(orderbook::PRICE_SCALE))
-                .and_then(|v| v.checked_div(u128::from(price)))
+                .try_mul(u128::from(orderbook::PRICE_SCALE))
+                .and_then(|v| v.try_div(u128::from(price)))
                 .expect("calculation");
             assert_eq!(
                 quoted_out_ask, expected_base_out,
@@ -5349,7 +5283,7 @@ mod tests {
 
                 let alice_quote_before = exchange.balance_of(alice, quote_token)?;
 
-                // Poison the flip target tick so commit_order_to_book overflows on checked_add
+                // Poison the flip target tick so commit_order_to_book overflows on try_add
                 let poisoned_level = TickLevel::with_values(0, 0, u128::MAX);
                 exchange.books[book_key]
                     .tick_level_handler_mut(flip_tick, false)
@@ -5646,7 +5580,7 @@ mod tests {
                 let next_id_before = exchange.next_order_id()?;
 
                 // Poison the flip target tick so commit_order_to_book
-                // overflows on checked_add — a system error.
+                // overflows on try_add — a system error.
                 let poisoned = TickLevel::with_values(0, 0, u128::MAX);
                 exchange.books[book_key]
                     .tick_level_handler_mut(flip_tick, false)

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -485,7 +485,8 @@ impl StablecoinDEX {
         // Calculate escrow amount and token based on order side
         let (escrow_token, escrow_amount, non_escrow_token) = if is_bid {
             // For bids, escrow quote tokens based on price
-            let quote_amount = base_to_quote(amount, tick, RoundingDirection::Up)?;
+            let quote_amount = base_to_quote(amount, tick, RoundingDirection::Up)
+                .map_err(|_| StablecoinDEXError::insufficient_balance().into())?;
             (quote_token, quote_amount, token)
         } else {
             // For asks, escrow base tokens
@@ -648,7 +649,8 @@ impl StablecoinDEX {
         // Calculate escrow amount and token based on order side
         let (escrow_token, escrow_amount, non_escrow_token) = if is_bid {
             // For bids, escrow quote tokens based on price
-            let quote_amount = base_to_quote(amount, tick, RoundingDirection::Up)?;
+            let quote_amount = base_to_quote(amount, tick, RoundingDirection::Up)
+                .map_err(|_| StablecoinDEXError::insufficient_balance().into())?;
             (quote_token, quote_amount, token)
         } else {
             // For asks, escrow base tokens
@@ -736,7 +738,8 @@ impl StablecoinDEX {
         // Calculate escrow amount and token based on order side
         let (escrow_token, escrow_amount, non_escrow_token) = if flipped.is_bid {
             // For bids, escrow quote tokens based on price
-            let quote_amount = base_to_quote(flipped.amount, flipped.tick, RoundingDirection::Up)?;
+            let quote_amount = base_to_quote(flipped.amount, flipped.tick, RoundingDirection::Up)
+                .map_err(|_| StablecoinDEXError::insufficient_balance().into())?;
             (quote_token, quote_amount, base_token)
         } else {
             // For asks, escrow base tokens

--- a/crates/precompiles/src/stablecoin_dex/orderbook.rs
+++ b/crates/precompiles/src/stablecoin_dex/orderbook.rs
@@ -1210,9 +1210,8 @@ mod tests {
 
             let expected = large_base_amount
                 .checked_mul(102)
-                .and_then(|v| v.checked_div(100))
-                .unwrap();
-            assert_eq!(result.unwrap(), expected);
+                .and_then(|v| v.checked_div(100));
+            assert_eq!(result.unwrap(), expected.unwrap());
         }
 
         #[test]

--- a/crates/precompiles/src/stablecoin_dex/orderbook.rs
+++ b/crates/precompiles/src/stablecoin_dex/orderbook.rs
@@ -1,7 +1,7 @@
 //! Orderbook and tick level management for the stablecoin DEX.
 
 use crate::{
-    error::Result,
+    error::{Result, TempoPrecompileError},
     stablecoin_dex::{IStablecoinDEX, TICK_SPACING},
     storage::{Handler, Mapping},
 };
@@ -40,9 +40,9 @@ pub enum RoundingDirection {
 /// * `tick` - Price tick
 /// * `rounding` - Rounding direction
 ///
-/// # Returns
-/// Quote token amount, or None if result exceeds u128
-pub fn base_to_quote(base_amount: u128, tick: i16, rounding: RoundingDirection) -> Option<u128> {
+/// # Errors
+/// Returns [`TempoPrecompileError::under_overflow`] if the result exceeds `u128`.
+pub fn base_to_quote(base_amount: u128, tick: i16, rounding: RoundingDirection) -> Result<u128> {
     let price = U256::from(tick_to_price(tick));
     let base = U256::from(base_amount);
     let scale = U256::from(PRICE_SCALE);
@@ -54,7 +54,9 @@ pub fn base_to_quote(base_amount: u128, tick: i16, rounding: RoundingDirection) 
         RoundingDirection::Up => numerator.div_ceil(scale),
     };
 
-    result.try_into().ok()
+    result
+        .try_into()
+        .map_err(|_| TempoPrecompileError::under_overflow())
 }
 
 /// Convert quote token amount to base token amount at a given tick.
@@ -68,9 +70,9 @@ pub fn base_to_quote(base_amount: u128, tick: i16, rounding: RoundingDirection) 
 /// * `tick` - Price tick
 /// * `rounding` - Rounding direction
 ///
-/// # Returns
-/// Base token amount, or None if result exceeds u128
-pub fn quote_to_base(quote_amount: u128, tick: i16, rounding: RoundingDirection) -> Option<u128> {
+/// # Errors
+/// Returns [`TempoPrecompileError::under_overflow`] if the result exceeds `u128`.
+pub fn quote_to_base(quote_amount: u128, tick: i16, rounding: RoundingDirection) -> Result<u128> {
     let price = U256::from(tick_to_price(tick));
     let quote = U256::from(quote_amount);
     let scale = U256::from(PRICE_SCALE);
@@ -82,7 +84,9 @@ pub fn quote_to_base(quote_amount: u128, tick: i16, rounding: RoundingDirection)
         RoundingDirection::Up => numerator.div_ceil(price),
     };
 
-    result.try_into().ok()
+    result
+        .try_into()
+        .map_err(|_| TempoPrecompileError::under_overflow())
 }
 
 /// Lowest representable scaled price (`PRICE_SCALE + MIN_TICK`).
@@ -1200,14 +1204,15 @@ mod tests {
             let result = base_to_quote(large_base_amount, MAX_TICK, RoundingDirection::Down);
 
             assert!(
-                result.is_some(),
+                result.is_ok(),
                 "base_to_quote should handle large amounts without overflow using U256"
             );
 
             let expected = large_base_amount
                 .checked_mul(102)
-                .and_then(|v| v.checked_div(100));
-            assert_eq!(result, expected);
+                .and_then(|v| v.checked_div(100))
+                .unwrap();
+            assert_eq!(result.unwrap(), expected);
         }
 
         #[test]
@@ -1224,7 +1229,7 @@ mod tests {
             let result = quote_to_base(large_quote_amount, MAX_TICK, RoundingDirection::Down);
 
             assert!(
-                result.is_some(),
+                result.is_ok(),
                 "quote_to_base should handle large amounts without overflow using U256"
             );
         }

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -21,7 +21,7 @@ pub use tempo_primitives::is_tip20_prefix;
 pub use slots as tip20_slots;
 
 use crate::{
-    PATH_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
+    CheckedMath, PATH_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
     account_keychain::AccountKeychain,
     address_registry::AddressRegistry,
     error::{Result, TempoPrecompileError},
@@ -523,9 +523,7 @@ impl TIP20Token {
         // Check if the resolved target address is authorized to receive minted tokens
         self.validate_mint(to)?;
 
-        let new_supply = total_supply
-            .checked_add(amount)
-            .ok_or(TempoPrecompileError::under_overflow())?;
+        let new_supply = total_supply.try_add(amount)?;
 
         let supply_cap = self.supply_cap()?;
         if new_supply > supply_cap {
@@ -536,9 +534,7 @@ impl TIP20Token {
 
         self.set_total_supply(new_supply)?;
         let to_balance = self.get_balance(to.target)?;
-        let new_to_balance: alloy::primitives::Uint<256, 4> = to_balance
-            .checked_add(amount)
-            .ok_or(TempoPrecompileError::under_overflow())?;
+        let new_to_balance: alloy::primitives::Uint<256, 4> = to_balance.try_add(amount)?;
         self.set_balance(to.target, new_to_balance)?;
 
         self.emit_event(to.build_transfer_event(Address::ZERO, amount))
@@ -741,11 +737,7 @@ impl TIP20Token {
         }
 
         // 5. Increment nonce
-        self.permit_nonces[call.owner].write(
-            nonce
-                .checked_add(U256::from(1))
-                .ok_or(TempoPrecompileError::under_overflow())?,
-        )?;
+        self.permit_nonces[call.owner].write(nonce.try_add(U256::from(1))?)?;
 
         // 6. Set allowance
         self.set_allowance(call.owner, call.spender, call.value)?;
@@ -1088,17 +1080,13 @@ impl TIP20Token {
         self.handle_rewards_on_transfer(from, to.target, amount)?;
 
         // Adjust balances
-        let new_from_balance = from_balance
-            .checked_sub(amount)
-            .ok_or(TempoPrecompileError::under_overflow())?;
+        let new_from_balance = from_balance.try_sub(amount)?;
 
         self.set_balance(from, new_from_balance)?;
 
         if to.target != Address::ZERO {
             let to_balance = self.get_balance(to.target)?;
-            let new_to_balance = to_balance
-                .checked_add(amount)
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            let new_to_balance = to_balance.try_add(amount)?;
 
             self.set_balance(to.target, new_to_balance)?;
         }
@@ -1133,9 +1121,7 @@ impl TIP20Token {
 
         // If user is opted into rewards, decrease opted-in supply
         if from_reward_recipient != Address::ZERO {
-            let opted_in_supply = U256::from(self.get_opted_in_supply()?)
-                .checked_sub(amount)
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            let opted_in_supply = U256::from(self.get_opted_in_supply()?).try_sub(amount)?;
             self.set_opted_in_supply(
                 opted_in_supply
                     .try_into()
@@ -1191,9 +1177,7 @@ impl TIP20Token {
 
         // If user is opted into rewards, increase opted-in supply by refund amount
         if to_reward_recipient != Address::ZERO {
-            let opted_in_supply = U256::from(self.get_opted_in_supply()?)
-                .checked_add(refund)
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            let opted_in_supply = U256::from(self.get_opted_in_supply()?).try_add(refund)?;
             self.set_opted_in_supply(
                 opted_in_supply
                     .try_into()

--- a/crates/precompiles/src/tip20/rewards.rs
+++ b/crates/precompiles/src/tip20/rewards.rs
@@ -7,6 +7,7 @@
 //! [Reward system]: <https://docs.tempo.xyz/protocol/tip20-rewards/overview>
 
 use crate::{
+    CheckedMath,
     error::{Result, TempoPrecompileError},
     storage::Handler,
     tip20::{Recipient, TIP20Token},
@@ -55,13 +56,10 @@ impl TIP20Token {
 
         let delta_rpt = call
             .amount
-            .checked_mul(ACC_PRECISION)
-            .and_then(|v| v.checked_div(opted_in_supply))
-            .ok_or(TempoPrecompileError::under_overflow())?;
+            .try_mul(ACC_PRECISION)?
+            .try_div(opted_in_supply)?;
         let current_rpt = self.get_global_reward_per_token()?;
-        let new_rpt = current_rpt
-            .checked_add(delta_rpt)
-            .ok_or(TempoPrecompileError::under_overflow())?;
+        let new_rpt = current_rpt.try_add(delta_rpt)?;
         self.set_global_reward_per_token(new_rpt)?;
 
         // Emit distributed reward event (recipients claim accrued rewards separately)
@@ -82,30 +80,21 @@ impl TIP20Token {
         let cached_delegate = info.reward_recipient;
 
         let global_reward_per_token = self.get_global_reward_per_token()?;
-        let reward_per_token_delta = global_reward_per_token
-            .checked_sub(info.reward_per_token)
-            .ok_or(TempoPrecompileError::under_overflow())?;
+        let reward_per_token_delta = global_reward_per_token.try_sub(info.reward_per_token)?;
 
         if reward_per_token_delta != U256::ZERO {
             if cached_delegate != Address::ZERO {
                 let holder_balance = self.get_balance(holder)?;
                 let reward = holder_balance
-                    .checked_mul(reward_per_token_delta)
-                    .and_then(|v| v.checked_div(ACC_PRECISION))
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                    .try_mul(reward_per_token_delta)?
+                    .try_div(ACC_PRECISION)?;
 
                 // Add reward to delegate's balance (or holder's own balance if self-delegated)
                 if cached_delegate == holder {
-                    info.reward_balance = info
-                        .reward_balance
-                        .checked_add(reward)
-                        .ok_or(TempoPrecompileError::under_overflow())?;
+                    info.reward_balance = info.reward_balance.try_add(reward)?;
                 } else {
                     let mut delegate_info = self.user_reward_info[cached_delegate].read()?;
-                    delegate_info.reward_balance = delegate_info
-                        .reward_balance
-                        .checked_add(reward)
-                        .ok_or(TempoPrecompileError::under_overflow())?;
+                    delegate_info.reward_balance = delegate_info.reward_balance.try_add(reward)?;
                     self.user_reward_info[cached_delegate].write(delegate_info)?;
                 }
             }
@@ -147,9 +136,8 @@ impl TIP20Token {
 
         if from_delegate != Address::ZERO {
             if call.recipient == Address::ZERO {
-                let opted_in_supply = U256::from(self.get_opted_in_supply()?)
-                    .checked_sub(holder_balance)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                let opted_in_supply =
+                    U256::from(self.get_opted_in_supply()?).try_sub(holder_balance)?;
                 self.set_opted_in_supply(
                     opted_in_supply
                         .try_into()
@@ -157,9 +145,8 @@ impl TIP20Token {
                 )?;
             }
         } else if call.recipient != Address::ZERO {
-            let opted_in_supply = U256::from(self.get_opted_in_supply()?)
-                .checked_add(holder_balance)
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            let opted_in_supply =
+                U256::from(self.get_opted_in_supply()?).try_add(holder_balance)?;
             self.set_opted_in_supply(
                 opted_in_supply
                     .try_into()
@@ -198,27 +185,19 @@ impl TIP20Token {
         let max_amount = amount.min(contract_balance);
 
         let reward_recipient = info.reward_recipient;
-        info.reward_balance = amount
-            .checked_sub(max_amount)
-            .ok_or(TempoPrecompileError::under_overflow())?;
+        info.reward_balance = amount.try_sub(max_amount)?;
         self.user_reward_info[msg_sender].write(info)?;
 
         if max_amount > U256::ZERO {
-            let new_contract_balance = contract_balance
-                .checked_sub(max_amount)
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            let new_contract_balance = contract_balance.try_sub(max_amount)?;
             self.set_balance(contract_address, new_contract_balance)?;
 
-            let recipient_balance = self
-                .get_balance(msg_sender)?
-                .checked_add(max_amount)
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            let recipient_balance = self.get_balance(msg_sender)?.try_add(max_amount)?;
             self.set_balance(msg_sender, recipient_balance)?;
 
             if reward_recipient != Address::ZERO {
-                let opted_in_supply = U256::from(self.get_opted_in_supply()?)
-                    .checked_add(max_amount)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                let opted_in_supply =
+                    U256::from(self.get_opted_in_supply()?).try_add(max_amount)?;
                 self.set_opted_in_supply(
                     opted_in_supply
                         .try_into()
@@ -268,9 +247,7 @@ impl TIP20Token {
 
         if !from_delegate.is_zero() {
             if to_delegate.is_zero() {
-                let opted_in_supply = U256::from(self.get_opted_in_supply()?)
-                    .checked_sub(amount)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                let opted_in_supply = U256::from(self.get_opted_in_supply()?).try_sub(amount)?;
                 self.set_opted_in_supply(
                     opted_in_supply
                         .try_into()
@@ -278,9 +255,7 @@ impl TIP20Token {
                 )?;
             }
         } else if !to_delegate.is_zero() {
-            let opted_in_supply = U256::from(self.get_opted_in_supply()?)
-                .checked_add(amount)
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            let opted_in_supply = U256::from(self.get_opted_in_supply()?).try_add(amount)?;
             self.set_opted_in_supply(
                 opted_in_supply
                     .try_into()
@@ -296,9 +271,7 @@ impl TIP20Token {
         let to_delegate = self.update_rewards(to)?;
 
         if !to_delegate.is_zero() {
-            let opted_in_supply = U256::from(self.get_opted_in_supply()?)
-                .checked_add(amount)
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            let opted_in_supply = U256::from(self.get_opted_in_supply()?).try_add(amount)?;
             self.set_opted_in_supply(
                 opted_in_supply
                     .try_into()
@@ -333,18 +306,14 @@ impl TIP20Token {
             let holder_balance = self.get_balance(account)?;
             if holder_balance > U256::ZERO {
                 let global_reward_per_token = self.get_global_reward_per_token()?;
-                let reward_per_token_delta = global_reward_per_token
-                    .checked_sub(info.reward_per_token)
-                    .ok_or(TempoPrecompileError::under_overflow())?;
+                let reward_per_token_delta =
+                    global_reward_per_token.try_sub(info.reward_per_token)?;
 
                 if reward_per_token_delta > U256::ZERO {
                     let accrued = holder_balance
-                        .checked_mul(reward_per_token_delta)
-                        .and_then(|v| v.checked_div(ACC_PRECISION))
-                        .ok_or(TempoPrecompileError::under_overflow())?;
-                    pending = pending
-                        .checked_add(accrued)
-                        .ok_or(TempoPrecompileError::under_overflow())?;
+                        .try_mul(reward_per_token_delta)?
+                        .try_div(ACC_PRECISION)?;
+                    pending = pending.try_add(accrued)?;
                 }
             }
         }

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -15,7 +15,7 @@ pub use tempo_contracts::precompiles::{
 use tempo_precompiles_macros::{Storable, contract};
 
 use crate::{
-    TIP403_REGISTRY_ADDRESS,
+    CheckedMath, TIP403_REGISTRY_ADDRESS,
     error::{Result, TempoPrecompileError},
     storage::{Handler, Mapping},
 };
@@ -245,11 +245,7 @@ impl TIP403Registry {
         let new_policy_id = self.policy_id_counter()?;
 
         // Increment counter
-        self.policy_id_counter.write(
-            new_policy_id
-                .checked_add(1)
-                .ok_or(TempoPrecompileError::under_overflow())?,
-        )?;
+        self.policy_id_counter.write(new_policy_id.try_add(1)?)?;
 
         // Store policy data
         self.policy_records[new_policy_id].base.write(PolicyData {
@@ -299,11 +295,7 @@ impl TIP403Registry {
         let new_policy_id = self.policy_id_counter()?;
 
         // Increment counter
-        self.policy_id_counter.write(
-            new_policy_id
-                .checked_add(1)
-                .ok_or(TempoPrecompileError::under_overflow())?,
-        )?;
+        self.policy_id_counter.write(new_policy_id.try_add(1)?)?;
 
         // Store policy data
         self.set_policy_data(new_policy_id, PolicyData { policy_type, admin })?;
@@ -485,11 +477,7 @@ impl TIP403Registry {
         let new_policy_id = self.policy_id_counter()?;
 
         // Increment counter
-        self.policy_id_counter.write(
-            new_policy_id
-                .checked_add(1)
-                .ok_or(TempoPrecompileError::under_overflow())?,
-        )?;
+        self.policy_id_counter.write(new_policy_id.try_add(1)?)?;
 
         // Store policy record with COMPOUND type and compound data
         self.policy_records[new_policy_id].write(PolicyRecord {

--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -1,4 +1,5 @@
 use crate::{
+    CheckedMath,
     error::{Result, TempoPrecompileError},
     storage::Handler,
     tip_fee_manager::{ITIPFeeAMM, TIPFeeAMMError, TIPFeeAMMEvent, TipFeeManager},
@@ -25,10 +26,7 @@ pub const MIN_LIQUIDITY: U256 = uint!(1000_U256);
 /// - `UnderOverflow` — multiplication of `amount_in * M` overflows
 #[inline]
 pub fn compute_amount_out(amount_in: U256) -> Result<U256> {
-    amount_in
-        .checked_mul(M)
-        .map(|product| product / SCALE)
-        .ok_or(TempoPrecompileError::under_overflow())
+    amount_in.try_mul(M).map(|product| product / SCALE)
 }
 
 /// AMM pool reserves for a user-token / validator-token pair.
@@ -145,11 +143,7 @@ impl TipFeeManager {
 
         // Rebalancing swaps are always from validatorToken to userToken
         // Calculate input and update reserves
-        let amount_in = amount_out
-            .checked_mul(N)
-            .and_then(|product| product.checked_div(SCALE))
-            .and_then(|result| result.checked_add(U256::ONE))
-            .ok_or(TempoPrecompileError::under_overflow())?;
+        let amount_in = amount_out.try_mul(N)?.try_div(SCALE)?.try_add(U256::ONE)?;
 
         let amount_in: u128 = amount_in
             .try_into()
@@ -247,17 +241,13 @@ impl TipFeeManager {
         let mut total_supply = self.get_total_supply(pool_id)?;
 
         let liquidity = if pool.reserve_user_token == 0 && pool.reserve_validator_token == 0 {
-            let half_amount = amount_validator_token
-                .checked_div(uint!(2_U256))
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            let half_amount = amount_validator_token.try_div(uint!(2_U256))?;
 
             if half_amount <= MIN_LIQUIDITY {
                 return Err(TIPFeeAMMError::insufficient_liquidity().into());
             }
 
-            total_supply = total_supply
-                .checked_add(MIN_LIQUIDITY)
-                .ok_or(TempoPrecompileError::under_overflow())?;
+            total_supply = total_supply.try_add(MIN_LIQUIDITY)?;
             self.set_total_supply(pool_id, total_supply)?;
 
             half_amount
@@ -309,21 +299,10 @@ impl TipFeeManager {
         self.pools[pool_id].write(pool)?;
 
         // Mint LP tokens
-        self.set_total_supply(
-            pool_id,
-            total_supply
-                .checked_add(liquidity)
-                .ok_or(TempoPrecompileError::under_overflow())?,
-        )?;
+        self.set_total_supply(pool_id, total_supply.try_add(liquidity)?)?;
 
         let balance = self.get_liquidity_balances(pool_id, to)?;
-        self.set_liquidity_balances(
-            pool_id,
-            to,
-            balance
-                .checked_add(liquidity)
-                .ok_or(TempoPrecompileError::under_overflow())?,
-        )?;
+        self.set_liquidity_balances(pool_id, to, balance.try_add(liquidity)?)?;
 
         // Emit Mint event
         self.emit_event(TIPFeeAMMEvent::mint(
@@ -400,20 +379,9 @@ impl TipFeeManager {
         }
 
         // Burn LP tokens
-        self.set_liquidity_balances(
-            pool_id,
-            msg_sender,
-            balance
-                .checked_sub(liquidity)
-                .ok_or(TempoPrecompileError::under_overflow())?,
-        )?;
+        self.set_liquidity_balances(pool_id, msg_sender, balance.try_sub(liquidity)?)?;
         let total_supply = self.get_total_supply(pool_id)?;
-        self.set_total_supply(
-            pool_id,
-            total_supply
-                .checked_sub(liquidity)
-                .ok_or(TempoPrecompileError::under_overflow())?,
-        )?;
+        self.set_total_supply(pool_id, total_supply.try_sub(liquidity)?)?;
 
         // Update reserves with underflow checks
         let user_amount: u128 = amount_user_token
@@ -473,13 +441,11 @@ impl TipFeeManager {
     ) -> Result<(U256, U256)> {
         let total_supply = self.get_total_supply(pool_id)?;
         let amount_user_token = liquidity
-            .checked_mul(U256::from(pool.reserve_user_token))
-            .and_then(|product| product.checked_div(total_supply))
-            .ok_or(TempoPrecompileError::under_overflow())?;
+            .try_mul(U256::from(pool.reserve_user_token))?
+            .try_div(total_supply)?;
         let amount_validator_token = liquidity
-            .checked_mul(U256::from(pool.reserve_validator_token))
-            .and_then(|product| product.checked_div(total_supply))
-            .ok_or(TempoPrecompileError::under_overflow())?;
+            .try_mul(U256::from(pool.reserve_validator_token))?
+            .try_div(total_supply)?;
 
         Ok((amount_user_token, amount_validator_token))
     }
@@ -583,14 +549,8 @@ impl TipFeeManager {
             .try_into()
             .map_err(|_| TempoPrecompileError::under_overflow())?;
 
-        pool.reserve_user_token = pool
-            .reserve_user_token
-            .checked_add(amount_in_u128)
-            .ok_or(TempoPrecompileError::under_overflow())?;
-        pool.reserve_validator_token = pool
-            .reserve_validator_token
-            .checked_sub(amount_out_u128)
-            .ok_or(TempoPrecompileError::under_overflow())?;
+        pool.reserve_user_token = pool.reserve_user_token.try_add(amount_in_u128)?;
+        pool.reserve_validator_token = pool.reserve_validator_token.try_sub(amount_out_u128)?;
 
         self.pools[pool_id].write(pool)?;
 

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -6,6 +6,7 @@ pub mod amm;
 pub mod dispatch;
 
 use crate::{
+    CheckedMath,
     error::{Result, TempoPrecompileError},
     storage::{Handler, Mapping},
     tip_fee_manager::amm::{FeeRoute, Pool, compute_amount_out},
@@ -276,11 +277,7 @@ impl TipFeeManager {
         }
 
         let collected_fees = self.collected_fees[validator][token].read()?;
-        self.collected_fees[validator][token].write(
-            collected_fees
-                .checked_add(amount)
-                .ok_or(TempoPrecompileError::under_overflow())?,
-        )?;
+        self.collected_fees[validator][token].write(collected_fees.try_add(amount)?)?;
 
         Ok(())
     }


### PR DESCRIPTION
this PR introduces a new `CheckedMath` trait, which provides built-in versions of the common `checked_<add/sub/mul/div>(rhs).ok_or_else(TempoPrecompileError::under_overflow())?;` pattern.

call sites are now much more compact and we can directly propagate the errors with `try_<add/sub/mul/div>?;`

additionally, it changes the return type of `fn base_to_quote` from `Option<u128>` to `Result<u128>` so that we can propagate directly without passing `TempoPrecompileError::under_overflow()`