### PR TITLE
chore: bump reth and revm

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           repository: foundry-rs/foundry
           # tmp: rus/bump-tempo-v1.7
-          ref: 55dd3846ec5b7938b484497c0fc861fe15bc8d04
+          ref: 5ad62bb61e88facba18f800c73b9ff7b60ef3fb7
           path: foundry
           persist-credentials: false
 
@@ -221,7 +221,7 @@ jobs:
         with:
           repository: foundry-rs/foundry
           # tmp: rus/bump-tempo-v1.7
-          ref: 55dd3846ec5b7938b484497c0fc861fe15bc8d04
+          ref: 5ad62bb61e88facba18f800c73b9ff7b60ef3fb7
           path: foundry
           persist-credentials: false
 

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           repository: foundry-rs/foundry
           # tmp: rus/bump-tempo-v1.7
-          ref: 2a70688470dd684e00d54b4ac1a9b165162960be
+          ref: 55dd3846ec5b7938b484497c0fc861fe15bc8d04
           path: foundry
           persist-credentials: false
 
@@ -221,7 +221,7 @@ jobs:
         with:
           repository: foundry-rs/foundry
           # tmp: rus/bump-tempo-v1.7
-          ref: 2a70688470dd684e00d54b4ac1a9b165162960be
+          ref: 55dd3846ec5b7938b484497c0fc861fe15bc8d04
           path: foundry
           persist-credentials: false
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,14 +119,14 @@ dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
@@ -155,10 +155,10 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-trie",
  "alloy-tx-macros",
  "arbitrary",
@@ -184,10 +184,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "arbitrary",
  "serde",
 ]
@@ -308,26 +308,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-eips"
-version = "1.8.3"
+name = "alloy-eip7928"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
+checksum = "4d93ce7e41bcd2b9ee2c1d92c223c1be4a274d387538d6d3f956b768986ce451"
 dependencies = [
- "alloy-eip2124",
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.8.3",
- "auto_impl",
  "borsh",
- "c-kzg",
- "derive_more",
- "either",
+ "once_cell",
  "serde",
- "serde_with",
- "sha2 0.10.9",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -339,10 +330,10 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-eip7928",
+ "alloy-eip7928 0.3.7",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "arbitrary",
  "auto_impl",
  "borsh",
@@ -358,12 +349,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
+checksum = "3585808f81853af97c12b062496d6be382e902df0e4f4c508e1305355b9e4d49"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -382,9 +373,9 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab0e0fe9e6d1120ad7bb9254c3fc2b9bc80a8df42a033fb626be6559c13d5153"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-trie",
  "borsh",
  "serde",
@@ -440,13 +431,13 @@ checksum = "a7db7b095b0b1db1d18ce7e91dcd2e82007f2d52bfb8125e6b64633a74a06bc3"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -465,9 +456,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
 ]
 
@@ -511,7 +502,7 @@ checksum = "8955ab30418343de57b356de2ea60200f9fb8016a7ea3bc7f5c6176f01a8b1cf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -632,7 +623,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
 ]
 
@@ -656,7 +647,7 @@ checksum = "2ff111a54268dc0bbd3b17f98571a7e27cc661dc081ad2999d91888647eb2e11"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
 ]
 
@@ -670,7 +661,7 @@ dependencies = [
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
  "serde_json",
 ]
@@ -681,7 +672,7 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a62f6ce2d95f59ed310bd90d5fd1566a29d1ec45cc219abbc5dcc807d31f136"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -715,10 +706,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eba59e1c069f168a01982f42a57797736923b76aa854194df4930be17867e1c"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -736,11 +727,11 @@ checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -757,10 +748,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed1004c1d68bfaee001712f83356f88031ab74a727b8560fb7fc738d1281ebe5"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
  "serde_json",
 ]
@@ -773,7 +764,7 @@ checksum = "514b4b1ce3354f65067b4fc7eb75358e0f2ec8be3340c96dea65d6894f9ca435"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -787,19 +778,8 @@ checksum = "76e34a42ebb4a71ab0bfdebc6d2f3c7bf809f01edf154d08fed159d10d1ef1d4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
-dependencies = [
- "alloy-primitives",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -6805,6 +6785,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8394,10 +8383,10 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "futures-core",
  "futures-util",
@@ -8421,10 +8410,10 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -8454,11 +8443,11 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -8474,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8487,11 +8476,11 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "backon",
@@ -8570,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8580,9 +8569,9 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "cfg-if",
  "eyre",
@@ -8600,12 +8589,12 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce542a96bf888f31854803e80b3340bc233927743aa580838014e8a88fe0d66"
+checksum = "0f54468f34d9ed03356dee71bb182a2815a490934f1a291f58158053eee946ba"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -8621,9 +8610,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634c90f1cc0f9887680ca785b0b21aa961070b9465917bf65afaec56a6d005bb"
+checksum = "c80c0516faf1698c57f91f07c98ecd9f3a9d3f163f1ad4bb263d9c495b3928e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8633,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8649,10 +8638,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928",
+ "alloy-eip7928 0.4.1",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
@@ -8663,10 +8652,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -8676,10 +8665,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -8701,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8730,7 +8719,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8756,7 +8745,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8786,9 +8775,9 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -8801,7 +8790,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8826,7 +8815,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8850,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8874,10 +8863,10 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "async-compression",
@@ -8909,10 +8898,10 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -8966,7 +8955,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8994,7 +8983,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9017,10 +9006,10 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -9042,11 +9031,11 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928",
- "alloy-eips 2.0.5",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -9101,7 +9090,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9131,10 +9120,10 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "ethereum_ssz",
@@ -9147,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9163,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9185,7 +9174,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9196,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9224,12 +9213,12 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eip7928",
- "alloy-eips 2.0.5",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -9246,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9287,7 +9276,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "clap",
  "eyre",
@@ -9310,10 +9299,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -9326,9 +9315,9 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -9342,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9355,10 +9344,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9385,10 +9374,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "reth-codecs",
@@ -9399,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9409,10 +9398,11 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -9433,10 +9423,10 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -9453,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9471,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9484,10 +9474,10 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -9503,10 +9493,10 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "eyre",
  "futures",
@@ -9541,9 +9531,9 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
@@ -9555,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "serde",
  "serde_json",
@@ -9565,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9593,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "bytes",
  "futures",
@@ -9613,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9630,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "bindgen",
  "cc",
@@ -9639,7 +9629,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "futures",
  "metrics",
@@ -9652,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9661,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9675,10 +9665,10 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -9733,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9758,10 +9748,10 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9781,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9796,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9810,7 +9800,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9827,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9851,10 +9841,10 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -9919,10 +9909,10 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
@@ -9974,9 +9964,9 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -10017,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10041,10 +10031,10 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -10065,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "bytes",
  "eyre",
@@ -10094,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10106,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10130,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10142,10 +10132,10 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -10165,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10174,12 +10164,12 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee12e304adbacbb32248c9806ebafbe1e2811fbfefe53c5e5b710a8438b7ec0"
+checksum = "2d1216ba179909d41d8d55c5eae6c1c33698bc7a3053c35fd425c7789a5de3c1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -10208,11 +10198,11 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928",
- "alloy-eips 2.0.5",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -10257,10 +10247,9 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
@@ -10286,7 +10275,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10302,7 +10291,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10317,11 +10306,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -10337,7 +10326,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -10393,9 +10382,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -10409,7 +10398,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -10423,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10466,7 +10455,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10486,9 +10475,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -10517,12 +10506,12 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eip7928",
- "alloy-eips 2.0.5",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
@@ -10530,7 +10519,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -10545,6 +10534,7 @@ dependencies = [
  "reth-network-api",
  "reth-node-api",
  "reth-primitives-traits",
+ "reth-prune-types",
  "reth-revm",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
@@ -10563,15 +10553,17 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
+ "alloy-serde",
  "alloy-sol-types",
  "alloy-transport",
  "derive_more",
@@ -10611,7 +10603,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10625,9 +10617,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -10640,9 +10632,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "860fe223501a76ff14aa3bf164f739f31008c2a2905ac85708bfd88f042e6151"
+checksum = "75186b77fef29e0160f476c9a6bde3363e503f0f32ac4ef47726ef1e3da81118"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10656,10 +10648,9 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
@@ -10708,9 +10699,9 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "aquamarine",
  "auto_impl",
@@ -10736,7 +10727,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10750,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10770,7 +10761,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10785,10 +10776,11 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -10810,9 +10802,9 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -10828,7 +10820,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10849,10 +10841,10 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "rand 0.8.6",
@@ -10865,7 +10857,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10875,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "clap",
  "eyre",
@@ -10894,7 +10886,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10913,10 +10905,10 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -10958,10 +10950,10 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -10984,13 +10976,13 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-trie",
  "arbitrary",
  "arrayvec",
@@ -11011,7 +11003,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11031,9 +11023,9 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
- "alloy-eip7928",
+ "alloy-eip7928 0.4.1",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -11060,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1be17eb#1be17ebbb695f6e9d0b6bb2f59314a5ce039715f"
+source = "git+https://github.com/paradigmxyz/reth?rev=aec6ba0#aec6ba00c87ccfb240132bef13130e79fce6f4dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11081,18 +11073,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12fafa33d2f420a9d39249a3e0357b1928d09429f30758b85280409092873b2"
+checksum = "80dcfa0327b7642cc41c71d8cd3626a48ac76fb8304c28bcbdf416a45615d020"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "38.0.0"
+version = "40.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91202d39dbe8e8d10e9e8f2b76c30da68ecd1d25be69ba6d853ad0d03a3a398a"
+checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11109,9 +11101,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "10.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbb3a3d735efa94c91f2ef6bf20a35f99a77bc78f3e25bd758336901bdf9661"
+checksum = "d8b378c2653331fe60969d9745e802cd773d82a20d8aaced914dfcf26ab8f0d9"
 dependencies = [
  "bitvec",
  "phf",
@@ -11121,9 +11113,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "16.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f68d928d8b228e0faeb1c6ed75c4fde7d124f1ddf9119b67e7a0ad4041237d"
+checksum = "bafa298114f3cab706945de14c04e73e6e6d7896302e4183dae273f968e52f80"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11138,9 +11130,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "17.0.1"
+version = "19.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3758e6167c4ba7a59a689c519a047edaefcd4c37d74f279b93ed87bc8aece4"
+checksum = "db9c13f1dfc79425931fd184b6bd373dfac7baba50859b01107d5c0e20549cbb"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11154,11 +11146,12 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "13.0.1"
+version = "15.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c281a1f11d3bcb8c0bba1199ed6bcb001d1aeb3d4fb366819e14f88723989a4e"
+checksum = "a69c3ce73454a09ef89a66177239d7c4f5f697227ae27254c99451866603b19d"
 dependencies = [
- "alloy-eips 1.8.3",
+ "alloy-eips",
+ "derive_more",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -11168,9 +11161,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "11.0.1"
+version = "12.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89efb9832a4e3742bb4ded5f7fe5bf905e8860e69427d4dfec153484fc6d304"
+checksum = "4a2656187f9f9c22ef9dd9300ed71aeaeca3506a6a0a229a07f264649b960d68"
 dependencies = [
  "auto_impl",
  "either",
@@ -11182,9 +11175,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "18.1.0"
+version = "20.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783e903d6922b7f5f9a940d1bb229530502d2924b1aed9d5ca5a94ebf065d460"
+checksum = "3ce1d66037ca1394128313bb995fa9f50d834927a389386bb34f8f0ef914648f"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11201,9 +11194,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "19.0.0"
+version = "21.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8216ad58422090d0daa9eb430e0a081f7ad07e7fd30681dee71f8420c99624e0"
+checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
 dependencies = [
  "auto_impl",
  "either",
@@ -11219,9 +11212,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731b682530a732ef9c189ef831589128e2ce34d4a306c956322ae2dffe009715"
+checksum = "2854f2c48cecac90e8ad48fe8d8842707f79df2b748913b67bd2439a9ea3b4ab"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11239,9 +11232,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "35.0.1"
+version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ece9f41b69658c15d748288a4dbdfc06a63f3ce93d983af440de3f1631dce6a"
+checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11252,9 +11245,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "34.0.0"
+version = "36.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a346a8cc6c8c39bd65306641c692191299c0a7b63d38810e39e8fe9b92378660"
+checksum = "191db865091e07ecb80b12ce3048192c76071ca3d2b0a315b111b271cd4ced37"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11278,24 +11271,24 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "23.0.0"
+version = "24.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c99bda77d9661521ba0b4bc04558c6692074f01e65dd420fa3b893033d9b8a2"
+checksum = "fe5102d804892908d4ebf68da29b8562895922dffa26c230ff2c4dadcf93916f"
 dependencies = [
  "alloy-primitives",
- "num_enum",
  "once_cell",
  "serde",
 ]
 
 [[package]]
 name = "revm-state"
-version = "11.0.1"
+version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32490ed687dba31c3c882beb8c20408bdd30ef96690d8f145b0ee9a87040bfe"
+checksum = "40eff6067185cf80932e06f6a9c8045b012ecb6f99a8d6edc618ec2792373e14"
 dependencies = [
- "alloy-eip7928",
+ "alloy-eip7928 0.4.1",
  "bitflags 2.11.1",
+ "nonmax",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -12627,14 +12620,14 @@ dependencies = [
  "alloy",
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -12667,7 +12660,7 @@ dependencies = [
 name = "tempo-chainspec"
 version = "1.5.4"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
  "alloy-hardforks",
@@ -12859,7 +12852,7 @@ name = "tempo-evm"
 version = "1.7.1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -12937,14 +12930,14 @@ name = "tempo-node"
 version = "1.7.1"
 dependencies = [
  "alloy",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "async-trait",
  "base64 0.22.1",
  "clap",
@@ -13039,7 +13032,7 @@ dependencies = [
 name = "tempo-payload-types"
 version = "1.7.1"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -13100,12 +13093,12 @@ name = "tempo-primitives"
 version = "1.7.3"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -13138,7 +13131,7 @@ name = "tempo-revm"
 version = "1.7.1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -13206,7 +13199,7 @@ name = "tempo-transaction-pool"
 version = "1.7.1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-signer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,77 +140,77 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-codecs = { version = "0.4.0", default-features = false }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-primitives-traits = { version = "0.4.0", default-features = false }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "1be17eb", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0", features = [
   "std",
   "optional-checks",
 ] }
-revm = { version = "38.0.0", features = ["optional_fee_charge"], default-features = false }
+revm = { version = "40.0.3", features = ["optional_fee_charge"], default-features = false }
 
 alloy = { version = "2.0.5", default-features = false }
 alloy-consensus = { version = "2.0.5", default-features = false }
 alloy-contract = { version = "2.0.5", default-features = false }
 alloy-eips = { version = "2.0.5", default-features = false }
-alloy-evm = { version = "0.34.0", default-features = false }
-revm-inspectors = "0.39.0"
+alloy-evm = { version = "0.35.0", default-features = false }
+revm-inspectors = "0.40.0"
 alloy-genesis = { version = "2.0.5", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-abi = { version = "1.6.0", default-features = false }

--- a/crates/e2e/src/execution_runtime.rs
+++ b/crates/e2e/src/execution_runtime.rs
@@ -12,7 +12,7 @@ use alloy::{
     signers::{local::MnemonicBuilder, utils::secret_key_to_address},
     transports::http::reqwest::Url,
 };
-use alloy_evm::{EvmFactory as _, revm::inspector::JournalExt as _};
+use alloy_evm::{EvmFactory as _, revm::context::JournalTr};
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{Address, B256, Keccak256, U256};
 use commonware_codec::Encode;

--- a/crates/evm/benches/tip20_execution.rs
+++ b/crates/evm/benches/tip20_execution.rs
@@ -35,9 +35,8 @@ use reth_trie::{
 };
 use revm::{
     DatabaseCommit,
-    context::{BlockEnv, CfgEnv},
+    context::{BlockEnv, CfgEnv, JournalTr},
     database::{CacheDB, DbAccount, EmptyDB},
-    inspector::JournalExt,
 };
 use std::{collections::BTreeSet, fs, hint::black_box, num::NonZeroU64, path::Path, sync::Arc};
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork, spec::TEMPO_T1_BASE_FEE};

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -114,7 +114,7 @@ impl TempoTxResult {
 
     /// Returns the state gas consumed by this transaction.
     pub fn state_gas_used(&self) -> u64 {
-        self.inner.result.result.gas().state_gas_spent()
+        self.inner.result.result.gas().state_gas_spent_final()
     }
 
     /// Returns the validator-credited fee amount (post-feeAMM haircut) for this transaction.
@@ -191,20 +191,18 @@ where
         &mut self,
         address: Address,
     ) -> Result<(), BlockExecutionError> {
-        let original_info = self
+        let info = self
             .inner
             .evm
             .db_mut()
             .basic(address)
             .map_err(BlockExecutionError::other)?
             .unwrap_or_default();
-        if original_info.is_empty_code_hash() {
+        if info.is_empty_code_hash() {
+            let mut account = Account::from(info);
             let code = Bytecode::new_legacy([0xef].into());
-            let mut new_info = original_info.clone();
-            new_info.code_hash = code.hash_slow();
-            new_info.code = Some(code);
-            let mut account: Account = new_info.into();
-            account.original_info = Box::new(original_info);
+            account.info.code_hash = code.hash_slow();
+            account.info.code = Some(code);
             account.mark_touch();
             let state = EvmState::from_iter([(address, account)]);
             self.inner.system_caller.on_state(
@@ -1746,7 +1744,7 @@ mod tests {
             "state hook should contain the deployed address"
         );
         assert_eq!(
-            *calls[0].1[&addr].original_info,
+            calls[0].1[&addr].original_info(),
             Default::default(),
             "state hook account should preserve original_info"
         );
@@ -1787,7 +1785,8 @@ mod tests {
         let calls = hook_calls.lock().unwrap();
         assert_eq!(calls.len(), 1, "state hook should be called exactly once");
         assert_eq!(
-            *calls[0].1[&addr].original_info, original_info,
+            calls[0].1[&addr].original_info(),
+            original_info,
             "state hook account should preserve existing original_info"
         );
     }

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -3,7 +3,10 @@ use alloy_evm::{
     precompiles::PrecompilesMap,
     revm::{
         Context, ExecuteEvm, InspectEvm, Inspector, SystemCallEvm,
-        context::result::{EVMError, ResultAndState, ResultGas},
+        context::{
+            DBErrorMarker,
+            result::{EVMError, ResultAndState, ResultGas},
+        },
         inspector::NoOpInspector,
     },
 };
@@ -29,8 +32,7 @@ impl EvmFactory for TempoEvmFactory {
     type Evm<DB: Database, I: Inspector<Self::Context<DB>>> = TempoEvm<DB, I>;
     type Context<DB: Database> = TempoContext<DB>;
     type Tx = TempoTxEnv;
-    type Error<DBError: std::error::Error + Send + Sync + 'static> =
-        EVMError<DBError, TempoInvalidTransaction>;
+    type Error<DBError: DBErrorMarker> = EVMError<DBError, TempoInvalidTransaction>;
     type HaltReason = TempoHaltReason;
     type Spec = TempoHardfork;
     type BlockEnv = TempoBlockEnv;

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -859,8 +859,7 @@ where
             .is_prague_active_at_timestamp(attributes.timestamp)
             .then(|| execution_result.requests.clone());
 
-        let sealed_block = Arc::new(block.sealed_block().clone());
-        let rlp_length = sealed_block.rlp_length();
+        let rlp_length = block.rlp_length();
 
         if is_osaka && rlp_length > MAX_RLP_BLOCK_SIZE {
             return Err(PayloadBuilderError::other(ConsensusError::BlockTooLarge {
@@ -898,7 +897,7 @@ where
 
         let elapsed = start.elapsed();
         self.metrics.payload_build_duration_seconds.record(elapsed);
-        let gas_per_second = sealed_block.gas_used() as f64 / elapsed.as_secs_f64();
+        let gas_per_second = block.gas_used() as f64 / elapsed.as_secs_f64();
         self.metrics.gas_per_second.record(gas_per_second);
         self.metrics.gas_per_second_last.set(gas_per_second);
         self.metrics.rlp_block_size_bytes.record(rlp_length as f64);
@@ -907,14 +906,14 @@ where
             .set(rlp_length as f64);
 
         info!(
-            parent_hash = ?sealed_block.parent_hash(),
-            number = sealed_block.number(),
-            hash = ?sealed_block.hash(),
-            timestamp = sealed_block.timestamp_millis(),
-            gas_limit = sealed_block.gas_limit(),
+            parent_hash = ?block.parent_hash(),
+            number = block.number(),
+            hash = ?block.hash(),
+            timestamp = block.timestamp_millis(),
+            gas_limit = block.gas_limit(),
             gas_used,
             cumulative_state_gas_used,
-            extra_data = %sealed_block.extra_data(),
+            extra_data = %block.extra_data(),
             subblocks_count,
             payment_transactions,
             pool_transactions_yielded,
@@ -937,7 +936,8 @@ where
             "Built payload"
         );
 
-        let eth_payload = EthBuiltPayload::new(sealed_block, total_fees, requests, None);
+        let block = Arc::new(block);
+        let eth_payload = EthBuiltPayload::new(block.clone(), total_fees, requests, None);
 
         let execution_output = BlockExecutionOutput {
             result: execution_result,
@@ -945,7 +945,7 @@ where
         };
 
         let executed_block = BuiltPayloadExecutedBlock {
-            recovered_block: Arc::new(block),
+            recovered_block: block,
             execution_output: Arc::new(execution_output),
             hashed_state: Arc::new(hashed_state),
             trie_updates: Arc::new(trie_updates),
@@ -1046,7 +1046,7 @@ mod tests {
     use alloy_consensus::BlockBody;
     use alloy_primitives::{Address, B256, Bytes};
     use core::num::NonZeroU64;
-    use reth_primitives_traits::SealedBlock;
+    use reth_primitives_traits::Block as _;
     use tempo_primitives::{
         AASigned, Block, SignedSubBlock, SubBlock, SubBlockVersion, TempoSignature,
         TempoTransaction,
@@ -1125,9 +1125,10 @@ mod tests {
                 ommers: vec![],
                 withdrawals: None,
             },
-        };
-        let sealed = Arc::new(SealedBlock::seal_slow(block));
-        let eth = EthBuiltPayload::new(sealed, U256::ZERO, None, None);
+        }
+        .try_into_recovered()
+        .unwrap();
+        let eth = EthBuiltPayload::new(Arc::new(block), U256::ZERO, None, None);
         TempoBuiltPayload::new(eth, None)
     }
 

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -300,7 +300,8 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
 
     #[inline]
     fn state_gas_used(&self) -> u64 {
-        self.gas_tracker.state_gas_spent()
+        // SAFETY: we never decrement the state gas spent counter
+        self.gas_tracker.state_gas_spent() as u64
     }
 
     #[inline]

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -98,14 +98,11 @@ impl<DB: Database, I> TempoEvm<DB, I> {
         // Pre-T0 it could happen that the initial gas spending is greater than the gas limit due to faulty validation.
         //
         // Before that it would overflow, so we are reproducing this behavior here by setting the gas limit to u64::MAX and the reservoir to 0.
-        if !self.cfg.spec.is_t0() && init_and_floor_gas.initial_total_gas > self.tx.gas_limit {
+        if !self.cfg.spec.is_t0() && init_and_floor_gas.initial_total_gas() > self.tx.gas_limit {
             (u64::MAX, 0)
         } else {
-            init_and_floor_gas.initial_gas_and_reservoir(
-                self.tx.gas_limit,
-                self.cfg.tx_gas_limit_cap(),
-                self.cfg.is_amsterdam_eip8037_enabled(),
-            )
+            init_and_floor_gas
+                .initial_gas_and_reservoir(self.tx.gas_limit, self.cfg.tx_gas_limit_cap())
         }
     }
 }
@@ -1679,10 +1676,10 @@ mod tests {
             let gas = result.unwrap();
             // Verify floor_gas > initial_total_gas for this calldata (EIP-7623 scenario)
             assert!(
-                gas.floor_gas > gas.initial_total_gas,
+                gas.floor_gas > gas.initial_total_gas(),
                 "Expected floor_gas ({}) > initial_total_gas ({}) for large calldata",
                 gas.floor_gas,
-                gas.initial_total_gas
+                gas.initial_total_gas()
             );
         }
 
@@ -1700,7 +1697,7 @@ mod tests {
 
             let gas = result.unwrap();
             assert!(
-                gas.initial_total_gas >= 21_000,
+                gas.initial_total_gas() >= 21_000,
                 "Initial gas should be at least 21k base"
             );
         }

--- a/crates/revm/src/gas_params.rs
+++ b/crates/revm/src/gas_params.rs
@@ -1,36 +1,14 @@
-use auto_impl::auto_impl;
 use revm::{
     context_interface::cfg::{GasId, GasParams},
     primitives::OnceLock,
 };
 use tempo_chainspec::hardfork::TempoHardfork;
 
-/// Extending [`GasParams`] for Tempo use case.
-#[auto_impl(&, Arc, Box, &mut)]
-pub trait TempoGasParams {
-    fn gas_params(&self) -> &GasParams;
-
-    fn tx_tip1000_auth_account_creation_cost(&self) -> u64 {
-        self.gas_params().get(GasId::new(255))
-    }
-
-    fn tx_tip1000_auth_account_creation_state_gas(&self) -> u64 {
-        self.gas_params().get(GasId::new(254))
-    }
-}
-
-impl TempoGasParams for GasParams {
-    fn gas_params(&self) -> &GasParams {
-        self
-    }
-}
-
 // TIP-1000 total gas costs (used by T1)
 pub const SSTORE_SET_COST: u64 = 250_000;
 const CREATE_COST: u64 = 500_000;
 const NEW_ACCOUNT_COST: u64 = 250_000;
 const CODE_DEPOSIT_COST_T1: u64 = 1_000;
-const AUTH_ACCOUNT_CREATION_COST: u64 = 250_000;
 const EIP7702_PER_EMPTY_ACCOUNT_COST_T1: u64 = 12_500;
 
 // TIP-1016 regular gas (computational overhead) — matches pre-TIP-1000 EVM costs.
@@ -42,7 +20,6 @@ const T4_SSTORE_SET_REGULAR: u64 = 20_000;
 const T4_NEW_ACCOUNT_REGULAR: u64 = 25_000;
 const T4_CREATE_REGULAR: u64 = 32_000;
 const T4_CODE_DEPOSIT_REGULAR: u64 = 200;
-const T4_EIP7702_PER_AUTH_TOTAL: u64 = 250_000; // 25k regular + 225k state
 
 // TIP-1016 state gas (permanent storage burden)
 const T4_SSTORE_SET_STATE: u64 = SSTORE_SET_COST - T4_SSTORE_SET_REGULAR; // 230,000
@@ -106,19 +83,15 @@ fn amsterdam_gas_params() -> GasParams {
         // EIP-7702 delegation: 25k regular + 225k state = 250k per auth
         (
             GasId::tx_eip7702_per_empty_account_cost(),
-            T4_EIP7702_PER_AUTH_TOTAL,
+            T4_NEW_ACCOUNT_REGULAR,
         ),
-        (
-            GasId::tx_eip7702_per_auth_state_gas(),
-            T4_NEW_ACCOUNT_STATE, // 225,000
-        ),
-        // Auth refund is zeroed by apply_eip7702_auth_list override (TIP-1000:
-        // "no refund if the account already exists"), but set the value for
-        // upstream split_eip7702_refund correctness if the override is bypassed.
+        // Auth refund is disabled post-T1.
         (GasId::tx_eip7702_auth_refund(), 0),
-        // Auth account creation (keychain): same split as account creation
-        (GasId::new(255), T4_NEW_ACCOUNT_REGULAR),
-        (GasId::new(254), T4_NEW_ACCOUNT_STATE),
+        // For each auth revm charges new_account_state_gas + tx_eip7702_state_gas_bytecode state gas
+        //
+        // Per TIP-1016, we only need 225k unconditional state gas charge (another 250k is charged only
+        // if nonce is zero). Thus, we are zeroing the bytecode cost so that only new_account_state_gas (225k) is charged.
+        (GasId::tx_eip7702_state_gas_bytecode(), 0),
     ]);
     gas_params
 }
@@ -138,7 +111,8 @@ fn t1_gas_params() -> GasParams {
             GasId::tx_eip7702_per_empty_account_cost(),
             EIP7702_PER_EMPTY_ACCOUNT_COST_T1,
         ),
-        (GasId::new(255), AUTH_ACCOUNT_CREATION_COST),
+        // Auth refund is disabled post-T1.
+        (GasId::tx_eip7702_auth_refund(), 0),
     ]);
     gas_params
 }
@@ -268,37 +242,29 @@ mod tests {
         );
         assert_eq!(gas_params.get(GasId::code_deposit_state_gas()), 2_300);
 
-        // Auth account creation: same split as account creation
-        assert_eq!(
-            gas_params.get(GasId::new(255)),
-            25_000,
-            "Auth account creation regular gas per spec"
-        );
-        assert_eq!(
-            gas_params.get(GasId::new(254)),
-            225_000,
-            "Auth account creation state gas per spec"
-        );
-
         // EIP-7702 delegation: 25,000 regular + 225,000 state per auth
         assert_eq!(
             gas_params.get(GasId::tx_eip7702_per_empty_account_cost()),
-            250_000,
+            25_000,
             "EIP-7702 per auth total = 25k regular + 225k state per spec"
         );
         assert_eq!(
-            gas_params.tx_eip7702_per_auth_state_gas(),
+            gas_params.tx_eip7702_per_empty_account_cost(),
+            250_000,
+            "EIP-7702 per auth state gas per spec"
+        );
+        assert_eq!(
+            gas_params.new_account_state_gas(),
             225_000,
             "EIP-7702 per auth state gas per spec"
         );
         assert_eq!(
-            gas_params.tx_eip7702_per_empty_account_cost()
-                - gas_params.tx_eip7702_per_auth_state_gas(),
+            gas_params.tx_eip7702_per_empty_account_cost() - gas_params.new_account_state_gas(),
             25_000,
             "EIP-7702 per auth regular gas = total - state = 25k"
         );
         assert_eq!(
-            gas_params.tx_eip7702_auth_refund(),
+            gas_params.tx_eip7702_auth_refund_regular(),
             0,
             "TIP-1000: no refund for existing accounts on T1+"
         );
@@ -360,17 +326,9 @@ mod tests {
             "code_deposit total must be 2,500/byte"
         );
 
-        // Auth account creation: 25,000 + 225,000 = 250,000
-        assert_eq!(
-            t4.get(GasId::new(255)) + t4.get(GasId::new(254)),
-            250_000,
-            "auth_account_creation total must be 250,000"
-        );
-
         // EIP-7702: 25,000 regular + 225,000 state = 250,000 per auth
         assert_eq!(
-            (t4.tx_eip7702_per_empty_account_cost() - t4.tx_eip7702_per_auth_state_gas())
-                + t4.tx_eip7702_per_auth_state_gas(),
+            t4.tx_eip7702_per_empty_account_cost(),
             250_000,
             "EIP-7702 per auth total must be 250,000"
         );

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -277,8 +277,8 @@ fn normalize_failed_batch_result_gas(
         frame_result
             .gas()
             .reservoir()
-            .saturating_add_signed(frame_result.gas().state_gas_spent())
-            .saturating_add_signed(accumulated_state_gas_spent),
+            .saturating_add_signed(accumulated_state_gas_spent)
+            .saturating_add_signed(frame_result.gas().state_gas_spent()),
     );
     *frame_result.gas_mut() = corrected_gas;
 }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -68,7 +68,7 @@ use crate::{
     common::TempoStateAccess,
     error::{FeePaymentError, TempoHaltReason},
     evm::TempoContext,
-    gas_params::{SSTORE_SET_COST, TempoGasParams},
+    gas_params::SSTORE_SET_COST,
 };
 
 /// Additional gas for P256 signature verification
@@ -260,11 +260,11 @@ fn call_scope_extra_gas(auth: &tempo_primitives::transaction::KeyAuthorization) 
 fn normalize_failed_batch_result_gas(
     frame_result: &mut FrameResult,
     final_gas_limit: u64,
-    accumulated_state_gas_spent: u64,
+    accumulated_state_gas_spent: i64,
 ) {
     // Create new Gas with correct limit, because Gas does not have a set_limit method
     // (the frame_result limit only covers the failed step).
-    let mut corrected_gas = Gas::new_spent(final_gas_limit);
+    let mut corrected_gas = Gas::new_spent_with_reservoir(final_gas_limit, 0);
     if frame_result.instruction_result().is_revert() {
         corrected_gas.erase_cost(frame_result.gas().remaining());
     }
@@ -274,9 +274,11 @@ fn normalize_failed_batch_result_gas(
     corrected_gas.set_state_gas_spent(0);
     // Reservoir and state gas are refunded on failure
     corrected_gas.set_reservoir(
-        frame_result.gas().reservoir()
-            + frame_result.gas().state_gas_spent()
-            + accumulated_state_gas_spent,
+        frame_result
+            .gas()
+            .reservoir()
+            .saturating_add_signed(frame_result.gas().state_gas_spent())
+            .saturating_add_signed(accumulated_state_gas_spent),
     );
     *frame_result.gas_mut() = corrected_gas;
 }
@@ -361,24 +363,23 @@ fn calculate_key_authorization_gas(
         }
 
         let sstore_cost = gas_params.get(GasId::sstore_set_without_load_cost());
-        let mut total_gas = sig_gas + sload_cost + sstore_cost * num_sstores + BUFFER;
+        let mut regular_gas = sig_gas + sload_cost + sstore_cost * num_sstores + BUFFER;
 
         if has_t5_witness {
-            total_gas += sload_cost + KEY_AUTH_T5_WITNESS_EVENT_BUFFER;
+            regular_gas += sload_cost + KEY_AUTH_T5_WITNESS_EVENT_BUFFER;
         }
 
         // T4+: include extra gas for call scopes configuration
         if spec.is_t4() {
-            total_gas += call_scope_extra_gas(&key_auth.authorization);
+            regular_gas += call_scope_extra_gas(&key_auth.authorization);
         }
 
         // TIP-1016: each storage-creating SSTORE also incurs state gas.
         let state_gas = gas_params
             .get(GasId::sstore_set_state_gas())
             .saturating_mul(num_sstores);
-        total_gas += state_gas;
 
-        (total_gas, state_gas)
+        (regular_gas, state_gas)
     } else {
         // Pre-T1B: Original heuristic constants
         (
@@ -551,7 +552,7 @@ where
         let mut frame_result = run_loop(self, evm, first_frame_input)?;
 
         // Handle last frame result
-        self.last_frame_result(evm, &mut frame_result)?;
+        self.last_frame_result(evm, reservoir, &mut frame_result)?;
 
         Ok(frame_result)
     }
@@ -602,7 +603,7 @@ where
         // Create checkpoint for atomic execution - captures state before any calls
         let checkpoint = evm.ctx().journal_mut().checkpoint();
         let mut accumulated_gas_refund = 0i64;
-        let mut accumulated_state_gas_spent = 0u64;
+        let mut accumulated_state_gas_spent = 0i64;
 
         // Store original TxEnv values to restore after batch execution
         let original_kind = evm.ctx().tx().kind();
@@ -839,7 +840,7 @@ where
     fn apply_eip7702_auth_list(
         &self,
         evm: &mut Self::Evm,
-        init_and_floor_gas: &mut InitialAndFloorGas,
+        _init_and_floor_gas: &mut InitialAndFloorGas,
     ) -> Result<u64, Self::Error> {
         let ctx = &mut evm.ctx;
         let spec = ctx.cfg.spec;
@@ -852,14 +853,11 @@ where
             .map(|aa_env| !aa_env.tempo_authorization_list.is_empty())
             .unwrap_or(false);
 
-        // If it's an AA transaction with authorization list, we need to apply it manually
-        // since the default implementation only checks for TransactionType::Eip7702
-        let refunded_gas = if has_aa_auth_list {
+        let refunded_accounts = if has_aa_auth_list {
             let tempo_tx_env = ctx.tx.tempo_tx_env.as_ref().unwrap();
 
             apply_auth_list::<_, Self::Error>(
                 ctx.cfg.chain_id,
-                ctx.cfg.gas_params.tx_eip7702_auth_refund(),
                 tempo_tx_env
                     .tempo_authorization_list
                     .iter()
@@ -867,16 +865,21 @@ where
                     .filter(|auth| !(spec.is_t0() && auth.signature().is_keychain())),
                 &mut ctx.journaled_state,
             )?
+            .0
         } else {
-            // For standard EIP-7702 transactions, use the default implementation
-            pre_execution::apply_eip7702_auth_list::<_, Self::Error>(evm.ctx(), init_and_floor_gas)?
+            apply_auth_list::<_, Self::Error>(
+                ctx.cfg.chain_id,
+                ctx.tx.authorization_list(),
+                &mut ctx.journaled_state,
+            )?
+            .0
         };
 
-        // TIP-1000: State Creation Cost Increase
-        // Authorization lists: There is no refund if the account already exists
-        if spec.is_t1() {
-            return Ok(0);
-        }
+        let refunded_gas = ctx
+            .cfg
+            .gas_params
+            .tx_eip7702_auth_refund_regular()
+            .saturating_mul(refunded_accounts);
 
         Ok(refunded_gas)
     }
@@ -950,16 +953,14 @@ where
             && tx.first_call().is_some_and(|(kind, _)| kind.is_create())
             && caller_account.nonce() == 0
         {
-            let account_cost = cfg.gas_params.get(GasId::new_account_cost());
-            let account_state_gas = cfg.gas_params.new_account_state_gas();
-            init_gas.initial_total_gas += account_cost + account_state_gas;
-            init_gas.initial_state_gas += account_state_gas;
+            init_gas.initial_regular_gas += cfg.gas_params.get(GasId::new_account_cost());
+            init_gas.initial_state_gas += cfg.gas_params.new_account_state_gas();
 
             // do the gas limit check again (include state gas for T4+).
-            if tx.gas_limit() < init_gas.initial_total_gas {
+            if tx.gas_limit() < init_gas.initial_total_gas() {
                 return Err(InvalidTransaction::CallGasCostMoreThanGasLimit {
                     gas_limit: tx.gas_limit(),
-                    initial_gas: init_gas.initial_total_gas,
+                    initial_gas: init_gas.initial_total_gas(),
                 }
                 .into());
             }
@@ -1288,7 +1289,7 @@ where
             // unlimited gas also eliminates the OOG path that caused the CREATE
             // nonce replay vulnerability (protocol nonce not bumped on OOG).
             let gas_limit = if spec.is_t1() && !spec.is_t1b() {
-                tx.gas_limit() - init_gas.initial_total_gas
+                tx.gas_limit() - init_gas.initial_total_gas()
             } else {
                 u64::MAX
             };
@@ -1406,10 +1407,10 @@ where
                 if spec.is_t1b() {
                     journal.checkpoint_commit();
                 } else if out_of_gas {
-                    init_gas.initial_total_gas = u64::MAX;
+                    init_gas.initial_regular_gas = u64::MAX;
                     journal.checkpoint_revert(keychain_checkpoint);
                 } else {
-                    init_gas.initial_total_gas += gas_used;
+                    init_gas.initial_regular_gas += gas_used;
                     journal.checkpoint_commit();
                 };
             }
@@ -1760,31 +1761,25 @@ where
             // no need for v1 fork check as gas_params would be zero
             for auth in tx.authorization_list() {
                 if auth.nonce == 0 {
-                    let auth_cost = gas_params.tx_tip1000_auth_account_creation_cost();
-                    let auth_state_gas = gas_params.tx_tip1000_auth_account_creation_state_gas();
-                    // Add both execution and state portions to initial_total_gas
-                    // (revm's invariant: initial_total_gas >= initial_state_gas)
-                    init_gas.initial_total_gas += auth_cost + auth_state_gas;
-                    init_gas.initial_state_gas += auth_state_gas;
+                    init_gas.initial_regular_gas += gas_params.get(GasId::new_account_cost());
+                    init_gas.initial_state_gas += gas_params.new_account_state_gas();
                 }
             }
 
             // TIP-1000: Storage pricing updates for launch
             // Transactions with any `nonce_key` and `nonce == 0` require an additional 250,000 gas.
             if spec.is_t1() && tx.nonce == 0 {
-                let account_cost = gas_params.get(GasId::new_account_cost());
-                let account_state_gas = gas_params.new_account_state_gas();
                 // Add both execution and state portions to initial_total_gas
                 // (revm's invariant: initial_total_gas >= initial_state_gas)
-                init_gas.initial_total_gas += account_cost + account_state_gas;
-                init_gas.initial_state_gas += account_state_gas;
+                init_gas.initial_regular_gas += gas_params.get(GasId::new_account_cost());
+                init_gas.initial_state_gas += gas_params.new_account_state_gas();
             }
 
             // Validate gas limit is sufficient for initial gas
-            if gas_limit < init_gas.initial_total_gas {
+            if gas_limit < init_gas.initial_total_gas() {
                 return Err(InvalidTransaction::CallGasCostMoreThanGasLimit {
                     gas_limit,
-                    initial_gas: init_gas.initial_total_gas,
+                    initial_gas: init_gas.initial_total_gas(),
                 }
                 .into());
             }
@@ -1925,44 +1920,42 @@ pub fn calculate_aa_batch_intrinsic_gas<'a>(
     let mut gas = InitialAndFloorGas::default();
 
     // 1. Base stipend (21k, once per transaction)
-    gas.initial_total_gas += gas_params.tx_base_stipend();
+    gas.initial_regular_gas += gas_params.tx_base_stipend();
 
     // 2. Signature verification gas
-    gas.initial_total_gas += tempo_signature_verification_gas(signature);
+    gas.initial_regular_gas += tempo_signature_verification_gas(signature);
 
     let cold_account_cost =
         gas_params.warm_storage_read_cost() + gas_params.cold_account_additional_cost();
 
     // 3. Per-call overhead: cold account access
     // if the `to` address has not appeared in the call batch before.
-    gas.initial_total_gas += cold_account_cost * calls.len().saturating_sub(1) as u64;
+    gas.initial_regular_gas += cold_account_cost * calls.len().saturating_sub(1) as u64;
 
     // 4. Authorization list costs (EIP-7702)
     let num_auths = authorization_list.len() as u64;
-    gas.initial_total_gas += num_auths * gas_params.tx_eip7702_per_empty_account_cost();
+    gas.initial_regular_gas +=
+        num_auths * gas_params.get(GasId::tx_eip7702_per_empty_account_cost());
     // TIP-1016: Track state gas portion of per-auth cost (225k on T4, 0 pre-T4).
-    gas.initial_state_gas += num_auths * gas_params.tx_eip7702_per_auth_state_gas();
+    gas.initial_state_gas += num_auths * gas_params.tx_eip7702_state_gas();
 
     // Add signature verification costs for each authorization
     // No need for v1 fork check as gas_params would be zero
     for auth in authorization_list {
-        gas.initial_total_gas += tempo_signature_verification_gas(auth.signature());
+        gas.initial_regular_gas += tempo_signature_verification_gas(auth.signature());
         // TIP-1000: Storage pricing updates for launch
         // EIP-7702 authorisation list entries with `auth_list.nonce == 0` require an additional 250,000 gas.
         if auth.nonce == 0 {
-            let auth_state_gas = gas_params.tx_tip1000_auth_account_creation_state_gas();
-            gas.initial_total_gas +=
-                gas_params.tx_tip1000_auth_account_creation_cost() + auth_state_gas;
-            // TIP-1016: Track state gas for auth account creation
-            gas.initial_state_gas += auth_state_gas;
+            gas.initial_regular_gas += gas_params.get(GasId::new_account_cost());
+            gas.initial_state_gas += gas_params.new_account_state_gas();
         }
     }
 
     // 5. Key authorization costs (if present)
     if let Some(key_auth) = key_authorization {
-        let (key_auth_gas, key_auth_state_gas) =
+        let (key_auth_regular_gas, key_auth_state_gas) =
             calculate_key_authorization_gas(key_auth, gas_params, spec);
-        gas.initial_total_gas += key_auth_gas;
+        gas.initial_regular_gas += key_auth_regular_gas;
         gas.initial_state_gas += key_auth_state_gas;
     }
 
@@ -1976,15 +1969,14 @@ pub fn calculate_aa_batch_intrinsic_gas<'a>(
 
         // 4b. CREATE-specific costs
         if call.to.is_create() {
-            let create_state_gas = gas_params.create_state_gas();
             // CREATE costs 500,000 gas in TIP-1000 (T1), 32,000 before
-            gas.initial_total_gas += gas_params.create_cost() + create_state_gas;
+            gas.initial_regular_gas += gas_params.create_cost();
 
             // EIP-3860: Initcode analysis gas using revm helper
-            gas.initial_total_gas += gas_params.tx_initcode_cost(call.input.len());
+            gas.initial_regular_gas += gas_params.tx_initcode_cost(call.input.len());
 
             // TIP-1016: Track predictable state gas for CREATE calls
-            gas.initial_state_gas += create_state_gas;
+            gas.initial_state_gas += gas_params.create_state_gas();
         }
 
         // Note: Transaction value is not allowed in AA transactions as there is no balances in accounts yet.
@@ -1996,23 +1988,23 @@ pub fn calculate_aa_batch_intrinsic_gas<'a>(
         // 4c. Value transfer cost using revm constant
         // left here for future reference.
         if !call.value.is_zero() && call.to.is_call() {
-            gas.initial_total_gas += gas_params.get(GasId::transfer_value_cost()); // 9000 gas
+            gas.initial_regular_gas += gas_params.get(GasId::transfer_value_cost()); // 9000 gas
         }
     }
 
-    gas.initial_total_gas += total_tokens * gas_params.tx_token_cost();
+    gas.initial_regular_gas += total_tokens * gas_params.tx_token_cost();
 
     // 5. Access list costs using revm constants
     if let Some(access_list) = access_list {
         let (accounts, storages) = access_list.fold((0, 0), |(acc_count, storage_count), item| {
             (acc_count + 1, storage_count + item.storage_slots().count())
         });
-        gas.initial_total_gas += accounts * gas_params.tx_access_list_address_cost(); // 2400 per account
-        gas.initial_total_gas += storages as u64 * gas_params.tx_access_list_storage_key_cost(); // 1900 per storage
+        gas.initial_regular_gas += accounts * gas_params.tx_access_list_address_cost(); // 2400 per account
+        gas.initial_regular_gas += storages as u64 * gas_params.tx_access_list_storage_key_cost(); // 1900 per storage
     }
 
     // 6. Floor gas using revm helper
-    gas.floor_gas = gas_params.tx_floor_cost(total_tokens); // tokens * 10 + 21000
+    gas.floor_gas = gas_params.tx_floor_cost_with_tokens(total_tokens); // tokens * 10 + 21000
 
     Ok(gas)
 }
@@ -2063,18 +2055,16 @@ where
             // - Expiring nonce (nonce_key == MAX, T1 active): ring buffer + seen mapping operations
             // - 2D nonce (nonce_key != 0): SLOAD + SSTORE for nonce increment
             // - Regular nonce (nonce_key == 0): no additional gas
-            batch_gas.initial_total_gas += EXPIRING_NONCE_GAS;
+            batch_gas.initial_regular_gas += EXPIRING_NONCE_GAS;
         } else if tx.nonce == 0 {
             // TIP-1000: Storage pricing updates for launch
             // Tempo transactions with any `nonce_key` and `nonce == 0` require an additional 250,000 gas
-            let account_cost = gas_params.get(GasId::new_account_cost());
-            let account_state_gas = gas_params.new_account_state_gas();
-            batch_gas.initial_total_gas += account_cost + account_state_gas;
-            batch_gas.initial_state_gas += account_state_gas;
+            batch_gas.initial_regular_gas += gas_params.get(GasId::new_account_cost());
+            batch_gas.initial_state_gas += gas_params.new_account_state_gas();
         } else if !aa_env.nonce_key.is_zero() {
             // Existing 2D nonce key usage (nonce > 0)
             // TIP-1000 Invariant 3: existing state updates must charge +5,000 gas
-            batch_gas.initial_total_gas += spec.gas_existing_nonce_key();
+            batch_gas.initial_regular_gas += spec.gas_existing_nonce_key();
         }
     } else if let Some(aa_env) = &tx.tempo_tx_env
         && !aa_env.nonce_key.is_zero()
@@ -2091,16 +2081,16 @@ where
     // with gas_limit < intrinsic + nonce_2d_gas to pass validation, but the gas is still
     // charged during execution via init_and_floor_gas (not evm.initial_gas)
     if spec.is_t0() {
-        batch_gas.initial_total_gas += nonce_2d_gas;
+        batch_gas.initial_regular_gas += nonce_2d_gas;
     }
 
     // Validate gas limit is sufficient for initial gas.
     // initial_total_gas already includes initial_state_gas as a subset,
     // so no need to add state gas separately.
-    if gas_limit < batch_gas.initial_total_gas {
+    if gas_limit < batch_gas.initial_total_gas() {
         return Err(InvalidTransaction::CallGasCostMoreThanGasLimit {
             gas_limit,
-            initial_gas: batch_gas.initial_total_gas,
+            initial_gas: batch_gas.initial_total_gas(),
         }
         .into());
     }
@@ -2108,7 +2098,7 @@ where
     // For pre-T0 (Genesis), add 2D nonce gas after validation
     // This gas will be charged via init_and_floor_gas, not evm.initial_gas
     if !spec.is_t0() {
-        batch_gas.initial_total_gas += nonce_2d_gas;
+        batch_gas.initial_regular_gas += nonce_2d_gas;
     }
 
     Ok(batch_gas)
@@ -2172,9 +2162,9 @@ where
 #[inline]
 fn oog_frame_result(kind: TxKind, gas_limit: u64) -> FrameResult {
     if kind.is_call() {
-        FrameResult::new_call_oog(gas_limit, 0..0)
+        FrameResult::new_call_oog(gas_limit, 0..0, 0)
     } else {
-        FrameResult::new_create_oog(gas_limit)
+        FrameResult::new_create_oog(gas_limit, 0)
     }
 }
 
@@ -2188,7 +2178,7 @@ fn check_gas_limit(
     tx: &TempoTxEnv,
     adjusted_gas: &InitialAndFloorGas,
 ) -> Option<FrameResult> {
-    if spec.is_t0() && tx.gas_limit() < adjusted_gas.initial_total_gas {
+    if spec.is_t0() && tx.gas_limit() < adjusted_gas.initial_total_gas() {
         let kind = *tx
             .first_call()
             .expect("we already checked that there is at least one call in aa tx")
@@ -2634,7 +2624,10 @@ mod tests {
         );
 
         // AA with secp256k1 + single call should match normal tx exactly
-        assert_eq!(aa_gas.initial_total_gas, normal_tx_gas.initial_total_gas);
+        assert_eq!(
+            aa_gas.initial_total_gas(),
+            normal_tx_gas.initial_total_gas()
+        );
     }
 
     #[test]
@@ -2688,11 +2681,11 @@ mod tests {
 
         // For 3 calls: base (21k) + 3*calldata + 2*per-call overhead (calls 2 and 3)
         // = 21k + 2*(calldata cost) + 2*COLD_ACCOUNT_ACCESS_COST
-        let expected = base_tx_gas.initial_total_gas
+        let expected = base_tx_gas.initial_total_gas()
             + 2 * (calldata.len() as u64 * 16)
             + 2 * COLD_ACCOUNT_ACCESS_COST;
         // Should charge per-call overhead for calls beyond the first
-        assert_eq!(gas.initial_total_gas, expected,);
+        assert_eq!(gas.initial_total_gas(), expected,);
     }
 
     #[test]
@@ -2741,8 +2734,8 @@ mod tests {
         let base_gas = calculate_initial_tx_gas(spec, &calldata, false, 0, 0, 0);
 
         // Expected: normal tx + P256_VERIFY_GAS
-        let expected = base_gas.initial_total_gas + P256_VERIFY_GAS;
-        assert_eq!(gas.initial_total_gas, expected,);
+        let expected = base_gas.initial_total_gas() + P256_VERIFY_GAS;
+        assert_eq!(gas.initial_total_gas(), expected,);
     }
 
     #[test]
@@ -2786,7 +2779,7 @@ mod tests {
         );
 
         // AA CREATE should match normal CREATE exactly
-        assert_eq!(gas.initial_total_gas, base_gas.initial_total_gas,);
+        assert_eq!(gas.initial_total_gas(), base_gas.initial_total_gas(),);
     }
 
     #[test]
@@ -2865,7 +2858,7 @@ mod tests {
         let base_gas = calculate_initial_tx_gas(spec, &calldata, false, 0, 0, 0);
 
         // Expected: normal tx
-        assert_eq!(gas.initial_total_gas, base_gas.initial_total_gas,);
+        assert_eq!(gas.initial_total_gas(), base_gas.initial_total_gas(),);
     }
 
     #[test]
@@ -3276,9 +3269,9 @@ mod tests {
         let sig_gas = ECRECOVER_GAS + primitive_signature_verification_gas(&key_auth.signature);
         let sload = gas_params.warm_storage_read_cost() + gas_params.cold_storage_additional_cost();
         let scope_extra_gas = call_scope_extra_gas(&key_auth.authorization);
-        let (gas, state_gas) =
+        let (regular_gas, state_gas) =
             calculate_key_authorization_gas(&key_auth, &gas_params, TempoHardfork::T4);
-        let helper_sstore_regular = gas - state_gas - sig_gas - sload - 2_000 - scope_extra_gas;
+        let helper_sstore_regular = regular_gas - sig_gas - sload - 2_000 - scope_extra_gas;
 
         assert_eq!(helper_sstore_regular, 20_000);
         assert_eq!(state_gas, 230_000);
@@ -3411,7 +3404,7 @@ mod tests {
         let expected_key_auth_gas = KEY_AUTH_BASE_GAS + ECRECOVER_GAS + 2 * KEY_AUTH_PER_LIMIT_GAS;
 
         assert_eq!(
-            gas_with_key_auth.initial_total_gas - gas_without_key_auth.initial_total_gas,
+            gas_with_key_auth.initial_total_gas() - gas_without_key_auth.initial_total_gas(),
             expected_key_auth_gas,
             "Key authorization should add exactly {expected_key_auth_gas} gas to batch",
         );
@@ -3419,15 +3412,17 @@ mod tests {
         // Also verify absolute values
         let spec = tempo_chainspec::hardfork::TempoHardfork::default();
         let base_tx_gas = calculate_initial_tx_gas(spec.into(), &calldata, false, 0, 0, 0);
-        let expected_without = base_tx_gas.initial_total_gas; // no cold access for single call
+        let expected_without = base_tx_gas.initial_total_gas(); // no cold access for single call
         let expected_with = expected_without + expected_key_auth_gas;
 
         assert_eq!(
-            gas_without_key_auth.initial_total_gas, expected_without,
+            gas_without_key_auth.initial_total_gas(),
+            expected_without,
             "Gas without key auth should match expected"
         );
         assert_eq!(
-            gas_with_key_auth.initial_total_gas, expected_with,
+            gas_with_key_auth.initial_total_gas(),
+            expected_with,
             "Gas with key auth should match expected"
         );
     }
@@ -3486,7 +3481,8 @@ mod tests {
                 let mut evm = make_evm(5, U256::ZERO);
                 let gas = handler.validate_initial_tx_gas(&mut evm).unwrap();
                 assert_eq!(
-                    gas.initial_total_gas, BASE_INTRINSIC_GAS,
+                    gas.initial_total_gas(),
+                    BASE_INTRINSIC_GAS,
                     "{spec:?}: protocol nonce (nonce_key=0, nonce>0) should have no extra gas"
                 );
             }
@@ -3503,7 +3499,8 @@ mod tests {
                 let mut evm = make_evm(0, U256::ONE);
                 let gas = handler.validate_initial_tx_gas(&mut evm).unwrap();
                 assert_eq!(
-                    gas.initial_total_gas, expected,
+                    gas.initial_total_gas(),
+                    expected,
                     "{spec:?}: nonce_key!=0, nonce==0 gas mismatch"
                 );
             }
@@ -3513,7 +3510,7 @@ mod tests {
                 let mut evm = make_evm(5, U256::ONE);
                 let gas = handler.validate_initial_tx_gas(&mut evm).unwrap();
                 assert_eq!(
-                    gas.initial_total_gas,
+                    gas.initial_total_gas(),
                     BASE_INTRINSIC_GAS + spec.gas_existing_nonce_key(),
                     "{spec:?}: existing 2D nonce key gas mismatch"
                 );
@@ -3698,11 +3695,11 @@ mod tests {
 
         let init_gas = test.validate_initial_tx_gas();
         assert!(
-            init_gas.floor_gas <= init_gas.initial_total_gas,
+            init_gas.floor_gas <= init_gas.initial_total_gas(),
             "test requires floor gas to not exceed intrinsic gas"
         );
 
-        test.evm.inner.ctx.tx.inner.gas_limit = init_gas.initial_total_gas;
+        test.evm.inner.ctx.tx.inner.gas_limit = init_gas.initial_total_gas();
 
         test.validate_against_state_and_deduct_caller()
             .expect("scope validation no longer runs during state validation");
@@ -3719,12 +3716,12 @@ mod tests {
         );
         assert_eq!(
             result.gas().limit(),
-            init_gas.initial_total_gas,
+            init_gas.initial_total_gas(),
             "batch OOG should report the full tx gas budget"
         );
         assert_eq!(
             result.gas().total_gas_spent(),
-            init_gas.initial_total_gas,
+            init_gas.initial_total_gas(),
             "batch OOG should consume the full tx gas budget"
         );
         assert_eq!(result.gas().refunded(), 0);
@@ -4136,13 +4133,13 @@ mod tests {
             let gas2 = compute_aa_gas(&make_single_call_env(Bytes::from(vec![1u8; calldata_len2])));
 
             if calldata_len1 <= calldata_len2 {
-                prop_assert!(gas1.initial_total_gas <= gas2.initial_total_gas,
+                prop_assert!(gas1.initial_total_gas() <= gas2.initial_total_gas(),
                     "More calldata should mean more gas: len1={}, gas1={}, len2={}, gas2={}",
-                    calldata_len1, gas1.initial_total_gas, calldata_len2, gas2.initial_total_gas);
+                    calldata_len1, gas1.initial_total_gas(), calldata_len2, gas2.initial_total_gas());
             } else {
-                prop_assert!(gas1.initial_total_gas >= gas2.initial_total_gas,
+                prop_assert!(gas1.initial_total_gas() >= gas2.initial_total_gas(),
                     "Less calldata should mean less gas: len1={}, gas1={}, len2={}, gas2={}",
-                    calldata_len1, gas1.initial_total_gas, calldata_len2, gas2.initial_total_gas);
+                    calldata_len1, gas1.initial_total_gas(), calldata_len2, gas2.initial_total_gas());
             }
         }
 
@@ -4157,13 +4154,13 @@ mod tests {
             let gas2 = compute_aa_gas(&make_single_call_env(Bytes::from(vec![0u8; calldata_len2])));
 
             if calldata_len1 <= calldata_len2 {
-                prop_assert!(gas1.initial_total_gas <= gas2.initial_total_gas,
+                prop_assert!(gas1.initial_total_gas() <= gas2.initial_total_gas(),
                     "More zero-byte calldata should mean more gas: len1={}, gas1={}, len2={}, gas2={}",
-                    calldata_len1, gas1.initial_total_gas, calldata_len2, gas2.initial_total_gas);
+                    calldata_len1, gas1.initial_total_gas(), calldata_len2, gas2.initial_total_gas());
             } else {
-                prop_assert!(gas1.initial_total_gas >= gas2.initial_total_gas,
+                prop_assert!(gas1.initial_total_gas() >= gas2.initial_total_gas(),
                     "Less zero-byte calldata should mean less gas: len1={}, gas1={}, len2={}, gas2={}",
-                    calldata_len1, gas1.initial_total_gas, calldata_len2, gas2.initial_total_gas);
+                    calldata_len1, gas1.initial_total_gas(), calldata_len2, gas2.initial_total_gas());
             }
         }
 
@@ -4174,9 +4171,9 @@ mod tests {
             let zero_gas = compute_aa_gas(&make_single_call_env(Bytes::from(vec![0u8; calldata_len])));
             let nonzero_gas = compute_aa_gas(&make_single_call_env(Bytes::from(vec![1u8; calldata_len])));
 
-            prop_assert!(zero_gas.initial_total_gas < nonzero_gas.initial_total_gas,
+            prop_assert!(zero_gas.initial_total_gas() < nonzero_gas.initial_total_gas(),
                 "Zero-byte calldata should cost less: len={}, zero_gas={}, nonzero_gas={}",
-                calldata_len, zero_gas.initial_total_gas, nonzero_gas.initial_total_gas);
+                calldata_len, zero_gas.initial_total_gas(), nonzero_gas.initial_total_gas());
         }
 
         /// Property: mixed calldata gas is bounded by all-zero and all-nonzero extremes.
@@ -4195,12 +4192,12 @@ mod tests {
             let zero_gas = compute_aa_gas(&make_single_call_env(Bytes::from(vec![0u8; calldata_len])));
             let nonzero_gas = compute_aa_gas(&make_single_call_env(Bytes::from(vec![1u8; calldata_len])));
 
-            prop_assert!(mixed_gas.initial_total_gas >= zero_gas.initial_total_gas,
+            prop_assert!(mixed_gas.initial_total_gas() >= zero_gas.initial_total_gas(),
                 "Mixed calldata gas should be >= all-zero gas: mixed={}, zero={}",
-                mixed_gas.initial_total_gas, zero_gas.initial_total_gas);
-            prop_assert!(mixed_gas.initial_total_gas <= nonzero_gas.initial_total_gas,
+                mixed_gas.initial_total_gas(), zero_gas.initial_total_gas());
+            prop_assert!(mixed_gas.initial_total_gas() <= nonzero_gas.initial_total_gas(),
                 "Mixed calldata gas should be <= all-nonzero gas: mixed={}, nonzero={}",
-                mixed_gas.initial_total_gas, nonzero_gas.initial_total_gas);
+                mixed_gas.initial_total_gas(), nonzero_gas.initial_total_gas());
         }
 
         /// Property: gas calculation monotonicity - more calls means more gas
@@ -4213,13 +4210,13 @@ mod tests {
             let gas2 = compute_aa_gas(&make_multi_call_env(num_calls2));
 
             if num_calls1 <= num_calls2 {
-                prop_assert!(gas1.initial_total_gas <= gas2.initial_total_gas,
+                prop_assert!(gas1.initial_total_gas() <= gas2.initial_total_gas(),
                     "More calls should mean more gas: calls1={}, gas1={}, calls2={}, gas2={}",
-                    num_calls1, gas1.initial_total_gas, num_calls2, gas2.initial_total_gas);
+                    num_calls1, gas1.initial_total_gas(), num_calls2, gas2.initial_total_gas());
             } else {
-                prop_assert!(gas1.initial_total_gas >= gas2.initial_total_gas,
+                prop_assert!(gas1.initial_total_gas() >= gas2.initial_total_gas(),
                     "Fewer calls should mean less gas: calls1={}, gas1={}, calls2={}, gas2={}",
-                    num_calls1, gas1.initial_total_gas, num_calls2, gas2.initial_total_gas);
+                    num_calls1, gas1.initial_total_gas(), num_calls2, gas2.initial_total_gas());
             }
         }
 
@@ -4238,9 +4235,9 @@ mod tests {
 
             // Expected exactly: 21k base + cold account access for each additional call
             let expected = 21_000 + COLD_ACCOUNT_ACCESS_COST * (num_calls.saturating_sub(1) as u64);
-            prop_assert_eq!(gas.initial_total_gas, expected,
+            prop_assert_eq!(gas.initial_total_gas(), expected,
                 "Gas {} should equal expected {} for {} calls (21k + {}*COLD_ACCOUNT_ACCESS_COST)",
-                gas.initial_total_gas, expected, num_calls, num_calls.saturating_sub(1));
+                gas.initial_total_gas(), expected, num_calls, num_calls.saturating_sub(1));
         }
 
         /// Property: first_call returns the first call for AA transactions with any number of calls
@@ -4496,7 +4493,7 @@ mod tests {
 
         // Delta-based assertion: the difference should be new_account_cost - EXISTING_NONCE_KEY_GAS
         // nonce=0 charges 250k (new account), nonce>0 charges 5k (existing key update)
-        let gas_delta = gas_nonce_zero.initial_total_gas - gas_nonce_five.initial_total_gas;
+        let gas_delta = gas_nonce_zero.initial_total_gas() - gas_nonce_five.initial_total_gas();
         let expected_delta = new_account_cost - EXISTING_NONCE_KEY_GAS;
         assert_eq!(
             gas_delta, expected_delta,
@@ -4516,7 +4513,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            gas_nonce_zero.initial_total_gas, gas_regular.initial_total_gas,
+            gas_nonce_zero.initial_total_gas(),
+            gas_regular.initial_total_gas(),
             "nonce=0 should charge the same regardless of nonce_key (2D vs regular)"
         );
     }
@@ -4582,7 +4580,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            gas_existing.initial_total_gas,
+            gas_existing.initial_total_gas(),
             BASE_INTRINSIC_GAS + EXISTING_NONCE_KEY_GAS,
             "T1 existing 2D nonce key (nonce>0) should charge BASE + EXISTING_NONCE_KEY_GAS ({EXISTING_NONCE_KEY_GAS})"
         );
@@ -4592,12 +4590,13 @@ mod tests {
         let gas_regular = handler.validate_initial_tx_gas(&mut evm_regular).unwrap();
 
         assert_eq!(
-            gas_regular.initial_total_gas, BASE_INTRINSIC_GAS,
+            gas_regular.initial_total_gas(),
+            BASE_INTRINSIC_GAS,
             "T1 regular nonce (nonce_key=0, nonce>0) should only charge BASE intrinsic gas"
         );
 
         // Verify the delta between 2D and regular nonce is exactly EXISTING_NONCE_KEY_GAS
-        let gas_delta = gas_existing.initial_total_gas - gas_regular.initial_total_gas;
+        let gas_delta = gas_existing.initial_total_gas() - gas_regular.initial_total_gas();
         assert_eq!(
             gas_delta, EXISTING_NONCE_KEY_GAS,
             "Difference between existing 2D nonce and regular nonce should be EXISTING_NONCE_KEY_GAS ({EXISTING_NONCE_KEY_GAS})"
@@ -5307,7 +5306,11 @@ mod tests {
                     TX_GAS_LIMIT,
                     CAP,
                 );
-                assert_eq!(gas.state_gas_spent(), 0, "halt reports zero state gas");
+                assert_eq!(
+                    gas.state_gas_spent_final(),
+                    0,
+                    "halt reports zero state gas"
+                );
             }
             other => panic!("expected ExecutionResult::Halt, got {other:?}"),
         }
@@ -5352,7 +5355,11 @@ mod tests {
                     "expected SubblockTxFeePayment halt, got {reason:?}"
                 );
                 assert_eq!(gas.total_gas_spent(), 100_000);
-                assert_eq!(gas.state_gas_spent(), 0, "halt reports zero state gas");
+                assert_eq!(
+                    gas.state_gas_spent_final(),
+                    0,
+                    "halt reports zero state gas"
+                );
             }
             other => panic!("expected ExecutionResult::Halt, got {other:?}"),
         }
@@ -5515,11 +5522,11 @@ mod tests {
     fn test_state_gas_multi_call_corrected_gas_success_preserves_state_gas() {
         let gas_limit: u64 = 1_000_000;
         let total_gas_spent: u64 = 400_000;
-        let accumulated_state_gas: u64 = 150_000;
+        let accumulated_state_gas: i64 = 150_000;
         let accumulated_refund: i64 = 5_000;
 
         // Simulate flattened gas reconstruction (same pattern as execute_multi_call_with)
-        let mut corrected_gas = Gas::new_spent(gas_limit);
+        let mut corrected_gas = Gas::new_spent_with_reservoir(gas_limit, 0);
         corrected_gas.erase_cost(gas_limit - total_gas_spent);
         corrected_gas.set_refund(accumulated_refund);
         corrected_gas.set_state_gas_spent(accumulated_state_gas);
@@ -5628,7 +5635,7 @@ mod tests {
     fn test_state_gas_auth_list_zero_on_t1() {
         let gas_params = tempo_gas_params(TempoHardfork::T1);
         assert_eq!(
-            gas_params.tx_tip1000_auth_account_creation_state_gas(),
+            gas_params.new_account_state_gas(),
             0,
             "Auth account creation state gas must be zero on T1"
         );
@@ -5743,9 +5750,9 @@ mod tests {
         .unwrap();
 
         assert!(
-            gas.initial_total_gas >= gas.initial_state_gas,
+            gas.initial_total_gas() >= gas.initial_state_gas,
             "invariant violated: initial_total_gas ({}) < initial_state_gas ({})",
-            gas.initial_total_gas,
+            gas.initial_total_gas(),
             gas.initial_state_gas,
         );
     }
@@ -5789,9 +5796,9 @@ mod tests {
         .unwrap();
 
         assert!(
-            gas.initial_total_gas >= gas.initial_state_gas,
+            gas.initial_total_gas() >= gas.initial_state_gas,
             "invariant violated: initial_total_gas ({}) < initial_state_gas ({})",
-            gas.initial_total_gas,
+            gas.initial_total_gas(),
             gas.initial_state_gas,
         );
     }
@@ -5860,7 +5867,7 @@ mod tests {
             .expect("execute_multi_call_with should return a failed frame result");
 
         let expected_spent =
-            init_gas.initial_total_gas + call_results.iter().map(|(_, spent)| spent).sum::<u64>();
+            init_gas.initial_total_gas() + call_results.iter().map(|(_, spent)| spent).sum::<u64>();
 
         // Pays CREATE state gas + both call costs. CREATE is charged upfront via intrinsic gas, and NOT refunded.
         assert_eq!(result.instruction_result(), InstructionResult::Revert);

--- a/crates/revm/src/instructions.rs
+++ b/crates/revm/src/instructions.rs
@@ -2,7 +2,9 @@ use crate::evm::TempoContext;
 use alloy_evm::Database;
 use revm::{
     handler::instructions::EthInstructions,
-    interpreter::{Instruction, InstructionContext, interpreter::EthInterpreter, push},
+    interpreter::{
+        Instruction, InstructionContext, InstructionResult, interpreter::EthInterpreter, push,
+    },
 };
 use tempo_chainspec::hardfork::TempoHardfork;
 
@@ -10,14 +12,17 @@ use tempo_chainspec::hardfork::TempoHardfork;
 const MILLIS_TIMESTAMP: u8 = 0x4F;
 
 /// Gas cost for [`MILLIS_TIMESTAMP`] instruction. Same as other opcodes accessing block information.
-const MILLIS_TIMESTAMP_GAS_COST: u64 = 2;
+const MILLIS_TIMESTAMP_GAS_COST: u16 = 2;
 
 /// Alias for Tempo-specific [`InstructionContext`].
 type TempoInstructionContext<'a, DB> = InstructionContext<'a, TempoContext<DB>, EthInterpreter>;
 
 /// Opcode returning current timestamp in milliseconds.
-fn millis_timestamp<DB: Database>(context: TempoInstructionContext<'_, DB>) {
+fn millis_timestamp<DB: Database>(
+    context: TempoInstructionContext<'_, DB>,
+) -> Result<(), InstructionResult> {
     push!(context.interpreter, context.host.block.timestamp_millis());
+    Ok(())
 }
 
 /// Returns configured instructions table for Tempo.
@@ -28,7 +33,8 @@ pub(crate) fn tempo_instructions<DB: Database>(
     if !spec.is_t1c() {
         instructions.insert_instruction(
             MILLIS_TIMESTAMP,
-            Instruction::new(millis_timestamp, MILLIS_TIMESTAMP_GAS_COST),
+            Instruction::new(millis_timestamp),
+            MILLIS_TIMESTAMP_GAS_COST,
         );
     }
     instructions

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -935,6 +935,16 @@ where
         announcement.retain_by_hash(|tx| !aa_pool.contains(tx))
     }
 
+    fn retain_contains<A>(&self, announcement: &mut A)
+    where
+        A: HandleMempoolData,
+    {
+        if announcement.is_empty() {
+            return;
+        }
+        announcement.retain_by_hash(|tx| self.contains(tx))
+    }
+
     fn contains(&self, tx_hash: &B256) -> bool {
         self.protocol_pool.contains(tx_hash) || self.aa_2d_pool.read().contains(tx_hash)
     }
@@ -1147,6 +1157,10 @@ where
     > {
         self.protocol_pool
             .get_blobs_for_versioned_hashes_v4(versioned_hashes, indices_bitarray)
+    }
+
+    fn blob_store(&self) -> Box<dyn reth_transaction_pool::BlobStore> {
+        TransactionPool::blob_store(&self.protocol_pool)
     }
 }
 

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -27,7 +27,6 @@ use reth_evm::{
         DatabaseCommit,
         context_interface::JournalTr as _,
         database::{CacheDB, EmptyDB},
-        inspector::JournalExt,
         state::{AccountInfo, Bytecode},
     },
 };


### PR DESCRIPTION
Main changes are initial gas now tracking `initial_regular_gas` separately and exposing `initial_total_gas` as an fn and some changes around how eip7702 gas values are calculated