### PR TITLE
refactor(txpool): update maintenance ordering

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -591,7 +591,24 @@ where
                 let bundle_state = tip.execution_outcome().state().state();
                 let tip_timestamp = tip.tip().header().timestamp();
 
-                // 1. Collect all block-level invalidation events
+                // 1. Update 2D nonce pool before scan-based maintenance.
+                // This removes mined 2D nonce transactions and promotes newly
+                // unblocked transactions before later pool scans.
+                let nonce_pool_start = Instant::now();
+                let _mined_aa_txs = pool.notify_aa_pool_on_state_updates(bundle_state);
+                metrics.nonce_pool_update_duration_seconds.record(nonce_pool_start.elapsed());
+
+                // 2. Update AMM liquidity cache before revalidation/invalidation scans.
+                let amm_start = Instant::now();
+                amm_cache.on_new_state(tip.execution_outcome());
+                if let Err(err) = amm_cache
+                    .on_new_blocks(tip.blocks_iter().map(|block| block.sealed_header()), pool.client())
+                {
+                    error!(target: "txpool", ?err, "AMM liquidity cache update failed");
+                }
+                metrics.amm_cache_update_duration_seconds.record(amm_start.elapsed());
+
+                // 3. Collect all block-level invalidation events
                 let mut updates = TempoPoolUpdates::from_chain(tip);
 
                 // Remove expiry tracking for mined transactions.
@@ -608,7 +625,7 @@ where
                 let expired = state.drain_expired(max_expiry);
                 updates.expired_txs = expired.into_iter().filter(|h| pool.contains(h)).collect();
 
-                // 2. Evict expired AA transactions
+                // 4. Evict expired AA transactions
                 let expired_start = Instant::now();
                 let expired_count = updates.expired_txs.len();
                 if expired_count > 0 {
@@ -623,7 +640,7 @@ where
                 }
                 metrics.expired_eviction_duration_seconds.record(expired_start.elapsed());
 
-                // 3. Handle fee token pause/unpause events
+                // 5. Handle fee token pause/unpause events
                 let pause_start = Instant::now();
 
                 // Collect pause tokens that need pool scanning.
@@ -736,7 +753,7 @@ where
                     }
                 }
 
-                // 4. Evict expired transactions from the paused pool
+                // 6. Evict expired transactions from the paused pool
                 let paused_expired = state.paused_pool.evict_expired(tip_timestamp);
                 let paused_timed_out = state.paused_pool.evict_timed_out();
                 let total_paused_evicted = paused_expired + paused_timed_out;
@@ -749,7 +766,7 @@ where
                     );
                 }
 
-                // 5. Evict hard keychain invalidations from paused pool
+                // 7. Evict hard keychain invalidations from paused pool
                 // Ignore spending_limit_spends here: AccessKeySpend only proves partial limit consumption, and paused txs are fully revalidated on unpause.
                 if !updates.revoked_keys.is_empty()
                     || !updates.spending_limit_changes.is_empty()
@@ -763,7 +780,7 @@ where
                 }
                 metrics.pause_events_duration_seconds.record(pause_start.elapsed());
 
-                // 5b. Handle potentially invalidating updates
+                // 8. Handle potentially invalidating updates
                 // When a cached value changes of a token (transfer policy, or quote token) changes,
                 // pending transactions using that token may become invalid. We need to remove them
                 // and re-add so they go through full validation against the updated state.
@@ -825,21 +842,7 @@ where
                     }
                 }
 
-                // 6. Update 2D nonce pool (also removes included expiring nonce txs
-                // via slot changes on the nonce precompile)
-                let nonce_pool_start = Instant::now();
-                let _mined_aa_txs = pool.notify_aa_pool_on_state_updates(bundle_state);
-                metrics.nonce_pool_update_duration_seconds.record(nonce_pool_start.elapsed());
-
-                // 7. Update AMM liquidity cache (must happen before validator token eviction)
-                let amm_start = Instant::now();
-                amm_cache.on_new_state(tip.execution_outcome());
-                if let Err(err) = amm_cache.on_new_blocks(tip.blocks_iter().map(|block| block.sealed_header()), pool.client()) {
-                    error!(target: "txpool", ?err, "AMM liquidity cache update failed");
-                }
-                metrics.amm_cache_update_duration_seconds.record(amm_start.elapsed());
-
-                // 8. Evict invalidated transactions in a single pool scan
+                // 9. Evict invalidated transactions in a single pool scan
                 // This checks revoked keys, spending limit changes, validator token changes,
                 // blacklist additions, and whitelist removals together to avoid scanning
                 // all transactions multiple times per block.
@@ -866,7 +869,7 @@ where
                         .record(invalidation_start.elapsed());
                 }
 
-                // 9. Evict stale pending transactions (must happen after AA pool promotions in step 6)
+                // 10. Evict stale pending transactions (must happen after AA pool promotions in step 1)
                 // Only runs once per interval (~30 min) to avoid overhead on every block.
                 // Transactions pending across two consecutive snapshots are considered stale.
                 if state.pending_staleness.should_check(tip_timestamp) {


### PR DESCRIPTION
Moves 2D nonce pool maintenance and AMM cache refresh ahead of scan-based txpool maintenance.

This removes mined 2D transactions and refreshes liquidity and quote-token cache state before pause, revalidation, and invalidation passes scan the pool.