### PR TITLE
chore: spawn txpool maintenace as blocking thread

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -473,7 +473,8 @@ where
 
         // Spawn unified Tempo pool maintenance task
         // This consolidates: expired AA txs, 2D nonce updates, AMM cache, and keychain revocations
-        ctx.task_executor().spawn_critical_task(
+        ctx.task_executor().spawn_critical_os_thread(
+            "tempo-txpool-maintenance",
             "txpool maintenance - tempo pool",
             tempo_transaction_pool::maintain::maintain_tempo_pool(transaction_pool.clone()),
         );


### PR DESCRIPTION
when processing new blocks txpool maintenace might block for 10s of milliseconds which is way too long for a task spawned on a non-blocking pool

this PR changes it to be spawned on its own thread which should mitigate its impact on runtime and make profiles more useful