### PR TITLE
perf(transaction-pool): gate keychain subject eviction checks

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -223,15 +223,20 @@ impl TempoPoolUpdates {
 
     /// Returns true if there are any invalidation events that require scanning the pool.
     pub fn has_invalidation_events(&self) -> bool {
-        !self.revoked_keys.is_empty()
-            || !self.spending_limit_changes.is_empty()
-            || !self.spending_limit_spends.is_empty()
+        self.has_keychain_subject_updates()
             || !self.validator_token_changes.is_empty()
             || !self.user_token_changes.is_empty()
             || !self.blacklist_additions.is_empty()
             || !self.whitelist_removals.is_empty()
             || !self.fee_balance_changes.is_empty()
             || !self.key_authorization_witness_burns.is_empty()
+    }
+
+    /// Returns true if updates may invalidate keychain-signature transactions.
+    pub fn has_keychain_subject_updates(&self) -> bool {
+        !self.revoked_keys.is_empty()
+            || !self.spending_limit_changes.is_empty()
+            || !self.spending_limit_spends.is_empty()
     }
 }
 
@@ -741,9 +746,7 @@ where
                 }
 
                 // 5. Evict revoked keys and spending limit updates from paused pool
-                if !updates.revoked_keys.is_empty()
-                    || !updates.spending_limit_changes.is_empty()
-                    || !updates.spending_limit_spends.is_empty()
+                if updates.has_keychain_subject_updates()
                     || !updates.key_authorization_witness_burns.is_empty()
                 {
                     state.paused_pool.evict_invalidated(

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -200,54 +200,57 @@ where
         let mut blacklisted_count = 0;
         let mut unwhitelisted_count = 0;
         let mut insolvent_fee_payer_count = 0;
+        let has_keychain_subject_updates = updates.has_keychain_subject_updates();
         let mut fee_balance_cache: HashMap<(Address, Address), U256> = HashMap::default();
 
         let all_txs = self.all_transactions();
         for tx in all_txs.pending.iter().chain(all_txs.queued.iter()) {
-            // Extract keychain subject once per transaction (if applicable)
-            let keychain_subject = tx.transaction.keychain_subject();
+            // Avoid recovering key ids unless a keychain invalidation can use them.
+            if has_keychain_subject_updates {
+                let keychain_subject = tx.transaction.keychain_subject();
 
-            // Check 1: Revoked keychain keys
-            if !updates.revoked_keys.is_empty()
-                && let Some(ref subject) = keychain_subject
-                && subject.matches_revoked(&updates.revoked_keys)
-            {
-                to_remove.push(*tx.hash());
-                revoked_count += 1;
-                continue;
-            }
+                // Check 1: Revoked keychain keys
+                if !updates.revoked_keys.is_empty()
+                    && let Some(ref subject) = keychain_subject
+                    && subject.matches_revoked(&updates.revoked_keys)
+                {
+                    to_remove.push(*tx.hash());
+                    revoked_count += 1;
+                    continue;
+                }
 
-            // Check 2: Spending limit updates
-            // Only evict if the transaction's fee token matches the token whose limit changed.
-            if !updates.spending_limit_changes.is_empty()
-                && let Some(ref subject) = keychain_subject
-                && subject.matches_spending_limit_update(&updates.spending_limit_changes)
-            {
-                to_remove.push(*tx.hash());
-                spending_limit_count += 1;
-                continue;
-            }
+                // Check 2: Spending limit updates
+                // Only evict if the transaction's fee token matches the token whose limit changed.
+                if !updates.spending_limit_changes.is_empty()
+                    && let Some(ref subject) = keychain_subject
+                    && subject.matches_spending_limit_update(&updates.spending_limit_changes)
+                {
+                    to_remove.push(*tx.hash());
+                    spending_limit_count += 1;
+                    continue;
+                }
 
-            // Check 2b: Spending limit spends
-            // AccessKeySpend receipt logs identify the exact (account, key_id, token)
-            // triples whose remaining limit changed during execution. We re-read the
-            // current remaining limit from state for matching pending txs and evict if
-            // the tx's fee cost now exceeds that remaining limit.
-            if !updates.spending_limit_spends.is_empty()
-                && let Some(ref subject) = keychain_subject
-                && subject.matches_spending_limit_update(&updates.spending_limit_spends)
-                && let Some(ref mut provider) = state_provider
-                && exceeds_spending_limit(
-                    provider,
-                    subject,
-                    tx.transaction.fee_token_cost(),
-                    tip_timestamp,
-                    spec,
-                )
-            {
-                to_remove.push(*tx.hash());
-                spending_limit_spend_count += 1;
-                continue;
+                // Check 2b: Spending limit spends
+                // AccessKeySpend receipt logs identify the exact (account, key_id, token)
+                // triples whose remaining limit changed during execution. We re-read the
+                // current remaining limit from state for matching pending txs and evict if
+                // the tx's fee cost now exceeds that remaining limit.
+                if !updates.spending_limit_spends.is_empty()
+                    && let Some(ref subject) = keychain_subject
+                    && subject.matches_spending_limit_update(&updates.spending_limit_spends)
+                    && let Some(ref mut provider) = state_provider
+                    && exceeds_spending_limit(
+                        provider,
+                        subject,
+                        tx.transaction.fee_token_cost(),
+                        tip_timestamp,
+                        spec,
+                    )
+                {
+                    to_remove.push(*tx.hash());
+                    spending_limit_spend_count += 1;
+                    continue;
+                }
             }
 
             // Check 2c: TIP-1053 key-authorization witness burns


### PR DESCRIPTION
Adds a `TempoPoolUpdates` predicate for keychain-subject invalidations and gates keychain subject derivation in eviction scans. This avoids recovering key ids for blocks whose updates cannot use them, while keeping paused-pool invalidation on the same predicate.

Best reviewed with hidden whitespace