### PR TITLE
Show elapsed time in bench results comments

### DIFF
--- a/.github/scripts/bench-duration.js
+++ b/.github/scripts/bench-duration.js
@@ -1,0 +1,22 @@
+function formatDuration(seconds) {
+  const totalSeconds = Math.max(0, Math.floor(Number(seconds) || 0));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+
+  const parts = [];
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0 || hours > 0) parts.push(`${minutes}m`);
+  parts.push(`${secs}s`);
+  return parts.join(' ');
+}
+
+function elapsedLine(startedAt, now = Date.now()) {
+  const started = Number(startedAt);
+  if (!Number.isFinite(started) || started <= 0) return '';
+
+  const elapsedSeconds = Math.floor((now - started * 1000) / 1000);
+  return `Overall time: \`${formatDuration(elapsedSeconds)}\``;
+}
+
+module.exports = { elapsedLine, formatDuration };

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -425,7 +425,9 @@ jobs:
         run: echo "::add-mask::$BENCH_VICTORIAMETRICS_URL"
 
       - name: Clean up previous results
-        run: sudo rm -rf bench-results/ 2>/dev/null || true
+        run: |
+          echo "BENCH_STARTED_AT=$(date +%s)" >> "$GITHUB_ENV"
+          sudo rm -rf bench-results/ 2>/dev/null || true
 
       - name: Resolve checkout ref
         id: checkout-ref
@@ -853,6 +855,7 @@ jobs:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
           script: |
             const fs = require('fs');
+            const { elapsedLine } = require('./.github/scripts/bench-duration.js');
             const resultsDir = process.env.BENCH_RESULTS_DIR;
 
             let summary = '';
@@ -969,7 +972,9 @@ jobs:
             }
 
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = `cc @${process.env.BENCH_ACTOR}\n\n${resultHeadline} [View job](${jobUrl})\n\n${summary}${grafanaSection}${samplySection}${tracySection}`;
+            const elapsed = elapsedLine(process.env.BENCH_STARTED_AT);
+            const elapsedSection = elapsed ? `\n${elapsed}` : '';
+            const body = `cc @${process.env.BENCH_ACTOR}\n\n${resultHeadline} [View job](${jobUrl})${elapsedSection}\n\n${summary}${grafanaSection}${samplySection}${tracySection}`;
             const ackCommentId = process.env.BENCH_COMMENT_ID;
 
             if (ackCommentId) {

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -282,7 +282,9 @@ jobs:
             core.setOutput('ref', sha);
 
       - name: Clean up root-owned files from previous runs
-        run: sudo rm -rf "$BENCH_WORK_DIR"
+        run: |
+          echo "BENCH_STARTED_AT=$(date +%s)" >> "$GITHUB_ENV"
+          sudo rm -rf "$BENCH_WORK_DIR"
 
       - uses: actions/checkout@v6
         with:
@@ -529,6 +531,7 @@ jobs:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             const fs = require('fs');
+            const { elapsedLine } = require('./.github/scripts/bench-duration.js');
 
             let comment = '';
             try {
@@ -561,7 +564,9 @@ jobs:
             const blocks = process.env.BENCH_BLOCKS || '5000';
             const warmup = process.env.BENCH_WARMUP_BLOCKS || String(Math.floor(Number(blocks) / 4));
             const runPairs = process.env.BENCH_RUN_PAIRS || '2';
-            const body = `cc @${process.env.BENCH_ACTOR}\n\n✅ Replay benchmark complete! [View job](${jobUrl})\n\nChain: \`${chain}\`\nWarmup: \`${warmup}\`\nBlocks: \`${blocks}\`\nRun pairs: \`${runPairs}\`\n\n${comment}`;
+            const elapsed = elapsedLine(process.env.BENCH_STARTED_AT);
+            const elapsedSection = elapsed ? `\n${elapsed}` : '';
+            const body = `cc @${process.env.BENCH_ACTOR}\n\n✅ Replay benchmark complete! [View job](${jobUrl})${elapsedSection}\n\nChain: \`${chain}\`\nWarmup: \`${warmup}\`\nBlocks: \`${blocks}\`\nRun pairs: \`${runPairs}\`\n\n${comment}`;
 
             await github.rest.issues.updateComment({
               owner: context.repo.owner,


### PR DESCRIPTION
Adds elapsed wall-clock time to Derek bench result comments for both e2e and replay runs.

The timer starts at bench job cleanup/setup and is rendered when the final results comment is posted.

Prompted by: @Rjected