### PR TITLE
feat(transaction-pool): share tx prewarm touches with builder

### DIFF
--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -194,6 +194,7 @@ impl TryIntoTxEnv<TempoTxEnv, TempoHardfork, TempoBlockEnv> for TempoTransaction
             } else {
                 None
             },
+            prewarm_storage_touches: Default::default(),
             inner: inner.try_into_tx_env(evm_env)?,
         })
     }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -41,7 +41,7 @@ use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_revm::{evm::TempoContext, gas_params::tempo_gas_params_with_amsterdam};
 
 pub use tempo_revm::{
-    TempoBlockEnv, TempoHaltReason, TempoInvalidTransaction, TempoStateAccess,
+    TempoBlockEnv, TempoHaltReason, TempoInvalidTransaction, TempoStateAccess, TempoStorageTouch,
     gas_params::SSTORE_SET_COST,
 };
 

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -14,7 +14,7 @@ use reth_tasks::{TaskExecutor, WorkerPool};
 use reth_transaction_pool::{
     BestTransactions, PoolTransaction, error::InvalidPoolTransactionError,
 };
-use tempo_evm::{TempoEvmConfig, evm::TempoEvm};
+use tempo_evm::{TempoEvmConfig, TempoStorageTouch, evm::TempoEvm};
 use tempo_precompiles::{
     DEFAULT_FEE_TOKEN, NONCE_PRECOMPILE_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
     nonce::slots as nonce_slots,
@@ -182,14 +182,19 @@ impl BestTransactionsPrewarming {
             let tx_hash = *tx.hash();
 
             let touched = if is_tip20_transfer_transaction(&tx) {
-                let touches =
-                    storage_touches_for_transaction(&tx, prewarm.evm_env.block_env.beneficiary);
+                let tx_env = tx.transaction.clone_tx_env();
+                let tx_env_touches = tx_env.prewarm_storage_touches();
+                let touches = if tx_env_touches.is_empty() {
+                    storage_touches_for_transaction(&tx, prewarm.evm_env.block_env.beneficiary)
+                } else {
+                    tx_env_touches.to_vec()
+                };
 
                 for touch in &touches {
                     if prewarm.is_stopped() {
                         return;
                     }
-                    if let Err(err) = touch.warm(evm) {
+                    if let Err(err) = warm_storage_touch(touch, evm) {
                         trace!(
                             target: "payload_builder",
                             %err,
@@ -338,25 +343,23 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum StorageTouch {
-    Account(Address),
-    Storage { address: Address, slot: U256 },
-}
-
-impl StorageTouch {
-    fn warm<DB: Database>(&self, evm: &mut TempoEvm<DB>) -> Result<(), DB::Error> {
-        match *self {
-            Self::Account(address) => {
-                let _ = evm.db_mut().basic(address)?;
-            }
-            Self::Storage { address, slot } => {
-                let _ = evm.db_mut().storage(address, slot)?;
-            }
+fn warm_storage_touch<DB>(
+    touch: &TempoStorageTouch,
+    evm: &mut TempoEvm<DB>,
+) -> Result<(), DB::Error>
+where
+    DB: Database,
+{
+    match *touch {
+        TempoStorageTouch::Account(address) => {
+            let _ = evm.db_mut().basic(address)?;
         }
-
-        Ok(())
+        TempoStorageTouch::Storage { address, slot } => {
+            let _ = evm.db_mut().storage(address, slot)?;
+        }
     }
+
+    Ok(())
 }
 
 fn is_tip20_transfer_transaction(tx: &BestTransaction) -> bool {
@@ -394,7 +397,7 @@ fn is_tip20_transfer_call(kind: TxKind, input: &[u8]) -> bool {
 fn storage_touches_for_transaction(
     tx: &BestTransaction,
     fee_recipient: Address,
-) -> Vec<StorageTouch> {
+) -> Vec<TempoStorageTouch> {
     let mut touches = Vec::new();
     let sender = tx.transaction.sender();
     let fee_payer = tx.transaction.inner().fee_payer(sender).unwrap_or(sender);
@@ -419,7 +422,11 @@ fn storage_touches_for_transaction(
     touches
 }
 
-fn add_tip20_fee_touches(touches: &mut Vec<StorageTouch>, fee_token: Address, fee_payer: Address) {
+fn add_tip20_fee_touches(
+    touches: &mut Vec<TempoStorageTouch>,
+    fee_token: Address,
+    fee_payer: Address,
+) {
     if !fee_token.is_tip20() {
         return;
     }
@@ -431,7 +438,7 @@ fn add_tip20_fee_touches(touches: &mut Vec<StorageTouch>, fee_token: Address, fe
 }
 
 fn add_tip20_call_touches(
-    touches: &mut Vec<StorageTouch>,
+    touches: &mut Vec<TempoStorageTouch>,
     sender: Address,
     kind: TxKind,
     input: &[u8],
@@ -494,7 +501,7 @@ fn add_tip20_call_touches(
     }
 }
 
-fn add_tip20_common_touches(touches: &mut Vec<StorageTouch>, token: Address) {
+fn add_tip20_common_touches(touches: &mut Vec<TempoStorageTouch>, token: Address) {
     add_account_touch(touches, token);
     add_storage_touch(touches, token, tip20_slots::CURRENCY);
     add_storage_touch(touches, token, tip20_slots::PAUSED);
@@ -503,12 +510,12 @@ fn add_tip20_common_touches(touches: &mut Vec<StorageTouch>, token: Address) {
     add_storage_touch(touches, token, tip20_slots::OPTED_IN_SUPPLY);
 }
 
-fn add_tip20_balance_touch(touches: &mut Vec<StorageTouch>, token: Address, account: Address) {
+fn add_tip20_balance_touch(touches: &mut Vec<TempoStorageTouch>, token: Address, account: Address) {
     add_storage_touch(touches, token, account.mapping_slot(tip20_slots::BALANCES));
 }
 
 fn add_tip20_allowance_touch(
-    touches: &mut Vec<StorageTouch>,
+    touches: &mut Vec<TempoStorageTouch>,
     token: Address,
     owner: Address,
     spender: Address,
@@ -520,7 +527,11 @@ fn add_tip20_allowance_touch(
     );
 }
 
-fn add_tip20_reward_touches(touches: &mut Vec<StorageTouch>, token: Address, account: Address) {
+fn add_tip20_reward_touches(
+    touches: &mut Vec<TempoStorageTouch>,
+    token: Address,
+    account: Address,
+) {
     let base_slot = account.mapping_slot(tip20_slots::USER_REWARD_INFO);
     add_storage_touch(touches, token, base_slot);
     add_storage_touch(touches, token, base_slot + U256::from(1));
@@ -528,7 +539,7 @@ fn add_tip20_reward_touches(touches: &mut Vec<StorageTouch>, token: Address, acc
 }
 
 fn add_fee_manager_touches(
-    touches: &mut Vec<StorageTouch>,
+    touches: &mut Vec<TempoStorageTouch>,
     fee_recipient: Address,
     fee_token: Address,
 ) {
@@ -545,7 +556,7 @@ fn add_fee_manager_touches(
     );
 }
 
-fn add_expiring_nonce_touches(touches: &mut Vec<StorageTouch>, tx: &BestTransaction) {
+fn add_expiring_nonce_touches(touches: &mut Vec<TempoStorageTouch>, tx: &BestTransaction) {
     let Some(expiring_nonce_slot) = tx.transaction.expiring_nonce_slot() else {
         return;
     };
@@ -559,16 +570,16 @@ fn add_expiring_nonce_touches(touches: &mut Vec<StorageTouch>, tx: &BestTransact
     );
 }
 
-fn add_account_touch(touches: &mut Vec<StorageTouch>, address: Address) {
-    add_unique_touch(touches, StorageTouch::Account(address));
+fn add_account_touch(touches: &mut Vec<TempoStorageTouch>, address: Address) {
+    add_unique_touch(touches, TempoStorageTouch::Account(address));
 }
 
-fn add_storage_touch(touches: &mut Vec<StorageTouch>, address: Address, slot: U256) {
+fn add_storage_touch(touches: &mut Vec<TempoStorageTouch>, address: Address, slot: U256) {
     add_account_touch(touches, address);
-    add_unique_touch(touches, StorageTouch::Storage { address, slot });
+    add_unique_touch(touches, TempoStorageTouch::Storage { address, slot });
 }
 
-fn add_unique_touch(touches: &mut Vec<StorageTouch>, touch: StorageTouch) {
+fn add_unique_touch(touches: &mut Vec<TempoStorageTouch>, touch: TempoStorageTouch) {
     if !touches.contains(&touch) {
         touches.push(touch);
     }
@@ -853,12 +864,12 @@ mod tests {
             );
         }
 
-        assert!(touches.contains(&StorageTouch::Account(token)));
-        assert!(touches.contains(&StorageTouch::Storage {
+        assert!(touches.contains(&TempoStorageTouch::Account(token)));
+        assert!(touches.contains(&TempoStorageTouch::Storage {
             address: token,
             slot: sender.mapping_slot(tip20_slots::BALANCES)
         }));
-        assert!(touches.contains(&StorageTouch::Storage {
+        assert!(touches.contains(&TempoStorageTouch::Storage {
             address: token,
             slot: recipient.mapping_slot(tip20_slots::BALANCES)
         }));

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -1,7 +1,10 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-    mpsc::{self, Receiver, Sender},
+use std::{
+    cell::RefCell,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, Receiver, Sender},
+    },
 };
 
 use alloy_primitives::{B256, Bytes, TxKind};
@@ -21,6 +24,27 @@ use tempo_transaction_pool::best::BestTransaction;
 use tracing::trace;
 
 type PrewarmEvmState = Option<TempoEvm<StateProviderDatabase<StateProviderBox>>>;
+
+thread_local! {
+    static PREWARM_EVM_STATE: RefCell<PrewarmEvmSlot> =
+        const { RefCell::new(PrewarmEvmSlot::new()) };
+}
+
+struct PrewarmEvmSlot {
+    key: usize,
+    evm: PrewarmEvmState,
+}
+
+impl PrewarmEvmSlot {
+    const fn new() -> Self {
+        Self { key: 0, evm: None }
+    }
+
+    fn clear(&mut self) {
+        self.key = 0;
+        self.evm = None;
+    }
+}
 
 /// Prewarming orchestrator that consumes source [`BestTransactions`] with bounded
 /// lookahead, prewarms buffered transactions in parallel, and produces a new
@@ -93,11 +117,6 @@ impl BestTransactionsPrewarming {
         let pool = executor.prewarming_pool();
 
         pool.in_place_scope(|scope| {
-            let prewarm = ctx.prewarm.clone();
-            scope.spawn(move |_| {
-                pool.init::<PrewarmEvmState>(|_| prewarm.evm_for_ctx());
-            });
-
             let advance = |ctx: &mut BestTransactionsPrewarmingContext<Txs, Provider>| {
                 let Some(tx) = ctx.best_txs.next() else {
                     let _ = ctx.transactions_tx.send(None);
@@ -155,6 +174,7 @@ impl BestTransactionsPrewarming {
             }
         });
 
+        clear_prewarm_evm_state(pool);
         pool.clear();
     }
 
@@ -168,10 +188,10 @@ impl BestTransactionsPrewarming {
             return;
         }
 
-        WorkerPool::with_worker_mut(|worker| {
-            let Some(evm) = worker.get_or_init::<PrewarmEvmState>(|| prewarm.evm_for_ctx()) else {
+        with_prewarm_evm(&prewarm, |evm| {
+            if prewarm.is_stopped() {
                 return;
-            };
+            }
 
             let tx_hash = *tx.hash();
             let tx_env_touches = tx
@@ -223,6 +243,32 @@ impl BestTransactionsPrewarming {
             );
         });
     }
+}
+
+fn with_prewarm_evm<Provider>(
+    prewarm: &PrewarmingExecutionContext<Provider>,
+    f: impl FnOnce(&mut TempoEvm<StateProviderDatabase<StateProviderBox>>),
+) where
+    Provider: StateProviderFactory + Clone + 'static,
+{
+    let key = Arc::as_ptr(&prewarm.stop) as usize;
+    PREWARM_EVM_STATE.with_borrow_mut(|slot| {
+        if slot.key != key {
+            slot.evm = prewarm.evm_for_ctx();
+            slot.key = key;
+        }
+
+        let Some(evm) = slot.evm.as_mut() else {
+            return;
+        };
+        f(evm);
+    });
+}
+
+fn clear_prewarm_evm_state(pool: &WorkerPool) {
+    pool.broadcast(pool.current_num_threads(), |_| {
+        PREWARM_EVM_STATE.with_borrow_mut(PrewarmEvmSlot::clear);
+    });
 }
 
 impl Drop for BestTransactionsPrewarming {

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -180,33 +180,36 @@ impl BestTransactionsPrewarming {
             };
 
             let tx_hash = *tx.hash();
+            let tx_env_touches = tx.transaction.tx_env().prewarm_storage_touches();
 
             let touched = if is_tip20_transfer_transaction(&tx) {
-                let tx_env = tx.transaction.clone_tx_env();
-                let tx_env_touches = tx_env.prewarm_storage_touches();
+                let fallback_touches;
                 let touches = if tx_env_touches.is_empty() {
-                    storage_touches_for_transaction(&tx, prewarm.evm_env.block_env.beneficiary)
+                    fallback_touches =
+                        storage_touches_for_transaction(&tx, prewarm.evm_env.block_env.beneficiary);
+                    fallback_touches.as_slice()
                 } else {
-                    tx_env_touches.to_vec()
+                    tx_env_touches
                 };
 
-                for touch in &touches {
-                    if prewarm.is_stopped() {
-                        return;
-                    }
-                    if let Err(err) = warm_storage_touch(touch, evm) {
-                        trace!(
-                            target: "payload_builder",
-                            %err,
-                            ?tx_hash,
-                            "Failed to prewarm transaction storage"
-                        );
-                        return;
-                    }
-                }
+                let Some(touched) = warm_storage_touches(touches, evm, &prewarm.stop, tx_hash)
+                else {
+                    return;
+                };
 
-                Some(touches.len())
+                Some(touched)
             } else {
+                let touched = if tx_env_touches.is_empty() {
+                    None
+                } else {
+                    let Some(touched) =
+                        warm_storage_touches(tx_env_touches, evm, &prewarm.stop, tx_hash)
+                    else {
+                        return;
+                    };
+                    Some(touched)
+                };
+
                 if prewarm.is_stopped() {
                     return;
                 }
@@ -221,7 +224,7 @@ impl BestTransactionsPrewarming {
                     return;
                 }
 
-                None
+                touched
             };
 
             trace!(
@@ -341,6 +344,34 @@ where
     fn stop(&self) {
         self.stop.store(true, Ordering::Relaxed);
     }
+}
+
+fn warm_storage_touches<DB>(
+    touches: &[TempoStorageTouch],
+    evm: &mut TempoEvm<DB>,
+    stop: &AtomicBool,
+    tx_hash: B256,
+) -> Option<usize>
+where
+    DB: Database,
+    DB::Error: std::fmt::Display,
+{
+    for touch in touches {
+        if stop.load(Ordering::Relaxed) {
+            return None;
+        }
+        if let Err(err) = warm_storage_touch(touch, evm) {
+            trace!(
+                target: "payload_builder",
+                %err,
+                ?tx_hash,
+                "Failed to prewarm transaction storage"
+            );
+            return None;
+        }
+    }
+
+    Some(touches.len())
 }
 
 fn warm_storage_touch<DB>(

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -180,7 +180,11 @@ impl BestTransactionsPrewarming {
             };
 
             let tx_hash = *tx.hash();
-            let tx_env_touches = tx.transaction.tx_env().prewarm_storage_touches();
+            let tx_env_touches = tx
+                .transaction
+                .cached_tx_env()
+                .map(|tx_env| tx_env.prewarm_storage_touches())
+                .unwrap_or(&[]);
 
             let touched = if is_tip20_transfer_transaction(&tx) {
                 let fallback_touches;

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -4,7 +4,7 @@ use std::sync::{
     mpsc::{self, Receiver, Sender},
 };
 
-use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
+use alloy_primitives::{B256, Bytes, TxKind};
 use alloy_sol_types::SolInterface;
 use reth_engine_tree::tree::{CachedStateMetrics, CachedStateProvider, SavedCache};
 use reth_evm::{Database, Evm, EvmEnvFor};
@@ -15,13 +15,7 @@ use reth_transaction_pool::{
     BestTransactions, PoolTransaction, error::InvalidPoolTransactionError,
 };
 use tempo_evm::{TempoEvmConfig, TempoStorageTouch, evm::TempoEvm};
-use tempo_precompiles::{
-    DEFAULT_FEE_TOKEN, NONCE_PRECOMPILE_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
-    nonce::slots as nonce_slots,
-    storage::StorageKey as _,
-    tip_fee_manager::slots as fee_manager_slots,
-    tip20::{ITIP20, tip20_slots},
-};
+use tempo_precompiles::tip20::ITIP20;
 use tempo_primitives::TempoAddressExt;
 use tempo_transaction_pool::best::BestTransaction;
 use tracing::trace;
@@ -186,49 +180,39 @@ impl BestTransactionsPrewarming {
                 .map(|tx_env| tx_env.prewarm_storage_touches())
                 .unwrap_or(&[]);
 
-            let touched = if is_tip20_transfer_transaction(&tx) {
-                let fallback_touches;
-                let touches = if tx_env_touches.is_empty() {
-                    fallback_touches =
-                        storage_touches_for_transaction(&tx, prewarm.evm_env.block_env.beneficiary);
-                    fallback_touches.as_slice()
-                } else {
-                    tx_env_touches
-                };
-
-                let Some(touched) = warm_storage_touches(touches, evm, &prewarm.stop, tx_hash)
+            let touched = if tx_env_touches.is_empty() {
+                None
+            } else {
+                let Some(touched) =
+                    warm_storage_touches(tx_env_touches, evm, &prewarm.stop, tx_hash)
                 else {
                     return;
                 };
-
                 Some(touched)
-            } else {
-                let touched = if tx_env_touches.is_empty() {
-                    None
-                } else {
-                    let Some(touched) =
-                        warm_storage_touches(tx_env_touches, evm, &prewarm.stop, tx_hash)
-                    else {
-                        return;
-                    };
-                    Some(touched)
-                };
+            };
 
-                if prewarm.is_stopped() {
-                    return;
-                }
+            if !tx_env_touches.is_empty() && is_tip20_transfer_transaction(&tx) {
+                trace!(
+                    target: "payload_builder",
+                    touched,
+                    ?tx_hash,
+                    "Prewarmed transaction"
+                );
+                return;
+            }
 
-                if let Err(err) = evm.transact_raw(tx.transaction.clone_tx_env()) {
-                    trace!(
-                        target: "payload_builder",
-                        %err,
-                        ?tx_hash,
-                        "Failed to prewarm transaction by execution"
-                    );
-                    return;
-                }
+            if prewarm.is_stopped() {
+                return;
+            }
 
-                touched
+            if let Err(err) = evm.transact_raw(tx.transaction.clone_tx_env()) {
+                trace!(
+                    target: "payload_builder",
+                    %err,
+                    ?tx_hash,
+                    "Failed to prewarm transaction by execution"
+                );
+                return;
             };
 
             trace!(
@@ -429,197 +413,6 @@ fn is_tip20_transfer_call(kind: TxKind, input: &[u8]) -> bool {
     )
 }
 
-fn storage_touches_for_transaction(
-    tx: &BestTransaction,
-    fee_recipient: Address,
-) -> Vec<TempoStorageTouch> {
-    let mut touches = Vec::new();
-    let sender = tx.transaction.sender();
-    let fee_payer = tx.transaction.inner().fee_payer(sender).unwrap_or(sender);
-    let fee_token = tx.transaction.resolved_fee_token().unwrap_or_else(|| {
-        tx.transaction
-            .inner()
-            .fee_token()
-            .unwrap_or(DEFAULT_FEE_TOKEN)
-    });
-
-    add_tip20_fee_touches(&mut touches, fee_token, fee_payer);
-    add_fee_manager_touches(&mut touches, fee_recipient, fee_token);
-
-    if tx.transaction.is_payment() {
-        for (kind, input) in tx.transaction.inner().calls() {
-            add_tip20_call_touches(&mut touches, sender, kind, input);
-        }
-    }
-
-    add_expiring_nonce_touches(&mut touches, tx);
-
-    touches
-}
-
-fn add_tip20_fee_touches(
-    touches: &mut Vec<TempoStorageTouch>,
-    fee_token: Address,
-    fee_payer: Address,
-) {
-    if !fee_token.is_tip20() {
-        return;
-    }
-
-    add_tip20_common_touches(touches, fee_token);
-    add_tip20_balance_touch(touches, fee_token, fee_payer);
-    add_tip20_balance_touch(touches, fee_token, TIP_FEE_MANAGER_ADDRESS);
-    add_tip20_reward_touches(touches, fee_token, fee_payer);
-}
-
-fn add_tip20_call_touches(
-    touches: &mut Vec<TempoStorageTouch>,
-    sender: Address,
-    kind: TxKind,
-    input: &[u8],
-) {
-    let Some(token) = kind.to().copied() else {
-        return;
-    };
-    if !token.is_tip20() {
-        return;
-    }
-
-    add_tip20_common_touches(touches, token);
-    let Ok(call) = ITIP20::ITIP20Calls::abi_decode(input) else {
-        return;
-    };
-
-    match call {
-        ITIP20::ITIP20Calls::transfer(call) => {
-            add_tip20_balance_touch(touches, token, sender);
-            add_tip20_balance_touch(touches, token, call.to);
-            add_tip20_reward_touches(touches, token, sender);
-            add_tip20_reward_touches(touches, token, call.to);
-        }
-        ITIP20::ITIP20Calls::transferWithMemo(call) => {
-            add_tip20_balance_touch(touches, token, sender);
-            add_tip20_balance_touch(touches, token, call.to);
-            add_tip20_reward_touches(touches, token, sender);
-            add_tip20_reward_touches(touches, token, call.to);
-        }
-        ITIP20::ITIP20Calls::transferFrom(call) => {
-            add_tip20_balance_touch(touches, token, call.from);
-            add_tip20_balance_touch(touches, token, call.to);
-            add_tip20_allowance_touch(touches, token, call.from, sender);
-            add_tip20_reward_touches(touches, token, call.from);
-            add_tip20_reward_touches(touches, token, call.to);
-        }
-        ITIP20::ITIP20Calls::transferFromWithMemo(call) => {
-            add_tip20_balance_touch(touches, token, call.from);
-            add_tip20_balance_touch(touches, token, call.to);
-            add_tip20_allowance_touch(touches, token, call.from, sender);
-            add_tip20_reward_touches(touches, token, call.from);
-            add_tip20_reward_touches(touches, token, call.to);
-        }
-        ITIP20::ITIP20Calls::approve(call) => {
-            add_tip20_allowance_touch(touches, token, sender, call.spender);
-        }
-        ITIP20::ITIP20Calls::mint(call) => {
-            add_tip20_balance_touch(touches, token, call.to);
-            add_tip20_reward_touches(touches, token, call.to);
-        }
-        ITIP20::ITIP20Calls::mintWithMemo(call) => {
-            add_tip20_balance_touch(touches, token, call.to);
-            add_tip20_reward_touches(touches, token, call.to);
-        }
-        ITIP20::ITIP20Calls::burn(_) | ITIP20::ITIP20Calls::burnWithMemo(_) => {
-            add_tip20_balance_touch(touches, token, sender);
-            add_tip20_reward_touches(touches, token, sender);
-        }
-        _ => {}
-    }
-}
-
-fn add_tip20_common_touches(touches: &mut Vec<TempoStorageTouch>, token: Address) {
-    add_account_touch(touches, token);
-    add_storage_touch(touches, token, tip20_slots::CURRENCY);
-    add_storage_touch(touches, token, tip20_slots::PAUSED);
-    add_storage_touch(touches, token, tip20_slots::TRANSFER_POLICY_ID);
-    add_storage_touch(touches, token, tip20_slots::GLOBAL_REWARD_PER_TOKEN);
-    add_storage_touch(touches, token, tip20_slots::OPTED_IN_SUPPLY);
-}
-
-fn add_tip20_balance_touch(touches: &mut Vec<TempoStorageTouch>, token: Address, account: Address) {
-    add_storage_touch(touches, token, account.mapping_slot(tip20_slots::BALANCES));
-}
-
-fn add_tip20_allowance_touch(
-    touches: &mut Vec<TempoStorageTouch>,
-    token: Address,
-    owner: Address,
-    spender: Address,
-) {
-    add_storage_touch(
-        touches,
-        token,
-        spender.mapping_slot(owner.mapping_slot(tip20_slots::ALLOWANCES)),
-    );
-}
-
-fn add_tip20_reward_touches(
-    touches: &mut Vec<TempoStorageTouch>,
-    token: Address,
-    account: Address,
-) {
-    let base_slot = account.mapping_slot(tip20_slots::USER_REWARD_INFO);
-    add_storage_touch(touches, token, base_slot);
-    add_storage_touch(touches, token, base_slot + U256::from(1));
-    add_storage_touch(touches, token, base_slot + U256::from(2));
-}
-
-fn add_fee_manager_touches(
-    touches: &mut Vec<TempoStorageTouch>,
-    fee_recipient: Address,
-    fee_token: Address,
-) {
-    add_account_touch(touches, TIP_FEE_MANAGER_ADDRESS);
-    add_storage_touch(
-        touches,
-        TIP_FEE_MANAGER_ADDRESS,
-        fee_recipient.mapping_slot(fee_manager_slots::VALIDATOR_TOKENS),
-    );
-    add_storage_touch(
-        touches,
-        TIP_FEE_MANAGER_ADDRESS,
-        fee_token.mapping_slot(fee_recipient.mapping_slot(fee_manager_slots::COLLECTED_FEES)),
-    );
-}
-
-fn add_expiring_nonce_touches(touches: &mut Vec<TempoStorageTouch>, tx: &BestTransaction) {
-    let Some(expiring_nonce_slot) = tx.transaction.expiring_nonce_slot() else {
-        return;
-    };
-
-    add_account_touch(touches, NONCE_PRECOMPILE_ADDRESS);
-    add_storage_touch(touches, NONCE_PRECOMPILE_ADDRESS, expiring_nonce_slot);
-    add_storage_touch(
-        touches,
-        NONCE_PRECOMPILE_ADDRESS,
-        nonce_slots::EXPIRING_NONCE_RING_PTR,
-    );
-}
-
-fn add_account_touch(touches: &mut Vec<TempoStorageTouch>, address: Address) {
-    add_unique_touch(touches, TempoStorageTouch::Account(address));
-}
-
-fn add_storage_touch(touches: &mut Vec<TempoStorageTouch>, address: Address, slot: U256) {
-    add_account_touch(touches, address);
-    add_unique_touch(touches, TempoStorageTouch::Storage { address, slot });
-}
-
-fn add_unique_touch(touches: &mut Vec<TempoStorageTouch>, touch: TempoStorageTouch) {
-    if !touches.contains(&touch) {
-        touches.push(touch);
-    }
-}
-
 /// Command sent by [`BestTransactionsPrewarming`] consumer.
 #[derive(Debug)]
 enum BestTransactionsCommand {
@@ -685,6 +478,7 @@ mod tests {
     };
     use tempo_chainspec::TempoChainSpec;
     use tempo_evm::{TempoEvmConfig, TempoNextBlockEnvAttributes};
+    use tempo_precompiles::DEFAULT_FEE_TOKEN;
     use tempo_primitives::{TempoHeader, TempoPrimitives, TempoTxEnvelope};
     use tempo_transaction_pool::transaction::TempoPooledTransaction;
 
@@ -871,43 +665,6 @@ mod tests {
             thread::sleep(Duration::from_millis(5));
         }
         assert!(condition(), "condition did not become true before timeout");
-    }
-
-    #[test]
-    fn tip20_touch_collection_dedups_overlapping_fee_and_call_slots() {
-        let sender = Address::random();
-        let recipient = Address::random();
-        let token = DEFAULT_FEE_TOKEN;
-        let mut touches = Vec::new();
-
-        add_tip20_fee_touches(&mut touches, token, sender);
-        add_tip20_call_touches(
-            &mut touches,
-            sender,
-            TxKind::Call(token),
-            &ITIP20::transferCall {
-                to: recipient,
-                amount: U256::from(1),
-            }
-            .abi_encode(),
-        );
-
-        for (index, touch) in touches.iter().enumerate() {
-            assert!(
-                !touches[index + 1..].contains(touch),
-                "duplicate storage prewarm touch: {touch:?}"
-            );
-        }
-
-        assert!(touches.contains(&TempoStorageTouch::Account(token)));
-        assert!(touches.contains(&TempoStorageTouch::Storage {
-            address: token,
-            slot: sender.mapping_slot(tip20_slots::BALANCES)
-        }));
-        assert!(touches.contains(&TempoStorageTouch::Storage {
-            address: token,
-            slot: recipient.mapping_slot(tip20_slots::BALANCES)
-        }));
     }
 
     #[test]

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -23,4 +23,4 @@ pub use error::{TempoHaltReason, TempoInvalidTransaction};
 pub use evm::TempoEvm;
 pub use handler::{ValidationContext, calculate_aa_batch_intrinsic_gas};
 pub use revm::interpreter::instructions::utility::IntoAddress;
-pub use tx::{TempoBatchCallEnv, TempoTxEnv};
+pub use tx::{TempoBatchCallEnv, TempoStorageTouch, TempoTxEnv};

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -12,6 +12,7 @@ use revm::context::{
         AccessList, AccessListItem, RecoveredAuthority, RecoveredAuthorization, SignedAuthorization,
     },
 };
+use std::sync::{Arc, OnceLock};
 use tempo_contracts::precompiles::ITIP20;
 use tempo_primitives::{
     AASigned, TempoAddressExt, TempoSignature, TempoTransaction, TempoTxEnvelope,
@@ -20,6 +21,15 @@ use tempo_primitives::{
         envelope::KEY_AUTHORIZATION_MAX_RLP_LEN,
     },
 };
+
+/// Account or storage location to read for transaction prewarming.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TempoStorageTouch {
+    /// Account metadata/code touch.
+    Account(Address),
+    /// Contract storage slot touch.
+    Storage { address: Address, slot: U256 },
+}
 
 /// Tempo transaction environment for AA features.
 #[derive(Debug, Clone, Default)]
@@ -95,9 +105,29 @@ pub struct TempoTxEnv {
 
     /// AA-specific transaction environment (boxed to keep TempoTxEnv lean for non-AA tx)
     pub tempo_tx_env: Option<Box<TempoBatchCallEnv>>,
+
+    /// Predicted account/storage locations touched by execution.
+    ///
+    /// This is populated by pool validation after fee-token and block-context dependent
+    /// state has been resolved. The `OnceLock` is shared across clones so a transaction
+    /// environment created during validation can be enriched before payload building.
+    pub prewarm_storage_touches: Arc<OnceLock<Vec<TempoStorageTouch>>>,
 }
 
 impl TempoTxEnv {
+    /// Stores predicted storage touches if they have not already been populated.
+    pub fn set_prewarm_storage_touches(&self, touches: Vec<TempoStorageTouch>) {
+        let _ = self.prewarm_storage_touches.set(touches);
+    }
+
+    /// Returns predicted storage touches for this transaction.
+    pub fn prewarm_storage_touches(&self) -> &[TempoStorageTouch] {
+        self.prewarm_storage_touches
+            .get()
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
     /// Resolves fee payer from the signature.
     pub fn fee_payer(&self) -> Result<Address, TempoInvalidTransaction> {
         if let Some(fee_payer) = self.fee_payer {
@@ -408,6 +438,7 @@ impl FromRecoveredTx<AASigned> for TempoTxEnv {
                 // can only be derived when given an entire block
                 expiring_nonce_idx: None,
             })),
+            prewarm_storage_touches: Default::default(),
         }
     }
 }
@@ -424,6 +455,7 @@ impl FromRecoveredTx<TempoTxEnvelope> for TempoTxEnv {
                 unique_tx_identifier,
                 fee_payer: None,
                 tempo_tx_env: None, // Non-AA transaction
+                prewarm_storage_touches: Default::default(),
             },
             TempoTxEnvelope::Eip2930(inner) => Self {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -12,7 +12,7 @@ use revm::context::{
         AccessList, AccessListItem, RecoveredAuthority, RecoveredAuthorization, SignedAuthorization,
     },
 };
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use tempo_contracts::precompiles::ITIP20;
 use tempo_primitives::{
     AASigned, TempoAddressExt, TempoSignature, TempoTransaction, TempoTxEnvelope,
@@ -107,25 +107,19 @@ pub struct TempoTxEnv {
     pub tempo_tx_env: Option<Box<TempoBatchCallEnv>>,
 
     /// Predicted account/storage locations touched by execution.
-    ///
-    /// This is populated by pool validation after fee-token and block-context dependent
-    /// state has been resolved. The `OnceLock` is shared across clones so a transaction
-    /// environment created during validation can be enriched before payload building.
-    pub prewarm_storage_touches: Arc<OnceLock<Vec<TempoStorageTouch>>>,
+    pub prewarm_storage_touches: Arc<Vec<TempoStorageTouch>>,
 }
 
 impl TempoTxEnv {
-    /// Stores predicted storage touches if they have not already been populated.
-    pub fn set_prewarm_storage_touches(&self, touches: Vec<TempoStorageTouch>) {
-        let _ = self.prewarm_storage_touches.set(touches);
+    /// Returns this transaction environment with predicted storage touches attached.
+    pub fn with_prewarm_storage_touches(mut self, touches: Vec<TempoStorageTouch>) -> Self {
+        self.prewarm_storage_touches = Arc::new(touches);
+        self
     }
 
     /// Returns predicted storage touches for this transaction.
     pub fn prewarm_storage_touches(&self) -> &[TempoStorageTouch] {
-        self.prewarm_storage_touches
-            .get()
-            .map(Vec::as_slice)
-            .unwrap_or(&[])
+        self.prewarm_storage_touches.as_slice()
     }
 
     /// Resolves fee payer from the signature.

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+pub(crate) mod prewarm;
 pub mod transaction;
 pub mod validator;
 

--- a/crates/transaction-pool/src/prewarm.rs
+++ b/crates/transaction-pool/src/prewarm.rs
@@ -6,34 +6,33 @@ use alloy_primitives::{Address, TxKind, U256};
 use alloy_sol_types::SolInterface;
 use reth_storage_api::{StateProvider, errors::ProviderError};
 use reth_transaction_pool::PoolTransaction;
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_precompiles::{
-    DEFAULT_FEE_TOKEN, NONCE_PRECOMPILE_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
+    NONCE_PRECOMPILE_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
     nonce::slots as nonce_slots,
     storage::StorageKey as _,
     tip_fee_manager::slots as fee_manager_slots,
     tip20::{ITIP20, tip20_slots},
 };
 use tempo_primitives::TempoAddressExt;
-use tempo_revm::TempoStorageTouch;
+use tempo_revm::{TempoStateAccess, TempoStorageTouch};
 
 /// Reads and discards predicted execution-time storage for a transaction.
 ///
 /// This is intentionally best-effort at the caller boundary: callers decide whether
 /// a read error should fail their current operation or only be traced.
 pub(crate) fn prewarm_transaction_storage<P>(
-    provider: &P,
+    provider: &mut P,
     transaction: &TempoPooledTransaction,
+    spec: TempoHardfork,
     fee_recipient: Address,
 ) -> Result<usize, ProviderError>
 where
-    P: StateProvider + ?Sized,
+    P: StateProvider + TempoStateAccess<((), (), ())>,
 {
-    if transaction.tx_env().prewarm_storage_touches().is_empty() {
-        let touches = storage_touches_for_transaction(transaction, fee_recipient);
-        transaction.tx_env().set_prewarm_storage_touches(touches);
-    }
-
-    let touches = transaction.tx_env().prewarm_storage_touches();
+    let touches = transaction
+        .tx_env(provider, spec, fee_recipient)
+        .prewarm_storage_touches();
     for touch in touches {
         warm_state_provider(touch, provider)?;
     }
@@ -58,16 +57,14 @@ where
 }
 
 /// Predicts the storage locations touched by Tempo fee handling and TIP-20 payments.
-fn storage_touches_for_transaction(
+pub(crate) fn storage_touches_for_transaction(
     tx: &TempoPooledTransaction,
     fee_recipient: Address,
+    fee_token: Address,
 ) -> Vec<TempoStorageTouch> {
     let mut touches = Vec::new();
     let sender = tx.sender();
     let fee_payer = tx.inner().fee_payer(sender).unwrap_or(sender);
-    let fee_token = tx
-        .resolved_fee_token()
-        .unwrap_or_else(|| tx.inner().fee_token().unwrap_or(DEFAULT_FEE_TOKEN));
 
     add_access_list_touches(&mut touches, tx);
     add_tip20_fee_touches(&mut touches, fee_token, fee_payer);
@@ -263,10 +260,12 @@ fn add_unique_touch(touches: &mut Vec<TempoStorageTouch>, touch: TempoStorageTou
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::TxBuilder;
+    use crate::test_utils::{TxBuilder, create_mock_provider};
     use alloy_eips::eip2930::{AccessList, AccessListItem};
     use alloy_primitives::B256;
     use alloy_sol_types::SolCall;
+    use reth_storage_api::StateProviderFactory;
+    use tempo_precompiles::DEFAULT_FEE_TOKEN;
 
     #[test]
     fn tip20_touch_collection_dedups_overlapping_fee_and_call_slots() {
@@ -316,12 +315,45 @@ mod tests {
             }]))
             .build();
 
-        let touches = storage_touches_for_transaction(&tx, Address::random());
+        let touches = storage_touches_for_transaction(&tx, Address::random(), DEFAULT_FEE_TOKEN);
 
         assert!(touches.contains(&TempoStorageTouch::Account(account)));
         assert!(touches.contains(&TempoStorageTouch::Storage {
             address: account,
             slot: U256::from_be_bytes(storage_key.0)
         }));
+    }
+
+    #[test]
+    fn tx_env_initialization_attaches_prewarm_touches() {
+        let account = Address::random();
+        let storage_key = B256::repeat_byte(0x24);
+        let tx = TxBuilder::aa(Address::random())
+            .access_list(AccessList(vec![AccessListItem {
+                address: account,
+                storage_keys: vec![storage_key],
+            }]))
+            .build();
+
+        assert!(tx.cached_tx_env().is_none());
+
+        let provider = create_mock_provider();
+        let mut state = provider.latest().expect("latest state");
+        let tx_env = tx.tx_env(&mut state, TempoHardfork::default(), Address::random());
+
+        assert!(tx.cached_tx_env().is_some());
+        assert!(
+            tx_env
+                .prewarm_storage_touches()
+                .contains(&TempoStorageTouch::Account(account))
+        );
+        assert!(
+            tx_env
+                .prewarm_storage_touches()
+                .contains(&TempoStorageTouch::Storage {
+                    address: account,
+                    slot: U256::from_be_bytes(storage_key.0),
+                })
+        );
     }
 }

--- a/crates/transaction-pool/src/prewarm.rs
+++ b/crates/transaction-pool/src/prewarm.rs
@@ -1,0 +1,327 @@
+//! Storage prewarming helpers for transactions that have entered the pool.
+
+use crate::transaction::TempoPooledTransaction;
+use alloy_consensus::Transaction as _;
+use alloy_primitives::{Address, TxKind, U256};
+use alloy_sol_types::SolInterface;
+use reth_storage_api::{StateProvider, errors::ProviderError};
+use reth_transaction_pool::PoolTransaction;
+use tempo_precompiles::{
+    DEFAULT_FEE_TOKEN, NONCE_PRECOMPILE_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
+    nonce::slots as nonce_slots,
+    storage::StorageKey as _,
+    tip_fee_manager::slots as fee_manager_slots,
+    tip20::{ITIP20, tip20_slots},
+};
+use tempo_primitives::TempoAddressExt;
+use tempo_revm::TempoStorageTouch;
+
+/// Reads and discards predicted execution-time storage for a transaction.
+///
+/// This is intentionally best-effort at the caller boundary: callers decide whether
+/// a read error should fail their current operation or only be traced.
+pub(crate) fn prewarm_transaction_storage<P>(
+    provider: &P,
+    transaction: &TempoPooledTransaction,
+    fee_recipient: Address,
+) -> Result<usize, ProviderError>
+where
+    P: StateProvider + ?Sized,
+{
+    if transaction.tx_env().prewarm_storage_touches().is_empty() {
+        let touches = storage_touches_for_transaction(transaction, fee_recipient);
+        transaction.tx_env().set_prewarm_storage_touches(touches);
+    }
+
+    let touches = transaction.tx_env().prewarm_storage_touches();
+    for touch in touches {
+        warm_state_provider(touch, provider)?;
+    }
+    Ok(touches.len())
+}
+
+/// Reads this touch from a reth [`StateProvider`] and discards the value.
+fn warm_state_provider<P>(touch: &TempoStorageTouch, provider: &P) -> Result<(), ProviderError>
+where
+    P: StateProvider + ?Sized,
+{
+    match *touch {
+        TempoStorageTouch::Account(address) => {
+            let _ = provider.basic_account(&address)?;
+        }
+        TempoStorageTouch::Storage { address, slot } => {
+            let _ = provider.storage(address, slot.into())?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Predicts the storage locations touched by Tempo fee handling and TIP-20 payments.
+fn storage_touches_for_transaction(
+    tx: &TempoPooledTransaction,
+    fee_recipient: Address,
+) -> Vec<TempoStorageTouch> {
+    let mut touches = Vec::new();
+    let sender = tx.sender();
+    let fee_payer = tx.inner().fee_payer(sender).unwrap_or(sender);
+    let fee_token = tx
+        .resolved_fee_token()
+        .unwrap_or_else(|| tx.inner().fee_token().unwrap_or(DEFAULT_FEE_TOKEN));
+
+    add_access_list_touches(&mut touches, tx);
+    add_tip20_fee_touches(&mut touches, fee_token, fee_payer);
+    add_fee_manager_touches(&mut touches, fee_recipient, fee_token);
+
+    if tx.is_payment() {
+        for (kind, input) in tx.inner().calls() {
+            add_tip20_call_touches(&mut touches, sender, kind, input);
+        }
+    }
+
+    add_expiring_nonce_touches(&mut touches, tx);
+
+    touches
+}
+
+fn add_access_list_touches(touches: &mut Vec<TempoStorageTouch>, tx: &TempoPooledTransaction) {
+    let Some(access_list) = tx.access_list() else {
+        return;
+    };
+
+    for item in &access_list.0 {
+        add_account_touch(touches, item.address);
+        for storage_key in &item.storage_keys {
+            add_storage_touch(touches, item.address, U256::from_be_bytes(storage_key.0));
+        }
+    }
+}
+
+fn add_tip20_fee_touches(
+    touches: &mut Vec<TempoStorageTouch>,
+    fee_token: Address,
+    fee_payer: Address,
+) {
+    if !fee_token.is_tip20() {
+        return;
+    }
+
+    add_tip20_common_touches(touches, fee_token);
+    add_tip20_balance_touch(touches, fee_token, fee_payer);
+    add_tip20_balance_touch(touches, fee_token, TIP_FEE_MANAGER_ADDRESS);
+    add_tip20_reward_touches(touches, fee_token, fee_payer);
+}
+
+fn add_tip20_call_touches(
+    touches: &mut Vec<TempoStorageTouch>,
+    sender: Address,
+    kind: TxKind,
+    input: &[u8],
+) {
+    let Some(token) = kind.to().copied() else {
+        return;
+    };
+    if !token.is_tip20() {
+        return;
+    }
+
+    add_tip20_common_touches(touches, token);
+    let Ok(call) = ITIP20::ITIP20Calls::abi_decode(input) else {
+        return;
+    };
+
+    match call {
+        ITIP20::ITIP20Calls::transfer(call) => {
+            add_tip20_balance_touch(touches, token, sender);
+            add_tip20_balance_touch(touches, token, call.to);
+            add_tip20_reward_touches(touches, token, sender);
+            add_tip20_reward_touches(touches, token, call.to);
+        }
+        ITIP20::ITIP20Calls::transferWithMemo(call) => {
+            add_tip20_balance_touch(touches, token, sender);
+            add_tip20_balance_touch(touches, token, call.to);
+            add_tip20_reward_touches(touches, token, sender);
+            add_tip20_reward_touches(touches, token, call.to);
+        }
+        ITIP20::ITIP20Calls::transferFrom(call) => {
+            add_tip20_balance_touch(touches, token, call.from);
+            add_tip20_balance_touch(touches, token, call.to);
+            add_tip20_allowance_touch(touches, token, call.from, sender);
+            add_tip20_reward_touches(touches, token, call.from);
+            add_tip20_reward_touches(touches, token, call.to);
+        }
+        ITIP20::ITIP20Calls::transferFromWithMemo(call) => {
+            add_tip20_balance_touch(touches, token, call.from);
+            add_tip20_balance_touch(touches, token, call.to);
+            add_tip20_allowance_touch(touches, token, call.from, sender);
+            add_tip20_reward_touches(touches, token, call.from);
+            add_tip20_reward_touches(touches, token, call.to);
+        }
+        ITIP20::ITIP20Calls::approve(call) => {
+            add_tip20_allowance_touch(touches, token, sender, call.spender);
+        }
+        ITIP20::ITIP20Calls::mint(call) => {
+            add_tip20_balance_touch(touches, token, call.to);
+            add_tip20_reward_touches(touches, token, call.to);
+        }
+        ITIP20::ITIP20Calls::mintWithMemo(call) => {
+            add_tip20_balance_touch(touches, token, call.to);
+            add_tip20_reward_touches(touches, token, call.to);
+        }
+        ITIP20::ITIP20Calls::burn(_) | ITIP20::ITIP20Calls::burnWithMemo(_) => {
+            add_tip20_balance_touch(touches, token, sender);
+            add_tip20_reward_touches(touches, token, sender);
+        }
+        _ => {}
+    }
+}
+
+fn add_tip20_common_touches(touches: &mut Vec<TempoStorageTouch>, token: Address) {
+    add_account_touch(touches, token);
+    add_storage_touch(touches, token, tip20_slots::CURRENCY);
+    add_storage_touch(touches, token, tip20_slots::PAUSED);
+    add_storage_touch(touches, token, tip20_slots::TRANSFER_POLICY_ID);
+    add_storage_touch(touches, token, tip20_slots::GLOBAL_REWARD_PER_TOKEN);
+    add_storage_touch(touches, token, tip20_slots::OPTED_IN_SUPPLY);
+}
+
+fn add_tip20_balance_touch(touches: &mut Vec<TempoStorageTouch>, token: Address, account: Address) {
+    add_storage_touch(touches, token, account.mapping_slot(tip20_slots::BALANCES));
+}
+
+fn add_tip20_allowance_touch(
+    touches: &mut Vec<TempoStorageTouch>,
+    token: Address,
+    owner: Address,
+    spender: Address,
+) {
+    add_storage_touch(
+        touches,
+        token,
+        spender.mapping_slot(owner.mapping_slot(tip20_slots::ALLOWANCES)),
+    );
+}
+
+fn add_tip20_reward_touches(
+    touches: &mut Vec<TempoStorageTouch>,
+    token: Address,
+    account: Address,
+) {
+    let base_slot = account.mapping_slot(tip20_slots::USER_REWARD_INFO);
+    add_storage_touch(touches, token, base_slot);
+    add_storage_touch(touches, token, base_slot + U256::from(1));
+    add_storage_touch(touches, token, base_slot + U256::from(2));
+}
+
+fn add_fee_manager_touches(
+    touches: &mut Vec<TempoStorageTouch>,
+    fee_recipient: Address,
+    fee_token: Address,
+) {
+    add_account_touch(touches, TIP_FEE_MANAGER_ADDRESS);
+    add_storage_touch(
+        touches,
+        TIP_FEE_MANAGER_ADDRESS,
+        fee_recipient.mapping_slot(fee_manager_slots::VALIDATOR_TOKENS),
+    );
+    add_storage_touch(
+        touches,
+        TIP_FEE_MANAGER_ADDRESS,
+        fee_token.mapping_slot(fee_recipient.mapping_slot(fee_manager_slots::COLLECTED_FEES)),
+    );
+}
+
+fn add_expiring_nonce_touches(touches: &mut Vec<TempoStorageTouch>, tx: &TempoPooledTransaction) {
+    let Some(expiring_nonce_slot) = tx.expiring_nonce_slot() else {
+        return;
+    };
+
+    add_account_touch(touches, NONCE_PRECOMPILE_ADDRESS);
+    add_storage_touch(touches, NONCE_PRECOMPILE_ADDRESS, expiring_nonce_slot);
+    add_storage_touch(
+        touches,
+        NONCE_PRECOMPILE_ADDRESS,
+        nonce_slots::EXPIRING_NONCE_RING_PTR,
+    );
+}
+
+fn add_account_touch(touches: &mut Vec<TempoStorageTouch>, address: Address) {
+    add_unique_touch(touches, TempoStorageTouch::Account(address));
+}
+
+fn add_storage_touch(touches: &mut Vec<TempoStorageTouch>, address: Address, slot: U256) {
+    add_account_touch(touches, address);
+    add_unique_touch(touches, TempoStorageTouch::Storage { address, slot });
+}
+
+fn add_unique_touch(touches: &mut Vec<TempoStorageTouch>, touch: TempoStorageTouch) {
+    if !touches.contains(&touch) {
+        touches.push(touch);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::TxBuilder;
+    use alloy_eips::eip2930::{AccessList, AccessListItem};
+    use alloy_primitives::B256;
+    use alloy_sol_types::SolCall;
+
+    #[test]
+    fn tip20_touch_collection_dedups_overlapping_fee_and_call_slots() {
+        let sender = Address::random();
+        let recipient = Address::random();
+        let token = DEFAULT_FEE_TOKEN;
+        let mut touches = Vec::new();
+
+        add_tip20_fee_touches(&mut touches, token, sender);
+        add_tip20_call_touches(
+            &mut touches,
+            sender,
+            TxKind::Call(token),
+            &ITIP20::transferCall {
+                to: recipient,
+                amount: U256::from(1),
+            }
+            .abi_encode(),
+        );
+
+        for (index, touch) in touches.iter().enumerate() {
+            assert!(
+                !touches[index + 1..].contains(touch),
+                "duplicate storage prewarm touch: {touch:?}"
+            );
+        }
+
+        assert!(touches.contains(&TempoStorageTouch::Account(token)));
+        assert!(touches.contains(&TempoStorageTouch::Storage {
+            address: token,
+            slot: sender.mapping_slot(tip20_slots::BALANCES)
+        }));
+        assert!(touches.contains(&TempoStorageTouch::Storage {
+            address: token,
+            slot: recipient.mapping_slot(tip20_slots::BALANCES)
+        }));
+    }
+
+    #[test]
+    fn access_list_touches_are_included() {
+        let account = Address::random();
+        let storage_key = B256::repeat_byte(0x42);
+        let tx = TxBuilder::aa(Address::random())
+            .access_list(AccessList(vec![AccessListItem {
+                address: account,
+                storage_keys: vec![storage_key],
+            }]))
+            .build();
+
+        let touches = storage_touches_for_transaction(&tx, Address::random());
+
+        assert!(touches.contains(&TempoStorageTouch::Account(account)));
+        assert!(touches.contains(&TempoStorageTouch::Storage {
+            address: account,
+            slot: U256::from_be_bytes(storage_key.0)
+        }));
+    }
+}

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -1,4 +1,7 @@
-use crate::tt_2d_pool::{AA2dTransactionId, AASequenceId};
+use crate::{
+    prewarm::storage_touches_for_transaction,
+    tt_2d_pool::{AA2dTransactionId, AASequenceId},
+};
 use alloy_consensus::{
     BlobTransactionValidationError, Transaction, crypto::RecoveryError, transaction::TxHashRef,
 };
@@ -13,6 +16,7 @@ use alloy_evm::FromRecoveredTx;
 use alloy_primitives::{Address, B256, Bytes, TxHash, TxKind, U256, bytes, map::AddressMap};
 use reth_evm::execute::WithTxEnv;
 use reth_primitives_traits::{InMemorySize, Recovered};
+use reth_storage_api::StateProvider;
 use reth_transaction_pool::{
     EthBlobTransactionSidecar, EthPoolTransaction, EthPooledTransaction, PoolTransaction,
     error::PoolTransactionError,
@@ -22,9 +26,10 @@ use std::{
     fmt::Debug,
     sync::{Arc, OnceLock},
 };
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_precompiles::{DEFAULT_FEE_TOKEN, nonce::NonceManager, tip20::TIP20Token};
 use tempo_primitives::{TempoTxEnvelope, transaction::calc_gas_balance_spending};
-use tempo_revm::{TempoInvalidTransaction, TempoTxEnv};
+use tempo_revm::{TempoInvalidTransaction, TempoStateAccess, TempoTxEnv};
 use thiserror::Error;
 
 /// Tempo pooled transaction representation.
@@ -200,17 +205,66 @@ impl TempoPooledTransaction {
         })
     }
 
-    /// Computes the [`TempoTxEnv`] for this transaction.
+    /// Computes the base [`TempoTxEnv`] for this transaction.
     fn tx_env_slow(&self) -> TempoTxEnv {
         TempoTxEnv::from_recovered_tx(self.inner().inner(), self.sender())
     }
 
-    /// Pre-computes and caches the [`TempoTxEnv`].
+    /// Computes the [`TempoTxEnv`] with predicted prewarm storage touches.
+    fn tx_env_with_prewarm<P>(
+        &self,
+        state_provider: &mut P,
+        spec: TempoHardfork,
+        fee_recipient: Address,
+    ) -> TempoTxEnv
+    where
+        P: StateProvider + TempoStateAccess<((), (), ())>,
+    {
+        let tx_env = self.tx_env_slow();
+        let fee_token = self.resolve_prewarm_fee_token(&tx_env, state_provider, spec);
+        let touches = storage_touches_for_transaction(self, fee_recipient, fee_token);
+        tx_env.with_prewarm_storage_touches(touches)
+    }
+
+    fn resolve_prewarm_fee_token<P>(
+        &self,
+        tx_env: &TempoTxEnv,
+        state_provider: &mut P,
+        spec: TempoHardfork,
+    ) -> Address
+    where
+        P: StateProvider + TempoStateAccess<((), (), ())>,
+    {
+        let fee_payer = tx_env.fee_payer().unwrap_or(tx_env.inner.caller);
+        <P as TempoStateAccess<((), (), ())>>::get_fee_token(
+            state_provider,
+            tx_env,
+            fee_payer,
+            spec,
+        )
+        .unwrap_or_else(|_| self.inner().fee_token().unwrap_or(DEFAULT_FEE_TOKEN))
+    }
+
+    /// Pre-computes and caches the [`TempoTxEnv`] with prewarm touches.
     ///
     /// This should be called during validation to prepare the transaction environment
     /// ahead of time, avoiding it during payload building.
-    pub fn tx_env(&self) -> &TempoTxEnv {
-        self.tx_env.get_or_init(|| self.tx_env_slow())
+    pub fn tx_env<'a, P>(
+        &'a self,
+        state_provider: &mut P,
+        spec: TempoHardfork,
+        fee_recipient: Address,
+    ) -> &'a TempoTxEnv
+    where
+        P: StateProvider + TempoStateAccess<((), (), ())>,
+    {
+        self.tx_env
+            .get_or_init(|| self.tx_env_with_prewarm(state_provider, spec, fee_recipient))
+    }
+
+    /// Returns the cached [`TempoTxEnv`], if it has already been prepared.
+    pub fn cached_tx_env(&self) -> Option<&TempoTxEnv> {
+        self.tx_env.get()
     }
 
     /// Returns a cloned [`TempoTxEnv`] for this transaction.
@@ -218,7 +272,9 @@ impl TempoPooledTransaction {
     /// This uses the cached value prepared by [`Self::tx_env`] when available,
     /// and computes it on-demand otherwise.
     pub fn clone_tx_env(&self) -> TempoTxEnv {
-        self.tx_env().clone()
+        self.cached_tx_env()
+            .cloned()
+            .unwrap_or_else(|| self.tx_env_slow())
     }
 
     /// Returns a [`WithTxEnv`] wrapper by cloning the cached [`TempoTxEnv`] and

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -1,5 +1,6 @@
 use crate::{
     amm::AmmLiquidityCache,
+    prewarm::prewarm_transaction_storage,
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
 
@@ -31,6 +32,7 @@ use tempo_revm::{
     TempoBlockEnv, TempoInvalidTransaction, TempoStateAccess, ValidationContext,
     error::FeePaymentError,
 };
+use tracing::trace;
 
 // Reject AA txs where `valid_before` is too close to current time (or already expired) to prevent block invalidation.
 const AA_VALID_BEFORE_MIN_SECS: u64 = 3;
@@ -547,6 +549,30 @@ where
                                 .into(),
                             );
                         }
+                    }
+                }
+
+                let fee_recipient = self.cached_evm_env.read().block_env.beneficiary;
+                match prewarm_transaction_storage(
+                    &state_provider,
+                    transaction.transaction(),
+                    fee_recipient,
+                ) {
+                    Ok(touched) => {
+                        trace!(
+                            target: "txpool",
+                            touched,
+                            tx_hash = ?transaction.hash(),
+                            "Prewarmed transaction storage"
+                        );
+                    }
+                    Err(err) => {
+                        trace!(
+                            target: "txpool",
+                            %err,
+                            tx_hash = ?transaction.hash(),
+                            "Failed to prewarm transaction storage"
+                        );
                     }
                 }
 

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -308,9 +308,14 @@ where
     fn validate_with_evm(
         &self,
         transaction: &TempoPooledTransaction,
-        state_provider: impl StateProvider,
+        mut state_provider: impl StateProvider,
     ) -> Result<ValidationContext, EVMError<ProviderError, TempoInvalidTransaction>> {
         let evm_env = self.cached_evm_env.read().clone();
+        let spec = evm_env.cfg_env.spec;
+        let fee_recipient = evm_env.block_env.beneficiary;
+        let tx_env = transaction
+            .tx_env(&mut state_provider, spec, fee_recipient)
+            .clone();
 
         // Create a throwaway EVM and run validation.
         // - Skip `valid_after` check: the pool intentionally accepts transactions with a
@@ -322,7 +327,7 @@ where
         evm.inner_mut().skip_valid_after_check = true;
         evm.inner_mut().skip_liquidity_check = true;
         evm.ctx_mut().cfg.disable_nonce_check = true;
-        evm.validate_transaction(transaction.tx_env().clone())
+        evm.validate_transaction(tx_env)
     }
 
     fn validate_one(
@@ -554,8 +559,9 @@ where
 
                 let fee_recipient = self.cached_evm_env.read().block_env.beneficiary;
                 match prewarm_transaction_storage(
-                    &state_provider,
+                    &mut state_provider,
                     transaction.transaction(),
+                    spec,
                     fee_recipient,
                 ) {
                     Ok(touched) => {


### PR DESCRIPTION
Adds predicted account/storage touches to TempoTxEnv during txpool validation, prewarming those slots best-effort when transactions enter the pool. Payload builder TIP-20 prewarming reuses those touches when present and keeps its existing local prediction as a fallback.