### PR TITLE
Fix typo in enum and bit range notation

### DIFF
--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -138,13 +138,13 @@ mapping(address => address) public addressRecoveryAuthority;
 | `65..72` | 8 | `senderPolicyType` |
 | `73..136` | 64 | `tokenFilterId` |
 | `137..144` | 8 | `tokenFilterType` |
-| `145-152` | 8 | `recoveryMode` |
+| `145..152` | 8 | `recoveryMode` |
 | `153..255` | 102 | reserved, MUST be zero |
 
 When `hasReceivePolicy == 0`, the address has no receive policy and all transfers and mints are allowed. The cached type fields are valid because policy type and token filter type are immutable after creation.
 
 for gas efficiency purposes, the packed struct holds a `recoveryMode` enum (`uint8`), which indicates the recovery authority:
-`RecoveryMode::Originator`, `RecoveryMode::Receiver`, or `RecoveryMode:ThirdParty`. When the recovery authority is a third-party, the protocol also stores its address in a dedicated slot `addressRecoveryAuthority[account]`.
+`RecoveryMode::Originator`, `RecoveryMode::Receiver`, or `RecoveryMode::ThirdParty`. When the recovery authority is a third-party, the protocol also stores its address in a dedicated slot `addressRecoveryAuthority[account]`.
 
 `recoveryAuthority` is stored separately because a 160-bit address does not fit in the packed config slot.
 


### PR DESCRIPTION
Two corrections in `tip-1028`:

1. Changed `RecoveryMode:ThirdParty` to `RecoveryMode::ThirdParty` for consistency with other enum variants.

2. Changed bit range `145-152` to `145..152` to unify notation within the same table.