### PR TITLE
docs: clarify access-key contract creation restriction

### DIFF
--- a/tips/tip-0001.md
+++ b/tips/tip-0001.md
@@ -613,7 +613,7 @@ A sender can authorize a key by signing over a "key authorization" item that con
   - Selector rules can additionally constrain TIP-20 recipient-bearing selectors to a recipient allowlist.
   - `Some([])` (an empty top-level allowlist) means scoped deny-all.
 
-Access-key-signed transactions cannot perform contract creation. Calls within the batch that would `CREATE` or `CREATE2` (including via factory contracts) are rejected. Use the root key for deployment flows.
+Access-key-signed transactions cannot use transaction-level contract creation. A Tempo batch call whose `to` is `TxKind::Create` is rejected when signed by an access key. This restriction does not inspect or reject `CREATE` or `CREATE2` opcodes executed by a called contract, so an access key that is allowed to call a factory contract can deploy through that factory.
 
 #### RLP Encoding
 
@@ -702,7 +702,8 @@ The protocol enforces a strict two-tier hierarchy:
 - Cannot call mutable precompile functions (`authorizeKey`, `revokeKey`, `updateSpendingLimit`, `setAllowedCalls`, `removeAllowedCalls`)
 - Precompile functions check `transactionKey[msg.sender] == 0` before allowing mutations
 - Subject to per-TIP20 token spending limits and call-scope checks during execution
-- Cannot create contracts (`CREATE` and `CREATE2` are rejected anywhere in the call batch)
+- Cannot include transaction-level contract creation in the batch (`TxKind::Create`)
+- Can create contracts indirectly if an allowed target contract executes `CREATE` or `CREATE2`
 - Can have expiry timestamps
 
 When an access key attempts to call any mutable keychain function:
@@ -756,7 +757,9 @@ When an access key has stored call scopes (`allowed_calls` was set at authorizat
 
 ##### Contract Creation Restriction
 
-Access-key-signed transactions cannot perform contract creation. Any `CREATE` or `CREATE2` (including via factory contracts or internal calls) reverts the transaction. Use the root key for deployment flows.
+Access-key-signed transactions cannot use transaction-level contract creation. The protocol rejects a batch signed by an access key if any call target is `TxKind::Create`.
+
+This restriction is not an opcode-level guard. If an access key is permitted to call a factory contract, that contract may still execute `CREATE` or `CREATE2` during normal EVM execution.
 
 ##### Creating and Using `KeyAuthorization`
 
@@ -1273,7 +1276,7 @@ T3 expanded access keys through [TIP-1011](./tip-1011.md) in the following ways:
 - `TokenLimit` gained `period` (recurring vs one-time spending limits)
 - The signed payload `SignedKeyAuthorization { authorization, signature }` is unchanged in shape, but `authorization` now uses the expanded `KeyAuthorization` and new RLP encoding. Low-level integrators that manually encode `key_authorization` must branch pre-T3 vs post-T3. The post-T3 digest and signed payload include `allowed_calls?` in addition to `expiry?` and `limits?`
 - A non-expiring `key_authorization` omits `expiry` in tx RLP. At the Account Keychain ABI boundary, the protocol translates that omission to `u64::MAX`. Literal `0` is not a valid non-expiring sentinel to rely on
-- Access-key validation gained two new execution checks: call scopes must pass before execution begins, and access-key-signed transactions may not perform contract creation anywhere in the batch
+- Access-key validation gained two new execution checks: call scopes must pass before execution begins, and access-key-signed transactions may not include transaction-level contract creation anywhere in the batch
 - The Account Keychain precompile ABI changed in lockstep. `authorizeKey(...)` now takes a `KeyRestrictions` tuple, `getRemainingLimit(...)` is replaced by `getRemainingLimitWithPeriod(...)`, and `setAllowedCalls(...)`, `removeAllowedCalls(...)`, and `getAllowedCalls(...)` are added. See the [Account Keychain specification](https://docs.tempo.xyz/protocol/transactions/AccountKeychain) for full details
 - Intrinsic gas for `key_authorization` accounts for periodic-limit state and call-scope storage. See [TIP-1011](./tip-1011.md) for the canonical slot-counting rules
 

--- a/tips/tip-1011.md
+++ b/tips/tip-1011.md
@@ -319,24 +319,26 @@ Scoped-call validation is performed in a metered pre-execution phase after trans
 If any call fails scoped-call validation, the transaction execution MUST fail atomically before any user call in the batch begins.
 
 
-#### Access-Key Contract Creation Ban
+#### Access-Key Transaction-Level Contract Creation Ban
 
-If a transaction is signed with an access key (`key != Address::ZERO`), contract creation MUST be rejected as an invalid transaction in all configurations.
+If a transaction is signed with an access key (`key != Address::ZERO`), transaction-level contract creation MUST be rejected as an invalid transaction in all configurations. This covers `TxKind::Create` calls encoded in the Tempo transaction batch.
+
+This restriction is not an opcode-level guard. It does not reject `CREATE` or `CREATE2` opcodes executed by a contract that the access key is allowed to call. For example, an access key scoped to a factory contract can still deploy contracts through that factory.
 
 This ban applies regardless of:
 
 1. Whether `allowed_calls` is `None` or `Some(...)`.
 2. Whether any target scope has `selector_rules = []` (allow-any-selector).
-3. Whether the creation call appears in a batch.
+3. Whether the direct creation call appears in a batch.
 
-Only the root key (`key == Address::ZERO`) may submit contract-creation calls; this is not a global create ban.
+Only the root key (`key == Address::ZERO`) may submit transaction-level contract-creation calls; this is not a global create ban.
 
 #### Single Call Validation
 
 For each call:
 
-1. If the transaction uses an access key and the call is contract creation, implementations MUST reject the transaction as invalid before execution.
-2. If `allowed_calls = None`, implementations MUST allow the call (subject to the contract-creation ban).
+1. If the transaction uses an access key and the call is transaction-level contract creation, implementations MUST reject the transaction as invalid before execution.
+2. If `allowed_calls = None`, implementations MUST allow address-targeted calls.
 3. If `allowed_calls = Some(...)`, implementations MUST enforce target and selector matching.
 4. If no target scope exists for `destination`, implementations MUST fail execution before the first user call begins.
 5. If the target scope is `selector_rules = []`, implementations MUST allow the call, including selectorless/fallback-style calldata.
@@ -569,7 +571,7 @@ The following MUST be fork-gated:
 8. New precompile storage writes/reads for selector-level recipient allowlists.
 9. Updated precompile read APIs (`getAllowedCalls(account,key)`, richer `getRemainingLimit`).
 10. New mutator function `setAllowedCalls`, which can only be called by root key.
-11. Global ban on contract creation when using access keys.
+11. Ban on transaction-level contract creation when using access keys.
 12. Selector-width enforcement (`selector length == 4` only).
 13. Constrained-selector allowlist and argument-0 canonical address checks.
 14. TIP-20 target verification for selector rules with recipient allowlists.
@@ -583,14 +585,15 @@ Pre-fork blocks MUST replay with pre-fork semantics to preserve state roots.
 1. `periodEnd` is monotonic and never set to the past.
 2. `remainingInPeriod <= limit` after any operation.
 3. Expiry check runs before spending and call-scope checks.
-4. If `key != Address::ZERO`, any contract-creation call MUST cause the transaction to be rejected as invalid before execution, regardless of `allowed_calls`.
-5. `allowed_calls = None` allows all non-create calls; `allowed_calls = Some(...)` requires target+selector-rule match and otherwise causes the transaction to be rejected as invalid before execution.
+4. If `key != Address::ZERO`, any transaction-level contract-creation call MUST cause the transaction to be rejected as invalid before execution, regardless of `allowed_calls`.
+5. `allowed_calls = None` allows all address-targeted calls; `allowed_calls = Some(...)` requires target+selector-rule match and otherwise causes the transaction to be rejected as invalid before execution.
 6. In scoped mode, calldata must contain at least 4 selector bytes only when explicit selector matching is required; address-only scopes allow selectorless/fallback-style calldata.
 7. For each `(account, key)`, target scopes are unique, selector rules are unique per target, and recipients are unique per selector rule.
 8. `setAllowedCalls(..., scopes)` with `scope.selectorRules = []` for a scope allows any selector on that target; `removeAllowedCalls(keyId, target)` disables that target scope.
 9. Selector rules with recipient allowlists are valid only for TIP-20 targets and only for the fixed constrained selector set.
 10. For recipient-allowlisted rules, calldata argument `0` must be a canonically encoded ABI address and must be in the configured recipient set.
 11. In the Solidity ABI, `selectorRules[i].recipients = []` means that selector has no recipient restriction.
+12. The access-key creation ban does not reject `CREATE` or `CREATE2` opcodes executed by an allowed target contract.
 ## Test Cases
 
 1. Periodic reset after elapsed period.
@@ -598,7 +601,7 @@ Pre-fork blocks MUST replay with pre-fork semantics to preserve state roots.
 3. Address + multi-selector scope allow.
 4. Address-only allow (`selector_rules=[]`).
 5. Deny when no scope matches.
-6. `allowed_calls=None` allows all non-create calls.
+6. `allowed_calls=None` allows all address-targeted calls.
 7. `allowed_calls=Some([])` denies all calls.
 8. Mixed one-time and periodic token limits.
 9. Existing keys continue to function after the fork.
@@ -609,8 +612,8 @@ Pre-fork blocks MUST replay with pre-fork semantics to preserve state roots.
 16. `setAllowedCalls` create-or-replace semantics are enforced.
 17. `removeAllowedCalls(keyId, target)` removes that target scope; if no target scopes remain, the key stays scoped but matches no calls.
 18. Address-only scopes allow selectorless/fallback-style calls to the scoped target.
-19. Access-key transactions with CREATE as first call are rejected.
-20. Access-key transactions with any CREATE in a batch are rejected.
+19. Access-key transactions with `TxKind::Create` as the first call are rejected.
+20. Access-key transactions with any `TxKind::Create` in a batch are rejected.
 21. For constrained TIP-20 selectors (`transfer`, `approve`, `transferWithMemo`), calls succeed iff calldata argument `0` is in the configured recipient set.
 22. Single-recipient and multi-recipient selector rules both enforce the same membership rule.
 23. Reject the transaction before execution when a selector rule with a recipient allowlist is matched and calldata is shorter than `4 + 32` bytes.
@@ -618,7 +621,8 @@ Pre-fork blocks MUST replay with pre-fork semantics to preserve state roots.
 25. Reject selector rules with recipient allowlists for selectors outside the fixed constrained-selector set.
 26. Reject duplicate selector rules for the same `(target, selector)`.
 27. Reject duplicate recipients within a selector rule.
-28. Reject key authorization when selector rules with recipient allowlists are used on a non-TIP-20 target.
+28. Access-key calls to an allowed factory are not rejected solely because the factory executes `CREATE` or `CREATE2`.
+29. Reject key authorization when selector rules with recipient allowlists are used on a non-TIP-20 target.
 
 ## References
 


### PR DESCRIPTION
Linear: https://linear.app/tempoxyz/issue/SIGP-271

Clarifies TIP-0001, TIP-1011, and AccountKeychain docs that access-key create restrictions only reject transaction-level `TxKind::Create` calls. Access keys scoped to factory contracts can still trigger `CREATE`/`CREATE2` opcodes during normal contract execution.

Validated with `cargo fmt --package tempo-contracts`, `git diff --check`, and `cargo check -p tempo-contracts`.