### PR TITLE
docs(tip-1059): explain discounted gas price overrides

### DIFF
--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -489,6 +489,9 @@ impl ReceiptConverter<TempoPrimitives> for TempoReceiptConverter {
                     })
                     && gas_used <= SSTORE_SET_COST
                 {
+                    // For pure TIP-20 payment transactions, patch the transaction-derived
+                    // `effective_gas_price` with TIP-1059's settlement discount:
+                    // https://github.com/tempoxyz/tempo/blob/main/tips/tip-1059.md#applying-the-discount
                     receipt.effective_gas_price = u128::from(TEMPO_T6_DISCOUNTED_PAYMENT_GAS_PRICE);
                 }
 

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1457,6 +1457,9 @@ where
         let gas = exec_result.gas();
         let gas_used = gas.used().saturating_sub(gas.reservoir());
         if context.cfg.spec.is_t6() && tx.is_discounted_payment() && gas_used <= SSTORE_SET_COST {
+            // For pure TIP-20 payment transactions, patch the transaction-derived effective gas
+            // price with TIP-1059's post-execution settlement discount before calculating actual spending:
+            // https://github.com/tempoxyz/tempo/blob/main/tips/tip-1059.md#applying-the-discount
             effective_gas_price = u128::from(TEMPO_T6_DISCOUNTED_PAYMENT_GAS_PRICE);
         }
 

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -162,7 +162,13 @@ impl TempoTxEnv {
         }
     }
 
-    /// Returns true if this transaction satisfies the TIP-1059 discounted-payment allow-list.
+    /// Returns true if this transaction satisfies the TIP-1059 discounted-payment call allow-list.
+    ///
+    /// This checks only the transaction shape: no access list, no EIP-7702 authorizations, and
+    /// either one direct TIP-20 payment call or a non-empty AA batch where every call is an eligible
+    /// TIP-20 payment call. T6 activation and the gas-used cap are enforced by the caller.
+    ///
+    /// See: <https://github.com/tempoxyz/tempo/blob/main/tips/tip-1059.md#eligibility-rules>
     pub fn is_discounted_payment(&self) -> bool {
         if self
             .access_list()


### PR DESCRIPTION
Stacked on #4139.

Adds short comments explaining where TIP-1059 discounted payment settlement overrides the transaction-derived effective gas price in execution reimbursement and RPC receipts.

Also expands the transaction predicate docs with the discounted-payment eligibility reference.