### PR TITLE
test: snapshot pre-T6 TIP20 memo transfer gas

### DIFF
--- a/crates/node/tests/it/gas/helpers.rs
+++ b/crates/node/tests/it/gas/helpers.rs
@@ -244,6 +244,12 @@ impl TempoCalls {
     }
 
     #[allow(dead_code)]
+    pub(crate) fn gas_limit(mut self, gas_limit: u64) -> Self {
+        self.gas_limit = gas_limit;
+        self
+    }
+
+    #[allow(dead_code)]
     pub(crate) fn expect_existing_nonce(mut self) -> Self {
         self.expect_existing_nonce = true;
         self

--- a/crates/node/tests/it/gas/snapshots/it__gas__tip20_transfers__tip20_transfer_with_memo_t0_gas_snapshot.snap
+++ b/crates/node/tests/it/gas/snapshots/it__gas__tip20_transfers__tip20_transfer_with_memo_t0_gas_snapshot.snap
@@ -1,0 +1,5 @@
+---
+source: crates/node/tests/it/gas/tip20_transfers.rs
+expression: gas
+---
+t0_transfer_with_memo: 72295

--- a/crates/node/tests/it/gas/tip20_transfers.rs
+++ b/crates/node/tests/it/gas/tip20_transfers.rs
@@ -3,7 +3,7 @@ use alloy::{
     providers::Provider,
     sol_types::SolEvent,
 };
-use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
+use tempo_chainspec::{hardfork::TempoHardfork, spec::TEMPO_T1_BASE_FEE};
 use tempo_contracts::precompiles::{
     IAddressRegistry, ITIP20, ITIP403Registry, ITIPFeeAMM, TIP_FEE_MANAGER_ADDRESS,
 };
@@ -19,7 +19,7 @@ use super::helpers::{
 };
 use crate::{
     gas::helpers::Receipt,
-    utils::{TestNodeBuilder, setup_test_token},
+    utils::{TestNodeBuilder, make_genesis_at, setup_test_token},
 };
 
 const MINT_AMOUNT: u64 = 1_000_000;
@@ -621,6 +621,52 @@ async fn test_tip20_transfer_gas_snapshots() -> eyre::Result<()> {
     let gas = run_tip20_transfer_gas_cases(&mut env, tip20_transfer_gas_cases()).await?;
 
     print_gas_snapshot("TIP20 transfer gas snapshot", &gas);
+    insta::assert_yaml_snapshot!(gas);
+
+    Ok(())
+}
+
+/// T6 TIP20 balance storage changes must not leak into pre-activation hardfork gas accounting.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tip20_transfer_with_memo_t0_gas_snapshot() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = TestNodeBuilder::new()
+        .with_genesis(make_genesis_at(TempoHardfork::T0))
+        .build_http_only()
+        .await?;
+    let mut sender = TempoTxSender::connect(setup.http_url, test_signer(0)?).await?;
+    let token = setup_test_token(sender.provider.clone(), sender.address()).await?;
+    sender.sync_nonce().await?;
+
+    TempoCalls::new()
+        .gas_limit(1_000_000)
+        .push(
+            *token.address(),
+            ITIP20::mintCall {
+                to: sender.address(),
+                amount: U256::from(1_000u64),
+            },
+        )
+        .send(&mut sender)
+        .await?;
+
+    let mut gas = GasSnapshot::new();
+    let receipt = TempoCalls::new()
+        .gas_limit(1_000_000)
+        .push(
+            *token.address(),
+            ITIP20::transferWithMemoCall {
+                to: fixed_signer(0x22).address(),
+                amount: U256::from(100u64),
+                memo: FixedBytes::repeat_byte(0x59),
+            },
+        )
+        .send(&mut sender)
+        .await?;
+    gas.record("t0_transfer_with_memo", receipt.gas_used);
+
+    print_gas_snapshot("TIP20 T0 transferWithMemo gas snapshot", &gas);
     insta::assert_yaml_snapshot!(gas);
 
     Ok(())


### PR DESCRIPTION
Add a T0 integration gas snapshot for TIP20 transferWithMemo so balance storage layout changes introduced for later hardforks cannot silently alter pre-activation gas accounting. The case uses the existing gas snapshot suite and a custom gas limit for T0's lower transaction cap.