### PR TITLE
feat(signature-verifier): add verifyAdmin

### DIFF
--- a/.changelog/verify-admin.md
+++ b/.changelog/verify-admin.md
@@ -2,4 +2,4 @@
 tempo-contracts: minor
 ---
 
-Added the T6 `SignatureVerifier.verifyAdmin` selector for checking root and admin access-key signatures.
+Added the T6 `SignatureVerifier.verifyKeychain` and `SignatureVerifier.verifyKeychainAdmin` selectors for checking account-bound active and admin keychain signatures.

--- a/.changelog/verify-admin.md
+++ b/.changelog/verify-admin.md
@@ -1,0 +1,5 @@
+---
+tempo-contracts: minor
+---
+
+Added the T6 `SignatureVerifier.verifyAdmin` selector for checking root and admin access-key signatures.

--- a/crates/contracts/src/precompiles/signature_verifier.rs
+++ b/crates/contracts/src/precompiles/signature_verifier.rs
@@ -18,6 +18,13 @@ crate::sol! {
         /// @return True if the input address signed, false otherwise. Reverts on invalid signatures.
         function verify(address signer, bytes32 hash, bytes calldata signature) external view returns (bool);
 
+        /// @notice Verifies whether a Tempo signature was produced by an account root or admin key.
+        /// @param account The account whose root/admin key set is checked
+        /// @param hash The message hash that was signed
+        /// @param signature The encoded signature (see Tempo Transaction spec for formats)
+        /// @return True if the recovered signer is the root or an active admin key for account.
+        function verifyAdmin(address account, bytes32 hash, bytes calldata signature) external view returns (bool);
+
         error InvalidFormat();
         error InvalidSignature();
     }

--- a/crates/contracts/src/precompiles/signature_verifier.rs
+++ b/crates/contracts/src/precompiles/signature_verifier.rs
@@ -18,12 +18,21 @@ crate::sol! {
         /// @return True if the input address signed, false otherwise. Reverts on invalid signatures.
         function verify(address signer, bytes32 hash, bytes calldata signature) external view returns (bool);
 
-        /// @notice Verifies whether a Tempo signature was produced by an account root or admin key.
-        /// @param account The account whose root/admin key set is checked
+        /// @notice Verifies whether a keychain signature was produced by an active key.
+        /// @param account The expected embedded root account
         /// @param hash The message hash that was signed
-        /// @param signature The encoded signature (see Tempo Transaction spec for formats)
-        /// @return True if the recovered signer is the root or an active admin key for account.
-        function verifyAdmin(address account, bytes32 hash, bytes calldata signature) external view returns (bool);
+        /// @param signature The encoded keychain signature
+        /// @dev Does not compare the inner signature type against the stored key type.
+        /// @return True if the keychain access key is active on account.
+        function verifyKeychain(address account, bytes32 hash, bytes calldata signature) external view returns (bool);
+
+        /// @notice Verifies whether a keychain signature was produced by a root or active admin key.
+        /// @param account The expected embedded root account
+        /// @param hash The message hash that was signed
+        /// @param signature The encoded keychain signature
+        /// @dev Does not compare the inner signature type against the stored key type.
+        /// @return True if the recovered key is account or an active admin key on account.
+        function verifyKeychainAdmin(address account, bytes32 hash, bytes calldata signature) external view returns (bool);
 
         error InvalidFormat();
         error InvalidSignature();

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -1099,6 +1099,9 @@ impl AccountKeychain {
     }
 
     /// Internal predicate for root/admin status.
+    ///
+    /// Warning: this returns true when `key_id == account`, because the root key
+    /// is implicitly admin even when it is not stored as an access key.
     pub fn is_admin_key(&self, account: Address, key_id: Address) -> Result<bool> {
         if key_id == account {
             return Ok(true);
@@ -1112,6 +1115,16 @@ impl AccountKeychain {
         };
 
         Ok(key.is_admin)
+    }
+
+    /// Internal predicate for active key status.
+    pub fn is_active_key(&self, account: Address, key_id: Address) -> Result<bool> {
+        let current_timestamp = self.storage.timestamp().saturating_to::<u64>();
+        match self.load_active_key(account, key_id, current_timestamp) {
+            Ok(_) => Ok(true),
+            Err(err) if err.is_system_error() => Err(err),
+            Err(_) => Ok(false),
+        }
     }
 
     fn ensure_key_authorization_witness_not_burned(

--- a/crates/precompiles/src/signature_verifier/dispatch.rs
+++ b/crates/precompiles/src/signature_verifier/dispatch.rs
@@ -68,6 +68,19 @@ mod tests {
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{ISignatureVerifier, UnknownFunctionSelector};
 
+    fn call_verify_admin(account: Address, hash: B256, signature: Vec<u8>) -> eyre::Result<bool> {
+        let calldata = ISignatureVerifier::verifyAdminCall {
+            account,
+            hash,
+            signature: signature.into(),
+        }
+        .abi_encode();
+
+        let output = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
+        let ret = ISignatureVerifier::verifyAdminCall::abi_decode_returns(&output.bytes)?;
+        Ok(ret)
+    }
+
     #[test]
     fn test_signature_verifier_selector_coverage() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
@@ -159,15 +172,7 @@ mod tests {
             let hash = B256::from([0xCC; 32]);
             let sig = signer.sign_hash_sync(&hash)?;
 
-            let calldata = ISignatureVerifier::verifyAdminCall {
-                account: signer.address(),
-                hash,
-                signature: sig.as_bytes().to_vec().into(),
-            }
-            .abi_encode();
-
-            let output = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
-            let ret = ISignatureVerifier::verifyAdminCall::abi_decode_returns(&output.bytes)?;
+            let ret = call_verify_admin(signer.address(), hash, sig.as_bytes().to_vec())?;
             assert!(ret, "root key should verify as admin");
             Ok(())
         })
@@ -192,15 +197,8 @@ mod tests {
 
             let hash = B256::from([0xDD; 32]);
             let sig = admin.sign_hash_sync(&hash)?;
-            let calldata = ISignatureVerifier::verifyAdminCall {
-                account,
-                hash,
-                signature: sig.as_bytes().to_vec().into(),
-            }
-            .abi_encode();
 
-            let output = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
-            let ret = ISignatureVerifier::verifyAdminCall::abi_decode_returns(&output.bytes)?;
+            let ret = call_verify_admin(account, hash, sig.as_bytes().to_vec())?;
             assert!(ret, "admin access key should verify as admin");
             Ok(())
         })
@@ -232,15 +230,8 @@ mod tests {
 
             let hash = B256::from([0xEE; 32]);
             let sig = access_key.sign_hash_sync(&hash)?;
-            let calldata = ISignatureVerifier::verifyAdminCall {
-                account,
-                hash,
-                signature: sig.as_bytes().to_vec().into(),
-            }
-            .abi_encode();
 
-            let output = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
-            let ret = ISignatureVerifier::verifyAdminCall::abi_decode_returns(&output.bytes)?;
+            let ret = call_verify_admin(account, hash, sig.as_bytes().to_vec())?;
             assert!(!ret, "non-admin access key should not verify as admin");
             Ok(())
         })
@@ -255,15 +246,7 @@ mod tests {
             let checked_hash = B256::from([0x22; 32]);
             let sig = signer.sign_hash_sync(&signed_hash)?;
 
-            let calldata = ISignatureVerifier::verifyAdminCall {
-                account: signer.address(),
-                hash: checked_hash,
-                signature: sig.as_bytes().to_vec().into(),
-            }
-            .abi_encode();
-
-            let output = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
-            let ret = ISignatureVerifier::verifyAdminCall::abi_decode_returns(&output.bytes)?;
+            let ret = call_verify_admin(signer.address(), checked_hash, sig.as_bytes().to_vec())?;
             assert!(!ret, "wrong digest should not verify as admin");
             Ok(())
         })
@@ -273,15 +256,7 @@ mod tests {
     fn test_verify_admin_returns_false_for_malformed_signature() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
         StorageCtx::enter(&mut storage, || {
-            let calldata = ISignatureVerifier::verifyAdminCall {
-                account: Address::random(),
-                hash: B256::ZERO,
-                signature: vec![0u8; 64].into(),
-            }
-            .abi_encode();
-
-            let output = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
-            let ret = ISignatureVerifier::verifyAdminCall::abi_decode_returns(&output.bytes)?;
+            let ret = call_verify_admin(Address::random(), B256::ZERO, vec![0u8; 64])?;
             assert!(!ret, "malformed signature should not verify as admin");
             Ok(())
         })

--- a/crates/precompiles/src/signature_verifier/dispatch.rs
+++ b/crates/precompiles/src/signature_verifier/dispatch.rs
@@ -1,9 +1,14 @@
 use super::SignatureVerifier;
-use crate::{Precompile, charge_input_cost, dispatch_call, view};
-use alloy::{primitives::Address, sol_types::SolInterface};
+use crate::{Precompile, SelectorSchedule, charge_input_cost, dispatch_call, view};
+use alloy::{
+    primitives::Address,
+    sol_types::{SolCall, SolInterface},
+};
 use revm::precompile::PrecompileResult;
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::{
-    ISignatureVerifier::ISignatureVerifierCalls as ISVCalls, SignatureVerifierError,
+    ISignatureVerifier::{self, ISignatureVerifierCalls as ISVCalls},
+    SignatureVerifierError,
 };
 use tempo_primitives::MAX_WEBAUTHN_SIGNATURE_LENGTH;
 
@@ -12,6 +17,8 @@ use tempo_primitives::MAX_WEBAUTHN_SIGNATURE_LENGTH;
 /// dynamic portion: selector(4) + args(4×32) + padded_sig_bytes.
 const MAX_CALLDATA_LEN: usize =
     4 + 32 * 4 + (MAX_WEBAUTHN_SIGNATURE_LENGTH + 1).next_multiple_of(32);
+
+const T6_ADDED: &[[u8; 4]] = &[ISignatureVerifier::verifyAdminCall::SELECTOR];
 
 impl Precompile for SignatureVerifier {
     fn call(&mut self, calldata: &[u8], _msg_sender: Address) -> PrecompileResult {
@@ -25,12 +32,20 @@ impl Precompile for SignatureVerifier {
                 .abi_revert(SignatureVerifierError::invalid_format()));
         }
 
-        dispatch_call(calldata, &[], ISVCalls::abi_decode, |call| match call {
-            ISVCalls::recover(call) => view(call, |c| self.recover(c.hash, c.signature)),
-            ISVCalls::verify(call) => view(call, |c| {
-                self.recover(c.hash, c.signature).map(|sig| sig == c.signer)
-            }),
-        })
+        dispatch_call(
+            calldata,
+            &[SelectorSchedule::new(TempoHardfork::T6).with_added(T6_ADDED)],
+            ISVCalls::abi_decode,
+            |call| match call {
+                ISVCalls::recover(call) => view(call, |c| self.recover(c.hash, c.signature)),
+                ISVCalls::verify(call) => view(call, |c| {
+                    self.recover(c.hash, c.signature).map(|sig| sig == c.signer)
+                }),
+                ISVCalls::verifyAdmin(call) => {
+                    view(call, |c| self.verify_admin(c.account, c.hash, c.signature))
+                }
+            },
+        )
     }
 }
 
@@ -38,19 +53,24 @@ impl Precompile for SignatureVerifier {
 mod tests {
     use super::*;
     use crate::{
-        Precompile, expect_precompile_revert,
+        Precompile,
+        account_keychain::{AccountKeychain, KeyRestrictions, SignatureType},
+        expect_precompile_revert,
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{assert_full_coverage, check_selector_coverage},
     };
-    use alloy::{primitives::B256, sol_types::SolCall};
+    use alloy::{
+        primitives::B256,
+        sol_types::{SolCall, SolError},
+    };
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use tempo_chainspec::hardfork::TempoHardfork;
-    use tempo_contracts::precompiles::ISignatureVerifier;
+    use tempo_contracts::precompiles::{ISignatureVerifier, UnknownFunctionSelector};
 
     #[test]
     fn test_signature_verifier_selector_coverage() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
         StorageCtx::enter(&mut storage, || {
             let mut verifier = SignatureVerifier::new();
 
@@ -62,6 +82,27 @@ mod tests {
             );
 
             assert_full_coverage([unsupported]);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_admin_selector_rejected_before_t6() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T5);
+        StorageCtx::enter(&mut storage, || {
+            let calldata = ISignatureVerifier::verifyAdminCall {
+                account: Address::random(),
+                hash: B256::ZERO,
+                signature: vec![0u8; 65].into(),
+            }
+            .abi_encode();
+
+            let result = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
+            assert!(result.is_revert());
+            assert!(
+                UnknownFunctionSelector::abi_decode(&result.bytes).is_ok(),
+                "verifyAdmin should be selector-gated before T6"
+            );
             Ok(())
         })
     }
@@ -106,6 +147,142 @@ mod tests {
             let output = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
             let ret = ISignatureVerifier::verifyCall::abi_decode_returns(&output.bytes)?;
             assert!(!ret, "verify should return false for a wrong signer");
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_admin_returns_true_for_root_key() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let signer = PrivateKeySigner::random();
+            let hash = B256::from([0xCC; 32]);
+            let sig = signer.sign_hash_sync(&hash)?;
+
+            let calldata = ISignatureVerifier::verifyAdminCall {
+                account: signer.address(),
+                hash,
+                signature: sig.as_bytes().to_vec().into(),
+            }
+            .abi_encode();
+
+            let output = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
+            let ret = ISignatureVerifier::verifyAdminCall::abi_decode_returns(&output.bytes)?;
+            assert!(ret, "root key should verify as admin");
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_admin_returns_true_for_admin_key() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let account = Address::random();
+            let admin = PrivateKeySigner::random();
+
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_tx_origin(account)?;
+            keychain.authorize_admin_key(
+                account,
+                admin.address(),
+                SignatureType::Secp256k1,
+                None,
+            )?;
+
+            let hash = B256::from([0xDD; 32]);
+            let sig = admin.sign_hash_sync(&hash)?;
+            let calldata = ISignatureVerifier::verifyAdminCall {
+                account,
+                hash,
+                signature: sig.as_bytes().to_vec().into(),
+            }
+            .abi_encode();
+
+            let output = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
+            let ret = ISignatureVerifier::verifyAdminCall::abi_decode_returns(&output.bytes)?;
+            assert!(ret, "admin access key should verify as admin");
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_admin_returns_false_for_non_admin_key() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let account = Address::random();
+            let access_key = PrivateKeySigner::random();
+
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_tx_origin(account)?;
+            keychain.authorize_key(
+                account,
+                access_key.address(),
+                SignatureType::Secp256k1,
+                KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: false,
+                    limits: vec![],
+                    allowAnyCalls: true,
+                    allowedCalls: vec![],
+                },
+                None,
+            )?;
+
+            let hash = B256::from([0xEE; 32]);
+            let sig = access_key.sign_hash_sync(&hash)?;
+            let calldata = ISignatureVerifier::verifyAdminCall {
+                account,
+                hash,
+                signature: sig.as_bytes().to_vec().into(),
+            }
+            .abi_encode();
+
+            let output = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
+            let ret = ISignatureVerifier::verifyAdminCall::abi_decode_returns(&output.bytes)?;
+            assert!(!ret, "non-admin access key should not verify as admin");
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_admin_returns_false_for_invalid_signature() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let signer = PrivateKeySigner::random();
+            let signed_hash = B256::from([0x11; 32]);
+            let checked_hash = B256::from([0x22; 32]);
+            let sig = signer.sign_hash_sync(&signed_hash)?;
+
+            let calldata = ISignatureVerifier::verifyAdminCall {
+                account: signer.address(),
+                hash: checked_hash,
+                signature: sig.as_bytes().to_vec().into(),
+            }
+            .abi_encode();
+
+            let output = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
+            let ret = ISignatureVerifier::verifyAdminCall::abi_decode_returns(&output.bytes)?;
+            assert!(!ret, "wrong digest should not verify as admin");
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_admin_returns_false_for_malformed_signature() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let calldata = ISignatureVerifier::verifyAdminCall {
+                account: Address::random(),
+                hash: B256::ZERO,
+                signature: vec![0u8; 64].into(),
+            }
+            .abi_encode();
+
+            let output = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
+            let ret = ISignatureVerifier::verifyAdminCall::abi_decode_returns(&output.bytes)?;
+            assert!(!ret, "malformed signature should not verify as admin");
             Ok(())
         })
     }

--- a/crates/precompiles/src/signature_verifier/dispatch.rs
+++ b/crates/precompiles/src/signature_verifier/dispatch.rs
@@ -18,7 +18,10 @@ use tempo_primitives::MAX_WEBAUTHN_SIGNATURE_LENGTH;
 const MAX_CALLDATA_LEN: usize =
     4 + 32 * 4 + (MAX_WEBAUTHN_SIGNATURE_LENGTH + 1).next_multiple_of(32);
 
-const T6_ADDED: &[[u8; 4]] = &[ISignatureVerifier::verifyAdminCall::SELECTOR];
+const T6_ADDED: &[[u8; 4]] = &[
+    ISignatureVerifier::verifyKeychainCall::SELECTOR,
+    ISignatureVerifier::verifyKeychainAdminCall::SELECTOR,
+];
 
 impl Precompile for SignatureVerifier {
     fn call(&mut self, calldata: &[u8], _msg_sender: Address) -> PrecompileResult {
@@ -41,9 +44,12 @@ impl Precompile for SignatureVerifier {
                 ISVCalls::verify(call) => view(call, |c| {
                     self.recover(c.hash, c.signature).map(|sig| sig == c.signer)
                 }),
-                ISVCalls::verifyAdmin(call) => {
-                    view(call, |c| self.verify_admin(c.account, c.hash, c.signature))
-                }
+                ISVCalls::verifyKeychain(call) => view(call, |c| {
+                    self.verify_keychain(c.account, c.hash, c.signature)
+                }),
+                ISVCalls::verifyKeychainAdmin(call) => view(call, |c| {
+                    self.verify_keychain_admin(c.account, c.hash, c.signature)
+                }),
             },
         )
     }
@@ -67,9 +73,16 @@ mod tests {
     use alloy_signer_local::PrivateKeySigner;
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{ISignatureVerifier, UnknownFunctionSelector};
+    use tempo_primitives::transaction::tt_signature::{
+        KeychainSignature, PrimitiveSignature, TempoSignature,
+    };
 
-    fn call_verify_admin(account: Address, hash: B256, signature: Vec<u8>) -> eyre::Result<bool> {
-        let calldata = ISignatureVerifier::verifyAdminCall {
+    fn call_verify_keychain(
+        account: Address,
+        hash: B256,
+        signature: Vec<u8>,
+    ) -> eyre::Result<bool> {
+        let calldata = ISignatureVerifier::verifyKeychainCall {
             account,
             hash,
             signature: signature.into(),
@@ -77,8 +90,40 @@ mod tests {
         .abi_encode();
 
         let output = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
-        let ret = ISignatureVerifier::verifyAdminCall::abi_decode_returns(&output.bytes)?;
+        let ret = ISignatureVerifier::verifyKeychainCall::abi_decode_returns(&output.bytes)?;
         Ok(ret)
+    }
+
+    fn call_verify_keychain_admin(
+        account: Address,
+        hash: B256,
+        signature: Vec<u8>,
+    ) -> eyre::Result<bool> {
+        let calldata = ISignatureVerifier::verifyKeychainAdminCall {
+            account,
+            hash,
+            signature: signature.into(),
+        }
+        .abi_encode();
+
+        let output = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
+        let ret = ISignatureVerifier::verifyKeychainAdminCall::abi_decode_returns(&output.bytes)?;
+        Ok(ret)
+    }
+
+    fn keychain_signature(
+        account: Address,
+        key: &PrivateKeySigner,
+        hash: B256,
+    ) -> eyre::Result<Vec<u8>> {
+        let signing_hash = KeychainSignature::signing_hash(hash, account);
+        let inner = key.sign_hash_sync(&signing_hash)?;
+        Ok(TempoSignature::Keychain(KeychainSignature::new(
+            account,
+            PrimitiveSignature::Secp256k1(inner),
+        ))
+        .to_bytes()
+        .to_vec())
     }
 
     #[test]
@@ -100,10 +145,10 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_admin_selector_rejected_before_t6() -> eyre::Result<()> {
+    fn test_verify_keychain_selector_rejected_before_t6() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T5);
         StorageCtx::enter(&mut storage, || {
-            let calldata = ISignatureVerifier::verifyAdminCall {
+            let calldata = ISignatureVerifier::verifyKeychainCall {
                 account: Address::random(),
                 hash: B256::ZERO,
                 signature: vec![0u8; 65].into(),
@@ -114,7 +159,28 @@ mod tests {
             assert!(result.is_revert());
             assert!(
                 UnknownFunctionSelector::abi_decode(&result.bytes).is_ok(),
-                "verifyAdmin should be selector-gated before T6"
+                "verifyKeychain should be selector-gated before T6"
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_keychain_admin_selector_rejected_before_t6() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T5);
+        StorageCtx::enter(&mut storage, || {
+            let calldata = ISignatureVerifier::verifyKeychainAdminCall {
+                account: Address::random(),
+                hash: B256::ZERO,
+                signature: vec![0u8; 65].into(),
+            }
+            .abi_encode();
+
+            let result = SignatureVerifier::new().call(&calldata, Address::ZERO)?;
+            assert!(result.is_revert());
+            assert!(
+                UnknownFunctionSelector::abi_decode(&result.bytes).is_ok(),
+                "verifyKeychainAdmin should be selector-gated before T6"
             );
             Ok(())
         })
@@ -165,47 +231,7 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_admin_returns_true_for_root_key() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
-        StorageCtx::enter(&mut storage, || {
-            let signer = PrivateKeySigner::random();
-            let hash = B256::from([0xCC; 32]);
-            let sig = signer.sign_hash_sync(&hash)?;
-
-            let ret = call_verify_admin(signer.address(), hash, sig.as_bytes().to_vec())?;
-            assert!(ret, "root key should verify as admin");
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_verify_admin_returns_true_for_admin_key() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
-        StorageCtx::enter(&mut storage, || {
-            let account = Address::random();
-            let admin = PrivateKeySigner::random();
-
-            let mut keychain = AccountKeychain::new();
-            keychain.initialize()?;
-            keychain.set_tx_origin(account)?;
-            keychain.authorize_admin_key(
-                account,
-                admin.address(),
-                SignatureType::Secp256k1,
-                None,
-            )?;
-
-            let hash = B256::from([0xDD; 32]);
-            let sig = admin.sign_hash_sync(&hash)?;
-
-            let ret = call_verify_admin(account, hash, sig.as_bytes().to_vec())?;
-            assert!(ret, "admin access key should verify as admin");
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_verify_admin_returns_false_for_non_admin_key() -> eyre::Result<()> {
+    fn test_verify_keychain_returns_true_for_active_key() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
         StorageCtx::enter(&mut storage, || {
             let account = Address::random();
@@ -228,36 +254,204 @@ mod tests {
                 None,
             )?;
 
-            let hash = B256::from([0xEE; 32]);
-            let sig = access_key.sign_hash_sync(&hash)?;
+            let hash = B256::from([0x44; 32]);
+            let signature = keychain_signature(account, &access_key, hash)?;
 
-            let ret = call_verify_admin(account, hash, sig.as_bytes().to_vec())?;
-            assert!(!ret, "non-admin access key should not verify as admin");
+            let ret = call_verify_keychain(account, hash, signature)?;
+            assert!(ret, "active keychain key should verify");
             Ok(())
         })
     }
 
     #[test]
-    fn test_verify_admin_returns_false_for_invalid_signature() -> eyre::Result<()> {
+    fn test_verify_keychain_returns_false_for_missing_key() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let account = Address::random();
+            let access_key = PrivateKeySigner::random();
+            let hash = B256::from([0x55; 32]);
+            let signature = keychain_signature(account, &access_key, hash)?;
+
+            let ret = call_verify_keychain(account, hash, signature)?;
+            assert!(!ret, "unknown keychain key should not verify");
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_keychain_returns_false_for_root_key_without_access_key() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let root = PrivateKeySigner::random();
+            let account = root.address();
+            let hash = B256::from([0x56; 32]);
+            let signature = keychain_signature(account, &root, hash)?;
+
+            let ret = call_verify_keychain(account, hash, signature)?;
+            assert!(
+                !ret,
+                "root key should not verify as an active access key unless explicitly stored"
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_keychain_returns_false_for_account_mismatch() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let account = Address::random();
+            let access_key = PrivateKeySigner::random();
+
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_tx_origin(account)?;
+            keychain.authorize_key(
+                account,
+                access_key.address(),
+                SignatureType::Secp256k1,
+                KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: false,
+                    limits: vec![],
+                    allowAnyCalls: true,
+                    allowedCalls: vec![],
+                },
+                None,
+            )?;
+
+            let hash = B256::from([0x57; 32]);
+            let signature = keychain_signature(account, &access_key, hash)?;
+
+            let ret = call_verify_keychain(Address::random(), hash, signature)?;
+            assert!(
+                !ret,
+                "keychain signature should not verify for a different account"
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_keychain_admin_returns_true_for_admin_key() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let account = Address::random();
+            let admin = PrivateKeySigner::random();
+
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_tx_origin(account)?;
+            keychain.authorize_admin_key(
+                account,
+                admin.address(),
+                SignatureType::Secp256k1,
+                None,
+            )?;
+
+            let hash = B256::from([0x66; 32]);
+            let signature = keychain_signature(account, &admin, hash)?;
+
+            let ret = call_verify_keychain_admin(account, hash, signature)?;
+            assert!(ret, "active admin keychain key should verify as admin");
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_keychain_admin_returns_true_for_root_key() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let root = PrivateKeySigner::random();
+            let account = root.address();
+            let hash = B256::from([0x67; 32]);
+            let signature = keychain_signature(account, &root, hash)?;
+
+            let ret = call_verify_keychain_admin(account, hash, signature)?;
+            assert!(ret, "root keychain key should verify as admin");
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_keychain_admin_returns_false_for_account_mismatch() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let account = Address::random();
+            let admin = PrivateKeySigner::random();
+
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_tx_origin(account)?;
+            keychain.authorize_admin_key(
+                account,
+                admin.address(),
+                SignatureType::Secp256k1,
+                None,
+            )?;
+
+            let hash = B256::from([0x68; 32]);
+            let signature = keychain_signature(account, &admin, hash)?;
+
+            let ret = call_verify_keychain_admin(Address::random(), hash, signature)?;
+            assert!(
+                !ret,
+                "admin keychain signature should not verify for a different account"
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_keychain_admin_returns_false_for_non_admin_key() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let account = Address::random();
+            let access_key = PrivateKeySigner::random();
+
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_tx_origin(account)?;
+            keychain.authorize_key(
+                account,
+                access_key.address(),
+                SignatureType::Secp256k1,
+                KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: false,
+                    limits: vec![],
+                    allowAnyCalls: true,
+                    allowedCalls: vec![],
+                },
+                None,
+            )?;
+
+            let hash = B256::from([0x77; 32]);
+            let signature = keychain_signature(account, &access_key, hash)?;
+
+            let ret = call_verify_keychain_admin(account, hash, signature)?;
+            assert!(!ret, "non-admin keychain key should not verify as admin");
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_keychain_reverts_for_non_keychain_signature() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
         StorageCtx::enter(&mut storage, || {
             let signer = PrivateKeySigner::random();
-            let signed_hash = B256::from([0x11; 32]);
-            let checked_hash = B256::from([0x22; 32]);
-            let sig = signer.sign_hash_sync(&signed_hash)?;
+            let hash = B256::from([0x88; 32]);
+            let sig = signer.sign_hash_sync(&hash)?;
 
-            let ret = call_verify_admin(signer.address(), checked_hash, sig.as_bytes().to_vec())?;
-            assert!(!ret, "wrong digest should not verify as admin");
-            Ok(())
-        })
-    }
+            let calldata = ISignatureVerifier::verifyKeychainCall {
+                account: signer.address(),
+                hash,
+                signature: sig.as_bytes().to_vec().into(),
+            }
+            .abi_encode();
 
-    #[test]
-    fn test_verify_admin_returns_false_for_malformed_signature() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
-        StorageCtx::enter(&mut storage, || {
-            let ret = call_verify_admin(Address::random(), B256::ZERO, vec![0u8; 64])?;
-            assert!(!ret, "malformed signature should not verify as admin");
+            let result = SignatureVerifier::new().call(&calldata, Address::ZERO);
+            expect_precompile_revert(&result, SignatureVerifierError::invalid_format());
             Ok(())
         })
     }

--- a/crates/precompiles/src/signature_verifier/mod.rs
+++ b/crates/precompiles/src/signature_verifier/mod.rs
@@ -1,6 +1,6 @@
 pub mod dispatch;
 
-use crate::{SIGNATURE_VERIFIER_ADDRESS, error::Result};
+use crate::{SIGNATURE_VERIFIER_ADDRESS, account_keychain::AccountKeychain, error::Result};
 use alloy::primitives::{Address, B256, Bytes};
 use tempo_contracts::precompiles::SignatureVerifierError;
 use tempo_precompiles_macros::contract;
@@ -24,21 +24,36 @@ impl SignatureVerifier {
     }
 
     pub fn recover(&mut self, hash: B256, signature: Bytes) -> Result<Address> {
-        // Parse and validate signature (handles size checks + type disambiguation).
-        let sig = PrimitiveSignature::from_bytes(&signature)
-            .map_err(|_| SignatureVerifierError::invalid_format())?;
+        let sig = Self::parse_signature(&signature)?;
+        self.deduct_signature_gas(sig.signature_type())?;
+        sig.recover_signer(&hash)
+            .map_err(|_| SignatureVerifierError::invalid_signature().into())
+    }
 
-        // Charge verification gas before performing verification.
-        let verify_gas = match sig.signature_type() {
+    pub fn verify_admin(&mut self, account: Address, hash: B256, signature: Bytes) -> Result<bool> {
+        let Ok(sig) = Self::parse_signature(&signature) else {
+            return Ok(false);
+        };
+        self.deduct_signature_gas(sig.signature_type())?;
+
+        let Ok(signer) = sig.recover_signer(&hash) else {
+            return Ok(false);
+        };
+
+        AccountKeychain::new().is_admin_key(account, signer)
+    }
+
+    fn parse_signature(signature: &[u8]) -> Result<PrimitiveSignature> {
+        PrimitiveSignature::from_bytes(signature)
+            .map_err(|_| SignatureVerifierError::invalid_format().into())
+    }
+
+    fn deduct_signature_gas(&mut self, signature_type: SignatureType) -> Result<()> {
+        self.storage.deduct_gas(match signature_type {
             SignatureType::Secp256k1 => SECP256K1_VERIFY_GAS,
             SignatureType::P256 => P256_VERIFY_GAS,
             SignatureType::WebAuthn => WEBAUTHN_VERIFY_GAS,
-        };
-        self.storage.deduct_gas(verify_gas)?;
-
-        // Verify and recover signer.
-        sig.recover_signer(&hash)
-            .map_err(|_| SignatureVerifierError::invalid_signature().into())
+        })
     }
 }
 

--- a/crates/precompiles/src/signature_verifier/mod.rs
+++ b/crates/precompiles/src/signature_verifier/mod.rs
@@ -1,14 +1,13 @@
 pub mod dispatch;
 
-use crate::{
-    SIGNATURE_VERIFIER_ADDRESS,
-    account_keychain::AccountKeychain,
-    error::{Result, TempoPrecompileError},
-};
+use crate::{SIGNATURE_VERIFIER_ADDRESS, account_keychain::AccountKeychain, error::Result};
 use alloy::primitives::{Address, B256, Bytes};
 use tempo_contracts::precompiles::SignatureVerifierError;
 use tempo_precompiles_macros::contract;
-use tempo_primitives::transaction::{SignatureType, tt_signature::PrimitiveSignature};
+use tempo_primitives::transaction::{
+    SignatureType,
+    tt_signature::{KeychainSignature, PrimitiveSignature, TempoSignature},
+};
 
 /// Gas cost for secp256k1 signature verification.
 const SECP256K1_VERIFY_GAS: u64 = 3_000;
@@ -45,13 +44,48 @@ impl SignatureVerifier {
             .map_err(|_| SignatureVerifierError::invalid_signature().into())
     }
 
-    pub fn verify_admin(&mut self, account: Address, hash: B256, signature: Bytes) -> Result<bool> {
-        let signer = match self.recover(hash, signature) {
-            Ok(signer) => signer,
-            Err(TempoPrecompileError::SignatureVerifierError(_)) => return Ok(false),
-            Err(err) => return Err(err),
-        };
-        AccountKeychain::new().is_admin_key(account, signer)
+    pub fn verify_keychain(
+        &mut self,
+        account: Address,
+        hash: B256,
+        signature: Bytes,
+    ) -> Result<bool> {
+        let (embedded_account, key_id) = self.recover_keychain_key(hash, signature)?;
+        if embedded_account != account {
+            return Ok(false);
+        }
+
+        AccountKeychain::new().is_active_key(account, key_id)
+    }
+
+    pub fn verify_keychain_admin(
+        &mut self,
+        account: Address,
+        hash: B256,
+        signature: Bytes,
+    ) -> Result<bool> {
+        let (embedded_account, key_id) = self.recover_keychain_key(hash, signature)?;
+        if embedded_account != account {
+            return Ok(false);
+        }
+
+        AccountKeychain::new().is_admin_key(account, key_id)
+    }
+
+    fn recover_keychain_key(&mut self, hash: B256, signature: Bytes) -> Result<(Address, Address)> {
+        let sig = TempoSignature::from_bytes(&signature)
+            .map_err(|_| SignatureVerifierError::invalid_format())?;
+        let keychain_sig = sig
+            .as_keychain()
+            .ok_or_else(SignatureVerifierError::invalid_format)?;
+
+        if keychain_sig.is_legacy() {
+            return Err(SignatureVerifierError::invalid_format().into());
+        }
+
+        let signing_hash = KeychainSignature::signing_hash(hash, keychain_sig.user_address);
+        let key_id = self.recover(signing_hash, keychain_sig.signature.to_bytes())?;
+        Ok((keychain_sig.user_address, key_id))
     }
 }
 

--- a/crates/precompiles/src/signature_verifier/mod.rs
+++ b/crates/precompiles/src/signature_verifier/mod.rs
@@ -1,6 +1,10 @@
 pub mod dispatch;
 
-use crate::{SIGNATURE_VERIFIER_ADDRESS, account_keychain::AccountKeychain, error::Result};
+use crate::{
+    SIGNATURE_VERIFIER_ADDRESS,
+    account_keychain::AccountKeychain,
+    error::{Result, TempoPrecompileError},
+};
 use alloy::primitives::{Address, B256, Bytes};
 use tempo_contracts::precompiles::SignatureVerifierError;
 use tempo_precompiles_macros::contract;
@@ -24,36 +28,30 @@ impl SignatureVerifier {
     }
 
     pub fn recover(&mut self, hash: B256, signature: Bytes) -> Result<Address> {
-        let sig = Self::parse_signature(&signature)?;
-        self.deduct_signature_gas(sig.signature_type())?;
+        // Parse and validate signature (handles size checks + type disambiguation).
+        let sig = PrimitiveSignature::from_bytes(&signature)
+            .map_err(|_| SignatureVerifierError::invalid_format())?;
+
+        // Charge verification gas before performing verification.
+        let verify_gas = match sig.signature_type() {
+            SignatureType::Secp256k1 => SECP256K1_VERIFY_GAS,
+            SignatureType::P256 => P256_VERIFY_GAS,
+            SignatureType::WebAuthn => WEBAUTHN_VERIFY_GAS,
+        };
+        self.storage.deduct_gas(verify_gas)?;
+
+        // Verify and recover signer.
         sig.recover_signer(&hash)
             .map_err(|_| SignatureVerifierError::invalid_signature().into())
     }
 
     pub fn verify_admin(&mut self, account: Address, hash: B256, signature: Bytes) -> Result<bool> {
-        let Ok(sig) = Self::parse_signature(&signature) else {
-            return Ok(false);
+        let signer = match self.recover(hash, signature) {
+            Ok(signer) => signer,
+            Err(TempoPrecompileError::SignatureVerifierError(_)) => return Ok(false),
+            Err(err) => return Err(err),
         };
-        self.deduct_signature_gas(sig.signature_type())?;
-
-        let Ok(signer) = sig.recover_signer(&hash) else {
-            return Ok(false);
-        };
-
         AccountKeychain::new().is_admin_key(account, signer)
-    }
-
-    fn parse_signature(signature: &[u8]) -> Result<PrimitiveSignature> {
-        PrimitiveSignature::from_bytes(signature)
-            .map_err(|_| SignatureVerifierError::invalid_format().into())
-    }
-
-    fn deduct_signature_gas(&mut self, signature_type: SignatureType) -> Result<()> {
-        self.storage.deduct_gas(match signature_type {
-            SignatureType::Secp256k1 => SECP256K1_VERIFY_GAS,
-            SignatureType::P256 => P256_VERIFY_GAS,
-            SignatureType::WebAuthn => WEBAUTHN_VERIFY_GAS,
-        })
     }
 }
 

--- a/tips/tip-1049.md
+++ b/tips/tip-1049.md
@@ -13,7 +13,7 @@ related: TIP-1011, TIP-1020
 
 ## Abstract
 
-This TIP adds an `admin` boolean flag to the `AuthorizedKey` storage struct. When `admin` is `true`, the access key may authorize and revoke other access keys on behalf of the account. The TIP also extends TIP-1020's `SignatureVerifier` precompile with a stateful `verifyAdmin` method so external contracts can verify that a signature was produced by the root key or an admin access key of a given account.
+This TIP adds an `admin` boolean flag to the `AuthorizedKey` storage struct. When `admin` is `true`, the access key may authorize and revoke other access keys on behalf of the account. The TIP also extends TIP-1020's `SignatureVerifier` precompile with stateful verification methods so external contracts can validate active and root/admin keychain signatures against the AccountKeychain state.
 
 ## Motivation
 
@@ -21,15 +21,15 @@ Access keys today are strictly subordinate: they can sign transactions within th
 
 1. **Cross-device key management.** A user with a passkey on their phone cannot authorize a second passkey on their laptop without a transaction from the root EOA key. In practice, multi-device setups require the root key to be available for every new device onboarding, which is inconvenient and fragile.
 
-2. **Onchain admin key signature verification.** Contracts that want to gate actions on "the root key or an admin access key of account X signed this" (e.g. ERC-1271-style flows) have no canonical primitive: today they would have to combine raw signature recovery with their own key-status lookups. A single stateful verification method that composes recovery with admin key-status checks removes that footgun.
+2. **Onchain admin/keychain signature verification.** Contracts that want to gate actions on "the root key or an admin access key of account X signed this" (e.g. ERC-1271-style flows), or validate that a keychain signature came from an active key, have no canonical primitive: today they would have to combine raw signature recovery with their own key-status lookups. Stateful verification methods that compose recovery with key-status checks remove that footgun.
 
-Adding an `admin` flag plus a stateful `verifyAdmin` method on the TIP-1020 `SignatureVerifier` precompile solves both problems with minimal surface area.
+Adding an `admin` flag plus stateful verification methods on the TIP-1020 `SignatureVerifier` precompile solves both problems with minimal surface area.
 
 ## Assumptions
 
 - The root EOA key is implicitly admin. The `admin` flag only applies to access keys registered in the AccountKeychain precompile.
 - Admin keys MUST NOT carry spending limits, call scopes, or expiry. Authorizations that combine `admin = true` with non-default `enforceLimits`, `allowedCalls`, or `expiry` MUST be rejected.
-- TIP-1020 (`SignatureVerifier`) is extended with a stateful `verifyAdmin` method that returns true only for signatures produced by the account's root key or an admin access key. Non-admin access keys MUST NOT satisfy `verifyAdmin`.
+- TIP-1020 (`SignatureVerifier`) is extended with stateful keychain verification methods. `verifyKeychain` validates that a keychain signature was produced by an active access key for the expected account. `verifyKeychainAdmin` validates that a keychain signature was produced by the expected account's root key or an active admin access key.
 
 ---
 
@@ -84,24 +84,40 @@ event AdminKeyAuthorized(
 );
 ```
 
-### `SignatureVerifier.verifyAdmin`
+### `SignatureVerifier` keychain/admin verification
 
-TIP-1020's `SignatureVerifier` precompile is extended with a single stateful method:
+TIP-1020's `SignatureVerifier` precompile is extended with stateful verification helpers:
 
 ```solidity
-/// @notice Returns true if `signature` over `digest` was produced by the
-/// root key or an admin access key of `account`. Returns false for non-admin
-/// access keys, unknown keys, and invalid signatures.
-function verifyAdmin(
+/// @notice Returns true if `signature` over `digest` is a valid keychain
+/// signature produced by an active access key on `account`. Returns false
+/// for account mismatches, unknown, revoked, or expired access keys. Reverts
+/// on malformed non-keychain signatures and invalid keychain signatures.
+/// @dev Does not compare the inner signature type against the stored key type.
+function verifyKeychain(
+    address account,
+    bytes32 digest,
+    bytes calldata signature
+) external view returns (bool);
+
+/// @notice Returns true if `signature` over `digest` is a valid keychain
+/// signature produced by the root key or an active admin access key on
+/// `account`. Returns false for account mismatches, non-admin, unknown,
+/// revoked, or expired access keys. Reverts on malformed non-keychain
+/// signatures and invalid keychain signatures.
+/// @dev Does not compare the inner signature type against the stored key type.
+function verifyKeychainAdmin(
     address account,
     bytes32 digest,
     bytes calldata signature
 ) external view returns (bool);
 ```
 
-`verifyAdmin` recovers the signer from `digest` directly using the same recovery rules as the existing stateless `verify(signer, digest, sig)`, then returns true if `isAdminKey(account, recovered)` returns true.
+`verifyKeychain` and `verifyKeychainAdmin` only accept V2 keychain signatures. They recover the embedded root account and access-key signer using the keychain signature rules, then require the embedded root account to equal `account`. `verifyKeychain` returns true when the recovered access key is active for `account`. `verifyKeychainAdmin` returns true when the recovered signer is `account` itself or an active admin access key for `account`.
 
-`verifyAdmin` does not bind `account` into `digest`. Callers MUST ensure that any digest accepted across account boundaries includes the intended account or another replay domain. Reusing the same admin key across multiple accounts without account-bound digests can make a signature valid for each account where that key is admin.
+**Note:** These methods do not compare the inner signature type against the key type stored in AccountKeychain. This avoids an additional storage read; callers that need to enforce the stored signature type must perform that check separately.
+
+Both methods propagate signature parsing and recovery errors using the existing `SignatureVerifier.InvalidFormat` and `SignatureVerifier.InvalidSignature` errors. Contracts that need non-reverting behavior SHOULD use Solidity `try`/`catch` and treat failures as invalid signatures.
 
 The existing stateless `verify(signer, digest, sig)` is unchanged.
 
@@ -133,7 +149,7 @@ For stored access-key rows, mutators operate on the row selected by `keyId`:
 
 ### TIP-1020 Compatibility
 
-TIP-1020's existing stateless `verify(signer, digest, sig)` is unchanged. This TIP only **adds** a new stateful `verifyAdmin(account, digest, sig)` method to the same `SignatureVerifier` precompile. Existing callers of `verify` are unaffected.
+TIP-1020's existing stateless `verify(signer, digest, sig)` is unchanged. This TIP only **adds** stateful admin/keychain verification methods to the same `SignatureVerifier` precompile. Existing callers of `verify` are unaffected.
 
 ### Admin Key Privilege Propagation
 


### PR DESCRIPTION
Stacked on top of #4265 
Adds the T6 `verifyAdmin(account, hash, signature)` selector to `SignatureVerifier`.

The method recovers Tempo signatures with the existing rules and returns whether the recovered signer is the account root or an active admin access key.