### PR TITLE
docs(tip-1065): address reward cache review

### DIFF
--- a/tips/tip-1065.md
+++ b/tips/tip-1065.md
@@ -53,7 +53,7 @@ For T6+ execution, TIP-20 APIs continue to expose balances normally. `balanceOf(
 
 ## General User-State Cache Rules
 
-Cache fields are performance optimizations derived from existing protocol state. The protocol MUST ensure that cache is never stale, and always matches the source of truth.
+Cache fields are performance optimizations derived from existing protocol state. The protocol MUST ensure that any initialized cache value is never stale, and always matches the source of truth. An `Uninitialized` cache value is not stale; it means the implementation MUST read the source of truth before using that field.
 
 All packed state writes MUST be charged according to the storage slot's actual zero/nonzero transition. In particular, creating a cache-only slot from `state == 0` is a zero-to-nonzero storage write and MUST be charged as new state under TIP-1000; changing a nonzero balance slot into a cache-only slot is a nonzero-to-nonzero write and MUST NOT receive a nonzero-to-zero refund; clearing any nonzero packed state to `state == 0` is a nonzero-to-zero write and receives whatever refund is otherwise available for clearing that slot; and changing a cache-only slot into a nonzero balance slot is a nonzero-to-nonzero write and MUST NOT be charged as new state.
 
@@ -71,11 +71,13 @@ Balance writes encode the new `balance` in the low 128 bits. Existing defined ca
 
 Any other encoded value is invalid and MUST be treated as `Uninitialized`.
 
-`rewardRecipient(account)` remains the source of truth for reward delegation and opt-in status, and the `rewardFlag` MUST always be aligned with it. As defined in TIP-20, `rewardRecipient != address(0)` means opted in, and `rewardRecipient == address(0)` means opted out.
+`rewardRecipient(account)` remains the source of truth for reward delegation and opt-in status, and any initialized `rewardFlag` MUST always be aligned with it. As defined in TIP-20, `rewardRecipient != address(0)` means opted in, and `rewardRecipient == address(0)` means opted out.
 
 The reward-state cache may be used by balance-changing paths that need to know whether a holder is opted into rewards, including transfers, mints, fee refunds, reward claims, and any internal balance movement that updates `optedInSupply`. These paths MAY use an initialized `rewardFlag` instead of reading reward info from separate mapping slots. When `rewardFlag` is `Uninitialized` or invalid, the implementation MUST read `rewardRecipient(account)` and derive the effective reward state from it.
 
-`setRewardRecipient(recipient)` MUST update `rewardRecipient`. It MUST also ensure that any existing `rewardFlag` cache for the account is not left stale: if the packed state slot is nonzero, `setRewardRecipient(recipient)` MUST update `rewardFlag` in that slot to match the new effective reward state before returning. If the packed state slot is zero, `setRewardRecipient(recipient)` MAY either leave it zero or create a cache-only packed state slot with `balance == 0` and `rewardFlag` matching the new effective reward state.
+Once `rewardFlag` has been initialized to `OptedOut` or `OptedIn`, it MUST NOT be reset to `Uninitialized`; future changes MUST move directly between initialized states.
+
+`setRewardRecipient(recipient)` MUST update `rewardRecipient`. It MUST also update the packed state slot before returning so `rewardFlag` matches the new effective reward state. If the packed state slot is zero, `setRewardRecipient(recipient)` MUST create a cache-only packed state slot with `balance == 0` and `rewardFlag` matching the new effective reward state.
 
 `optedInSupply` updates MUST be based on effective opt-in transitions, preserving the existing supply accounting semantics. A cached `rewardFlag` value MUST NOT be used in a way that changes the result relative to deriving opt-in status from `rewardRecipient`.
 
@@ -88,4 +90,4 @@ The reward-state cache may be used by balance-changing paths that need to know w
 - At T6 activation, existing valid balances MUST decode to the same `balance` with `rewardFlag == Uninitialized`.
 - `balanceOf(account)` MUST return the low 128-bit `balance` and MUST NOT expose cache fields.
 - Invalid `rewardFlag` values MUST be treated as `Uninitialized`.
-- `rewardRecipient` MUST remain the source of truth for reward delegation and opt-in status. Any update that changes `rewardRecipient` MUST atomically update any existing initialized `rewardFlag` for the same account, so `rewardFlag` cannot become stale. Using `rewardFlag` MUST NOT change `optedInSupply` or reward-accounting results relative to deriving opt-in status from `rewardRecipient`.
+- `rewardRecipient` MUST remain the source of truth for reward delegation and opt-in status. Any update that changes `rewardRecipient` MUST atomically update `rewardFlag` for the same account, creating a cache-only packed state slot if needed, so an initialized `rewardFlag` cannot become stale. Once initialized, `rewardFlag` MUST NOT return to `Uninitialized`. Using `rewardFlag` MUST NOT change `optedInSupply` or reward-accounting results relative to deriving opt-in status from `rewardRecipient`.


### PR DESCRIPTION
Addresses review comments on https://github.com/tempoxyz/tempo/pull/4191.

- Clarifies that `Uninitialized` is an unknown cache state rather than stale cache.
- Requires `setRewardRecipient` to update/create the packed state slot and keep initialized `rewardFlag` values from returning to `Uninitialized`.

Prompted by: @0xrusowsky