### PR TITLE
Use binary target for Foundry forge builds

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -245,7 +245,7 @@ jobs:
       - name: Build foundry forge with coverage instrumentation
         if: needs.check-precompiles.outputs.coverage == 'true'
         working-directory: foundry
-        run: RUSTFLAGS="-C instrument-coverage" cargo build -p forge --profile release --no-default-features
+        run: RUSTFLAGS="-C instrument-coverage" cargo build --bin forge --profile release --no-default-features
 
       - name: Run Forge tests with Rust precompiles (with coverage)
         if: needs.check-precompiles.outputs.coverage == 'true'
@@ -258,7 +258,7 @@ jobs:
       - name: Build foundry forge
         if: needs.check-precompiles.outputs.coverage != 'true'
         working-directory: foundry
-        run: cargo build -p forge --profile release --no-default-features
+        run: cargo build --bin forge --profile release --no-default-features
 
       - name: Run Forge tests with Rust precompiles
         if: needs.check-precompiles.outputs.coverage != 'true'

--- a/tempo.nu
+++ b/tempo.nu
@@ -2903,7 +2903,7 @@ tempo-precompiles = { path = '($tempo_root)/crates/precompiles' }
                 # Update Cargo.lock to resolve patched crate versions
                 cargo update
                 with-env { RUSTFLAGS: "-C instrument-coverage", RUSTC_WRAPPER: "" } {
-                    cargo build -p forge --profile release
+                    cargo build --bin forge --profile release
                 }
             }
         } catch { |e|


### PR DESCRIPTION
## Summary
- Build Foundry forge by binary target in specs CI
- Update local coverage tooling to use the same binary-target pattern
- Avoid future package-name ambiguity in Foundry workspace builds

## Test
- rg -n "cargo build.*-p (forge|cast|anvil)|cargo build.*--package (forge|cast|anvil)|-p forge|-p cast|-p anvil" /home/agent/branches/tempoxyz/tempo /home/agent/branches/tempoxyz/workflows -S || true
- cargo build --bin forge --profile release --no-default-features --quiet # against current foundry-rs/foundry master

Prompted by: @grandizzy