### PR TITLE
refactor(primitives): align is_aa with as_aa

### DIFF
--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -263,9 +263,9 @@ impl TempoTxEnvelope {
         self.as_aa().map(|tx| tx.tx().nonce_key)
     }
 
-    /// Returns true if this is a Tempo transaction
+    /// Returns true if this envelope contains an [`AASigned`] transaction.
     pub fn is_aa(&self) -> bool {
-        matches!(self, Self::AA(_))
+        self.as_aa().is_some()
     }
 
     /// Returns iterator over the calls in the transaction.


### PR DESCRIPTION
Clarifies `TempoTxEnvelope::is_aa` as the named boolean form of `as_aa().is_some()` by delegating directly to the existing accessor and documenting that it detects `AASigned` envelopes.

This keeps the helper behavior tied to the AA accessor for callers that only need the predicate.