### PR TITLE
fix: account for extra data when estimating block size

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -335,7 +335,8 @@ where
             .as_ref()
             .map(|w| w.length())
             .unwrap_or(0)
-            + 1024;
+            + 1024
+            + attributes.extra_data().length();
         let mut payment_transactions = 0u64;
         let mut pool_transactions_yielded = 0u64;
         let mut pool_transactions_included = 0u64;


### PR DESCRIPTION
fixes SIGP-267

Right now when estimating block size in the builder we don't account for a potentially large extra data from DKG service. This PR fixes it so that estimate is more correct