### PR TITLE
fix(txpool): use resolved fee token in maintenance

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -640,14 +640,18 @@ where
                 if !pause_tokens.is_empty() {
                     let all_txs = pool.all_transactions();
 
-                    // Group transactions by fee token for efficient batch processing.
+                    // Group transactions by effective fee token for efficient batch processing.
                     // This single pass over all transactions handles all pause events.
-                    let mut by_token: AddressMap<Vec<TxHash>> = AddressMap::default();
-                    for tx in all_txs.pending.iter().chain(all_txs.queued.iter()) {
-                        if let Some(fee_token) = tx.transaction.inner().fee_token() {
-                            by_token.entry(fee_token).or_default().push(*tx.hash());
-                        }
-                    }
+                    let mut by_token = all_txs.into_iter().fold(
+                        AddressMap::<Vec<TxHash>>::default(),
+                        |mut by_token, tx| {
+                            by_token
+                                .entry(tx.transaction.effective_fee_token())
+                                .or_default()
+                                .push(*tx.hash());
+                            by_token
+                        },
+                    );
 
                     // Process each pause token
                     for token in pause_tokens {

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -322,13 +322,12 @@ where
                 }
             }
 
-            // Check 4: Blacklisted fee payers
-            // Only check AA transactions with a fee token (non-AA transactions don't have
-            // a fee payer that can be blacklisted via TIP403)
+            // Check 4: Blacklisted fee payers.
+            // AA transactions use their recovered fee payer; non-AA transactions use their sender.
             if !updates.blacklist_additions.is_empty()
                 && let Some(ref mut provider) = state_provider
-                && let Some(fee_token) = tx.transaction.inner().fee_token()
             {
+                let fee_token = tx.transaction.effective_fee_token();
                 let fee_payer = tx
                     .transaction
                     .inner()
@@ -368,13 +367,13 @@ where
                 }
             }
 
-            // Check 5: Un-whitelisted fee payers
-            // When a fee payer is removed from a whitelist, their pending transactions
-            // will fail validation at execution time.
+            // Check 5: Un-whitelisted fee payers.
+            // When a fee payer or sender is removed from a whitelist, their pending
+            // transactions will fail validation at execution time.
             if !updates.whitelist_removals.is_empty()
                 && let Some(ref mut provider) = state_provider
-                && let Some(fee_token) = tx.transaction.inner().fee_token()
             {
+                let fee_token = tx.transaction.effective_fee_token();
                 let fee_payer = tx
                     .transaction
                     .inner()
@@ -1309,6 +1308,7 @@ mod tests {
         validate::{EthTransactionValidatorBuilder, ValidTransaction},
     };
     use tempo_chainspec::{
+        TempoChainSpec,
         hardfork::TempoHardfork,
         spec::{MODERATO, TEMPO_T1_TX_GAS_LIMIT_CAP},
     };
@@ -1401,6 +1401,65 @@ mod tests {
                 (balance_slot.into(), balance),
             ]),
         );
+    }
+
+    fn set_transfer_policy(
+        provider: &MockEthProvider<TempoPrimitives, TempoChainSpec>,
+        fee_token: Address,
+        policy_id: u64,
+    ) {
+        let transfer_policy_id_packed =
+            U256::from(policy_id) << (tip20_slots::TRANSFER_POLICY_ID_OFFSET * 8);
+
+        provider.add_account(
+            fee_token,
+            ExtendedAccount::new(0, U256::ZERO).extend_storage([(
+                tip20_slots::TRANSFER_POLICY_ID.into(),
+                transfer_policy_id_packed,
+            )]),
+        );
+    }
+
+    fn create_test_pool(
+        provider: MockEthProvider<TempoPrimitives, TempoChainSpec>,
+    ) -> TempoTransactionPool<MockEthProvider<TempoPrimitives, TempoChainSpec>> {
+        let inner =
+            EthTransactionValidatorBuilder::new(provider.clone(), TempoEvmConfig::mainnet())
+                .disable_balance_check()
+                .build(InMemoryBlobStore::default());
+        let amm_cache =
+            AmmLiquidityCache::new(provider).expect("failed to setup AmmLiquidityCache");
+        let validator = TempoTransactionValidator::new(
+            inner,
+            crate::validator::DEFAULT_AA_VALID_AFTER_MAX_SECS,
+            crate::validator::DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
+            amm_cache,
+        );
+
+        let (executor, _task) = TransactionValidationTaskExecutor::new(validator);
+        let protocol_pool = Pool::new(
+            executor,
+            CoinbaseTipOrdering::default(),
+            InMemoryBlobStore::default(),
+            PoolConfig::default(),
+        );
+        TempoTransactionPool::new(protocol_pool, AA2dPool::new(Default::default()))
+    }
+
+    fn add_validated(
+        pool: &TempoTransactionPool<MockEthProvider<TempoPrimitives, TempoChainSpec>>,
+        pooled: TempoPooledTransaction,
+    ) {
+        let validated = TransactionValidationOutcome::Valid {
+            balance: *pooled.cost(),
+            state_nonce: pooled.nonce(),
+            bytecode_hash: None,
+            transaction: ValidTransaction::new(pooled, None),
+            propagate: true,
+            authorities: None,
+        };
+        pool.add_validated_transaction(TransactionOrigin::External, validated)
+            .expect("transaction should be admitted");
     }
 
     #[tokio::test]
@@ -1499,6 +1558,84 @@ mod tests {
             .entry(PATH_USD_ADDRESS)
             .or_default()
             .insert(fee_payer);
+
+        let evicted = pool.evict_invalidated_transactions(&updates);
+        assert_eq!(evicted, vec![*pooled.hash()]);
+        assert!(pool.get(pooled.hash()).is_none());
+    }
+
+    #[tokio::test]
+    async fn blacklist_eviction_uses_resolved_fee_token() {
+        let sender = Address::random();
+        let resolved_fee_token = address!("20C0000000000000000000000000000000000002");
+        let policy_id = 7;
+        let pooled = crate::test_utils::TxBuilder::aa(sender).build();
+
+        assert_eq!(pooled.inner().fee_token(), None);
+        pooled.set_resolved_fee_token(resolved_fee_token);
+
+        let provider = MockEthProvider::<TempoPrimitives>::new()
+            .with_chain_spec(std::sync::Arc::unwrap_or_clone(MODERATO.clone()));
+        provider.add_account(sender, ExtendedAccount::new(pooled.nonce(), *pooled.cost()));
+        provider.add_block(
+            B256::random(),
+            Block {
+                header: TempoHeader {
+                    inner: Header {
+                        gas_limit: TEMPO_T1_TX_GAS_LIMIT_CAP,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        set_transfer_policy(&provider, resolved_fee_token, policy_id);
+
+        let pool = create_test_pool(provider);
+        add_validated(&pool, pooled.clone());
+
+        let mut updates = crate::maintain::TempoPoolUpdates::new();
+        updates.blacklist_additions.push((policy_id, sender));
+
+        let evicted = pool.evict_invalidated_transactions(&updates);
+        assert_eq!(evicted, vec![*pooled.hash()]);
+        assert!(pool.get(pooled.hash()).is_none());
+    }
+
+    #[tokio::test]
+    async fn whitelist_eviction_uses_resolved_fee_token() {
+        let sender = Address::random();
+        let resolved_fee_token = address!("20C0000000000000000000000000000000000002");
+        let policy_id = 9;
+        let pooled = crate::test_utils::TxBuilder::aa(sender).build();
+
+        assert_eq!(pooled.inner().fee_token(), None);
+        pooled.set_resolved_fee_token(resolved_fee_token);
+
+        let provider = MockEthProvider::<TempoPrimitives>::new()
+            .with_chain_spec(std::sync::Arc::unwrap_or_clone(MODERATO.clone()));
+        provider.add_account(sender, ExtendedAccount::new(pooled.nonce(), *pooled.cost()));
+        provider.add_block(
+            B256::random(),
+            Block {
+                header: TempoHeader {
+                    inner: Header {
+                        gas_limit: TEMPO_T1_TX_GAS_LIMIT_CAP,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        set_transfer_policy(&provider, resolved_fee_token, policy_id);
+
+        let pool = create_test_pool(provider);
+        add_validated(&pool, pooled.clone());
+
+        let mut updates = crate::maintain::TempoPoolUpdates::new();
+        updates.whitelist_removals.push((policy_id, sender));
 
         let evicted = pool.evict_invalidated_transactions(&updates);
         assert_eq!(evicted, vec![*pooled.hash()]);

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -251,17 +251,32 @@ impl TempoPooledTransaction {
         self.key_expiry.get().copied().flatten()
     }
 
-    /// Caches the resolved fee token determined during validation.
+    /// Caches the effective fee token determined during transaction validation.
+    ///
+    /// The validator sets this after EVM validation resolves the token from the
+    /// transaction's explicit `fee_token` field or from fee-manager state. Pool
+    /// maintenance code should not call this directly.
     pub fn set_resolved_fee_token(&self, fee_token: Address) {
         let _ = self.resolved_fee_token.set(fee_token);
     }
 
-    /// Returns the resolved fee token cached during validation, if available.
+    /// Returns the fee token cached during transaction validation, if available.
+    ///
+    /// This is `None` for transactions that have not completed validation through
+    /// the pool validator. Prefer [`Self::effective_fee_token`] in maintenance code
+    /// that needs the token a transaction will actually use to pay fees.
     pub fn resolved_fee_token(&self) -> Option<Address> {
         self.resolved_fee_token.get().copied()
     }
 
-    /// Returns the effective fee token for the transaction
+    /// Returns the effective fee token for pool maintenance and accounting.
+    ///
+    /// This prefers the token cached by validation, then falls back to the raw
+    /// transaction `fee_token` field, and finally to [`DEFAULT_FEE_TOKEN`]. This
+    /// fallback covers non-AA transactions and AA transactions without an explicit
+    /// fee token. Use this when checking liquidity, token pause state, balances, or
+    /// transfer policies. Use the raw `fee_token` field only when the code
+    /// specifically needs to know whether the transaction explicitly supplied a token.
     pub fn effective_fee_token(&self) -> Address {
         self.resolved_fee_token()
             .unwrap_or_else(|| self.inner().fee_token().unwrap_or(DEFAULT_FEE_TOKEN))


### PR DESCRIPTION
Fixes SIGP-261

Uses the cached resolved fee token for txpool pause grouping and TIP-403 maintenance evictions, so implicitly resolved AA fee-token transactions are rechecked against the token they were validated with.

Also documents when resolved fee tokens are cached and when maintenance code should use the effective token helper.