### PR TITLE
TIP-1066: TIP-20 channel storage credits

### DIFF
--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -1,0 +1,176 @@
+---
+id: TIP-1066
+title: TIP-20 Channel Storage Credits
+description: Adds payer-attributed reusable storage credits to the TIP-20 channel precompile, using TIP-1060 precompile storage gas tokens to offset later channel-open storage creation costs.
+authors: Dankrad Feist
+status: Draft
+related: TIP-1000, TIP-1034, TIP-1060
+protocolVersion: T5
+---
+
+# TIP-1066: TIP-20 Channel Storage Credits
+
+## Abstract
+
+This TIP adds payer-level reusable storage accounting to the TIP-20 channel precompile defined in
+TIP-1034. When a terminal `close` or `withdraw` deletes a packed channel state slot, the precompile
+credits that channel's payer with one channel storage credit. When the same payer later opens a
+channel, the precompile consumes that payer's credits before allowing a TIP-1060 precompile storage
+gas token to offset the TIP-1000 storage creation cost.
+
+This lets payers reuse channel storage they previously freed without making the underlying
+precompile-level TIP-1060 token balance available to unrelated users.
+
+## Motivation
+
+TIP-1034 channels use one packed storage slot for mutable channel state. Terminal `close` and
+`withdraw` remove that slot entirely, while later `open` calls create a new packed state slot under
+a different `channelId`.
+
+TIP-1060 gives the channel precompile a precompile-level storage gas token balance when it deletes
+storage, but that mechanism alone does not decide which payer should receive the benefit of a
+later cheaper storage creation. Without payer-level accounting, one payer could delete a channel
+and another payer could consume the resulting precompile token.
+
+This TIP defines the channel-specific owner accounting layer on top of TIP-1060.
+
+---
+
+# Specification
+
+## Terminology
+
+- **Channel storage credit**: A protocol-maintained `uint64` counter associated with one payer
+  address in the TIP-20 channel precompile.
+- **Packed channel state slot**: The single TIP-1034 `ChannelState` storage slot keyed by
+  `channelId`.
+- **Storage owner**: The `descriptor.payer` address associated with a packed channel state slot.
+- **TIP-1060 token**: A precompile-level storage gas token minted or consumed by the TIP-20 channel
+  precompile under TIP-1060.
+
+## State
+
+The TIP-20 channel precompile MUST maintain:
+
+```text
+channel_storage_credits: mapping(address payer => uint64 credits)
+```
+
+The `channel_storage_credits` mapping is TIP-20 channel precompile state. Creating or updating a
+payer's `channel_storage_credits` counter, including the first creation of that counter's backing
+storage slot, is subject to normal TIP-1000 state gas and TIP-1060 rules. The channel precompile
+MUST consume a TIP-1060 storage token to change `channel_storage_credits[payer]` from `0` to `1`.
+Inversely, it obtains a TIP-1060 storage token when `channel_storage_credits[payer]` returns to
+zero. One of the payer's channel storage credits is effectively stored in the slot occupied by the
+`channel_storage_credits[payer]` value.
+
+If `channel_storage_credits[payer] == type(uint64).max`, additional credits for that payer MUST
+saturate at `type(uint64).max`.
+
+## Creditable Channel Storage
+
+The only storage covered by channel storage credits is the packed channel state slot keyed by
+`channelId`. Its storage owner is `descriptor.payer`.
+
+Transient same-transaction opened-channel tracking, TIP-1060 precompile gas token state,
+`channel_storage_credits` counters, TIP-20 token balances, token allowances, policy state, EOA
+state, and ordinary smart-contract storage MUST NOT mint or consume channel storage credits for any
+user.
+
+## TIP-1060 Mode Selection
+
+The channel precompile MUST explicitly control TIP-1060 storage creation mode for every
+zero-to-nonzero storage write it performs:
+
+```text
+tip1060_use_storage_token(TIP20_CHANNEL_RESERVE)
+tip1060_use_gas(TIP20_CHANNEL_RESERVE)
+```
+
+`tip1060_use_storage_token(P)` selects TIP-1060 consume-token mode for eligible precompile `P`, so
+the next eligible storage creation by `P` consumes one available TIP-1060 storage token before
+charging the TIP-1000 storage creation component.
+
+`tip1060_use_gas(P)` selects TIP-1060 preserve-token mode for eligible precompile `P`, so the next
+eligible storage creation by `P` pays the full TIP-1000 storage creation cost and leaves any
+available TIP-1060 storage tokens untouched.
+
+These are internal protocol calls made by the channel precompile during its own execution. They
+are not exposed through the channel ABI and MUST NOT let ordinary contracts or users change another
+precompile's TIP-1060 mode.
+
+## Crediting Deleted Storage
+
+When terminal `close` or `withdraw` changes a packed channel state slot owned by payer `P` from
+nonzero to zero:
+
+1. Apply the normal channel state transition.
+2. The TIP-1060 precompile automatically credits the channel precompile with a storage token.
+3. Increment `channel_storage_credits[P]` by one, saturating at `type(uint64).max`.
+
+Deleting a packed channel state slot credits exactly one channel storage credit to its payer,
+regardless of the payee, operator, token, salt, authorized signer, transaction sender, or terminal
+call path.
+
+## Charging Created Storage
+
+When `open` changes a packed channel state slot for payer `P` from zero to nonzero:
+
+1. If `channel_storage_credits[P] > 0`:
+   - Decrement `channel_storage_credits[P]` by one.
+   - Execute the packed channel state slot creation in TIP-1060 consume-token mode so one available
+     channel precompile TIP-1060 token is consumed instead of charging the TIP-1000 storage
+     creation component.
+2. Otherwise:
+   - Leave `channel_storage_credits[P]` unchanged.
+   - Execute the packed channel state slot creation in TIP-1060 preserve-token mode so the payer
+     pays the full TIP-1000-mandated storage creation cost and the channel precompile TIP-1060
+     token balance is not consumed.
+
+Before creating any storage that is not eligible for channel storage credits, the channel
+precompile MUST select TIP-1060 preserve-token mode. In particular, the storage backing a new
+`channel_storage_credits[P]` counter MUST NOT consume a channel storage credit owned by `P`; only
+the packed channel state slot may do so.
+
+The channel storage credit debit, TIP-1060 mode selection, TIP-1060 token debit if any, and packed
+channel state write MUST be atomic. If the operation reverts, all credit, mode, and token changes
+made in the same execution scope MUST revert according to normal EVM revert semantics.
+
+## Query Interface
+
+The TIP-20 channel precompile interface MUST expose:
+
+```solidity
+/// @notice Returns the number of reusable channel storage credits owned by a payer.
+/// @param payer The payer whose channel storage credit balance is queried.
+/// @return credits The number of storage credits available to that payer.
+function storageCredits(address payer) external view returns (uint64 credits);
+```
+
+This function is read-only and does not expose any ability to transfer, mint, burn, or set storage
+credits.
+
+## Compatibility
+
+This TIP changes gas costs for TIP-20 channel `open` calls that create packed channel state. A
+payer who has previously freed channel state may pay less for a later `open`. A payer without
+credits still pays the TIP-1000 storage creation cost for net-new channel state.
+
+Existing channel lifecycle semantics, channel identity, voucher verification, reserve movement,
+events, and close-grace behavior are unchanged except for the new `storageCredits(address)` view.
+
+---
+
+# Invariants
+
+1. A payer's channel storage credit balance increases only when a packed channel state slot
+   attributed to that payer changes from nonzero to zero.
+2. A payer's channel storage credit balance decreases only when `open` creates a packed channel
+   state slot attributed to that payer and a channel precompile TIP-1060 token is consumed.
+3. A channel storage credit can offset at most one packed channel state storage creation.
+4. Channel storage credits are not transferable between users.
+5. Channel precompile TIP-1060 tokens cannot be consumed for a payer who has no channel storage
+   credits.
+6. Channel storage credit accounting changes revert with the execution scope that caused them.
+7. Storage that is not a packed channel state slot does not mint, consume, credit, or debit channel
+   storage credits.


### PR DESCRIPTION
## Summary
- add standalone TIP-1066 for TIP-20 channel payer storage credits
- base channel credit accounting on TIP-1060 precompile storage gas tokens
- keep TIP-1034 unchanged while specifying the channel-specific storage credit layer

## Testing
- git diff --check

Prompted by: @jenpaff