### PR TITLE
chore: pin reth to paradigmxyz/reth#24355

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8394,7 +8394,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8421,7 +8421,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8454,7 +8454,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8474,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8487,7 +8487,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8570,7 +8570,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8580,7 +8580,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8633,7 +8633,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8663,7 +8663,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8676,7 +8676,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8701,7 +8701,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8730,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8756,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8786,7 +8786,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8826,7 +8826,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8850,7 +8850,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8874,7 +8874,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8909,7 +8909,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -8966,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8994,7 +8994,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9017,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9101,7 +9101,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9131,7 +9131,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9163,7 +9163,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9185,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9196,7 +9196,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9224,7 +9224,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9246,7 +9246,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9287,7 +9287,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "clap",
  "eyre",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9326,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9342,7 +9342,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9355,7 +9355,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9385,7 +9385,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9409,7 +9409,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9433,7 +9433,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9453,7 +9453,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9471,7 +9471,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9484,7 +9484,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9503,7 +9503,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9541,7 +9541,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -9555,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "serde",
  "serde_json",
@@ -9565,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9593,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "bytes",
  "futures",
@@ -9613,7 +9613,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9630,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "bindgen",
  "cc",
@@ -9639,7 +9639,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "futures",
  "metrics",
@@ -9652,7 +9652,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9661,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9733,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9758,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9781,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9796,7 +9796,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9810,7 +9810,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9827,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9851,7 +9851,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9919,7 +9919,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -9974,7 +9974,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-network",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10041,7 +10041,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10065,7 +10065,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "bytes",
  "eyre",
@@ -10094,7 +10094,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10106,7 +10106,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10130,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10142,7 +10142,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10165,7 +10165,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10208,7 +10208,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10257,7 +10257,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10286,7 +10286,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10302,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10317,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10393,7 +10393,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -10423,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10466,7 +10466,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10486,7 +10486,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -10517,7 +10517,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10545,6 +10545,7 @@ dependencies = [
  "reth-network-api",
  "reth-node-api",
  "reth-primitives-traits",
+ "reth-prune-types",
  "reth-revm",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
@@ -10563,7 +10564,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10572,6 +10573,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
+ "alloy-serde 2.0.5",
  "alloy-sol-types",
  "alloy-transport",
  "derive_more",
@@ -10611,7 +10613,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10625,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -10656,7 +10658,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10708,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -10736,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10750,7 +10752,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10770,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10785,7 +10787,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10810,7 +10812,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -10828,7 +10830,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10849,7 +10851,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10865,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10875,7 +10877,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "clap",
  "eyre",
@@ -10894,7 +10896,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10913,7 +10915,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10958,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
@@ -10984,7 +10986,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11011,7 +11013,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11031,7 +11033,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11060,7 +11062,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef649aa#ef649aa1c8f1f90222292c1d5b4edeae13604f18"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "ef649aa", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -23,7 +23,7 @@ use reth_transaction_pool::{
     TransactionEvents, TransactionOrigin, TransactionPool, TransactionPoolExt,
     TransactionValidationOutcome, TransactionValidationTaskExecutor, TransactionValidator,
     ValidPoolTransaction,
-    blobstore::InMemoryBlobStore,
+    blobstore::{BlobStore, InMemoryBlobStore},
     error::{PoolError, PoolErrorKind},
     identifier::TransactionId,
 };
@@ -1143,6 +1143,10 @@ where
     > {
         self.protocol_pool
             .get_blobs_for_versioned_hashes_v4(versioned_hashes, indices_bitarray)
+    }
+
+    fn blob_store(&self) -> Box<dyn BlobStore> {
+        Box::new(self.protocol_pool.blob_store().clone())
     }
 }
 


### PR DESCRIPTION
Pins workspace Reth git dependencies to paradigmxyz/reth#24355 and refreshes Cargo.lock. Also forwards the new TransactionPool::blob_store method to the delegated protocol pool so Tempo continues to compile.