### PR TITLE
fix(ci): force reinstall txgen bench tools

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -117,7 +117,7 @@ cleanup_reth_ipc() {
 # ============================================================================
 
 echo "Installing txgen-tempo and bench-cli..."
-cargo install --git "https://x-access-token:${DEREK_BENCH_TOKEN}@github.com/tempoxyz/txgen" --locked txgen-tempo bench-cli
+cargo install --force --git "https://x-access-token:${DEREK_BENCH_TOKEN}@github.com/tempoxyz/txgen" --locked txgen-tempo bench-cli
 command -v "$TXGEN_TEMPO_BIN"
 command -v "$TXGEN_BENCH_BIN"
 

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -527,7 +527,7 @@ jobs:
           export PATH="$CARGO_BIN_DIR:$PATH"
 
           TXGEN_GIT_URL="https://x-access-token:${TXGEN_GIT_TOKEN}@github.com/tempoxyz/txgen"
-          install_args=(--git "$TXGEN_GIT_URL" --locked)
+          install_args=(--force --git "$TXGEN_GIT_URL" --locked)
           if [ -n "$BENCH_TXGEN_REF" ]; then
             TXGEN_REV="$(git ls-remote "$TXGEN_GIT_URL" "$BENCH_TXGEN_REF" "refs/heads/$BENCH_TXGEN_REF" "refs/tags/$BENCH_TXGEN_REF" | awk 'BEGIN { rev = "" } /\^\{\}$/ { rev = $1; exit } rev == "" { rev = $1 } END { if (rev != "") print rev }')"
             install_args+=(--rev "${TXGEN_REV:-$BENCH_TXGEN_REF}")


### PR DESCRIPTION
Forces txgen benchmark tool installs in e2e and replay benchmarks so persistent self-hosted runners do not keep using already-installed binaries after the txgen repository advances.