### PR TITLE
refactor(transaction-pool): simplify expiring nonce eviction order

### DIFF
--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -1464,8 +1464,10 @@ impl AA2dInternalTransaction {
 /// Order:
 /// 1. Priority ascending (lowest priority evicted first)
 /// 2. Submission ID descending (newer transactions evicted first among equal priority)
-/// 3. Expiring nonce hash ascending (stable total order)
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `submission_id` is unique for live entries, so `expiring_hash` is carried
+/// only as removal payload and is not part of the ordering.
+#[derive(Debug, Clone)]
 struct ExpiringNonceEvictionKey {
     expiring_hash: B256,
     priority: Priority<u128>,
@@ -1482,12 +1484,19 @@ impl ExpiringNonceEvictionKey {
     }
 }
 
+impl PartialEq for ExpiringNonceEvictionKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.submission_id == other.submission_id
+    }
+}
+
+impl Eq for ExpiringNonceEvictionKey {}
+
 impl Ord for ExpiringNonceEvictionKey {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.priority
             .cmp(&other.priority)
             .then_with(|| other.submission_id.cmp(&self.submission_id))
-            .then_with(|| self.expiring_hash.cmp(&other.expiring_hash))
     }
 }
 


### PR DESCRIPTION
Removes the expiring nonce hash tie-breaker from `ExpiringNonceEvictionKey` ordering. Submission IDs are unique for live entries, so the hash is only retained as removal payload.

This keeps the eviction key ordering aligned with the data that can actually affect ordering.