### PR TITLE
fix(txpool): revalidate fee tokens on fee recipient updates

### DIFF
--- a/crates/transaction-pool/src/amm.rs
+++ b/crates/transaction-pool/src/amm.rs
@@ -234,49 +234,24 @@ impl AmmLiquidityCache {
 
         for header in headers {
             let beneficiary = header.beneficiary();
-            let validator_token_slot = TipFeeManager::new().validator_tokens[beneficiary].slot();
 
-            let cached_preference = self
-                .inner
-                .read()
-                .validator_preferences
-                .get(&beneficiary)
-                .copied();
-
-            let preference = if let Some(cached) = cached_preference {
-                cached
+            let fee_token = if let Some(fee_token) =
+                self.cached_validator_fee_token_for_beneficiary(beneficiary)
+            {
+                fee_token
             } else {
-                // If no cached preference, load from state
-
-                // Lazily initialize the state provider for the latest block in the set
+                // Lazily initialize the state provider for the latest block in the set.
                 if state.is_none() {
                     state = Some(client.state_by_block_hash(latest_hash)?);
                 }
 
-                state
-                    .as_mut()
-                    .expect("initialized above")
-                    .storage(TIP_FEE_MANAGER_ADDRESS, validator_token_slot.into())?
-                    .unwrap_or_default()
-                    .into_address()
-            };
-
-            // Get the actual fee token, accounting for defaults.
-            let fee_token = if preference.is_zero() {
-                DEFAULT_FEE_TOKEN
-            } else {
-                preference
+                self.validator_fee_token_for_beneficiary(
+                    state.as_mut().expect("initialized above"),
+                    beneficiary,
+                )?
             };
 
             let mut inner = self.inner.write();
-
-            // Track the new fee token preference, if any
-            if cached_preference.is_none() {
-                inner.validator_preferences.insert(beneficiary, preference);
-                inner
-                    .slot_to_validator
-                    .insert(validator_token_slot, beneficiary);
-            }
 
             // Track the new observed fee token
             inner.last_seen_tokens.push_back(fee_token);
@@ -354,6 +329,21 @@ impl AmmLiquidityCache {
         self.inner.read().unique_tokens.contains(token)
     }
 
+    /// Resolves the fee token accepted by a block beneficiary.
+    ///
+    /// The payload builder may use ValidatorConfigV2 fee recipients as block beneficiaries, and
+    /// TipFeeManager stores validator fee token preferences by beneficiary address. A zero
+    /// preference falls back to the protocol default.
+    pub(crate) fn validator_fee_token_for_beneficiary(
+        &self,
+        state_provider: &mut impl StateProvider,
+        beneficiary: Address,
+    ) -> ProviderResult<Address> {
+        let preference =
+            self.validator_token_preference_for_beneficiary(state_provider, beneficiary)?;
+        Ok(Self::fee_token_from_preference(preference))
+    }
+
     /// Injects tokens into `unique_tokens` so `has_enough_liquidity` sees them.
     /// Returns `true` if any of the input tokens is added to the `unique_tokens` list.
     ///
@@ -373,6 +363,51 @@ impl AmmLiquidityCache {
             }
         }
         updated
+    }
+
+    fn cached_validator_fee_token_for_beneficiary(&self, beneficiary: Address) -> Option<Address> {
+        self.inner
+            .read()
+            .validator_preferences
+            .get(&beneficiary)
+            .copied()
+            .map(Self::fee_token_from_preference)
+    }
+
+    fn validator_token_preference_for_beneficiary(
+        &self,
+        state_provider: &mut impl StateProvider,
+        beneficiary: Address,
+    ) -> ProviderResult<Address> {
+        if let Some(preference) = self
+            .inner
+            .read()
+            .validator_preferences
+            .get(&beneficiary)
+            .copied()
+        {
+            return Ok(preference);
+        }
+
+        let slot = TipFeeManager::new().validator_tokens[beneficiary].slot();
+        let preference = state_provider
+            .storage(TIP_FEE_MANAGER_ADDRESS, slot.into())?
+            .unwrap_or_default()
+            .into_address();
+
+        let mut inner = self.inner.write();
+        inner.validator_preferences.insert(beneficiary, preference);
+        inner.slot_to_validator.insert(slot, beneficiary);
+
+        Ok(preference)
+    }
+
+    fn fee_token_from_preference(preference: Address) -> Address {
+        if preference.is_zero() {
+            DEFAULT_FEE_TOKEN
+        } else {
+            preference
+        }
     }
 }
 

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -24,9 +24,12 @@ use std::{
     time::Instant,
 };
 use tempo_chainspec::TempoChainSpec;
-use tempo_contracts::precompiles::{IAccountKeychain, IFeeManager, ITIP20, ITIP403Registry};
+use tempo_contracts::precompiles::{
+    IAccountKeychain, IFeeManager, ITIP20, ITIP403Registry, IValidatorConfigV2,
+};
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP403_REGISTRY_ADDRESS,
+    VALIDATOR_CONFIG_V2_ADDRESS,
 };
 use tempo_primitives::{TempoAddressExt, TempoHeader, TempoPrimitives};
 use tracing::{debug, error};
@@ -51,10 +54,15 @@ pub struct TempoPoolUpdates {
     /// may become unexecutable if the new limit is below their value.
     /// Indexed by account for efficient lookup.
     pub spending_limit_changes: SpendingLimitUpdates,
-    /// Validator token preference changes: validator to new_token (last-write-wins).
+    /// Validator fee token preference changes: validator to new_token (last-write-wins).
     /// Uses `AddressMap` to deduplicate by validator, preventing resource amplification
     /// when a validator emits multiple `ValidatorTokenSet` events in the same block.
     pub validator_token_changes: AddressMap<Address>,
+    /// ValidatorConfigV2 fee recipient changes.
+    ///
+    /// When a validator changes the fee recipient that will become the block beneficiary, the
+    /// txpool must re-check the new beneficiary's validator fee token preference.
+    pub fee_recipient_updates: AddressSet,
     /// User token preference changes.
     /// When a user changes their fee token preference via `setUserToken()`, pending
     /// transactions from that user that don't have an explicit fee_token set may now
@@ -117,11 +125,12 @@ impl TempoPoolUpdates {
             && self.fee_balance_changes.is_empty()
             && self.spending_limit_spends.is_empty()
             && self.key_authorization_witness_burns.is_empty()
+            && self.fee_recipient_updates.is_empty()
     }
 
     /// Extracts pool updates from a committed chain segment.
     ///
-    /// Parses receipts for relevant events (key revocations, validator token changes,
+    /// Parses receipts for relevant events (key revocations, validator fee token changes,
     /// blacklist additions, pause events).
     pub fn from_chain(chain: &Chain<TempoPrimitives>) -> Self {
         let mut updates = Self::new();
@@ -178,6 +187,15 @@ impl TempoPoolUpdates {
                     None => {}
                 }
             }
+            // ValidatorConfigV2 fee recipient changes
+            else if log.address == VALIDATOR_CONFIG_V2_ADDRESS {
+                match ValidatorConfigV2PoolEvent::decode(log) {
+                    Some(ValidatorConfigV2PoolEvent::FeeRecipientUpdated(event)) => {
+                        updates.fee_recipient_updates.insert(event.feeRecipient);
+                    }
+                    None => {}
+                }
+            }
             // TIP403 blacklist additions and whitelist removals
             else if log.address == TIP403_REGISTRY_ADDRESS {
                 match Tip403PoolEvent::decode(log) {
@@ -230,6 +248,7 @@ impl TempoPoolUpdates {
             || !self.whitelist_removals.is_empty()
             || !self.fee_balance_changes.is_empty()
             || !self.key_authorization_witness_burns.is_empty()
+            || !self.fee_recipient_updates.is_empty()
     }
 
     /// Returns true if updates may invalidate keychain-signature transactions.
@@ -287,6 +306,24 @@ impl FeeManagerPoolEvent {
                 decode_event(log).map(Self::ValidatorTokenSet)
             }
             IFeeManager::UserTokenSet::SIGNATURE_HASH => decode_event(log).map(Self::UserTokenSet),
+            _ => None,
+        }
+    }
+}
+
+/// Transaction-pool relevant subset of `IValidatorConfigV2::IValidatorConfigV2Events`.
+enum ValidatorConfigV2PoolEvent {
+    /// [`IValidatorConfigV2::FeeRecipientUpdated`] log.
+    FeeRecipientUpdated(IValidatorConfigV2::FeeRecipientUpdated),
+}
+
+impl ValidatorConfigV2PoolEvent {
+    /// Decodes only validator-config-v2 events used by transaction-pool maintenance.
+    fn decode(log: &Log) -> Option<Self> {
+        match first_topic(log)? {
+            IValidatorConfigV2::FeeRecipientUpdated::SIGNATURE_HASH => {
+                decode_event(log).map(Self::FeeRecipientUpdated)
+            }
             _ => None,
         }
     }
@@ -826,7 +863,7 @@ where
                 let _mined_aa_txs = pool.notify_aa_pool_on_state_updates(bundle_state);
                 metrics.nonce_pool_update_duration_seconds.record(nonce_pool_start.elapsed());
 
-                // 7. Update AMM liquidity cache (must happen before validator token eviction)
+                // 7. Update AMM liquidity cache (must happen before validator fee token eviction)
                 let amm_start = Instant::now();
                 amm_cache.on_new_state(tip.execution_outcome());
                 if let Err(err) = amm_cache.on_new_blocks(tip.blocks_iter().map(|block| block.sealed_header()), pool.client()) {
@@ -835,7 +872,7 @@ where
                 metrics.amm_cache_update_duration_seconds.record(amm_start.elapsed());
 
                 // 8. Evict invalidated transactions in a single pool scan
-                // This checks revoked keys, spending limit changes, validator token changes,
+                // This checks revoked keys, spending limit changes, validator fee token changes,
                 // blacklist additions, and whitelist removals together to avoid scanning
                 // all transactions multiple times per block.
                 if updates.has_invalidation_events() {
@@ -846,6 +883,7 @@ where
                         spending_limit_changes = updates.spending_limit_changes.len(),
                         spending_limit_spends = updates.spending_limit_spends.len(),
                         validator_token_changes = updates.validator_token_changes.len(),
+                        fee_recipient_updates = updates.fee_recipient_updates.len(),
                         user_token_changes = updates.user_token_changes.len(),
                         blacklist_additions = updates.blacklist_additions.len(),
                         whitelist_removals = updates.whitelist_removals.len(),
@@ -1219,6 +1257,24 @@ mod tests {
                 FeeManagerPoolEvent,
                 UserTokenSet,
                 IFeeManager::UserTokenSet,
+                log
+            );
+        }
+
+        #[test]
+        fn validator_config_v2_decode_matches_generated_event_decoders() {
+            let log = event_log(
+                VALIDATOR_CONFIG_V2_ADDRESS,
+                IValidatorConfigV2::FeeRecipientUpdated {
+                    index: 7,
+                    feeRecipient: Address::random(),
+                    caller: Address::random(),
+                },
+            );
+            assert_decodes_like_generated!(
+                ValidatorConfigV2PoolEvent,
+                FeeRecipientUpdated,
+                IValidatorConfigV2::FeeRecipientUpdated,
                 log
             );
         }
@@ -1619,7 +1675,7 @@ mod tests {
             );
         }
 
-        /// Duplicate validator token changes must be deduplicated (last-write-wins).
+        /// Duplicate validator fee token changes must be deduplicated (last-write-wins).
         #[test]
         fn validator_token_changes_deduplicates_by_validator() {
             let validator = Address::random();
@@ -1640,6 +1696,33 @@ mod tests {
                 Some(token_b),
                 "last-write-wins: second token should overwrite the first"
             );
+        }
+
+        #[test]
+        fn extracts_fee_recipient_updates_from_validator_config_v2_logs() {
+            let fee_recipient = Address::random();
+            let log = alloy_primitives::Log::new_from_event_unchecked(
+                VALIDATOR_CONFIG_V2_ADDRESS,
+                IValidatorConfigV2::FeeRecipientUpdated {
+                    index: 3,
+                    feeRecipient: fee_recipient,
+                    caller: Address::random(),
+                },
+            )
+            .reserialize();
+            let receipt = TempoReceipt {
+                tx_type: TempoTxType::Legacy,
+                success: true,
+                cumulative_gas_used: 21_000,
+                logs: vec![log],
+            };
+
+            let block = create_block_with_txs(1, vec![], vec![]);
+            let chain = create_test_chain_with_receipts(vec![block], vec![vec![receipt]]);
+            let updates = TempoPoolUpdates::from_chain(&chain);
+
+            assert!(updates.fee_recipient_updates.contains(&fee_recipient));
+            assert!(updates.has_invalidation_events());
         }
     }
 }

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -113,8 +113,8 @@ where
     ///    from state) is now insufficient after included keychain txs decremented it
     ///    2c. **Key-authorization witness burns**: AA transactions with a witness-bearing
     ///    inline key authorization whose `(account, witness)` has been manually burned
-    /// 3. **Validator token changes**: Transactions that would fail due to insufficient
-    ///    liquidity in the new (user_token, validator_token) AMM pool
+    /// 3. **Validator fee token changes**: Transactions that would fail due to insufficient
+    ///    liquidity after validator fee token or fee recipient updates
     /// 4. **Fee payer balance changes**: Transactions whose fee payer no longer has enough
     ///    balance in the resolved fee token after a TIP20 transfer
     ///
@@ -129,11 +129,12 @@ where
         }
 
         // Fetch state provider if any check needs on-chain reads:
-        // - validator token changes (liquidity check)
+        // - validator fee token changes (liquidity check)
         // - blacklist/whitelist (policy check)
         // - fee payer balance changes (balance check)
         // - spending limit spends (remaining limit check)
         let mut state_provider = if !updates.validator_token_changes.is_empty()
+            || !updates.fee_recipient_updates.is_empty()
             || !updates.blacklist_additions.is_empty()
             || !updates.whitelist_removals.is_empty()
             || !updates.fee_balance_changes.is_empty()
@@ -175,7 +176,8 @@ where
             .map(|(policy_id, _)| *policy_id)
             .collect();
 
-        // Re-check liquidity for all pooled txs when an active validator changes token.
+        // Re-check liquidity for all pooled txs when an active validator changes token or a
+        // ValidatorConfigV2 fee-recipient update introduces a new beneficiary fee token.
         // Leverages the per-tx `has_enough_liquidity` check, which passes if ANY validator pair has
         // enough liquidity, matching admission and preventing mass-eviction of valid txs.
         let amm_cache = self.amm_liquidity_cache();
@@ -189,6 +191,27 @@ where
                 .collect();
             amm_cache.track_tokens(&active_new_tokens)
         };
+        let has_fee_recipient_validator_fee_token_changes =
+            !updates.fee_recipient_updates.is_empty() && {
+                let new_recipient_tokens = state_provider
+                    .as_mut()
+                    .map(|provider| {
+                        updates
+                            .fee_recipient_updates
+                            .iter()
+                            .filter_map(|&fee_recipient| {
+                                amm_cache
+                                    .validator_fee_token_for_beneficiary(provider, fee_recipient)
+                                    .ok()
+                            })
+                            .filter(|token| !amm_cache.is_active_validator_token(token))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                amm_cache.track_tokens(&new_recipient_tokens)
+            };
+        let has_validator_fee_token_changes =
+            has_active_validator_token_changes || has_fee_recipient_validator_fee_token_changes;
 
         let mut to_remove = Vec::new();
         let mut revoked_count = 0;
@@ -266,11 +289,12 @@ where
                 continue;
             }
 
-            // Check 3: Validator token changes (re-check liquidity for all transactions)
+            // Check 3: Validator fee token changes (re-check liquidity for all transactions)
             // Prevents mass eviction because it only:
-            // - evicts when NO validator token has enough liquidity
-            // - considers active validators (protects from permissionless `setValidatorToken`)
-            if has_active_validator_token_changes && let Some(ref mut provider) = state_provider {
+            // - evicts when NO validator fee token has enough liquidity
+            // - limits `setValidatorToken` handling to active validators and
+            //   `FeeRecipientUpdated` handling to ValidatorConfigV2-authorized updates
+            if has_validator_fee_token_changes && let Some(ref mut provider) = state_provider {
                 let user_token = tx.transaction.effective_fee_token();
                 let cost = tx.transaction.fee_token_cost();
 
@@ -1317,6 +1341,7 @@ mod tests {
     use tempo_precompiles::{
         PATH_USD_ADDRESS,
         account_keychain::{AccountKeychain, AuthorizedKey, SpendingLimitState},
+        tip_fee_manager::TipFeeManager,
         tip20::slots as tip20_slots,
         tip403_registry::{CompoundPolicyData, PolicyData, TIP403Registry},
     };
@@ -1561,7 +1586,7 @@ mod tests {
             authorities: None,
         };
         pool.add_validated_transaction(TransactionOrigin::External, validated)
-            .expect("transaction should be admitted before validator token change");
+            .expect("transaction should be admitted before validator fee token change");
 
         let mut updates = crate::maintain::TempoPoolUpdates::new();
         updates
@@ -1571,6 +1596,63 @@ mod tests {
         let evicted = pool.evict_invalidated_transactions(&updates);
         assert!(evicted.is_empty());
         assert!(pool.get(pooled.hash()).is_some());
+    }
+
+    #[tokio::test]
+    async fn fee_recipient_update_tracks_recipient_validator_fee_token_for_liquidity_recheck() {
+        let fee_recipient = Address::random();
+        let recipient_token = address!("20C0000000000000000000000000000000000002");
+
+        let provider = MockEthProvider::<TempoPrimitives>::new()
+            .with_chain_spec(std::sync::Arc::unwrap_or_clone(MODERATO.clone()));
+        provider.add_block(
+            B256::random(),
+            Block {
+                header: TempoHeader {
+                    inner: Header {
+                        gas_limit: TEMPO_T1_TX_GAS_LIMIT_CAP,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        provider
+            .setup_storage(TempoHardfork::default(), || {
+                TipFeeManager::new().validator_tokens[fee_recipient].write(recipient_token)
+            })
+            .unwrap();
+
+        let inner = EthTransactionValidatorBuilder::new(provider, TempoEvmConfig::mainnet())
+            .disable_balance_check()
+            .build(InMemoryBlobStore::default());
+        let amm_cache = AmmLiquidityCache::with_unique_tokens(vec![]);
+        let validator = TempoTransactionValidator::new(
+            inner,
+            crate::validator::DEFAULT_AA_VALID_AFTER_MAX_SECS,
+            crate::validator::DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
+            amm_cache,
+        );
+
+        let (executor, _task) = TransactionValidationTaskExecutor::new(validator);
+        let protocol_pool = Pool::new(
+            executor,
+            CoinbaseTipOrdering::default(),
+            InMemoryBlobStore::default(),
+            PoolConfig::default(),
+        );
+        let pool = TempoTransactionPool::new(protocol_pool, AA2dPool::new(Default::default()));
+
+        let mut updates = crate::maintain::TempoPoolUpdates::new();
+        updates.fee_recipient_updates.insert(fee_recipient);
+
+        let evicted = pool.evict_invalidated_transactions(&updates);
+        assert!(evicted.is_empty());
+        assert!(
+            pool.amm_liquidity_cache()
+                .is_active_validator_token(&recipient_token)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes SIGP-275.

Parses ValidatorConfigV2 `FeeRecipientUpdated` logs into txpool invalidation updates and resolves the new beneficiary's validator fee token during liquidity revalidation.

This prevents pending transactions from staying admitted against stale validator fee token state after a validator changes its future block fee recipient.