### PR TITLE
perf(revm): do not compute unique tx identifier twice

### DIFF
--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -414,30 +414,30 @@ impl FromRecoveredTx<AASigned> for TempoTxEnv {
 
 impl FromRecoveredTx<TempoTxEnvelope> for TempoTxEnv {
     fn from_recovered_tx(tx: &TempoTxEnvelope, sender: Address) -> Self {
-        let unique_tx_identifier = Some(tx.unique_tx_identifier(sender));
-
+        // [`TempoTxEnv::from_recovered_tx`] calculates `unique_tx_identifier` on its own,
+        // so we compute it on demand only for non-AA transactions
         match tx {
             tx @ TempoTxEnvelope::Legacy(inner) => Self {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
                 fee_token: None,
                 is_system_tx: tx.is_system_tx(),
-                unique_tx_identifier,
+                unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 fee_payer: None,
                 tempo_tx_env: None, // Non-AA transaction
             },
             TempoTxEnvelope::Eip2930(inner) => Self {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
-                unique_tx_identifier,
+                unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 ..Default::default()
             },
             TempoTxEnvelope::Eip1559(inner) => Self {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
-                unique_tx_identifier,
+                unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 ..Default::default()
             },
             TempoTxEnvelope::Eip7702(inner) => Self {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
-                unique_tx_identifier,
+                unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 ..Default::default()
             },
             TempoTxEnvelope::AA(tx) => Self::from_recovered_tx(tx, sender),

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -414,8 +414,6 @@ impl FromRecoveredTx<AASigned> for TempoTxEnv {
 
 impl FromRecoveredTx<TempoTxEnvelope> for TempoTxEnv {
     fn from_recovered_tx(tx: &TempoTxEnvelope, sender: Address) -> Self {
-        // [`TempoTxEnv::from_recovered_tx`] calculates `unique_tx_identifier` on its own,
-        // so we compute it on demand only for non-AA transactions
         match tx {
             tx @ TempoTxEnvelope::Legacy(inner) => Self {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),


### PR DESCRIPTION
We computed it twice for AA transactions.