### PR TITLE
perf(transaction-pool): cache fee token cost

### DIFF
--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -31,6 +31,8 @@ use thiserror::Error;
 #[derive(Debug, Clone)]
 pub struct TempoPooledTransaction {
     inner: EthPooledTransaction<TempoTxEnvelope>,
+    /// Cached cost of the transaction in the fee token.
+    fee_token_cost: U256,
     /// Cached payment classification for efficient block building
     is_payment: bool,
     /// Precomputed sender-scoped hash used to deduplicate expiring nonce transactions.
@@ -68,17 +70,19 @@ impl TempoPooledTransaction {
                 .is_expiring_nonce_tx()
                 .then(|| tx.expiring_nonce_hash(sender))
         });
+        let value = transaction.value();
+        let cost =
+            calc_gas_balance_spending(transaction.gas_limit(), transaction.max_fee_per_gas())
+                .saturating_add(value);
+        let fee_token_cost = cost - value;
         Self {
             inner: EthPooledTransaction {
-                cost: calc_gas_balance_spending(
-                    transaction.gas_limit(),
-                    transaction.max_fee_per_gas(),
-                )
-                .saturating_add(transaction.value()),
+                cost,
                 encoded_length: transaction.encode_2718_len(),
                 blob_sidecar: EthBlobTransactionSidecar::None,
                 transaction,
             },
+            fee_token_cost,
             is_payment,
             expiring_nonce_hash,
             nonce_key_slot: OnceLock::new(),
@@ -92,8 +96,8 @@ impl TempoPooledTransaction {
 
     /// Get the cost of the transaction in the fee token.
     #[inline]
-    pub fn fee_token_cost(&self) -> U256 {
-        self.inner.cost - self.inner.value()
+    pub const fn fee_token_cost(&self) -> U256 {
+        self.fee_token_cost
     }
 
     /// Returns a reference to inner [`TempoTxEnvelope`].
@@ -801,6 +805,7 @@ mod tests {
         //              = (1_000_000 * 20_000_000_000) / 1_000_000_000_000 = 20000
         let expected_fee_cost = U256::from(20000);
         assert_eq!(tx.fee_token_cost(), expected_fee_cost);
+        assert_eq!(tx.fee_token_cost, expected_fee_cost);
         assert_eq!(tx.inner.cost, expected_fee_cost + value);
     }
 


### PR DESCRIPTION
Reapplies #4180 on latest `main`, caching `TempoPooledTransaction`'s fee-token cost at construction and returning that cached value from `fee_token_cost()`.

This avoids repeated `U256` subtraction in a quite hot payloadbuilding path: `try_build` pulls the pool iterator into payload construction ([code](https://github.com/tempoxyz/tempo/blob/1192619a8d05dc52ad1e8f8bafd2e28df1f21e2f/crates/payload/builder/src/lib.rs#L183-L190)), `build_payload` wraps it with `StateAwareBestTransactions` ([code](https://github.com/tempoxyz/tempo/blob/1192619a8d05dc52ad1e8f8bafd2e28df1f21e2f/crates/payload/builder/src/lib.rs#L442-L463)), and that iterator calls `fee_token_cost()` while filtering transactions after balance decreases ([code](https://github.com/tempoxyz/tempo/blob/1192619a8d05dc52ad1e8f8bafd2e28df1f21e2f/crates/transaction-pool/src/best.rs#L158-L175)). See the [profile](https://profiler.firefox.com/public/fzd0g7qgxj3w0phrf520c7zhcdry61k1bmkbs38/flame-graph/?globalTrackOrder=0w3&hiddenGlobalTracks=01&thread=Me&transforms=ff-24972&v=16).