### PR TITLE
ci(bench): handle quoted e2e node args

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -762,6 +762,23 @@ jobs:
             fi
           }
 
+          quote_derek_arg() {
+            local arg="$1"
+            if [[ "$arg" == *=* ]]; then
+              local name="${arg%%=*}"
+              local value="${arg#*=}"
+              if [[ "$value" =~ ^[A-Za-z0-9._/:=@+-]+$ ]]; then
+                printf '%s=%s' "$name" "$value"
+              else
+                value="${value//\\/\\\\}"
+                value="${value//\"/\\\"}"
+                printf '%s=\"%s\"' "$name" "$value"
+              fi
+            else
+              quote_arg "$arg"
+            fi
+          }
+
           derek_cmd=(derek bench mode="$BENCH_MODE")
           derek_cmd+=(
             preset="$BENCH_PRESET"
@@ -794,7 +811,7 @@ jobs:
             if [ -n "$DEREK_BENCH_COMMAND" ]; then
               DEREK_BENCH_COMMAND+=" "
             fi
-            DEREK_BENCH_COMMAND+="$(quote_arg "$arg")"
+            DEREK_BENCH_COMMAND+="$(quote_derek_arg "$arg")"
           done
           export DEREK_BENCH_COMMAND
           echo "DEREK_BENCH_COMMAND=$DEREK_BENCH_COMMAND" >> "$GITHUB_ENV"

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -727,7 +727,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
     let hardfork = ($run | get -o hardfork | default "")
     let side_args = if $run_type == "baseline" { $ctx.baseline_args } else { $ctx.feature_args }
     let side_env = if $run_type == "baseline" { $ctx.baseline_env } else { $ctx.feature_env }
-    let extra_args = if $side_args == "" { [] } else { $side_args | split row " " }
+    let extra_args = (parse-cli-args $side_args)
 
     cleanup-local-e2e-processes
     bench-restore-at $ctx.a.state_path $ctx.a.mount $ctx.a.datadir

--- a/tempo.nu
+++ b/tempo.nu
@@ -511,6 +511,64 @@ def dedup-args [base_args: list<string>, extra_args: list<string>] {
     $result | append $extra_args
 }
 
+def parse-cli-args [args: string] {
+    mut result = []
+    mut current = ""
+    mut quote = ""
+    mut escaped = false
+    mut token_started = false
+
+    for ch in ($args | split chars) {
+        if $escaped {
+            $current = $"($current)($ch)"
+            $escaped = false
+            $token_started = true
+            continue
+        }
+        if $ch == "\\" {
+            $escaped = true
+            $token_started = true
+            continue
+        }
+        if $quote != "" {
+            if $ch == $quote {
+                $quote = ""
+            } else {
+                $current = $"($current)($ch)"
+            }
+            $token_started = true
+            continue
+        }
+        if $ch == "'" or $ch == '"' {
+            $quote = $ch
+            $token_started = true
+            continue
+        }
+        if $ch in [" " "\t" "\n" "\r"] {
+            if $token_started {
+                $result = ($result | append $current)
+                $current = ""
+                $token_started = false
+            }
+            continue
+        }
+        $current = $"($current)($ch)"
+        $token_started = true
+    }
+
+    if $escaped {
+        $current = $"($current)('\')"
+    }
+    if $quote != "" {
+        print $"Error: unterminated quote in args: ($args)"
+        exit 1
+    }
+    if $token_started {
+        $result = ($result | append $current)
+    }
+    $result
+}
+
 # Run a single benchmark run (start node, run bench, stop node, collect report)
 def run-bench-single [
     --tempo-bin: string
@@ -554,7 +612,7 @@ def run-bench-single [
     let run_type = if ($run_label | str starts-with "baseline") { "baseline" } else { "feature" }
 
     # Parse extra node args
-    let extra_args = if $node_args == "" { [] } else { $node_args | split row " " }
+    let extra_args = (parse-cli-args $node_args)
 
     # Build node arguments, then dedup so user-provided args override defaults
     let base_args = (build-base-args $genesis_path $datadir $log_dir "0.0.0.0" 8545 9001)
@@ -1570,7 +1628,7 @@ def "main localnet" [
     }
 
     # Parse custom args
-    let extra_args = if $node_args == "" { [] } else { $node_args | split row " " }
+    let extra_args = (parse-cli-args $node_args)
     let samply_args_list = if $samply_args == "" { [] } else { $samply_args | split row " " }
 
     # Build first (unless skipped)
@@ -1873,7 +1931,7 @@ def "main follower" [
         exit 1
     }
 
-    let extra_args = if $node_args == "" { [] } else { $node_args | split row " " }
+    let extra_args = (parse-cli-args $node_args)
     if not $skip_build {
         build-tempo ["tempo"] $profile $features
     }


### PR DESCRIPTION
## Summary
- parse `baseline-args` and `feature-args` with quote handling so values containing spaces stay intact
- render Derek key/value args with spaces as `name="value with spaces"`
- apply the same parser to existing `tempo.nu` `node-args` entry points that previously split on raw spaces

## Validation
- `nu -c 'source tempo.nu; parse-cli-args "--foo \"a b\" --bar=1 --empty \"\" --single '\''c d'\''" | to json'`
- verified Derek rendering: `baseline-args="--builder.max-tasks 1 --engine.share-sparse-trie-with-payload-builder"`
- `nu --ide-check 0 tempo.nu`
- `nu --ide-check 0 bench-e2e.nu`
- `git diff --check`

Prompted by: @shekhirin