### PR TITLE
perf(pool): precompute fee balance slot during pool validation

### DIFF
--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -550,6 +550,9 @@ where
                     }
                 }
 
+                // Precompute the fee balance slot after validation has resolved the fee token.
+                transaction.transaction().fee_balance_slot();
+
                 TransactionValidationOutcome::Valid {
                     balance,
                     state_nonce,


### PR DESCRIPTION
## Summary
- Precompute `fee_balance_slot` when a transaction becomes valid in the tx pool
- Reuse the resolved fee token cached by EVM validation so `next()` does not need to compute the slot lazily

## Profiles

### Before

<img width="1502" height="1225" alt="image" src="https://github.com/user-attachments/assets/04eae49d-c7c4-4b34-94fd-d787d871d05f" />

### After

<img width="1504" height="1225" alt="image" src="https://github.com/user-attachments/assets/d757e836-8197-43c8-9309-d5b38fe3ea64" />


Prompted by: @shekhirin