### PR TITLE
fix(txpool): refresh tracked fee balance top-ups

### DIFF
--- a/crates/transaction-pool/src/best.rs
+++ b/crates/transaction-pool/src/best.rs
@@ -143,6 +143,8 @@ where
                 if storage_slot.present_value < storage_slot.original_value {
                     self.decreased_balances
                         .insert((address, slot), storage_slot.present_value);
+                } else if let Some(balance) = self.decreased_balances.get_mut(&(address, slot)) {
+                    *balance = storage_slot.present_value;
                 }
             }
         }


### PR DESCRIPTION
Fixes SIGP-264.

Refreshes tracked TIP-20 fee-payer balance slots when a later same-block top-up touches a slot that was previously recorded as decreased. This prevents the payload builder from skipping payable transactions based on a stale low-balance cache entry while still ignoring unrelated increases.