### PR TITLE
refactor(txpool): relax AMM liquidity provider borrow

### DIFF
--- a/crates/transaction-pool/src/amm.rs
+++ b/crates/transaction-pool/src/amm.rs
@@ -63,7 +63,7 @@ impl AmmLiquidityCache {
         &self,
         user_token: Address,
         fee: U256,
-        state_provider: &mut impl StateProvider,
+        mut state_provider: impl StateProvider,
     ) -> Result<bool, ProviderError> {
         let mut missing_in_cache = Vec::new();
         let hardfork;
@@ -419,10 +419,10 @@ mod tests {
         };
 
         let provider = create_mock_provider();
-        let mut state = provider.latest().unwrap();
+        let state = provider.latest().unwrap();
 
         let user_token = address!("1111111111111111111111111111111111111111");
-        let result = cache.has_enough_liquidity(user_token, U256::from(100), &mut state);
+        let result = cache.has_enough_liquidity(user_token, U256::from(100), &state);
 
         assert!(result.is_ok());
         assert!(
@@ -449,9 +449,9 @@ mod tests {
         };
 
         let provider = create_mock_provider();
-        let mut state = provider.latest().unwrap();
+        let state = provider.latest().unwrap();
 
-        let result = cache.has_enough_liquidity(user_token, U256::from(1000), &mut state);
+        let result = cache.has_enough_liquidity(user_token, U256::from(1000), &state);
         assert!(result.is_ok());
         assert!(
             result.unwrap(),
@@ -477,9 +477,9 @@ mod tests {
         };
 
         let provider = create_mock_provider();
-        let mut state = provider.latest().unwrap();
+        let state = provider.latest().unwrap();
 
-        let result = cache.has_enough_liquidity(user_token, U256::from(1000), &mut state);
+        let result = cache.has_enough_liquidity(user_token, U256::from(1000), &state);
         assert!(result.is_ok());
         assert!(
             !result.unwrap(),
@@ -494,10 +494,10 @@ mod tests {
         };
 
         let provider = create_mock_provider();
-        let mut state = provider.latest().unwrap();
+        let state = provider.latest().unwrap();
 
         let user_token = address!("1111111111111111111111111111111111111111");
-        let result = cache.has_enough_liquidity(user_token, U256::from(1000), &mut state);
+        let result = cache.has_enough_liquidity(user_token, U256::from(1000), &state);
         assert!(result.is_ok());
         assert!(
             !result.unwrap(),
@@ -534,9 +534,9 @@ mod tests {
         // Provider would return zero for any storage read; if the slow path runs we'd see
         // either a `false` result or a panic from the missing TIP-20 prefix on `user`.
         let provider = create_mock_provider();
-        let mut state = provider.latest().unwrap();
+        let state = provider.latest().unwrap();
 
-        let result = cache.has_enough_liquidity(user, U256::from(100), &mut state);
+        let result = cache.has_enough_liquidity(user, U256::from(100), &state);
         assert!(result.is_ok());
         assert!(
             result.unwrap(),
@@ -558,10 +558,10 @@ mod tests {
         };
 
         let provider = create_mock_provider();
-        let mut state = provider.latest().unwrap();
+        let state = provider.latest().unwrap();
 
         // Provider returns default (zero) storage values
-        let result = cache.has_enough_liquidity(user_token, U256::from(1000), &mut state);
+        let result = cache.has_enough_liquidity(user_token, U256::from(1000), &state);
         assert!(result.is_ok());
         assert!(
             !result.unwrap(),

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -270,7 +270,7 @@ where
             // Prevents mass eviction because it only:
             // - evicts when NO validator token has enough liquidity
             // - considers active validators (protects from permissionless `setValidatorToken`)
-            if has_active_validator_token_changes && let Some(ref mut provider) = state_provider {
+            if has_active_validator_token_changes && let Some(ref provider) = state_provider {
                 let user_token = tx.transaction.effective_fee_token();
                 let cost = tx.transaction.fee_token_cost();
 

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -445,7 +445,7 @@ where
         match self.amm_liquidity_cache.has_enough_liquidity(
             validation_ctx.fee_token,
             fee,
-            &mut state_provider,
+            &state_provider,
         ) {
             Ok(true) => {}
             Ok(false) => {
@@ -2439,7 +2439,7 @@ mod tests {
         // Verify has_enough_liquidity would bypass (return true) for this token
         // because it matches a validator token. This confirms the vulnerability we're testing.
         let liquidity_result =
-            amm_cache.has_enough_liquidity(paused_validator_token, U256::from(1000), &mut state);
+            amm_cache.has_enough_liquidity(paused_validator_token, U256::from(1000), &state);
         assert!(
             liquidity_result.is_ok() && liquidity_result.unwrap(),
             "Token in unique_tokens should bypass liquidity check and return true"


### PR DESCRIPTION
Allows `AmmLiquidityCache::has_enough_liquidity` to accept an immutable `StateProvider` reference and updates callers/tests to stop requiring mutable borrows for liquidity checks.

This keeps the API aligned with how the check uses provider state and leaves mutable provider borrows only where other validation paths need them.