### PR TITLE
bench(txpool): best transactions and maintain microbenchmarks

### DIFF
--- a/.github/workflows/codspeed-microbench.yml
+++ b/.github/workflows/codspeed-microbench.yml
@@ -20,7 +20,7 @@ on:
       benchmarks:
         description: "Cargo bench target(s), separated by spaces; leave empty for every bench in the package(s)"
         required: false
-        default: "tip20_execution best_transactions"
+        default: "tip20_execution best_transactions txpool_maintenance"
         type: string
       filters:
         description: "Optional benchmark name filter passed to cargo codspeed run"
@@ -64,7 +64,7 @@ jobs:
         id: args
         env:
           INPUT_PACKAGES: ${{ inputs.packages || 'tempo-evm tempo-transaction-pool' }}
-          INPUT_BENCHMARKS: ${{ inputs.benchmarks || 'tip20_execution best_transactions' }}
+          INPUT_BENCHMARKS: ${{ inputs.benchmarks || 'tip20_execution best_transactions txpool_maintenance' }}
           INPUT_FILTERS: ${{ inputs.filters || '' }}
           INPUT_MEASUREMENT_MODES: ${{ inputs.measurement_modes || 'simulation' }}
         run: |

--- a/.github/workflows/codspeed-microbench.yml
+++ b/.github/workflows/codspeed-microbench.yml
@@ -15,17 +15,17 @@ on:
       packages:
         description: "Cargo package(s) containing benchmark targets, separated by spaces"
         required: true
-        default: "tempo-evm"
+        default: "tempo-evm tempo-transaction-pool"
         type: string
       benchmarks:
         description: "Cargo bench target(s), separated by spaces; leave empty for every bench in the package(s)"
         required: false
-        default: "tip20_execution"
+        default: "tip20_execution best_transactions"
         type: string
       filters:
         description: "Optional benchmark name filter passed to cargo codspeed run"
         required: false
-        default: "tip20_"
+        default: ""
         type: string
       measurement_modes:
         description: "CodSpeed measurement mode(s), separated by commas"
@@ -63,9 +63,9 @@ jobs:
       - name: Resolve cargo codspeed arguments
         id: args
         env:
-          INPUT_PACKAGES: ${{ inputs.packages || 'tempo-evm' }}
-          INPUT_BENCHMARKS: ${{ inputs.benchmarks || 'tip20_execution' }}
-          INPUT_FILTERS: ${{ inputs.filters || 'tip20_' }}
+          INPUT_PACKAGES: ${{ inputs.packages || 'tempo-evm tempo-transaction-pool' }}
+          INPUT_BENCHMARKS: ${{ inputs.benchmarks || 'tip20_execution best_transactions' }}
+          INPUT_FILTERS: ${{ inputs.filters || '' }}
           INPUT_MEASUREMENT_MODES: ${{ inputs.measurement_modes || 'simulation' }}
         run: |
           set -euo pipefail
@@ -86,14 +86,18 @@ jobs:
             [ -n "$benchmark" ] && cargo_args+=("--bench" "$benchmark")
           done < <(split_words "$INPUT_BENCHMARKS")
 
-          # tempo-precompiles benchmarks require the test-utils feature;
+          # Some benchmark targets require package-scoped test-utils features;
           # --features is only valid for `cargo codspeed build`, not `run`.
           feature_args=()
           while IFS= read -r package; do
-            if [ "$package" = "tempo-precompiles" ]; then
-              feature_args+=("--features" "tempo-precompiles/test-utils")
-              break
-            fi
+            case "$package" in
+              tempo-precompiles)
+                feature_args+=("--features" "tempo-precompiles/test-utils")
+                ;;
+              tempo-transaction-pool)
+                feature_args+=("--features" "tempo-transaction-pool/test-utils")
+                ;;
+            esac
           done < <(split_words "$INPUT_PACKAGES")
 
           build_args=("${cargo_args[@]}" "${feature_args[@]}")

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13212,6 +13212,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
+ "codspeed-criterion-compat",
  "futures",
  "itertools 0.14.0",
  "metrics",

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -76,3 +76,8 @@ test-case.workspace = true
 name = "best_transactions"
 harness = false
 required-features = ["test-utils"]
+
+[[bench]]
+name = "txpool_maintenance"
+harness = false
+required-features = ["test-utils"]

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -60,6 +60,7 @@ test-utils = [
 ]
 
 [dev-dependencies]
+criterion.workspace = true
 reth-ethereum-primitives = { workspace = true, features = ["test-utils"] }
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
@@ -70,3 +71,8 @@ alloy-signer.workspace = true
 alloy-signer-local.workspace = true
 tokio.workspace = true
 test-case.workspace = true
+
+[[bench]]
+name = "best_transactions"
+harness = false
+required-features = ["test-utils"]

--- a/crates/transaction-pool/benches/best_transactions.rs
+++ b/crates/transaction-pool/benches/best_transactions.rs
@@ -1,0 +1,49 @@
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use std::{hint::black_box, time::Duration};
+use tempo_transaction_pool::bench_support::{
+    aa2d_pool_fixture, best_transactions_snapshot, expiring_nonce_pool_fixture,
+};
+
+const TOTAL_TXS: usize = 50_000;
+const TXS_PER_SENDER: usize = 16;
+const SEQUENCES: usize = TOTAL_TXS / TXS_PER_SENDER;
+
+fn best_transactions(c: &mut Criterion) {
+    let mut group = c.benchmark_group("best_transactions");
+    group
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(2))
+        .sample_size(10);
+
+    let aa2d_pool = aa2d_pool_fixture(SEQUENCES, TXS_PER_SENDER);
+    bench_next_one(&mut group, "aa2d/next/50k_txs_16_per_sender", &aa2d_pool);
+
+    let expiring_nonce_pool = expiring_nonce_pool_fixture(SEQUENCES, TXS_PER_SENDER);
+    bench_next_one(
+        &mut group,
+        "expiring_nonce/next/50k_txs_16_per_sender",
+        &expiring_nonce_pool,
+    );
+
+    group.finish();
+}
+
+fn bench_next_one(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    id: &str,
+    pool: &tempo_transaction_pool::AA2dPool,
+) {
+    group.bench_function(id, |b| {
+        b.iter_batched_ref(
+            || best_transactions_snapshot(pool),
+            |best_txs| {
+                let yielded = black_box(best_txs.next().is_some());
+                assert!(yielded);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+criterion_group!(benches, best_transactions);
+criterion_main!(benches);

--- a/crates/transaction-pool/benches/txpool_maintenance.rs
+++ b/crates/transaction-pool/benches/txpool_maintenance.rs
@@ -1,0 +1,31 @@
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use std::{hint::black_box, time::Duration};
+use tempo_transaction_pool::bench_support::expired_txpool_maintenance_fixture;
+
+const TOTAL_TXS: usize = 50_000;
+const TXS_PER_SENDER: usize = 16;
+const SEQUENCES: usize = TOTAL_TXS / TXS_PER_SENDER;
+
+fn txpool_maintenance(c: &mut Criterion) {
+    let mut group = c.benchmark_group("txpool_maintenance");
+    group
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(2))
+        .sample_size(10);
+
+    group.bench_function("expired_valid_before/50k_txs_16_per_sender", |b| {
+        b.iter_batched_ref(
+            || expired_txpool_maintenance_fixture(SEQUENCES, TXS_PER_SENDER),
+            |fixture| {
+                let evicted = black_box(fixture.run_one());
+                assert_eq!(evicted, TOTAL_TXS);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, txpool_maintenance);
+criterion_main!(benches);

--- a/crates/transaction-pool/src/bench_support.rs
+++ b/crates/transaction-pool/src/bench_support.rs
@@ -1,0 +1,184 @@
+//! Benchmark helpers for transaction-pool internals.
+
+use crate::{
+    AA2dPoolConfig, best::MergeBestTransactions, transaction::TempoPooledTransaction,
+    tt_2d_pool::AA2dPool,
+};
+use alloy_consensus::Transaction;
+use alloy_primitives::{Address, Signature, TxKind, U256};
+use reth_primitives_traits::Recovered;
+use reth_transaction_pool::{
+    CoinbaseTipOrdering, Pool, PoolConfig, SubPoolLimit, TransactionOrigin, ValidPoolTransaction,
+    blobstore::InMemoryBlobStore, identifier::TransactionId, test_utils::OkValidator,
+};
+use std::{num::NonZeroU64, sync::Arc, time::Instant};
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_primitives::{
+    TempoTxEnvelope,
+    transaction::{
+        TEMPO_EXPIRING_NONCE_KEY, TempoTransaction,
+        tempo_transaction::Call,
+        tt_signature::{PrimitiveSignature, TempoSignature},
+        tt_signed::AASigned,
+    },
+};
+
+const BENCH_CHAIN_ID: u64 = 42431;
+const BENCH_NONCE_KEY: u64 = 1;
+const BENCH_GAS_LIMIT: u64 = 1_000_000;
+const BENCH_MAX_PRIORITY_FEE_PER_GAS: u128 = 1_000_000_000;
+const BENCH_MAX_FEE_PER_GAS: u128 = 20_000_000_000;
+const BENCH_VALID_BEFORE: u64 = 1_700_000_010;
+
+/// Builds an AA 2D pool with `sequences` independent nonce chains of `chain_len` txs each.
+pub fn aa2d_pool_fixture(sequences: usize, chain_len: usize) -> AA2dPool {
+    assert!(
+        sequences > 0,
+        "benchmark fixture must have at least one sequence"
+    );
+    assert!(
+        chain_len > 0,
+        "benchmark fixture must have at least one tx per sequence"
+    );
+
+    let mut pool = AA2dPool::new(AA2dPoolConfig {
+        pending_limit: SubPoolLimit::max(),
+        queued_limit: SubPoolLimit::max(),
+        max_txs_per_sender: chain_len,
+        ..Default::default()
+    });
+
+    for sequence in 0..sequences {
+        let sender = bench_address(0x10, sequence);
+        let target = bench_address(0x20, sequence);
+
+        for nonce in 0..chain_len {
+            let tx = bench_aa_tx(
+                sender,
+                target,
+                U256::from(BENCH_NONCE_KEY),
+                nonce as u64,
+                None,
+            );
+            pool.add_transaction(Arc::new(wrap_valid_tx(tx)), 0, TempoHardfork::T1)
+                .expect("benchmark AA 2D transaction must be accepted");
+        }
+    }
+
+    pool
+}
+
+/// Builds an AA pool with independent expiring-nonce transactions.
+pub fn expiring_nonce_pool_fixture(sequences: usize, txs_per_sender: usize) -> AA2dPool {
+    assert!(
+        sequences > 0,
+        "benchmark fixture must have at least one sequence"
+    );
+    assert!(
+        txs_per_sender > 0,
+        "benchmark fixture must have at least one tx per sender"
+    );
+
+    let mut pool = AA2dPool::new(AA2dPoolConfig {
+        pending_limit: SubPoolLimit::max(),
+        queued_limit: SubPoolLimit::max(),
+        max_txs_per_sender: txs_per_sender,
+        ..Default::default()
+    });
+
+    for sequence in 0..sequences {
+        let sender = bench_address(0x30, sequence);
+
+        for tx_idx in 0..txs_per_sender {
+            let target = bench_address(0x40, sequence * txs_per_sender + tx_idx);
+            let tx = bench_aa_tx(
+                sender,
+                target,
+                TEMPO_EXPIRING_NONCE_KEY,
+                expiring_nonce_value(),
+                NonZeroU64::new(BENCH_VALID_BEFORE + tx_idx as u64),
+            );
+            pool.add_transaction(Arc::new(wrap_valid_tx(tx)), 0, TempoHardfork::T1)
+                .expect("benchmark expiring nonce transaction must be accepted");
+        }
+    }
+
+    pool
+}
+
+/// Creates a merged best-transaction snapshot.
+pub fn best_transactions_snapshot(pool: &AA2dPool) -> MergeBestTransactions {
+    MergeBestTransactions::new(empty_protocol_best_transactions(), pool.best_transactions())
+}
+
+fn empty_protocol_best_transactions()
+-> reth_transaction_pool::pool::BestTransactions<CoinbaseTipOrdering<TempoPooledTransaction>> {
+    let pool = Pool::new(
+        OkValidator::<TempoPooledTransaction>::default(),
+        CoinbaseTipOrdering::default(),
+        InMemoryBlobStore::default(),
+        PoolConfig::default(),
+    );
+
+    pool.inner().best_transactions()
+}
+
+fn bench_aa_tx(
+    sender: Address,
+    target: Address,
+    nonce_key: U256,
+    nonce: u64,
+    valid_before: Option<NonZeroU64>,
+) -> TempoPooledTransaction {
+    let tx = TempoTransaction {
+        chain_id: BENCH_CHAIN_ID,
+        max_priority_fee_per_gas: BENCH_MAX_PRIORITY_FEE_PER_GAS,
+        max_fee_per_gas: BENCH_MAX_FEE_PER_GAS,
+        gas_limit: BENCH_GAS_LIMIT,
+        calls: vec![Call {
+            to: TxKind::Call(target),
+            value: U256::ZERO,
+            input: Default::default(),
+        }],
+        nonce_key,
+        nonce,
+        fee_token: None,
+        fee_payer_signature: None,
+        valid_after: None,
+        valid_before,
+        access_list: Default::default(),
+        tempo_authorization_list: Default::default(),
+        key_authorization: None,
+    };
+
+    let signature =
+        TempoSignature::Primitive(PrimitiveSignature::Secp256k1(Signature::test_signature()));
+    let aa_signed = AASigned::new_unhashed(tx, signature);
+    let envelope: TempoTxEnvelope = aa_signed.into();
+    let recovered = Recovered::new_unchecked(envelope, sender);
+
+    TempoPooledTransaction::new(recovered)
+}
+
+fn wrap_valid_tx(tx: TempoPooledTransaction) -> ValidPoolTransaction<TempoPooledTransaction> {
+    let tx_id = TransactionId::new(0u64.into(), tx.nonce());
+    ValidPoolTransaction {
+        transaction: tx,
+        transaction_id: tx_id,
+        propagate: true,
+        timestamp: Instant::now(),
+        origin: TransactionOrigin::Local,
+        authority_ids: None,
+    }
+}
+
+fn expiring_nonce_value() -> u64 {
+    u64::default()
+}
+
+fn bench_address(prefix: u8, index: usize) -> Address {
+    let mut bytes = [0u8; 20];
+    bytes[0] = prefix;
+    bytes[12..].copy_from_slice(&(index as u64).to_be_bytes());
+    Address::from(bytes)
+}

--- a/crates/transaction-pool/src/bench_support.rs
+++ b/crates/transaction-pool/src/bench_support.rs
@@ -1,20 +1,35 @@
 //! Benchmark helpers for transaction-pool internals.
 
 use crate::{
-    AA2dPoolConfig, best::MergeBestTransactions, transaction::TempoPooledTransaction,
+    AA2dPoolConfig, TempoTransactionPool,
+    amm::AmmLiquidityCache,
+    best::MergeBestTransactions,
+    maintain::{TempoPoolState, process_tempo_pool_block_update},
+    metrics::TempoPoolMaintenanceMetrics,
+    transaction::TempoPooledTransaction,
     tt_2d_pool::AA2dPool,
+    validator::{
+        DEFAULT_AA_VALID_AFTER_MAX_SECS, DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
+        TempoTransactionValidator,
+    },
 };
-use alloy_consensus::Transaction;
+use alloy_consensus::{Header, Transaction};
 use alloy_primitives::{Address, Signature, TxKind, U256};
 use reth_primitives_traits::Recovered;
+use reth_provider::{
+    Chain, ExecutionOutcome,
+    test_utils::{ExtendedAccount, MockEthProvider},
+};
 use reth_transaction_pool::{
-    CoinbaseTipOrdering, Pool, PoolConfig, SubPoolLimit, TransactionOrigin, ValidPoolTransaction,
-    blobstore::InMemoryBlobStore, identifier::TransactionId, test_utils::OkValidator,
+    CoinbaseTipOrdering, Pool, PoolConfig, SubPoolLimit, TransactionOrigin,
+    TransactionValidationTaskExecutor, ValidPoolTransaction, blobstore::InMemoryBlobStore,
+    identifier::TransactionId, test_utils::OkValidator, validate::EthTransactionValidatorBuilder,
 };
 use std::{num::NonZeroU64, sync::Arc, time::Instant};
-use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork, spec::MODERATO};
+use tempo_evm::TempoEvmConfig;
 use tempo_primitives::{
-    TempoTxEnvelope,
+    Block, BlockBody, TempoHeader, TempoPrimitives, TempoTxEnvelope,
     transaction::{
         TEMPO_EXPIRING_NONCE_KEY, TempoTransaction,
         tempo_transaction::Call,
@@ -29,6 +44,9 @@ const BENCH_GAS_LIMIT: u64 = 1_000_000;
 const BENCH_MAX_PRIORITY_FEE_PER_GAS: u128 = 1_000_000_000;
 const BENCH_MAX_FEE_PER_GAS: u128 = 20_000_000_000;
 const BENCH_VALID_BEFORE: u64 = 1_700_000_010;
+const BENCH_MAINTENANCE_TIP_TIMESTAMP: u64 = BENCH_VALID_BEFORE + 1;
+
+type BenchProvider = MockEthProvider<TempoPrimitives, TempoChainSpec>;
 
 /// Builds an AA 2D pool with `sequences` independent nonce chains of `chain_len` txs each.
 pub fn aa2d_pool_fixture(sequences: usize, chain_len: usize) -> AA2dPool {
@@ -66,6 +84,85 @@ pub fn aa2d_pool_fixture(sequences: usize, chain_len: usize) -> AA2dPool {
     }
 
     pool
+}
+
+/// Fixture for one expired-transaction txpool maintenance block update.
+pub struct ExpiredTxpoolMaintenanceFixture {
+    pool: TempoTransactionPool<BenchProvider>,
+    state: TempoPoolState,
+    metrics: TempoPoolMaintenanceMetrics,
+    amm_cache: AmmLiquidityCache,
+    chain: Arc<Chain<TempoPrimitives>>,
+}
+
+impl ExpiredTxpoolMaintenanceFixture {
+    /// Runs one maintenance block update and returns the number of expired transactions evicted.
+    pub fn run_one(&mut self) -> usize {
+        process_tempo_pool_block_update(
+            &self.pool,
+            &mut self.state,
+            &self.metrics,
+            &self.amm_cache,
+            &self.chain,
+        )
+        .expired_evicted
+    }
+}
+
+/// Builds a txpool maintenance fixture where all AA2D transactions are expired.
+pub fn expired_txpool_maintenance_fixture(
+    sequences: usize,
+    txs_per_sender: usize,
+) -> ExpiredTxpoolMaintenanceFixture {
+    assert!(
+        sequences > 0,
+        "benchmark fixture must have at least one sequence"
+    );
+    assert!(
+        txs_per_sender > 0,
+        "benchmark fixture must have at least one tx per sender"
+    );
+
+    let mut state = TempoPoolState::default();
+    let mut aa_pool = AA2dPool::new(AA2dPoolConfig {
+        pending_limit: SubPoolLimit::max(),
+        queued_limit: SubPoolLimit::max(),
+        max_txs_per_sender: txs_per_sender,
+        ..Default::default()
+    });
+
+    for sequence in 0..sequences {
+        let sender = bench_address(0x50, sequence);
+        let target = bench_address(0x60, sequence);
+
+        for nonce in 0..txs_per_sender {
+            let tx = bench_aa_tx(
+                sender,
+                target,
+                U256::from(BENCH_NONCE_KEY),
+                nonce as u64,
+                NonZeroU64::new(BENCH_VALID_BEFORE),
+            );
+            state.track(&tx);
+            aa_pool
+                .add_transaction(Arc::new(wrap_valid_tx(tx)), 0, TempoHardfork::T1)
+                .expect("benchmark expired AA 2D transaction must be accepted");
+        }
+    }
+
+    let provider = bench_provider();
+    let protocol_pool = bench_protocol_pool(provider);
+    let pool = TempoTransactionPool::new(protocol_pool, aa_pool);
+    let amm_cache = pool.amm_liquidity_cache();
+    let chain = maintenance_chain(BENCH_MAINTENANCE_TIP_TIMESTAMP);
+
+    ExpiredTxpoolMaintenanceFixture {
+        pool,
+        state,
+        metrics: TempoPoolMaintenanceMetrics::default(),
+        amm_cache,
+        chain,
+    }
 }
 
 /// Builds an AA pool with independent expiring-nonce transactions.
@@ -121,6 +218,61 @@ fn empty_protocol_best_transactions()
     );
 
     pool.inner().best_transactions()
+}
+
+fn bench_provider() -> BenchProvider {
+    let provider = MockEthProvider::<TempoPrimitives>::new()
+        .with_chain_spec(Arc::unwrap_or_clone(MODERATO.clone()))
+        .with_genesis_block();
+    provider.add_account(Address::ZERO, ExtendedAccount::new(0, U256::MAX));
+    provider
+}
+
+fn bench_protocol_pool(
+    provider: BenchProvider,
+) -> Pool<
+    TransactionValidationTaskExecutor<TempoTransactionValidator<BenchProvider>>,
+    CoinbaseTipOrdering<TempoPooledTransaction>,
+    InMemoryBlobStore,
+> {
+    let inner = EthTransactionValidatorBuilder::new(provider, TempoEvmConfig::mainnet())
+        .disable_balance_check()
+        .build(InMemoryBlobStore::default());
+    let validator = TempoTransactionValidator::new(
+        inner,
+        DEFAULT_AA_VALID_AFTER_MAX_SECS,
+        DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
+        AmmLiquidityCache::with_unique_validators(Vec::new()),
+    );
+    let (executor, _task) = TransactionValidationTaskExecutor::new(validator);
+
+    Pool::new(
+        executor,
+        CoinbaseTipOrdering::default(),
+        InMemoryBlobStore::default(),
+        PoolConfig::default(),
+    )
+}
+
+fn maintenance_chain(tip_timestamp: u64) -> Arc<Chain<TempoPrimitives>> {
+    let block = Block::new(
+        TempoHeader {
+            inner: Header {
+                number: 1,
+                timestamp: tip_timestamp,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        BlockBody::default(),
+    );
+    let recovered = reth_primitives_traits::RecoveredBlock::new_unhashed(block, Vec::new());
+
+    Arc::new(Chain::new(
+        vec![recovered],
+        ExecutionOutcome::default(),
+        Default::default(),
+    ))
 }
 
 fn bench_aa_tx(

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -27,5 +27,8 @@ pub use maintain::TempoPoolUpdates;
 pub use metrics::{AA2dPoolMetrics, TempoPoolMaintenanceMetrics};
 pub use tt_2d_pool::{AA2dPool, AA2dPoolConfig, AASequenceId, DEFAULT_MAX_TXS_PER_SENDER};
 
+#[cfg(feature = "test-utils")]
+pub mod bench_support;
+
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     RevokedKeys, SpendingLimitUpdates, TempoTransactionPool,
+    amm::AmmLiquidityCache,
     metrics::TempoPoolMaintenanceMetrics,
     paused::{PausedEntry, PausedFeeTokenPool},
     transaction::TempoPooledTransaction,
@@ -365,7 +366,7 @@ fn decode_event<T: SolEvent>(log: &Log) -> Option<T> {
 /// when we check `pool.contains()` before eviction. This avoids the overhead of
 /// subscribing to all transaction lifecycle events.
 #[derive(Default)]
-struct TempoPoolState {
+pub(crate) struct TempoPoolState {
     /// Maps timestamp to transactions that are going to be invalidated at that time (due to `valid_after` or keychain-related expiry).
     expiry_map: BTreeMap<u64, B256Set>,
     /// Reverse mapping: tx_hash -> valid_before timestamp (for cleanup during drain).
@@ -378,7 +379,7 @@ struct TempoPoolState {
 
 impl TempoPoolState {
     /// Tracks an AA transaction with a `valid_before` timestamp.
-    fn track(&mut self, tx: &TempoPooledTransaction) {
+    pub(crate) fn track(&mut self, tx: &TempoPooledTransaction) {
         let valid_before = tx
             .inner()
             .as_aa()
@@ -524,6 +525,360 @@ impl Default for PendingStalenessTracker {
     }
 }
 
+/// Summary of one synchronous txpool maintenance block update.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TempoPoolMaintenanceOutcome {
+    /// Number of expired transactions selected for eviction.
+    pub(crate) expired_evicted: usize,
+}
+
+/// Processes the synchronous per-block maintenance body.
+pub(crate) fn process_tempo_pool_block_update<Client>(
+    pool: &TempoTransactionPool<Client>,
+    state: &mut TempoPoolState,
+    metrics: &TempoPoolMaintenanceMetrics,
+    amm_cache: &AmmLiquidityCache,
+    tip: &Chain<TempoPrimitives>,
+) -> TempoPoolMaintenanceOutcome
+where
+    Client: StateProviderFactory
+        + HeaderProvider<Header = TempoHeader>
+        + ChainSpecProvider<ChainSpec = TempoChainSpec>
+        + Send
+        + Sync
+        + 'static,
+{
+    let mut outcome = TempoPoolMaintenanceOutcome::default();
+    let block_update_start = Instant::now();
+
+    let bundle_state = tip.execution_outcome().state().state();
+    let tip_timestamp = tip.tip().header().timestamp();
+
+    // 1. Collect all block-level invalidation events
+    let mut updates = TempoPoolUpdates::from_chain(tip);
+
+    // Remove expiry tracking for mined transactions.
+    let mined_hashes = tip
+        .blocks_iter()
+        .flat_map(|block| block.body().transactions())
+        .map(|tx| tx.tx_hash());
+    state.untrack_many(mined_hashes);
+
+    // Evict transactions slightly before they expire to prevent
+    // broadcasting near-expiry txs that peers would reject.
+    let max_expiry = tip_timestamp.saturating_add(EVICTION_BUFFER_SECS);
+
+    // Add expired transactions (from local tracking state)
+    let expired = state.drain_expired(max_expiry);
+    updates.expired_txs = expired.into_iter().filter(|h| pool.contains(h)).collect();
+
+    // 2. Evict expired AA transactions
+    let expired_start = Instant::now();
+    let expired_count = updates.expired_txs.len();
+    outcome.expired_evicted = expired_count;
+    if expired_count > 0 {
+        debug!(
+            target: "txpool",
+            count = expired_count,
+            tip_timestamp,
+            "Evicting expired AA transactions (valid_before)"
+        );
+        pool.remove_transactions(updates.expired_txs.clone());
+        metrics
+            .expired_transactions_evicted
+            .increment(expired_count as u64);
+    }
+    metrics
+        .expired_eviction_duration_seconds
+        .record(expired_start.elapsed());
+
+    // 3. Handle fee token pause/unpause events
+    let pause_start = Instant::now();
+
+    // Collect pause tokens that need pool scanning.
+    // For pause events, we need to scan the pool. For unpause events, we
+    // only need to check the paused_pool (O(1) lookup by token).
+    let pause_tokens: Vec<Address> = updates
+        .pause_events
+        .iter()
+        .filter_map(|(token, is_paused)| is_paused.then_some(*token))
+        .collect();
+
+    // Process pause events: fetch pool transactions once for all pause tokens.
+    // This avoids the O(pause_events * pool_size) cost of fetching per event.
+    if !pause_tokens.is_empty() {
+        let all_txs = pool.all_transactions();
+
+        // Group transactions by fee token for efficient batch processing.
+        // This single pass over all transactions handles all pause events.
+        let mut by_token: AddressMap<Vec<TxHash>> = AddressMap::default();
+        for tx in all_txs.pending.iter().chain(all_txs.queued.iter()) {
+            if let Some(fee_token) = tx.transaction.inner().fee_token() {
+                by_token.entry(fee_token).or_default().push(*tx.hash());
+            }
+        }
+
+        // Process each pause token
+        for token in pause_tokens {
+            let Some(hashes_to_pause) = by_token.remove(&token) else {
+                // No transactions use this fee token - skip
+                continue;
+            };
+
+            let removed_txs = pool.remove_transactions(hashes_to_pause);
+            let count = removed_txs.len();
+
+            if count > 0 {
+                // Clean up expiry tracking for paused txs
+                for tx in &removed_txs {
+                    state.untrack(tx.hash());
+                }
+
+                let entries: Vec<_> = removed_txs
+                    .into_iter()
+                    .map(|tx| {
+                        let valid_before = tx
+                            .transaction
+                            .inner()
+                            .as_aa()
+                            .and_then(|aa| aa.tx().valid_before.map(|value| value.get()));
+                        PausedEntry { tx, valid_before }
+                    })
+                    .collect();
+
+                let cap_evicted = state.paused_pool.insert_batch(token, entries);
+                metrics.transactions_paused.increment(count as u64);
+                if cap_evicted > 0 {
+                    metrics
+                        .paused_pool_cap_evicted
+                        .increment(cap_evicted as u64);
+                    debug!(
+                        target: "txpool",
+                        cap_evicted,
+                        "Evicted oldest paused transactions due to global cap"
+                    );
+                }
+                debug!(
+                    target: "txpool",
+                    %token,
+                    count,
+                    "Moved transactions to paused pool (fee token paused)"
+                );
+            }
+        }
+    }
+
+    // Process unpause events: O(1) lookup per token in paused_pool
+    for (token, is_paused) in &updates.pause_events {
+        if *is_paused {
+            continue; // Already handled above
+        }
+
+        // Unpause: drain from paused pool and re-add to main pool
+        let paused_entries = state.paused_pool.drain_token(token);
+        if !paused_entries.is_empty() {
+            let count = paused_entries.len();
+            metrics.transactions_unpaused.increment(count as u64);
+            let pool_clone = pool.clone();
+            let token = *token;
+            tokio::spawn(async move {
+                let txs: Vec<_> = paused_entries
+                    .into_iter()
+                    .map(|e| e.tx.transaction.clone())
+                    .collect();
+
+                let results = pool_clone.add_external_transactions(txs).await;
+
+                let success = results.iter().filter(|r| r.is_ok()).count();
+                debug!(
+                    target: "txpool",
+                    %token,
+                    total = count,
+                    success,
+                    "Restored transactions from paused pool (fee token unpaused)"
+                );
+            });
+        }
+    }
+
+    // 4. Evict expired transactions from the paused pool
+    let paused_expired = state.paused_pool.evict_expired(tip_timestamp);
+    let paused_timed_out = state.paused_pool.evict_timed_out();
+    let total_paused_evicted = paused_expired + paused_timed_out;
+    if total_paused_evicted > 0 {
+        debug!(
+            target: "txpool",
+            count = total_paused_evicted,
+            tip_timestamp,
+            "Evicted expired transactions from paused pool"
+        );
+    }
+
+    // 5. Evict hard keychain invalidations from paused pool
+    // Ignore spending_limit_spends here: AccessKeySpend only proves partial limit consumption,
+    // and paused txs are fully revalidated on unpause.
+    if !updates.revoked_keys.is_empty()
+        || !updates.spending_limit_changes.is_empty()
+        || !updates.key_authorization_witness_burns.is_empty()
+    {
+        state.paused_pool.evict_invalidated(
+            &updates.revoked_keys,
+            &updates.spending_limit_changes,
+            &updates.key_authorization_witness_burns,
+        );
+    }
+    metrics
+        .pause_events_duration_seconds
+        .record(pause_start.elapsed());
+
+    // 5b. Handle potentially invalidating updates
+    // When a cached value changes of a token (transfer policy, or quote token) changes,
+    // pending transactions using that token may become invalid. We need to remove them
+    // and re-add so they go through full validation against the updated state.
+    for (updated, counter, reason) in [
+        (
+            &updates.transfer_policy_updates,
+            &metrics.transfer_policy_revalidated,
+            "transfer policy update",
+        ),
+        (
+            &updates.quote_token_updates,
+            &metrics.quote_token_revalidated,
+            "quote token update",
+        ),
+    ] {
+        if updated.is_empty() {
+            continue;
+        }
+
+        let all_txs = pool.all_transactions();
+        let hashes: Vec<TxHash> = all_txs
+            .pending
+            .iter()
+            .chain(all_txs.queued.iter())
+            .filter(|tx| {
+                tx.transaction
+                    .resolved_fee_token()
+                    .is_some_and(|t| updated.contains(&t))
+            })
+            .map(|tx| *tx.hash())
+            .collect();
+        if !hashes.is_empty() {
+            let removed_txs = pool.remove_transactions(hashes);
+            let count = removed_txs.len();
+
+            for tx in &removed_txs {
+                state.untrack(tx.hash());
+            }
+
+            counter.increment(count as u64);
+
+            let pool_clone = pool.clone();
+            tokio::spawn(async move {
+                let txs: Vec<_> = removed_txs
+                    .into_iter()
+                    .map(|tx| (tx.origin, tx.transaction.clone()))
+                    .collect();
+
+                let results = pool_clone.add_transactions_with_origins(txs).await;
+                let success = results.iter().filter(|r| r.is_ok()).count();
+                debug!(
+                    target: "txpool",
+                    total = count,
+                    success,
+                    reason,
+                    "Re-validated transactions"
+                );
+            });
+        }
+    }
+
+    // 6. Update 2D nonce pool (also removes included expiring nonce txs
+    // via slot changes on the nonce precompile)
+    let nonce_pool_start = Instant::now();
+    let _mined_aa_txs = pool.notify_aa_pool_on_state_updates(bundle_state);
+    metrics
+        .nonce_pool_update_duration_seconds
+        .record(nonce_pool_start.elapsed());
+
+    // 7. Update AMM liquidity cache (must happen before validator token eviction)
+    let amm_start = Instant::now();
+    amm_cache.on_new_state(tip.execution_outcome());
+    if let Err(err) = amm_cache.on_new_blocks(
+        tip.blocks_iter().map(|block| block.sealed_header()),
+        pool.client(),
+    ) {
+        error!(target: "txpool", ?err, "AMM liquidity cache update failed");
+    }
+    metrics
+        .amm_cache_update_duration_seconds
+        .record(amm_start.elapsed());
+
+    // 8. Evict invalidated transactions in a single pool scan
+    // This checks revoked keys, spending limit changes, validator token changes,
+    // blacklist additions, and whitelist removals together to avoid scanning
+    // all transactions multiple times per block.
+    if updates.has_invalidation_events() {
+        let invalidation_start = Instant::now();
+        debug!(
+            target: "txpool",
+            revoked_keys = updates.revoked_keys.len(),
+            spending_limit_changes = updates.spending_limit_changes.len(),
+            spending_limit_spends = updates.spending_limit_spends.len(),
+            validator_token_changes = updates.validator_token_changes.len(),
+            user_token_changes = updates.user_token_changes.len(),
+            blacklist_additions = updates.blacklist_additions.len(),
+            whitelist_removals = updates.whitelist_removals.len(),
+            "Processing transaction invalidation events"
+        );
+        let evicted = pool.evict_invalidated_transactions(&updates);
+        for hash in &evicted {
+            state.untrack(hash);
+        }
+        metrics
+            .transactions_invalidated
+            .increment(evicted.len() as u64);
+        metrics
+            .invalidation_eviction_duration_seconds
+            .record(invalidation_start.elapsed());
+    }
+
+    // 9. Evict stale pending transactions (must happen after AA pool promotions in step 6)
+    // Only runs once per interval (~30 min) to avoid overhead on every block.
+    // Transactions pending across two consecutive snapshots are considered stale.
+    if state.pending_staleness.should_check(tip_timestamp) {
+        let current_pending: B256Set = pool
+            .pending_transactions()
+            .iter()
+            .map(|tx| *tx.hash())
+            .collect();
+        let stale_to_evict = state
+            .pending_staleness
+            .check_and_update(current_pending, tip_timestamp);
+
+        if !stale_to_evict.is_empty() {
+            debug!(
+                target: "txpool",
+                count = stale_to_evict.len(),
+                tip_timestamp,
+                "Evicting stale pending transactions"
+            );
+            // Clean up expiry tracking for stale txs to prevent orphaned entries
+            for hash in &stale_to_evict {
+                state.untrack(hash);
+            }
+            pool.remove_transactions(stale_to_evict);
+        }
+    }
+
+    // Record total block update duration
+    metrics
+        .block_update_duration_seconds
+        .record(block_update_start.elapsed());
+
+    outcome
+}
+
 /// Unified maintenance task for the Tempo transaction pool.
 ///
 /// Handles:
@@ -585,309 +940,13 @@ where
                     CanonStateNotification::Commit { new } => new,
                 };
 
-                let block_update_start = Instant::now();
-
-                let tip = &new;
-                let bundle_state = tip.execution_outcome().state().state();
-                let tip_timestamp = tip.tip().header().timestamp();
-
-                // 1. Collect all block-level invalidation events
-                let mut updates = TempoPoolUpdates::from_chain(tip);
-
-                // Remove expiry tracking for mined transactions.
-                let mined_hashes = tip.blocks_iter()
-                    .flat_map(|block| block.body().transactions())
-                    .map(|tx| tx.tx_hash());
-                state.untrack_many(mined_hashes);
-
-                // Evict transactions slightly before they expire to prevent
-                // broadcasting near-expiry txs that peers would reject.
-                let max_expiry = tip_timestamp.saturating_add(EVICTION_BUFFER_SECS);
-
-                // Add expired transactions (from local tracking state)
-                let expired = state.drain_expired(max_expiry);
-                updates.expired_txs = expired.into_iter().filter(|h| pool.contains(h)).collect();
-
-                // 2. Evict expired AA transactions
-                let expired_start = Instant::now();
-                let expired_count = updates.expired_txs.len();
-                if expired_count > 0 {
-                    debug!(
-                        target: "txpool",
-                        count = expired_count,
-                        tip_timestamp,
-                        "Evicting expired AA transactions (valid_before)"
-                    );
-                    pool.remove_transactions(updates.expired_txs.clone());
-                    metrics.expired_transactions_evicted.increment(expired_count as u64);
-                }
-                metrics.expired_eviction_duration_seconds.record(expired_start.elapsed());
-
-                // 3. Handle fee token pause/unpause events
-                let pause_start = Instant::now();
-
-                // Collect pause tokens that need pool scanning.
-                // For pause events, we need to scan the pool. For unpause events, we
-                // only need to check the paused_pool (O(1) lookup by token).
-                let pause_tokens: Vec<Address> = updates
-                    .pause_events
-                    .iter()
-                    .filter_map(|(token, is_paused)| is_paused.then_some(*token))
-                    .collect();
-
-                // Process pause events: fetch pool transactions once for all pause tokens.
-                // This avoids the O(pause_events * pool_size) cost of fetching per event.
-                if !pause_tokens.is_empty() {
-                    let all_txs = pool.all_transactions();
-
-                    // Group transactions by fee token for efficient batch processing.
-                    // This single pass over all transactions handles all pause events.
-                    let mut by_token: AddressMap<Vec<TxHash>> = AddressMap::default();
-                    for tx in all_txs.pending.iter().chain(all_txs.queued.iter()) {
-                        if let Some(fee_token) = tx.transaction.inner().fee_token() {
-                            by_token.entry(fee_token).or_default().push(*tx.hash());
-                        }
-                    }
-
-                    // Process each pause token
-                    for token in pause_tokens {
-                        let Some(hashes_to_pause) = by_token.remove(&token) else {
-                            // No transactions use this fee token - skip
-                            continue;
-                        };
-
-                        let removed_txs = pool.remove_transactions(hashes_to_pause);
-                        let count = removed_txs.len();
-
-                        if count > 0 {
-                            // Clean up expiry tracking for paused txs
-                            for tx in &removed_txs {
-                                state.untrack(tx.hash());
-                            }
-
-                            let entries: Vec<_> = removed_txs
-                                .into_iter()
-                                .map(|tx| {
-                                    let valid_before = tx
-                                        .transaction
-                                        .inner()
-                                        .as_aa()
-                                        .and_then(|aa| aa.tx().valid_before.map(|value| value.get()));
-                                    PausedEntry { tx, valid_before }
-                                })
-                                .collect();
-
-                            let cap_evicted = state.paused_pool.insert_batch(token, entries);
-                            metrics.transactions_paused.increment(count as u64);
-                            if cap_evicted > 0 {
-                                metrics.paused_pool_cap_evicted.increment(cap_evicted as u64);
-                                debug!(
-                                    target: "txpool",
-                                    cap_evicted,
-                                    "Evicted oldest paused transactions due to global cap"
-                                );
-                            }
-                            debug!(
-                                target: "txpool",
-                                %token,
-                                count,
-                                "Moved transactions to paused pool (fee token paused)"
-                            );
-                        }
-                    }
-                }
-
-                // Process unpause events: O(1) lookup per token in paused_pool
-                for (token, is_paused) in &updates.pause_events {
-                    if *is_paused {
-                        continue; // Already handled above
-                    }
-
-                    // Unpause: drain from paused pool and re-add to main pool
-                    let paused_entries = state.paused_pool.drain_token(token);
-                    if !paused_entries.is_empty() {
-                        let count = paused_entries.len();
-                        metrics.transactions_unpaused.increment(count as u64);
-                        let pool_clone = pool.clone();
-                        let token = *token;
-                        tokio::spawn(async move {
-                            let txs: Vec<_> = paused_entries
-                                .into_iter()
-                                .map(|e| e.tx.transaction.clone())
-                                .collect();
-
-                            let results = pool_clone
-                                .add_external_transactions(txs)
-                                .await;
-
-                            let success = results.iter().filter(|r| r.is_ok()).count();
-                            debug!(
-                                target: "txpool",
-                                %token,
-                                total = count,
-                                success,
-                                "Restored transactions from paused pool (fee token unpaused)"
-                            );
-                        });
-                    }
-                }
-
-                // 4. Evict expired transactions from the paused pool
-                let paused_expired = state.paused_pool.evict_expired(tip_timestamp);
-                let paused_timed_out = state.paused_pool.evict_timed_out();
-                let total_paused_evicted = paused_expired + paused_timed_out;
-                if total_paused_evicted > 0 {
-                    debug!(
-                        target: "txpool",
-                        count = total_paused_evicted,
-                        tip_timestamp,
-                        "Evicted expired transactions from paused pool"
-                    );
-                }
-
-                // 5. Evict hard keychain invalidations from paused pool
-                // Ignore spending_limit_spends here: AccessKeySpend only proves partial limit consumption, and paused txs are fully revalidated on unpause.
-                if !updates.revoked_keys.is_empty()
-                    || !updates.spending_limit_changes.is_empty()
-                    || !updates.key_authorization_witness_burns.is_empty()
-                {
-                    state.paused_pool.evict_invalidated(
-                        &updates.revoked_keys,
-                        &updates.spending_limit_changes,
-                        &updates.key_authorization_witness_burns,
-                    );
-                }
-                metrics.pause_events_duration_seconds.record(pause_start.elapsed());
-
-                // 5b. Handle potentially invalidating updates
-                // When a cached value changes of a token (transfer policy, or quote token) changes,
-                // pending transactions using that token may become invalid. We need to remove them
-                // and re-add so they go through full validation against the updated state.
-                for (updated, counter, reason) in [
-                    (
-                        &updates.transfer_policy_updates,
-                        &metrics.transfer_policy_revalidated,
-                        "transfer policy update",
-                    ),
-                    (
-                        &updates.quote_token_updates,
-                        &metrics.quote_token_revalidated,
-                        "quote token update",
-                    ),
-                ] {
-                    if updated.is_empty() {
-                        continue;
-                    }
-
-                    let all_txs = pool.all_transactions();
-                    let hashes: Vec<TxHash> = all_txs
-                        .pending
-                        .iter()
-                        .chain(all_txs.queued.iter())
-                        .filter(|tx| {
-                            tx.transaction
-                                .resolved_fee_token()
-                                .is_some_and(|t| updated.contains(&t))
-                        })
-                        .map(|tx| *tx.hash())
-                        .collect();
-                    if !hashes.is_empty() {
-                        let removed_txs = pool.remove_transactions(hashes);
-                        let count = removed_txs.len();
-
-                        for tx in &removed_txs {
-                            state.untrack(tx.hash());
-                        }
-
-                        counter.increment(count as u64);
-
-                        let pool_clone = pool.clone();
-                        tokio::spawn(async move {
-                            let txs: Vec<_> = removed_txs
-                                .into_iter()
-                                .map(|tx| (tx.origin, tx.transaction.clone()))
-                                .collect();
-
-                            let results = pool_clone.add_transactions_with_origins(txs).await;
-                            let success = results.iter().filter(|r| r.is_ok()).count();
-                            debug!(
-                                target: "txpool",
-                                total = count,
-                                success,
-                                reason,
-                                "Re-validated transactions"
-                            );
-                        });
-                    }
-                }
-
-                // 6. Update 2D nonce pool (also removes included expiring nonce txs
-                // via slot changes on the nonce precompile)
-                let nonce_pool_start = Instant::now();
-                let _mined_aa_txs = pool.notify_aa_pool_on_state_updates(bundle_state);
-                metrics.nonce_pool_update_duration_seconds.record(nonce_pool_start.elapsed());
-
-                // 7. Update AMM liquidity cache (must happen before validator token eviction)
-                let amm_start = Instant::now();
-                amm_cache.on_new_state(tip.execution_outcome());
-                if let Err(err) = amm_cache.on_new_blocks(tip.blocks_iter().map(|block| block.sealed_header()), pool.client()) {
-                    error!(target: "txpool", ?err, "AMM liquidity cache update failed");
-                }
-                metrics.amm_cache_update_duration_seconds.record(amm_start.elapsed());
-
-                // 8. Evict invalidated transactions in a single pool scan
-                // This checks revoked keys, spending limit changes, validator token changes,
-                // blacklist additions, and whitelist removals together to avoid scanning
-                // all transactions multiple times per block.
-                if updates.has_invalidation_events() {
-                    let invalidation_start = Instant::now();
-                    debug!(
-                        target: "txpool",
-                        revoked_keys = updates.revoked_keys.len(),
-                        spending_limit_changes = updates.spending_limit_changes.len(),
-                        spending_limit_spends = updates.spending_limit_spends.len(),
-                        validator_token_changes = updates.validator_token_changes.len(),
-                        user_token_changes = updates.user_token_changes.len(),
-                        blacklist_additions = updates.blacklist_additions.len(),
-                        whitelist_removals = updates.whitelist_removals.len(),
-                        "Processing transaction invalidation events"
-                    );
-                    let evicted = pool.evict_invalidated_transactions(&updates);
-                    for hash in &evicted {
-                        state.untrack(hash);
-                    }
-                    metrics.transactions_invalidated.increment(evicted.len() as u64);
-                    metrics
-                        .invalidation_eviction_duration_seconds
-                        .record(invalidation_start.elapsed());
-                }
-
-                // 9. Evict stale pending transactions (must happen after AA pool promotions in step 6)
-                // Only runs once per interval (~30 min) to avoid overhead on every block.
-                // Transactions pending across two consecutive snapshots are considered stale.
-                if state.pending_staleness.should_check(tip_timestamp) {
-                    let current_pending: B256Set =
-                        pool.pending_transactions().iter().map(|tx| *tx.hash()).collect();
-                    let stale_to_evict =
-                        state.pending_staleness.check_and_update(current_pending, tip_timestamp);
-
-                    if !stale_to_evict.is_empty() {
-                        debug!(
-                            target: "txpool",
-                            count = stale_to_evict.len(),
-                            tip_timestamp,
-                            "Evicting stale pending transactions"
-                        );
-                        // Clean up expiry tracking for stale txs to prevent orphaned entries
-                        for hash in &stale_to_evict {
-                            state.untrack(hash);
-                        }
-                        pool.remove_transactions(stale_to_evict);
-                    }
-                }
-
-                // Record total block update duration
-                metrics.block_update_duration_seconds.record(block_update_start.elapsed());
+                let _ = process_tempo_pool_block_update(
+                    &pool,
+                    &mut state,
+                    &metrics,
+                    &amm_cache,
+                    &new,
+                );
             }
         }
     }


### PR DESCRIPTION
Adds a CodSpeed-compatible transaction-pool benchmark for the merged best-transaction iterator. The benchmark covers one `next()` call for regular AA2D nonce chains and expiring-nonce transactions, and includes the transaction-pool bench target in the default CodSpeed microbench workflow.