### PR TITLE
docs(tip-1065): quantify transfer storage savings

### DIFF
--- a/tips/tip-1065.md
+++ b/tips/tip-1065.md
@@ -83,7 +83,9 @@ Once `rewardFlag` has been initialized to `OptedOut` or `OptedIn`, it MUST NOT b
 
 ## Transfer Storage Accounting
 
-For a transfer, reward accounting is applied independently to the sender and recipient before their balances are updated. The legacy reward-accounting baseline per participant is reading the whole `UserRewardInfo` struct, which includes `rewardRecipient`, `rewardPerToken`, and `rewardBalance`, plus reading `globalRewardPerToken`; this is 4 `SLOAD`s total. The table below counts reward-accounting storage operations per participant and excludes the balance `SLOAD`s and `SSTORE`s that are still required to move tokens, as well as any `optedInSupply` update caused by moving value between opted-in and opted-out accounts.
+For a transfer, reward accounting is applied independently to the sender and recipient before their balances are updated. The legacy reward-accounting baseline per participant reads the whole `UserRewardInfo` struct (`rewardRecipient`, `rewardPerToken`, and `rewardBalance`) and `globalRewardPerToken`; this is 4 `SLOAD`s total.
+
+The following table counts reward-accounting storage operations per participant and excludes the balance `SLOAD`s and `SSTORE`s that are still required to move tokens, as well as any `optedInSupply` update caused by moving value between opted-in and opted-out accounts.
 
 | Token reward state | User reward state | User accumulation state | Legacy reward accounting | T6 reward accounting with initialized `rewardFlag` | Savings per participant |
 |---|---|---|---|---|---|

--- a/tips/tip-1065.md
+++ b/tips/tip-1065.md
@@ -81,6 +81,20 @@ Once `rewardFlag` has been initialized to `OptedOut` or `OptedIn`, it MUST NOT b
 
 `optedInSupply` updates MUST be based on effective opt-in transitions, preserving the existing supply accounting semantics. A cached `rewardFlag` value MUST NOT be used in a way that changes the result relative to deriving opt-in status from `rewardRecipient`.
 
+## Transfer Storage Accounting
+
+For a transfer, reward accounting is applied independently to the sender and recipient before their balances are updated. The legacy reward-accounting baseline per participant is reading the whole `UserRewardInfo` struct, which includes `rewardRecipient`, `rewardPerToken`, and `rewardBalance`, plus reading `globalRewardPerToken`; this is 4 `SLOAD`s total. The table below counts reward-accounting storage operations per participant and excludes the balance `SLOAD`s and `SSTORE`s that are still required to move tokens, as well as any `optedInSupply` update caused by moving value between opted-in and opted-out accounts.
+
+| Token reward state | User reward state | User accumulation state | Legacy reward accounting | T6 reward accounting with initialized `rewardFlag` | Savings per participant |
+|---|---|---|---|---|---|
+| No rewards distributed (`globalRewardPerToken == 0`) | Opted out | No accumulated rewards | baseline | none | 4 `SLOAD`s |
+| No rewards distributed (`globalRewardPerToken == 0`) | Opted in | No accumulated rewards | baseline | `SLOAD globalRewardPerToken` | 3 `SLOAD`s |
+| Rewards distributed | Opted out | No accumulated rewards | baseline; if `rewardPerToken` is stale, `SSTORE rewardPerToken` | none | 4 `SLOAD`s and, when stale, 1 `SSTORE` |
+| Rewards distributed | Opted in | No accumulated rewards (`rewardPerToken == globalRewardPerToken`) | baseline | `SLOAD globalRewardPerToken`, `SLOAD rewardPerToken` | 2 `SLOAD`s |
+| Rewards distributed | Opted in | Accumulated rewards (`rewardPerToken < globalRewardPerToken`) | baseline, plus recipient reward-balance read/write when delegated; `SSTORE rewardPerToken` and `SSTORE rewardBalance` | `SLOAD globalRewardPerToken`, `SLOAD rewardPerToken`, `SLOAD rewardRecipient`, plus recipient reward-balance read/write when rewards are nonzero; `SSTORE rewardPerToken` and recipient `SSTORE rewardBalance` when rewards are nonzero | 1 `SLOAD`; if the holder self-delegates, also avoids the holder `rewardBalance` `SSTORE` by using the same recipient reward-balance path |
+
+For a standard nonzero transfer, these per-participant savings apply once to the sender and once to the recipient. The maximum common transfer saving is therefore 8 reward-accounting `SLOAD`s when both participants are opted out, while transfers between initialized opted-in accounts with no pending accumulation save 4 reward-accounting `SLOAD`s.
+
 ## Invariants
 
 - The low 128 bits of each T6+ user-state word MUST equal the account's TIP-20 balance.


### PR DESCRIPTION
Adds a transfer storage-accounting table to TIP-1065, based on the reward-handling implementation in #4161. The table breaks down reward-accounting SLOAD/SSTORE savings by token reward state, user opt-in state, and accumulated reward state.

Prompted by: @0xrusowsky