### PR TITLE
ci(bench): fix scheduled replay state scoping

### DIFF
--- a/.github/scripts/bench-replay-scheduled-refs.sh
+++ b/.github/scripts/bench-replay-scheduled-refs.sh
@@ -24,11 +24,21 @@ set -euxo pipefail
 FORCE="${1:-false}"
 REPO="${GITHUB_REPOSITORY:-tempoxyz/tempo}"
 STATE_REPO="${BENCH_REPLAY_STATE_REPO:-decofe/tempo-bench-charts}"
-STATE_FILE="${BENCH_REPLAY_STATE_FILE:-state/replay-nightly-last-feature-ref}"
+CHAIN="${BENCH_REPLAY_CHAIN:-mainnet}"
+STATE_FILE="${BENCH_REPLAY_STATE_FILE:-state/replay-nightly-${CHAIN}-last-feature-ref}"
 STALE_THRESHOLD_HOURS="${BENCH_REPLAY_STALE_THRESHOLD_HOURS:-24}"
+
+case "$CHAIN" in
+  mainnet|testnet) ;;
+  *)
+    echo "::error::Unknown chain value for replay state: $CHAIN"
+    exit 1
+    ;;
+esac
 
 echo "Force: $FORCE"
 echo "Repository: $REPO"
+echo "Chain: $CHAIN"
 
 # --- Step 1: Query latest successful scheduled docker.yml run ---
 echo "::group::Querying latest nightly docker build"

--- a/.github/workflows/bench-replay-scheduled.yml
+++ b/.github/workflows/bench-replay-scheduled.yml
@@ -140,6 +140,7 @@ jobs:
           DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           INPUT_FORCE: ${{ inputs.force || 'false' }}
+          BENCH_REPLAY_CHAIN: ${{ steps.config.outputs.chain }}
         run: bash .github/scripts/bench-replay-scheduled-refs.sh "$INPUT_FORCE"
 
       - name: Alert on stale nightly
@@ -257,9 +258,11 @@ jobs:
         env:
           DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
           FEATURE_REF: ${{ needs.resolve-refs.outputs.feature-ref }}
+          BENCH_REPLAY_CHAIN: ${{ needs.resolve-refs.outputs.chain }}
         run: |
           CHARTS_REPO="https://x-access-token:${DEREK_TOKEN}@github.com/decofe/tempo-bench-charts.git"
           TMP_DIR=$(mktemp -d)
+          STATE_FILE="replay-nightly-${BENCH_REPLAY_CHAIN}-last-feature-ref"
 
           if git clone --depth 1 --branch state "${CHARTS_REPO}" "${TMP_DIR}" 2>/dev/null; then
             true
@@ -269,10 +272,10 @@ jobs:
           fi
 
           mkdir -p "${TMP_DIR}/state"
-          echo "${FEATURE_REF}" > "${TMP_DIR}/state/replay-nightly-last-feature-ref"
+          echo "${FEATURE_REF}" > "${TMP_DIR}/state/${STATE_FILE}"
           git -C "${TMP_DIR}" add state/
           git -C "${TMP_DIR}" diff --cached --quiet && echo "No state change" && exit 0
           git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
-            commit -m "bench: update replay nightly state to ${FEATURE_REF}"
+            commit -m "bench: update ${BENCH_REPLAY_CHAIN} replay nightly state to ${FEATURE_REF}"
           git -C "${TMP_DIR}" push origin HEAD:state
           rm -rf "${TMP_DIR}"


### PR DESCRIPTION
## Summary
- Scope scheduled replay persisted state by chain.
- Read and write `state/replay-nightly-mainnet-last-feature-ref` or `state/replay-nightly-testnet-last-feature-ref`.
- Validate the resolver chain value before reading state.

## Testing
- `bash -n .github/scripts/bench-replay-scheduled-refs.sh`
- `BENCH_REPLAY_CHAIN=bogus GITHUB_OUTPUT=/tmp/out GH_TOKEN=x DEREK_TOKEN=x bash .github/scripts/bench-replay-scheduled-refs.sh false` exits with `::error::Unknown chain value for replay state: bogus`

Prompted by: @shekhirin