### PR TITLE
chore(tip-1034): use remaining slot space for u64 timestamps

### DIFF
--- a/crates/contracts/src/precompiles/tip20_channel_reserve.rs
+++ b/crates/contracts/src/precompiles/tip20_channel_reserve.rs
@@ -43,7 +43,7 @@ crate::sol! {
             /// Total deposit currently locked by the channel.
             uint96 deposit;
             /// Payer close-request timestamp, or zero when no close is pending.
-            uint32 closeRequestedAt;
+            uint64 closeRequestedAt;
         }
 
         /// Full descriptor plus current state.

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -50,7 +50,7 @@ static VERSION_HASH: LazyLock<B256> = LazyLock::new(|| keccak256(b"1"));
 struct PackedChannelState {
     settled: U96,
     deposit: U96,
-    close_requested_at: u32,
+    close_requested_at: u64,
 }
 
 impl PackedChannelState {
@@ -60,7 +60,7 @@ impl PackedChannelState {
     }
 
     /// Returns the payer's close request timestamp, if the close timer is active.
-    fn close_requested_at(self) -> Option<u32> {
+    fn close_requested_at(self) -> Option<u64> {
         (self.close_requested_at != 0).then_some(self.close_requested_at)
     }
 
@@ -308,7 +308,7 @@ impl TIP20ChannelReserve {
             return Ok(());
         }
 
-        let close_requested_at = self.now_u32();
+        let close_requested_at = self.now();
         state.close_requested_at = close_requested_at;
         self.channel_states[channel_id].write(state)?;
         self.emit_event(TIP20ChannelReserveEvent::CloseRequested(
@@ -418,7 +418,7 @@ impl TIP20ChannelReserve {
 
         let close_ready = state
             .close_requested_at()
-            .is_some_and(|requested_at| self.now() >= u64::from(requested_at) + CLOSE_GRACE_PERIOD);
+            .is_some_and(|requested_at| self.now() >= requested_at + CLOSE_GRACE_PERIOD);
         if !close_ready {
             return Err(TIP20ChannelReserveError::close_not_ready().into());
         }
@@ -518,11 +518,6 @@ impl TIP20ChannelReserve {
     /// Returns the current block timestamp as `u64`.
     fn now(&self) -> u64 {
         self.storage.timestamp().saturating_to::<u64>()
-    }
-
-    /// Returns the current block timestamp as the packed close-request representation.
-    fn now_u32(&self) -> u32 {
-        self.storage.timestamp().saturating_to::<u32>()
     }
 
     /// Computes the channel id from a descriptor.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -67,7 +67,7 @@ struct ChannelDescriptor {
 struct ChannelState {
     uint96 settled;
     uint96 deposit;
-    uint32 closeRequestedAt;
+    uint64 closeRequestedAt;
 }
 
 struct Channel {
@@ -86,17 +86,15 @@ The packed slot layout is:
 ```text
 bits   0..95   settled        uint96
 bits  96..191  deposit        uint96
-bits 192..223  closeRequestedAt uint32
-bits 224..255  reserved       zero
+bits 192..255  closeRequestedAt uint64
 ```
 
 These widths are chosen to keep the entire mutable channel state in one storage slot without
 introducing any practical limit for production usage. `uint96` supports up to
 `2^96 - 1 = 79,228,162,514,264,337,593,543,950,335` base units, which is far above the supply or
-reserve size of any realistic TIP-20 token deployment. `uint32` stores second-resolution unix
-timestamps through February 2106, which is sufficient for close-request tracking because channels
-are expected to live for minutes, hours, days, or months rather than many decades. The reserved
-high 32 bits MUST remain zero.
+reserve size of any realistic TIP-20 token deployment. `uint64` stores second-resolution unix
+timestamps far beyond any practical protocol horizon while keeping close-grace comparisons in the
+same timestamp domain as `block.timestamp`.
 
 `closeRequestedAt` MUST be encoded as:
 
@@ -210,7 +208,7 @@ Execution semantics are:
 2. `open` MUST derive `expiringNonceHash` from the enclosing transaction's replay-protected context hash, persist only the packed `ChannelState` slot, and MUST emit the full immutable descriptor in `ChannelOpened`.
 3. Post-open methods (`settle`, `topUp`, `close`, `requestClose`, `withdraw`, and descriptor-based views) MUST recompute `channelId` from the supplied descriptor and use that derived id for storage lookup.
 4. If `closeRequestedAt != 0`, a successful `topUp` MUST clear it back to `0` and emit `CloseRequestCancelled`.
-5. `requestClose` MUST set `closeRequestedAt = uint32(block.timestamp)` on the first successful call and leave it unchanged on later successful calls.
+5. `requestClose` MUST set `closeRequestedAt = uint64(block.timestamp)` on the first successful call and leave it unchanged on later successful calls.
 6. `settle` and `close` MUST be callable only by `payee`, or by `operator` when `operator != address(0)`.
 7. `close` MUST validate the voucher signature via TIP-1020 for any capture-increasing close.
 8. Signer MUST be `authorizedSigner` from the supplied descriptor when set, otherwise `payer` from the supplied descriptor.

--- a/tips/verify/src/interfaces/ITIP20ChannelReserve.sol
+++ b/tips/verify/src/interfaces/ITIP20ChannelReserve.sol
@@ -18,7 +18,7 @@ interface ITIP20ChannelReserve {
     struct ChannelState {
         uint96 settled;
         uint96 deposit;
-        uint32 closeRequestedAt;
+        uint64 closeRequestedAt;
     }
 
     struct Channel {


### PR DESCRIPTION
ref: `SIGP-281`