### PR TITLE
perf(builder): enable sparse trie sharing by default

### DIFF
--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -169,7 +169,7 @@ fn init_download_urls() {
 fn init_payload_builder_defaults() {
     DefaultPayloadBuilderValues::default()
         .with_interval(Duration::from_millis(100))
-        .with_max_payload_tasks(16)
+        .with_max_payload_tasks(1)
         .with_deadline(4)
         .try_init()
         .expect("failed to initialize payload builder defaults");
@@ -211,6 +211,7 @@ fn init_engine_defaults() {
         .with_always_process_payload_attributes_on_canonical_head(true)
         // Defer persistence I/O during active payload builds.
         .with_suppress_persistence_during_build(true)
+        .with_share_sparse_trie_with_payload_builder(true)
         .try_init()
         .expect("failed to initialize engine defaults");
 }

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -743,25 +743,34 @@ fn main() -> eyre::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{sync::Once, time::Duration};
 
     use clap::Parser;
 
-    use super::{Commands, TempoCli};
+    use super::{Commands, TempoCli, defaults};
+
+    fn init_defaults_once() {
+        static INIT: Once = Once::new();
+        INIT.call_once(defaults::init_defaults);
+    }
 
     #[test]
     fn transaction_execution_wait_default_depends_on_sparse_trie_sharing() {
+        init_defaults_once();
+
         let cli = TempoCli::try_parse_from(["tempo", "node", "--dev"]).unwrap();
         let Commands::Node(node_cmd) = cli.command else {
             panic!("expected node command");
         };
+        assert!(node_cmd.engine.share_sparse_trie_with_payload_builder);
+        assert_eq!(node_cmd.builder.max_payload_tasks, 1);
         assert_eq!(
             node_cmd
                 .ext
                 .consensus
                 .time_to_prepare_proposal_transactions
                 .into_duration(),
-            Duration::from_millis(200)
+            Duration::from_millis(350)
         );
 
         let cli = TempoCli::try_parse_from([


### PR DESCRIPTION
## Summary
- enable sparse trie sharing with the payload builder by default
- set the payload builder max task default to 1 to satisfy the sparse-trie sharing constraint
- update the CLI default test to initialize Tempo defaults and assert the new behavior

## Tests
- cargo fmt --check
- cargo test -p tempo transaction_execution_wait_default_depends_on_sparse_trie_sharing

Prompted by: @joshieDo