### PR TITLE
feat: add per-side otlp controls for benches

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -110,6 +110,16 @@ on:
         type: boolean
         required: true
         default: true
+      baseline-otlp:
+        description: Override OTLP for baseline phases (true/false, empty inherits otlp).
+        type: string
+        required: false
+        default: ""
+      feature-otlp:
+        description: Override OTLP for feature phases (true/false, empty inherits otlp).
+        type: string
+        required: false
+        default: ""
       baseline-args:
         description: Extra args passed only to the baseline node.
         type: string
@@ -254,6 +264,14 @@ on:
         type: string
         required: false
         default: "true"
+      baseline-otlp:
+        type: string
+        required: false
+        default: ""
+      feature-otlp:
+        type: string
+        required: false
+        default: ""
       baseline-args:
         type: string
         required: false
@@ -371,8 +389,10 @@ jobs:
       BENCH_TRACY: ${{ (inputs.profiling == 'Tracy' || inputs.profiling == 'Both') && 'on' || ((inputs.profiling == 'Off' || inputs.profiling == 'Samply') && 'off' || inputs.tracy) }}
       BENCH_TRACY_SECONDS: ${{ inputs.tracy-seconds || '30' }}
       BENCH_TRACY_OFFSET: ${{ inputs.tracy-offset || '120' }}
-      BENCH_OTLP: ${{ inputs.otlp != false && inputs.otlp != 'false' }}
-      BENCH_FEATURES: ${{ (inputs.otlp != false && inputs.otlp != 'false') && 'jemalloc,asm-keccak,keccak-cache-global,otlp' || 'jemalloc,asm-keccak,keccak-cache-global' }}
+      BENCH_OTLP: ${{ inputs.otlp != false && inputs.otlp != 'false' && 'true' || 'false' }}
+      BENCH_BASELINE_OTLP: ${{ inputs.baseline-otlp != '' && inputs.baseline-otlp || ((inputs.otlp != false && inputs.otlp != 'false') && 'true' || 'false') }}
+      BENCH_FEATURE_OTLP: ${{ inputs.feature-otlp != '' && inputs.feature-otlp || ((inputs.otlp != false && inputs.otlp != 'false') && 'true' || 'false') }}
+      BENCH_BASE_FEATURES: jemalloc,asm-keccak,keccak-cache-global
       BENCH_BASELINE_ARGS: ${{ inputs.baseline-args }}
       BENCH_FEATURE_ARGS: ${{ inputs.feature-args }}
       BENCH_GAS_LIMIT: ${{ inputs.gas-limit || '1000000000' }}
@@ -398,7 +418,7 @@ jobs:
       SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
     steps:
       - name: Configure OTLP telemetry
-        if: env.BENCH_OTLP == 'true'
+        if: env.BENCH_BASELINE_OTLP == 'true' || env.BENCH_FEATURE_OTLP == 'true'
         env:
           TEMPO_TELEMETRY_URL_SECRET: ${{ secrets.TEMPO_TELEMETRY_URL }}
           GRAFANA_TEMPO_SECRET: ${{ secrets.GRAFANA_TEMPO }}
@@ -492,8 +512,11 @@ jobs:
             const samplyNote = samply ? ', samply: `enabled`' : '';
             const tracy = process.env.BENCH_TRACY;
             const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
-            const otlp = process.env.BENCH_OTLP === 'true';
-            const otlpNote = otlp ? ', otlp: `enabled`' : ', otlp: `disabled`';
+            const baselineOtlp = process.env.BENCH_BASELINE_OTLP === 'true';
+            const featureOtlp = process.env.BENCH_FEATURE_OTLP === 'true';
+            const otlpNote = baselineOtlp === featureOtlp
+              ? (baselineOtlp ? ', otlp: `enabled`' : ', otlp: `disabled`')
+              : `, otlp: \`baseline ${baselineOtlp ? 'enabled' : 'disabled'}, feature ${featureOtlp ? 'enabled' : 'disabled'}\``;
             const noCache = process.env.BENCH_NO_CACHE === 'true';
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const gasLimit = process.env.BENCH_GAS_LIMIT;
@@ -679,8 +702,11 @@ jobs:
             const samplyNote = samply ? ', samply: `enabled`' : '';
             const tracy = process.env.BENCH_TRACY;
             const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
-            const otlp = process.env.BENCH_OTLP === 'true';
-            const otlpNote = otlp ? ', otlp: `enabled`' : ', otlp: `disabled`';
+            const baselineOtlp = process.env.BENCH_BASELINE_OTLP === 'true';
+            const featureOtlp = process.env.BENCH_FEATURE_OTLP === 'true';
+            const otlpNote = baselineOtlp === featureOtlp
+              ? (baselineOtlp ? ', otlp: `enabled`' : ', otlp: `disabled`')
+              : `, otlp: \`baseline ${baselineOtlp ? 'enabled' : 'disabled'}, feature ${featureOtlp ? 'enabled' : 'disabled'}\``;
             const noCache = process.env.BENCH_NO_CACHE === 'true';
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const gasLimit = process.env.BENCH_GAS_LIMIT;
@@ -713,7 +739,7 @@ jobs:
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
           BENCH_GH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
         run: |
-          if [ "$BENCH_OTLP" != "true" ]; then
+          if [ "$BENCH_BASELINE_OTLP" != "true" ] && [ "$BENCH_FEATURE_OTLP" != "true" ]; then
             unset TEMPO_TELEMETRY_URL
             unset GRAFANA_TEMPO
             unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
@@ -739,7 +765,9 @@ jobs:
             --feature-name "${{ steps.refs.outputs.feature-name }}"
             --tune
             --no-default-features
-            --features "$BENCH_FEATURES"
+            --features "$BENCH_BASE_FEATURES"
+            --baseline-otlp "$BENCH_BASELINE_OTLP"
+            --feature-otlp "$BENCH_FEATURE_OTLP"
             --skip-summary
           )
           [ "$BENCH_FORCE_BLOAT" = "true" ] && cmd+=(--force-bloat)
@@ -800,6 +828,8 @@ jobs:
             gas-limit="$BENCH_GAS_LIMIT"
             run-pairs="$BENCH_RUN_PAIRS"
             otlp="$BENCH_OTLP"
+            baseline-otlp="$BENCH_BASELINE_OTLP"
+            feature-otlp="$BENCH_FEATURE_OTLP"
             no-cache="$BENCH_NO_CACHE"
             force-bloat="$BENCH_FORCE_BLOAT"
           )

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -106,20 +106,15 @@ on:
           - Tracy
           - Both
       otlp:
-        description: Export OTLP traces and logs.
-        type: boolean
+        description: OTLP mode.
+        type: choice
         required: true
-        default: true
-      baseline-otlp:
-        description: Override OTLP for baseline phases (true/false, empty inherits otlp).
-        type: string
-        required: false
-        default: ""
-      feature-otlp:
-        description: Override OTLP for feature phases (true/false, empty inherits otlp).
-        type: string
-        required: false
-        default: ""
+        default: "true"
+        options:
+          - "true"
+          - "false"
+          - baseline
+          - feature
       baseline-args:
         description: Extra args passed only to the baseline node.
         type: string
@@ -389,9 +384,9 @@ jobs:
       BENCH_TRACY: ${{ (inputs.profiling == 'Tracy' || inputs.profiling == 'Both') && 'on' || ((inputs.profiling == 'Off' || inputs.profiling == 'Samply') && 'off' || inputs.tracy) }}
       BENCH_TRACY_SECONDS: ${{ inputs.tracy-seconds || '30' }}
       BENCH_TRACY_OFFSET: ${{ inputs.tracy-offset || '120' }}
-      BENCH_OTLP: ${{ inputs.otlp != false && inputs.otlp != 'false' && 'true' || 'false' }}
-      BENCH_BASELINE_OTLP: ${{ inputs.baseline-otlp != '' && inputs.baseline-otlp || ((inputs.otlp != false && inputs.otlp != 'false') && 'true' || 'false') }}
-      BENCH_FEATURE_OTLP: ${{ inputs.feature-otlp != '' && inputs.feature-otlp || ((inputs.otlp != false && inputs.otlp != 'false') && 'true' || 'false') }}
+      BENCH_OTLP: ${{ inputs.otlp || 'true' }}
+      BENCH_BASELINE_OTLP: ${{ inputs.baseline-otlp != '' && inputs.baseline-otlp || ((inputs.otlp == false || inputs.otlp == 'false' || inputs.otlp == 'feature') && 'false' || 'true') }}
+      BENCH_FEATURE_OTLP: ${{ inputs.feature-otlp != '' && inputs.feature-otlp || ((inputs.otlp == false || inputs.otlp == 'false' || inputs.otlp == 'baseline') && 'false' || 'true') }}
       BENCH_BASE_FEATURES: jemalloc,asm-keccak,keccak-cache-global
       BENCH_BASELINE_ARGS: ${{ inputs.baseline-args }}
       BENCH_FEATURE_ARGS: ${{ inputs.feature-args }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -47,6 +47,8 @@ jobs:
       tracy-seconds: ${{ steps.args.outputs.tracy-seconds }}
       tracy-offset: ${{ steps.args.outputs.tracy-offset }}
       otlp: ${{ steps.args.outputs.otlp }}
+      baseline-otlp: ${{ steps.args.outputs.baseline-otlp }}
+      feature-otlp: ${{ steps.args.outputs.feature-otlp }}
       baseline-args: ${{ steps.args.outputs.baseline-args }}
       feature-args: ${{ steps.args.outputs.feature-args }}
       gas-limit: ${{ steps.args.outputs.gas-limit }}
@@ -106,7 +108,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
-            let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs;
+            let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, baselineOtlp, featureOtlp, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs;
             let explicitWarmup = false;
             let explicitDuration = false;
             let explicitRunPairs = false;
@@ -118,10 +120,10 @@ jobs:
             const intArgs = new Set(['duration', 'bloat', 'tps', 'accounts', 'max-concurrent-requests', 'gas-limit', 'tracy-seconds', 'tracy-offset', 'blocks', 'warmup', 'run-pairs']);
             const refArgs = new Set(['baseline', 'feature', 'txgen-ref']);
             const stringArgs = new Set(['mode', 'preset', 'tracy', 'baseline-args', 'feature-args', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain', 'baseline-hardfork', 'feature-hardfork']);
-            const boolArgs = new Set(['samply', 'force-bloat', 'no-cache', 'no-slack', 'otlp']);
+            const boolArgs = new Set(['samply', 'force-bloat', 'no-cache', 'no-slack', 'otlp', 'baseline-otlp', 'feature-otlp']);
             const bloatValues = new Set(['1', '10', '100']);
             const hardforkValues = new Set(['T0', 'T1', 'T1A', 'T1B', 'T1C', 'T2', 'T3', 'T4', 'T5', 'T6']);
-            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '20000', accounts: '1000', 'max-concurrent-requests': '100', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'true', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2' };
+            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '20000', accounts: '1000', 'max-concurrent-requests': '100', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'true', 'baseline-otlp': '', 'feature-otlp': '', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2' };
             const unknown = [];
             const invalid = [];
             const defaultWarmup = (blockCount) => String(Math.floor(Number(blockCount) / 4));
@@ -188,7 +190,7 @@ jobs:
             if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
             if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
             if (errors.length) {
-              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [txgen-ref=REF] [samply] [otlp] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
+              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [txgen-ref=REF] [samply] [otlp=true|false] [baseline-otlp=true|false] [feature-otlp=true|false] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -215,6 +217,8 @@ jobs:
             tracySeconds = defaults['tracy-seconds'];
             tracyOffset = defaults['tracy-offset'];
             otlp = defaults.otlp;
+            baselineOtlp = defaults['baseline-otlp'] === '' ? otlp : defaults['baseline-otlp'];
+            featureOtlp = defaults['feature-otlp'] === '' ? otlp : defaults['feature-otlp'];
             baselineArgs = defaults['baseline-args'];
             featureArgs = defaults['feature-args'];
             gasLimit = defaults['gas-limit'];
@@ -238,7 +242,7 @@ jobs:
               warmup = defaultWarmup(blocks);
             }
 
-            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [txgen-ref=REF] [samply] [otlp] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
+            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [txgen-ref=REF] [samply] [otlp=true|false] [baseline-otlp=true|false] [feature-otlp=true|false] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 
             // Validate chain value
             if (!['mainnet', 'testnet'].includes(chain)) {
@@ -372,6 +376,8 @@ jobs:
             core.setOutput('tracy-seconds', tracySeconds);
             core.setOutput('tracy-offset', tracyOffset);
             core.setOutput('otlp', otlp);
+            core.setOutput('baseline-otlp', baselineOtlp);
+            core.setOutput('feature-otlp', featureOtlp);
             core.setOutput('baseline-args', baselineArgs || '');
             core.setOutput('feature-args', featureArgs || '');
             core.setOutput('gas-limit', gasLimit);
@@ -409,6 +415,8 @@ jobs:
           ACK_SAMPLY: ${{ steps.args.outputs.samply }}
           ACK_TRACY: ${{ steps.args.outputs.tracy }}
           ACK_OTLP: ${{ steps.args.outputs.otlp }}
+          ACK_BASELINE_OTLP: ${{ steps.args.outputs.baseline-otlp }}
+          ACK_FEATURE_OTLP: ${{ steps.args.outputs.feature-otlp }}
           ACK_BASELINE_ARGS: ${{ steps.args.outputs.baseline-args }}
           ACK_FEATURE_ARGS: ${{ steps.args.outputs.feature-args }}
           ACK_GAS_LIMIT: ${{ steps.args.outputs.gas-limit }}
@@ -448,8 +456,11 @@ jobs:
             const samplyNote = samply ? ', samply: `enabled`' : '';
             const tracy = process.env.ACK_TRACY;
             const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
-            const otlp = process.env.ACK_OTLP === 'true';
-            const otlpNote = otlp ? ', otlp: `enabled`' : ', otlp: `disabled`';
+            const baselineOtlp = process.env.ACK_BASELINE_OTLP === 'true';
+            const featureOtlp = process.env.ACK_FEATURE_OTLP === 'true';
+            const otlpNote = baselineOtlp === featureOtlp
+              ? (baselineOtlp ? ', otlp: `enabled`' : ', otlp: `disabled`')
+              : `, otlp: \`baseline ${baselineOtlp ? 'enabled' : 'disabled'}, feature ${featureOtlp ? 'enabled' : 'disabled'}\``;
             const bNa = process.env.ACK_BASELINE_ARGS || '';
             const fNa = process.env.ACK_FEATURE_ARGS || '';
             const naNote = (bNa || fNa) ? `${bNa ? `, baseline-args: \`${bNa}\`` : ''}${fNa ? `, feature-args: \`${fNa}\`` : ''}` : '';
@@ -494,6 +505,8 @@ jobs:
       tracy-seconds: ${{ needs.tempo-bench-ack.outputs.tracy-seconds }}
       tracy-offset: ${{ needs.tempo-bench-ack.outputs.tracy-offset }}
       otlp: ${{ needs.tempo-bench-ack.outputs.otlp }}
+      baseline-otlp: ${{ needs.tempo-bench-ack.outputs.baseline-otlp }}
+      feature-otlp: ${{ needs.tempo-bench-ack.outputs.feature-otlp }}
       baseline-args: ${{ needs.tempo-bench-ack.outputs.baseline-args }}
       feature-args: ${{ needs.tempo-bench-ack.outputs.feature-args }}
       gas-limit: ${{ needs.tempo-bench-ack.outputs.gas-limit }}

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -373,6 +373,40 @@ def derive-tracing-otlp [tracing_otlp: string] {
     $tracing_otlp
 }
 
+def parse-otlp-toggle [value: string, default: bool] {
+    let normalized = ($value | str trim | str downcase)
+    if $normalized == "" { return $default }
+    if $normalized in ["true" "1" "yes" "on"] { return true }
+    if $normalized in ["false" "0" "no" "off"] { return false }
+
+    print $"Error: OTLP toggle must be true or false \(got '($value)'\)"
+    exit 1
+}
+
+def cargo-feature-list [features: string] {
+    if ($features | str trim) == "" { return [] }
+
+    mut result = []
+    for feature in ($features | split row "," | each { |f| $f | str trim } | where { |f| $f != "" }) {
+        if $feature not-in $result {
+            $result = ($result | append $feature)
+        }
+    }
+    $result
+}
+
+def set-cargo-feature-enabled [features: string, feature: string, enabled: bool] {
+    mut list = (cargo-feature-list $features)
+    if $enabled {
+        if $feature not-in $list {
+            $list = ($list | append $feature)
+        }
+    } else {
+        $list = ($list | where { |f| $f != $feature })
+    }
+    $list | str join ","
+}
+
 def systemd-scope-command [unit: string, cpus: string, memory: string, script: string] {
     let can_scope = (^uname | str trim) == "Linux" and ((which systemd-run | length) > 0) and ($cpus != "" or $memory != "")
     if not $can_scope {
@@ -726,6 +760,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
     let run_type = if ($phase | str starts-with "baseline") { "baseline" } else { "feature" }
     let genesis = ($run | get -o genesis | default $ctx.genesis)
     let hardfork = ($run | get -o hardfork | default "")
+    let side_otlp = if $run_type == "baseline" { $ctx.baseline_otlp } else { $ctx.feature_otlp }
     let side_args = if $run_type == "baseline" { $ctx.baseline_args } else { $ctx.feature_args }
     let side_env = if $run_type == "baseline" { $ctx.baseline_env } else { $ctx.feature_env }
     let extra_args = (parse-cli-args $side_args)
@@ -785,14 +820,14 @@ def run-local-e2e-phase [run: record, ctx: record] {
         | append (log-filter-args $ctx.loud)
         | append (if $ctx.gas_limit != "" { ["--builder.gaslimit" $ctx.gas_limit] } else { [] })
         | append (if $ctx.tracy != "off" { ["--log.tracy" "--log.tracy.filter" $ctx.tracy_filter] } else { [] })
-        | append (if $ctx.tracing_otlp != "" { [$"--tracing-otlp=($ctx.tracing_otlp)"] } else { [] })
+        | append (if $side_otlp and $ctx.tracing_otlp != "" { [$"--tracing-otlp=($ctx.tracing_otlp)"] } else { [] })
     let b_base_args = (build-base-args $genesis $ctx.b.datadir $b_log_dir "0.0.0.0" 8645 9101)
         | append (build-e2e-consensus-args $ctx.b.node_dir $ctx.trusted_peers $ctx.b.consensus_port $ctx.b.ip)
         | append $E2E_LOCAL_RETH_ARGS
         | append (log-filter-args $ctx.loud)
         | append (if $ctx.gas_limit != "" { ["--builder.gaslimit" $ctx.gas_limit] } else { [] })
         | append (if $ctx.tracy != "off" { ["--log.tracy" "--log.tracy.filter" $ctx.tracy_filter] } else { [] })
-        | append (if $ctx.tracing_otlp != "" { [$"--tracing-otlp=($ctx.tracing_otlp)"] } else { [] })
+        | append (if $side_otlp and $ctx.tracing_otlp != "" { [$"--tracing-otlp=($ctx.tracing_otlp)"] } else { [] })
     let a_args = (dedup-args $a_base_args $extra_args)
     let b_args = (dedup-args $b_base_args $extra_args)
 
@@ -801,7 +836,13 @@ def run-local-e2e-phase [run: record, ctx: record] {
     } else if $ctx.tracy == "full" {
         "TRACY_SAMPLING_HZ=1 "
     } else { "" }
-    let env_prefix = if $side_env != "" { $"($side_env) " } else { "" }
+    let otlp_env_prefix = if $side_otlp {
+        ""
+    } else {
+        "unset TEMPO_TELEMETRY_URL GRAFANA_TEMPO OTEL_EXPORTER_OTLP_TRACES_ENDPOINT OTEL_EXPORTER_OTLP_LOGS_ENDPOINT OTEL_EXPORTER_OTLP_HEADERS; "
+    }
+    let user_env_prefix = if $side_env != "" { $"($side_env) " } else { "" }
+    let env_prefix = $"($otlp_env_prefix)($user_env_prefix)"
     let a_otel = $"OTEL_RESOURCE_ATTRIBUTES=benchmark_id=($ctx.benchmark_id),benchmark_run=($phase),runner_role=a,run_type=($run_type),git_ref=($run.ref),reference_epoch=($ctx.reference_epoch) "
     let b_otel = $"OTEL_RESOURCE_ATTRIBUTES=benchmark_id=($ctx.benchmark_id),benchmark_run=($phase),runner_role=b,run_type=($run_type),git_ref=($run.ref),reference_epoch=($ctx.reference_epoch) "
 
@@ -956,6 +997,8 @@ def e2e-write-summary-config [
     reference_epoch: int
     baseline_hardfork: string
     feature_hardfork: string
+    baseline_otlp: bool
+    feature_otlp: bool
 ] {
     {
         baseline_label: $baseline_label
@@ -968,6 +1011,8 @@ def e2e-write-summary-config [
         reference_epoch: $reference_epoch
         baseline_hardfork: $baseline_hardfork
         feature_hardfork: $feature_hardfork
+        baseline_otlp: $baseline_otlp
+        feature_otlp: $feature_otlp
     } | to json | save -f $"($results_dir)/summary-config.json"
 }
 
@@ -1025,6 +1070,8 @@ def "main e2e" [
     --tracy-seconds: int = 30                           # Tracy capture duration limit in seconds
     --tracy-offset: int = 120                           # Seconds to wait before starting tracy capture
     --tracing-otlp: string = ""                         # OTLP endpoint for tracing (auto-derived from GRAFANA_TEMPO/TEMPO_TELEMETRY_URL)
+    --baseline-otlp: string = ""                        # Enable OTLP for baseline phases (true/false, empty = auto)
+    --feature-otlp: string = ""                         # Enable OTLP for feature phases (true/false, empty = auto)
     --victoriametrics-url: string = ""                  # VictoriaMetrics base URL for txgen metric sample import
     --clickhouse-url: string = ""                       # ClickHouse HTTP endpoint for txgen result upload
     --clickhouse-run: string = "feature-1"              # Run label allowed to use the ClickHouse reporter; empty = every run
@@ -1115,7 +1162,10 @@ def "main e2e" [
     let reference_epoch = (($run_started_at | into int) / 1_000_000_000 | into int)
     let gas_limit_args = if $gas_limit != "" { ["--gas-limit" $gas_limit] } else { [] }
     let tracing_otlp = (derive-tracing-otlp $tracing_otlp)
-    if $tracing_otlp != "" {
+    let default_otlp = $tracing_otlp != ""
+    let baseline_otlp_enabled = (parse-otlp-toggle $baseline_otlp $default_otlp)
+    let feature_otlp_enabled = (parse-otlp-toggle $feature_otlp $default_otlp)
+    if $tracing_otlp != "" and ($baseline_otlp_enabled or $feature_otlp_enabled) {
         $env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = $tracing_otlp
     }
 
@@ -1232,21 +1282,22 @@ def "main e2e" [
     git worktree add $baseline_wt $baseline
     git worktree add $feature_wt $feature
 
-    let tbc = (tracy-build-config $features $tracy)
-    let effective_features = $tbc.features
-    let effective_extra_rustflags = $tbc.extra_rustflags
+    let baseline_features = (set-cargo-feature-enabled $features "otlp" $baseline_otlp_enabled)
+    let feature_features = (set-cargo-feature-enabled $features "otlp" $feature_otlp_enabled)
+    let baseline_tbc = (tracy-build-config $baseline_features $tracy)
+    let feature_tbc = (tracy-build-config $feature_features $tracy)
     let effective_no_cache = $no_cache or ($tracy != "off")
     # Build baseline and feature in parallel — they use separate worktrees
     # with independent target/ directories, so cargo invocations don't collide.
     let builds = [
-        { wt: $baseline_wt, ref_name: $baseline, sha: $baseline, label: "baseline" }
-        { wt: $feature_wt, ref_name: $feature, sha: $feature, label: "feature" }
+        { wt: $baseline_wt, ref_name: $baseline, sha: $baseline, label: "baseline", features: $baseline_tbc.features, bench_features: $baseline_features, extra_rustflags: $baseline_tbc.extra_rustflags }
+        { wt: $feature_wt, ref_name: $feature, sha: $feature, label: "feature", features: $feature_tbc.features, bench_features: $feature_features, extra_rustflags: $feature_tbc.extra_rustflags }
     ]
     $builds | par-each { |b|
         if $effective_no_cache {
-            build-in-worktree --no-cache --no-default-features=$no_default_features --extra-rustflags $effective_extra_rustflags --bench-features $features $b.wt $b.ref_name $profile $effective_features $b.sha
+            build-in-worktree --no-cache --no-default-features=$no_default_features --extra-rustflags $b.extra_rustflags --bench-features $b.bench_features $b.wt $b.ref_name $profile $b.features $b.sha
         } else {
-            build-in-worktree --no-default-features=$no_default_features $b.wt $b.ref_name $profile $effective_features $b.sha
+            build-in-worktree --no-default-features=$no_default_features $b.wt $b.ref_name $profile $b.features $b.sha
         }
     } | ignore
     let baseline_tempo = (worktree-bin $baseline_wt $profile "tempo")
@@ -1292,6 +1343,8 @@ def "main e2e" [
         tracy_filter: $tracy_filter
         tracy_seconds: $tracy_seconds
         tracy_offset: $tracy_offset
+        baseline_otlp: $baseline_otlp_enabled
+        feature_otlp: $feature_otlp_enabled
         baseline_args: $baseline_args
         feature_args: $feature_args
         bench_args: $bench_args
@@ -1345,7 +1398,7 @@ def "main e2e" [
         exit 1
     }
     $valid_run_labels | str join "\n" | save -f $"($results_dir)/run-order.txt"
-    e2e-write-summary-config $results_dir $baseline_base_label $feature_base_label $bloat_mib $preset $tps $duration $benchmark_id $reference_epoch $baseline_hardfork_name $feature_hardfork_name
+    e2e-write-summary-config $results_dir $baseline_base_label $feature_base_label $bloat_mib $preset $tps $duration $benchmark_id $reference_epoch $baseline_hardfork_name $feature_hardfork_name $baseline_otlp_enabled $feature_otlp_enabled
     let num_phases = ($runs | length)
     mut e2e_exit = 0
     for idx in 0..<$num_phases {

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -373,8 +373,8 @@ def derive-tracing-otlp [tracing_otlp: string] {
     $tracing_otlp
 }
 
-def parse-otlp-toggle [value: string, default: bool] {
-    let normalized = ($value | str trim | str downcase)
+def parse-otlp-toggle [value: any, default: bool] {
+    let normalized = ($value | into string | str trim | str downcase)
     if $normalized == "" { return $default }
     if $normalized in ["true" "1" "yes" "on"] { return true }
     if $normalized in ["false" "0" "no" "off"] { return false }
@@ -1070,8 +1070,8 @@ def "main e2e" [
     --tracy-seconds: int = 30                           # Tracy capture duration limit in seconds
     --tracy-offset: int = 120                           # Seconds to wait before starting tracy capture
     --tracing-otlp: string = ""                         # OTLP endpoint for tracing (auto-derived from GRAFANA_TEMPO/TEMPO_TELEMETRY_URL)
-    --baseline-otlp: string = ""                        # Enable OTLP for baseline phases (true/false, empty = auto)
-    --feature-otlp: string = ""                         # Enable OTLP for feature phases (true/false, empty = auto)
+    --baseline-otlp: any = ""                           # Enable OTLP for baseline phases (true/false, empty = auto)
+    --feature-otlp: any = ""                            # Enable OTLP for feature phases (true/false, empty = auto)
     --victoriametrics-url: string = ""                  # VictoriaMetrics base URL for txgen metric sample import
     --clickhouse-url: string = ""                       # ClickHouse HTTP endpoint for txgen result upload
     --clickhouse-run: string = "feature-1"              # Run label allowed to use the ClickHouse reporter; empty = every run


### PR DESCRIPTION
- Adds `baseline-otlp` and `feature-otlp` switches to the bench comment workflow and e2e harness so OTLP can be enabled on one side and disabled on the other.
- Builds each side with its own Cargo feature set, and only passes `--tracing-otlp` to runs that should actually export traces.
- When a side is disabled, the harness also clears OTEL-related env vars before starting that node.

