### PR TITLE
docs(tip-1065): note checkpoint savings caveat

### DIFF
--- a/tips/tip-1065.md
+++ b/tips/tip-1065.md
@@ -95,6 +95,8 @@ The following table counts reward-accounting storage operations per participant 
 | Rewards distributed | Opted in | No accumulated rewards (`rewardPerToken == globalRewardPerToken`) | baseline | `SLOAD globalRewardPerToken`, `SLOAD rewardPerToken` | 2 `SLOAD`s |
 | Rewards distributed | Opted in | Accumulated rewards (`rewardPerToken < globalRewardPerToken`) | baseline, plus recipient reward-balance read/write when delegated; `SSTORE rewardPerToken` and `SSTORE rewardBalance` | `SLOAD globalRewardPerToken`, `SLOAD rewardPerToken`, `SLOAD rewardRecipient`, plus recipient reward-balance read/write when rewards are nonzero; `SSTORE rewardPerToken` and recipient `SSTORE rewardBalance` when rewards are nonzero | 1 `SLOAD`; if the holder self-delegates, also avoids the holder `rewardBalance` `SSTORE` by using the same recipient reward-balance path |
 
+Reward-state mutation and checkpoint paths, such as `claimRewards` and `setRewardRecipient`, may realize less of the transfer-path savings because they call reward checkpointing, which may persist the user's current `rewardPerToken` before rewards are claimed or the reward recipient changes.
+
 For a standard nonzero transfer, these per-participant savings apply once to the sender and once to the recipient. The maximum common transfer saving is therefore 8 reward-accounting `SLOAD`s when both participants are opted out, while transfers between initialized opted-in accounts with no pending accumulation save 4 reward-accounting `SLOAD`s.
 
 ## Invariants


### PR DESCRIPTION
Adds a short note after the transfer storage-accounting table clarifying that reward-state mutation and checkpoint paths can realize less of the transfer-path savings because they must persist the current rewardFlag in the balance slot.

Prompted by: @0xrusowsky