### PR TITLE
Restrict witness burning to admin keys

### DIFF
--- a/crates/contracts/src/precompiles/account_keychain.rs
+++ b/crates/contracts/src/precompiles/account_keychain.rs
@@ -127,7 +127,7 @@ crate::sol! {
         ) external;
 
         /// Burn a TIP-1053 key-authorization witness without authorizing a key.
-        /// @dev Callable by the account root key or an active access key.
+        /// @dev Callable only by the account admin key.
         function burnKeyAuthorizationWitness(bytes32 witness) external;
 
         /// Revoke an authorized key

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -326,7 +326,7 @@ impl AccountKeychain {
         msg_sender: Address,
         call: burnKeyAuthorizationWitnessCall,
     ) -> Result<()> {
-        self.ensure_account_caller(msg_sender, true)?;
+        self.ensure_admin_caller(msg_sender)?;
         self.burn_key_authorization_witness_value(msg_sender, call.witness)
     }
 
@@ -997,18 +997,9 @@ impl AccountKeychain {
     /// `tx_origin` is seeded by the handler before validation/execution.
     /// If origin is not seeded (zero), admin ops are rejected.
     fn ensure_admin_caller(&self, msg_sender: Address) -> Result<()> {
-        self.ensure_account_caller(msg_sender, false)
-    }
-
-    fn ensure_account_caller(&self, msg_sender: Address, allow_active_key: bool) -> Result<()> {
         let transaction_key = self.transaction_key.t_read()?;
         if !transaction_key.is_zero() {
-            if allow_active_key {
-                let current_timestamp = self.storage.timestamp().saturating_to::<u64>();
-                self.load_active_key(msg_sender, transaction_key, current_timestamp)?;
-            } else {
-                return Err(AccountKeychainError::unauthorized_caller().into());
-            }
+            return Err(AccountKeychainError::unauthorized_caller().into());
         }
 
         if self.storage.spec().is_t2() {
@@ -1564,7 +1555,7 @@ mod tests {
     }
 
     #[test]
-    fn test_t5_access_key_can_burn_key_authorization_witness() -> eyre::Result<()> {
+    fn test_t5_access_key_cannot_burn_key_authorization_witness() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T5);
         let account = Address::random();
         let access_key = Address::random();
@@ -1586,12 +1577,16 @@ mod tests {
             )?;
 
             keychain.set_transaction_key(access_key)?;
-            keychain.burn_key_authorization_witness(
+            let result = keychain.burn_key_authorization_witness(
                 account,
                 burnKeyAuthorizationWitnessCall { witness },
-            )?;
+            );
 
-            assert!(keychain.is_key_authorization_witness_burned(
+            assert_unauthorized_error(
+                result.expect_err("access key must not burn authorization witness"),
+            );
+
+            assert!(!keychain.is_key_authorization_witness_burned(
                 isKeyAuthorizationWitnessBurnedCall { account, witness }
             )?);
 

--- a/tips/tip-1053.md
+++ b/tips/tip-1053.md
@@ -94,7 +94,7 @@ This gives users and wallets a clean recovery primitive when:
 - A signed authorization is lost or leaked before submission.
 - A user wants to supersede an outstanding authorization with a new one for the same `key_id`.
 
-Burning is restricted to the account itself (or any key authorized to act on its behalf, subject to that key's scope rules).
+Burning is restricted to the account admin key. Access keys MUST NOT burn authorization witnesses, even if active and otherwise authorized to act on the account's behalf.
 
 ## Verification
 
@@ -136,3 +136,5 @@ The `witness` format is application-defined when used as a challenge digest. The
 3. **Manual burn.** For any account `A` and any present `witness` value `w`, a successful burn of `(A, w)` MUST cause later `key_authorization` registrations carrying `(A, w)` to revert.
 
 4. **No happy-path consumption.** A successful witness-bearing `key_authorization` MUST NOT burn `(account, witness)`.
+
+5. **Admin-only burn.** A witness burn MUST fail when submitted through an access key.


### PR DESCRIPTION
## Summary
- restrict TIP-1053 key-authorization witness burns to admin-key transactions
- reject access-key witness burns with the existing unauthorized-caller path
- update TIP-1053 and AccountKeychain interface docs

## Tests
- cargo test -p tempo-precompiles account_keychain::tests::test_t5_ --features test-utils
- cargo fmt --check
- git diff --check