### PR TITLE
docs(tip-1034): explain close cumulative amount

### DIFF
--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -228,6 +228,12 @@ amount, while `captureAmount` chooses the final reserve-bounded payout. `settle`
 separate capture parameter, so its `cumulativeAmount` is the exact new settled amount and MUST
 remain bounded by the current deposit.
 
+This lets a payee recover the remaining reserve when it accepted a voucher whose cumulative amount
+exceeds the current deposit, rather than forcing the terminal close to revert. It also preserves
+support for partial authorization and capture flows where the payer can authorize a larger future
+amount than is presently reserved, while correct payee implementations still check the on-chain
+deposit before accepting a voucher.
+
 ## Native Reserve Movement
 
 In this precompile, reserve transfers MUST use system TIP-20 movement semantics equivalent to `systemTransferFrom`.


### PR DESCRIPTION
Documents why TIP-1034 allows close vouchers whose cumulative amount exceeds the current deposit. The actual capture remains deposit-bounded, while this keeps terminal close available for remaining reserve recovery and partial auth/capture flows.