### PR TITLE
perf(builder): enable execution cache sharing

### DIFF
--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -211,6 +211,7 @@ fn init_engine_defaults() {
         .with_always_process_payload_attributes_on_canonical_head(true)
         // Defer persistence I/O during active payload builds.
         .with_suppress_persistence_during_build(true)
+        .with_share_execution_cache_with_payload_builder(true)
         .try_init()
         .expect("failed to initialize engine defaults");
 }

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -743,18 +743,26 @@ fn main() -> eyre::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{sync::Once, time::Duration};
 
     use clap::Parser;
 
-    use super::{Commands, TempoCli};
+    use super::{Commands, TempoCli, defaults};
+
+    fn init_defaults_once() {
+        static INIT: Once = Once::new();
+        INIT.call_once(defaults::init_defaults);
+    }
 
     #[test]
     fn transaction_execution_wait_default_depends_on_sparse_trie_sharing() {
+        init_defaults_once();
+
         let cli = TempoCli::try_parse_from(["tempo", "node", "--dev"]).unwrap();
         let Commands::Node(node_cmd) = cli.command else {
             panic!("expected node command");
         };
+        assert!(node_cmd.engine.share_execution_cache_with_payload_builder);
         assert_eq!(
             node_cmd
                 .ext


### PR DESCRIPTION
## Summary
- enable execution cache sharing with the payload builder by default
- initialize Tempo defaults in the CLI defaults test
- assert parsed node args enable execution cache sharing

## Tests
- cargo fmt --check
- cargo test -p tempo transaction_execution_wait_default_depends_on_sparse_trie_sharing

Prompted by: @joshieDo