### PR TITLE
perf(payload): use cached payment classification

### DIFF
--- a/.changelog/cool-donkeys-wash.md
+++ b/.changelog/cool-donkeys-wash.md
@@ -1,0 +1,6 @@
+---
+tempo-payload-builder: patch
+tempo-transaction-pool: patch
+---
+
+Use the cached T5+ payment classification from pooled transactions in the payload builder's T5 path while keeping the pre-T5 payment check for legacy gas lane accounting.

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -521,7 +521,7 @@ where
             }
 
             let is_payment = if hardfork.is_t5() {
-                pool_tx.transaction.inner().is_payment_v2()
+                pool_tx.transaction.is_payment()
             } else {
                 pool_tx.transaction.inner().is_payment_v1()
             };

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -35,7 +35,7 @@ pub struct TempoPooledTransaction {
     inner: EthPooledTransaction<TempoTxEnvelope>,
     /// Cached cost of the transaction in the fee token.
     fee_token_cost: U256,
-    /// Cached payment classification for efficient block building
+    /// Cached T5+ payment classification for efficient block building.
     is_payment: bool,
     /// Precomputed sender-scoped hash used to deduplicate expiring nonce transactions.
     expiring_nonce_hash: Option<B256>,
@@ -132,7 +132,7 @@ impl TempoPooledTransaction {
         })
     }
 
-    /// Returns whether this is a payment transaction according to the builder criteria.
+    /// Returns whether this is a payment transaction according to the T5+ builder criteria.
     pub fn is_payment(&self) -> bool {
         self.is_payment
     }


### PR DESCRIPTION
Uses `TempoPooledTransaction`'s cached T5+ payment classification in the payload builder's T5 path instead of recomputing `is_payment_v2()` for each candidate transaction.

The pre-T5 path still calls `is_payment_v1()`, preserving hardfork-specific payment lane gas accounting while removing work from the active T5 hot path.