### PR TITLE
perf(tip-1034): cache domain separator

### DIFF
--- a/crates/chainspec/src/constants.rs
+++ b/crates/chainspec/src/constants.rs
@@ -125,7 +125,8 @@ pub mod gas {
 }
 
 pub mod mainnet {
-    //! Tempo mainnet (Presto) hardfork activation constants.
+    //! Tempo mainnet (Presto) chain id and hardfork activation constants.
+    pub const MAINNET_CHAIN_ID: u64 = 4217;
 
     /// Genesis activation block.
     pub const MAINNET_GENESIS_BLOCK: u64 = 0;
@@ -170,7 +171,8 @@ pub mod mainnet {
 }
 
 pub mod moderato {
-    //! Moderato testnet hardfork activation constants.
+    //! Moderato testnet chain id and hardfork activation constants.
+    pub const TESTNET_CHAIN_ID: u64 = 42431;
 
     /// Genesis activation block.
     pub const MODERATO_GENESIS_BLOCK: u64 = 0;

--- a/crates/chainspec/src/constants.rs
+++ b/crates/chainspec/src/constants.rs
@@ -172,7 +172,7 @@ pub mod mainnet {
 
 pub mod moderato {
     //! Moderato testnet chain id and hardfork activation constants.
-    pub const TESTNET_CHAIN_ID: u64 = 42431;
+    pub const MODERATO_CHAIN_ID: u64 = 42431;
 
     /// Genesis activation block.
     pub const MODERATO_GENESIS_BLOCK: u64 = 0;

--- a/crates/commonware-node/src/follow/driver.rs
+++ b/crates/commonware-node/src/follow/driver.rs
@@ -90,7 +90,9 @@ pub(super) fn try_init<TContext>(
             .extra_data()
             .as_ref(),
     )
-    .wrap_err("the genesis header did not contain a DKG outcome")?;
+    .wrap_err_with(|| {
+        format!("the last boundary (`{last_boundary}`) block header did not contain a DKG outcome")
+    })?;
 
     config.scheme_provider.register(
         onchain_outcome.epoch,

--- a/crates/node/tests/it/gas/snapshots/it__gas__tip20_channel_reserve__tip20_channel_reserve_gas_snapshots.snap
+++ b/crates/node/tests/it/gas/snapshots/it__gas__tip20_channel_reserve__tip20_channel_reserve_gas_snapshots.snap
@@ -2,12 +2,12 @@
 source: crates/node/tests/it/gas/tip20_channel_reserve.rs
 expression: gas
 ---
-close_existing_channel_after_settlement: 62973
-close_existing_channel_no_prior_settlement: 62973
+close_existing_channel_after_settlement: 62913
+close_existing_channel_no_prior_settlement: 62913
 open_new_channel_existing_reserve_balance: 294425
 open_new_channel_first_reserve_balance: 791625
 request_close_existing_channel: 30123
-settle_existing_channel_existing_payee_balance: 301691
-settle_existing_channel_new_payee_balance: 559931
+settle_existing_channel_existing_payee_balance: 301631
+settle_existing_channel_new_payee_balance: 559871
 top_up_existing_channel: 46805
 top_up_existing_channel_cancel_close_request: 48680

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -19,6 +19,7 @@ use alloy::{
     sol_types::SolValue,
 };
 use std::sync::LazyLock;
+use tempo_chainspec::constants::{mainnet::MAINNET_CHAIN_ID, moderato::TESTNET_CHAIN_ID};
 pub use tempo_contracts::precompiles::{
     ITIP20ChannelReserve, TIP20_CHANNEL_RESERVE_ADDRESS, TIP20ChannelReserveError,
     TIP20ChannelReserveEvent,
@@ -32,7 +33,7 @@ pub const CLOSE_GRACE_PERIOD: u64 = 15 * 60;
 /// EIP-712 type hash for signed cumulative payment vouchers.
 static VOUCHER_TYPEHASH: LazyLock<B256> =
     LazyLock::new(|| keccak256(b"Voucher(bytes32 channelId,uint96 cumulativeAmount)"));
-/// EIP-712 domain type hash used by [`TIP20ChannelReserve::domain_separator_inner`].
+/// EIP-712 domain type hash used by [`TIP20ChannelReserve::domain_separator`].
 static EIP712_DOMAIN_TYPEHASH: LazyLock<B256> = LazyLock::new(|| {
     keccak256(b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
 });
@@ -40,6 +41,13 @@ static EIP712_DOMAIN_TYPEHASH: LazyLock<B256> = LazyLock::new(|| {
 static NAME_HASH: LazyLock<B256> = LazyLock::new(|| keccak256(b"TIP20 Channel Reserve"));
 /// EIP-712 domain version hash for the reserve voucher domain.
 static VERSION_HASH: LazyLock<B256> = LazyLock::new(|| keccak256(b"1"));
+
+/// EIP-712 domain separator for the reserve voucher domain on mainnet.
+static DOMAIN_SEPARATOR_MAINNET: LazyLock<B256> =
+    LazyLock::new(|| domain_separator_inner(MAINNET_CHAIN_ID));
+/// EIP-712 domain separator for the reserve voucher domain on testnet.
+static DOMAIN_SEPARATOR_TESTNET: LazyLock<B256> =
+    LazyLock::new(|| domain_separator_inner(TESTNET_CHAIN_ID));
 
 /// Packed persistent state for one channel.
 ///
@@ -512,7 +520,13 @@ impl TIP20ChannelReserve {
 
     /// Returns the EIP-712 domain separator for this chain and precompile address.
     pub fn domain_separator(&self) -> Result<B256> {
-        self.domain_separator_inner()
+        let hash = match self.storage.chain_id() {
+            MAINNET_CHAIN_ID => *DOMAIN_SEPARATOR_MAINNET,
+            TESTNET_CHAIN_ID => *DOMAIN_SEPARATOR_TESTNET,
+            chain_id => domain_separator_inner(chain_id),
+        };
+
+        Ok(hash)
     }
 
     /// Returns the current block timestamp as `u64`.
@@ -629,7 +643,7 @@ impl TIP20ChannelReserve {
         let struct_hash = self
             .storage
             .keccak256(&(*VOUCHER_TYPEHASH, channel_id, cumulative_amount).abi_encode())?;
-        let domain_separator = self.domain_separator_inner()?;
+        let domain_separator = self.domain_separator()?;
 
         let mut digest_input = [0u8; 66];
         digest_input[0] = 0x19;
@@ -638,20 +652,22 @@ impl TIP20ChannelReserve {
         digest_input[34..66].copy_from_slice(struct_hash.as_slice());
         self.storage.keccak256(&digest_input)
     }
+}
 
-    /// Computes the EIP-712 domain separator.
-    fn domain_separator_inner(&self) -> Result<B256> {
-        self.storage.keccak256(
-            &(
-                *EIP712_DOMAIN_TYPEHASH,
-                *NAME_HASH,
-                *VERSION_HASH,
-                U256::from(self.storage.chain_id()),
-                self.address,
-            )
-                .abi_encode(),
+/// Computes the EIP-712 domain separator.
+///
+/// NOTE: This keccak is unmetered because it is not computed at tx runtime.
+fn domain_separator_inner(chain_id: u64) -> B256 {
+    keccak256(
+        &(
+            *EIP712_DOMAIN_TYPEHASH,
+            *NAME_HASH,
+            *VERSION_HASH,
+            U256::from(chain_id),
+            TIP20_CHANNEL_RESERVE_ADDRESS,
         )
-    }
+            .abi_encode(),
+    )
 }
 
 #[cfg(test)]

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -662,7 +662,7 @@ impl TIP20ChannelReserve {
 /// NOTE: This keccak is unmetered because it is not computed at tx runtime.
 fn domain_separator_inner(chain_id: u64) -> B256 {
     keccak256(
-        &(
+        (
             *EIP712_DOMAIN_TYPEHASH,
             *NAME_HASH,
             *VERSION_HASH,

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -19,7 +19,7 @@ use alloy::{
     sol_types::SolValue,
 };
 use std::sync::LazyLock;
-use tempo_chainspec::constants::{mainnet::MAINNET_CHAIN_ID, moderato::TESTNET_CHAIN_ID};
+use tempo_chainspec::constants::{mainnet::MAINNET_CHAIN_ID, moderato::MODERATO_CHAIN_ID};
 pub use tempo_contracts::precompiles::{
     ITIP20ChannelReserve, TIP20_CHANNEL_RESERVE_ADDRESS, TIP20ChannelReserveError,
     TIP20ChannelReserveEvent,
@@ -47,7 +47,7 @@ static DOMAIN_SEPARATOR_MAINNET: LazyLock<B256> =
     LazyLock::new(|| domain_separator_inner(MAINNET_CHAIN_ID));
 /// EIP-712 domain separator for the reserve voucher domain on testnet.
 static DOMAIN_SEPARATOR_TESTNET: LazyLock<B256> =
-    LazyLock::new(|| domain_separator_inner(TESTNET_CHAIN_ID));
+    LazyLock::new(|| domain_separator_inner(MODERATO_CHAIN_ID));
 
 /// Packed persistent state for one channel.
 ///
@@ -525,7 +525,7 @@ impl TIP20ChannelReserve {
     pub fn domain_separator(&self) -> Result<B256> {
         let hash = match self.storage.chain_id() {
             MAINNET_CHAIN_ID => *DOMAIN_SEPARATOR_MAINNET,
-            TESTNET_CHAIN_ID => *DOMAIN_SEPARATOR_TESTNET,
+            MODERATO_CHAIN_ID => *DOMAIN_SEPARATOR_TESTNET,
             chain_id => domain_separator_inner(chain_id),
         };
 


### PR DESCRIPTION
ref: `SIGP-284`

this PR addresses the misc informational issues from the T5 audit:
- caches the domain separator for TIP-1034.
- makes a DKG error description more accurate