### PR TITLE
perf(payload): remove per-transaction builder timing

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -469,8 +469,6 @@ where
         let execution_start = Instant::now();
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
         let mut skipped_oversized_block = false;
-        let mut normal_included_transaction_execution_elapsed = Duration::ZERO;
-        let mut normal_invalid_transaction_execution_elapsed = Duration::ZERO;
         let mut invalid_pool_transaction_execution_attempts = 0u64;
         let mut normal_transaction_fill_idle_elapsed = Duration::ZERO;
         let block_build_stop_reason = loop {
@@ -570,7 +568,6 @@ where
                 .then(|| format!("{:?}", pool_tx.transaction))
                 .unwrap_or_default();
 
-            let tx_execution_start = Instant::now();
             let tx_with_env = pool_tx.transaction.clone_into_with_tx_env();
             let execution_result =
                 builder.execute_transaction_with_result_closure(tx_with_env, |result| {
@@ -587,8 +584,6 @@ where
                     // Notify transactions iterator about the new state.
                     best_txs.on_new_result(result);
                 });
-            let elapsed = tx_execution_start.elapsed();
-
             if let Err(err) = execution_result {
                 if let BlockExecutionError::Validation(BlockValidationError::InvalidTx {
                     error,
@@ -596,10 +591,6 @@ where
                 }) = &err
                 {
                     invalid_pool_transaction_execution_attempts += 1;
-                    normal_invalid_transaction_execution_elapsed += elapsed;
-                    self.metrics
-                        .normal_invalid_transaction_execution_duration_seconds
-                        .record(elapsed);
 
                     if error.is_nonce_too_low() {
                         // if the nonce is too low, we can skip this transaction
@@ -622,11 +613,7 @@ where
                     return Err(PayloadBuilderError::evm(err));
                 }
             };
-            normal_included_transaction_execution_elapsed += elapsed;
-            self.metrics
-                .normal_included_transaction_execution_duration_seconds
-                .record(elapsed);
-            trace!(?elapsed, "Transaction executed");
+            trace!("Transaction executed");
 
             pool_transactions_included += 1;
             block_size_used += tx_rlp_length;
@@ -635,20 +622,9 @@ where
         self.metrics
             .inc_block_build_stop_reason(block_build_stop_reason);
         let normal_transaction_fill_elapsed = execution_start.elapsed();
-        let normal_transaction_execution_elapsed = normal_included_transaction_execution_elapsed
-            + normal_invalid_transaction_execution_elapsed;
-        let normal_transaction_fill_overhead_elapsed = normal_transaction_fill_elapsed
-            .saturating_sub(normal_transaction_execution_elapsed)
-            .saturating_sub(normal_transaction_fill_idle_elapsed);
         self.metrics
             .normal_transaction_fill_idle_duration_seconds
             .record(normal_transaction_fill_idle_elapsed);
-        self.metrics
-            .normal_transaction_fill_overhead_duration_seconds
-            .record(normal_transaction_fill_overhead_elapsed);
-        self.metrics
-            .total_normal_invalid_transaction_execution_duration_seconds
-            .record(normal_invalid_transaction_execution_elapsed);
         self.metrics
             .payment_transactions
             .record(payment_transactions as f64);
@@ -740,14 +716,6 @@ where
         self.metrics
             .system_transactions_execution_duration_seconds
             .record(system_txs_execution_elapsed);
-
-        let total_included_transaction_execution_elapsed =
-            normal_included_transaction_execution_elapsed
-                + total_subblock_transaction_execution_elapsed
-                + system_txs_execution_elapsed;
-        self.metrics
-            .total_normal_included_transaction_execution_duration_seconds
-            .record(total_included_transaction_execution_elapsed);
 
         let payload_finalization_start = Instant::now();
         let _finish_span = debug_span!(target: "payload_builder", "finish_block").entered();
@@ -923,13 +891,8 @@ where
             subblock_transactions,
             total_transactions,
             ?elapsed,
-            tx_exec = ?normal_transaction_execution_elapsed,
-            tx_exec_included = ?normal_included_transaction_execution_elapsed,
-            tx_exec_invalid = ?normal_invalid_transaction_execution_elapsed,
-            tx_exec_included_total = ?total_included_transaction_execution_elapsed,
             ?normal_transaction_fill_elapsed,
             ?normal_transaction_fill_idle_elapsed,
-            ?normal_transaction_fill_overhead_elapsed,
             ?total_subblock_transaction_execution_elapsed,
             ?sparse_trie_state_root_wait_elapsed,
             ?builder_finish_elapsed,

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -75,18 +75,8 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) state_setup_duration_seconds: Histogram,
     /// The time it took to prepare system transactions in seconds.
     pub(crate) prepare_system_transactions_duration_seconds: Histogram,
-    /// The time it took to prepare and execute one included normal transaction.
-    pub(crate) normal_included_transaction_execution_duration_seconds: Histogram,
-    /// The time it took to prepare and execute one invalid normal transaction attempt.
-    pub(crate) normal_invalid_transaction_execution_duration_seconds: Histogram,
-    /// Total time spent executing transactions included in the payload.
-    pub(crate) total_normal_included_transaction_execution_duration_seconds: Histogram,
-    /// Total time spent preparing and executing invalid normal pool transaction attempts.
-    pub(crate) total_normal_invalid_transaction_execution_duration_seconds: Histogram,
     /// Time spent waiting for more normal transactions during block fill.
     pub(crate) normal_transaction_fill_idle_duration_seconds: Histogram,
-    /// Normal block-fill time not spent preparing or executing transactions.
-    pub(crate) normal_transaction_fill_overhead_duration_seconds: Histogram,
     /// The time it took to execute subblock transactions in seconds.
     pub(crate) total_subblock_transaction_execution_duration_seconds: Histogram,
     /// Execution time for a single subblock.

--- a/tempo.nu
+++ b/tempo.nu
@@ -883,18 +883,12 @@ def generate-summary [
     mut feature_builder_latency_values = []
     mut baseline_builder_finish_samples = []
     mut feature_builder_finish_samples = []
-    mut baseline_builder_included_tx_samples = []
-    mut feature_builder_included_tx_samples = []
-    mut baseline_builder_invalid_tx_samples = []
-    mut feature_builder_invalid_tx_samples = []
     mut baseline_builder_invalid_tx_execution_attempts_samples = []
     mut feature_builder_invalid_tx_execution_attempts_samples = []
     mut baseline_builder_invalid_tx_skips = []
     mut feature_builder_invalid_tx_skips = []
     mut baseline_builder_nonce_too_low_skips = []
     mut feature_builder_nonce_too_low_skips = []
-    mut baseline_builder_fill_overhead_samples = []
-    mut feature_builder_fill_overhead_samples = []
     mut baseline_builder_fill_idle_samples = []
     mut feature_builder_fill_idle_samples = []
     mut baseline_validation_latency_values = []
@@ -1019,15 +1013,9 @@ def generate-summary [
     let metric_sample_names = [
         "reth_tempo_payload_builder_payload_finalization_duration_seconds_sum"
         "reth_tempo_payload_builder_payload_finalization_duration_seconds_count"
-        "reth_tempo_payload_builder_total_normal_included_transaction_execution_duration_seconds_sum"
-        "reth_tempo_payload_builder_total_normal_included_transaction_execution_duration_seconds_count"
-        "reth_tempo_payload_builder_total_normal_invalid_transaction_execution_duration_seconds_sum"
-        "reth_tempo_payload_builder_total_normal_invalid_transaction_execution_duration_seconds_count"
         "reth_tempo_payload_builder_invalid_pool_transaction_execution_attempts_sum"
         "reth_tempo_payload_builder_invalid_pool_transaction_execution_attempts_count"
         "reth_tempo_payload_builder_pool_transactions_skipped_total"
-        "reth_tempo_payload_builder_normal_transaction_fill_overhead_duration_seconds_sum"
-        "reth_tempo_payload_builder_normal_transaction_fill_overhead_duration_seconds_count"
         "reth_tempo_payload_builder_normal_transaction_fill_idle_duration_seconds_sum"
         "reth_tempo_payload_builder_normal_transaction_fill_idle_duration_seconds_count"
         "reth_tempo_payload_builder_payload_build_duration_seconds_sum"
@@ -1091,8 +1079,6 @@ def generate-summary [
         }
         let builder_latency_values = (do $counter_metric_values "reth_tempo_payload_builder_payload_build_duration_seconds" 1000.0)
         let builder_finish_samples = (do $counter_metric_values "reth_tempo_payload_builder_payload_finalization_duration_seconds" 1000.0)
-        let builder_included_tx_samples = (do $counter_metric_values "reth_tempo_payload_builder_total_normal_included_transaction_execution_duration_seconds" 1000.0)
-        let builder_invalid_tx_samples = (do $counter_metric_values "reth_tempo_payload_builder_total_normal_invalid_transaction_execution_duration_seconds" 1000.0)
         let builder_invalid_tx_execution_attempts_samples = (do $counter_metric_values "reth_tempo_payload_builder_invalid_pool_transaction_execution_attempts" 1.0)
         let builder_pool_tx_skip_samples = ($metric_samples | where name == "reth_tempo_payload_builder_pool_transactions_skipped_total")
         let builder_pool_tx_skips_for_reason = { |reason: string|
@@ -1104,7 +1090,6 @@ def generate-summary [
         }
         let builder_invalid_tx_skips = do $builder_pool_tx_skips_for_reason "invalid_tx"
         let builder_nonce_too_low_skips = do $builder_pool_tx_skips_for_reason "nonce_too_low"
-        let builder_fill_overhead_samples = (do $counter_metric_values "reth_tempo_payload_builder_normal_transaction_fill_overhead_duration_seconds" 1000.0)
         let builder_fill_idle_samples = (do $counter_metric_values "reth_tempo_payload_builder_normal_transaction_fill_idle_duration_seconds" 1000.0)
         let validation_latency_values = (do $counter_metric_values "reth_consensus_engine_beacon_new_payload_latency" 1000.0)
         let builder_gas_values = (do $counter_metric_values "reth_tempo_payload_builder_gas_per_second" 1.0)
@@ -1155,12 +1140,9 @@ def generate-summary [
             $baseline_tps_samples = ($baseline_tps_samples | append $block_tps_samples)
             $baseline_builder_latency_values = ($baseline_builder_latency_values | append $builder_latency_values)
             $baseline_builder_finish_samples = ($baseline_builder_finish_samples | append $builder_finish_samples)
-            $baseline_builder_included_tx_samples = ($baseline_builder_included_tx_samples | append $builder_included_tx_samples)
-            $baseline_builder_invalid_tx_samples = ($baseline_builder_invalid_tx_samples | append $builder_invalid_tx_samples)
             $baseline_builder_invalid_tx_execution_attempts_samples = ($baseline_builder_invalid_tx_execution_attempts_samples | append $builder_invalid_tx_execution_attempts_samples)
             $baseline_builder_invalid_tx_skips = ($baseline_builder_invalid_tx_skips | append $builder_invalid_tx_skips)
             $baseline_builder_nonce_too_low_skips = ($baseline_builder_nonce_too_low_skips | append $builder_nonce_too_low_skips)
-            $baseline_builder_fill_overhead_samples = ($baseline_builder_fill_overhead_samples | append $builder_fill_overhead_samples)
             $baseline_builder_fill_idle_samples = ($baseline_builder_fill_idle_samples | append $builder_fill_idle_samples)
             $baseline_validation_latency_values = ($baseline_validation_latency_values | append $validation_latency_values)
             $baseline_builder_gas_values = ($baseline_builder_gas_values | append $builder_gas_values)
@@ -1171,12 +1153,9 @@ def generate-summary [
             $feature_tps_samples = ($feature_tps_samples | append $block_tps_samples)
             $feature_builder_latency_values = ($feature_builder_latency_values | append $builder_latency_values)
             $feature_builder_finish_samples = ($feature_builder_finish_samples | append $builder_finish_samples)
-            $feature_builder_included_tx_samples = ($feature_builder_included_tx_samples | append $builder_included_tx_samples)
-            $feature_builder_invalid_tx_samples = ($feature_builder_invalid_tx_samples | append $builder_invalid_tx_samples)
             $feature_builder_invalid_tx_execution_attempts_samples = ($feature_builder_invalid_tx_execution_attempts_samples | append $builder_invalid_tx_execution_attempts_samples)
             $feature_builder_invalid_tx_skips = ($feature_builder_invalid_tx_skips | append $builder_invalid_tx_skips)
             $feature_builder_nonce_too_low_skips = ($feature_builder_nonce_too_low_skips | append $builder_nonce_too_low_skips)
-            $feature_builder_fill_overhead_samples = ($feature_builder_fill_overhead_samples | append $builder_fill_overhead_samples)
             $feature_builder_fill_idle_samples = ($feature_builder_fill_idle_samples | append $builder_fill_idle_samples)
             $feature_validation_latency_values = ($feature_validation_latency_values | append $validation_latency_values)
             $feature_builder_gas_values = ($feature_builder_gas_values | append $builder_gas_values)
@@ -1262,18 +1241,12 @@ def generate-summary [
     let f_builder = do $compute_value_stats $feature_builder_latency_values
     let b_builder_finish = do $compute_value_stats $baseline_builder_finish_samples
     let f_builder_finish = do $compute_value_stats $feature_builder_finish_samples
-    let b_builder_included_tx = do $compute_value_stats $baseline_builder_included_tx_samples
-    let f_builder_included_tx = do $compute_value_stats $feature_builder_included_tx_samples
-    let b_builder_invalid_tx = do $compute_value_stats $baseline_builder_invalid_tx_samples
-    let f_builder_invalid_tx = do $compute_value_stats $feature_builder_invalid_tx_samples
     let b_builder_invalid_tx_execution_attempts = do $compute_value_stats $baseline_builder_invalid_tx_execution_attempts_samples
     let f_builder_invalid_tx_execution_attempts = do $compute_value_stats $feature_builder_invalid_tx_execution_attempts_samples
     let b_builder_invalid_tx_skips = if ($baseline_builder_invalid_tx_skips | length) > 0 { $baseline_builder_invalid_tx_skips | math sum | math round --precision 0 } else { 0.0 }
     let f_builder_invalid_tx_skips = if ($feature_builder_invalid_tx_skips | length) > 0 { $feature_builder_invalid_tx_skips | math sum | math round --precision 0 } else { 0.0 }
     let b_builder_nonce_too_low_skips = if ($baseline_builder_nonce_too_low_skips | length) > 0 { $baseline_builder_nonce_too_low_skips | math sum | math round --precision 0 } else { 0.0 }
     let f_builder_nonce_too_low_skips = if ($feature_builder_nonce_too_low_skips | length) > 0 { $feature_builder_nonce_too_low_skips | math sum | math round --precision 0 } else { 0.0 }
-    let b_builder_fill_overhead = do $compute_value_stats $baseline_builder_fill_overhead_samples
-    let f_builder_fill_overhead = do $compute_value_stats $feature_builder_fill_overhead_samples
     let b_builder_fill_idle = do $compute_value_stats $baseline_builder_fill_idle_samples
     let f_builder_fill_idle = do $compute_value_stats $feature_builder_fill_idle_samples
     let b_validation = do $compute_value_stats $baseline_validation_latency_values
@@ -1429,16 +1402,10 @@ def generate-summary [
         $"| Latency P99 [ms] | ($b_builder.p99) | ($f_builder.p99) | (do $delta $b_builder.p99 $f_builder.p99)% |"
         (do $stat_row "Finish P50 [ms]" $b_builder_finish $f_builder_finish p50)
         (do $stat_row "Finish P99 [ms]" $b_builder_finish $f_builder_finish p99)
-        (do $nonzero_stat_row "Included Tx Exec P50 [ms]" $b_builder_included_tx $f_builder_included_tx p50)
-        (do $nonzero_stat_row "Included Tx Exec P99 [ms]" $b_builder_included_tx $f_builder_included_tx p99)
-        (do $nonzero_stat_row "Invalid Tx Exec P50 [ms]" $b_builder_invalid_tx $f_builder_invalid_tx p50)
-        (do $nonzero_stat_row "Invalid Tx Exec P99 [ms]" $b_builder_invalid_tx $f_builder_invalid_tx p99)
         (do $nonzero_stat_row "Invalid Tx Attempts P50" $b_builder_invalid_tx_execution_attempts $f_builder_invalid_tx_execution_attempts p50)
         (do $nonzero_stat_row "Invalid Tx Attempts P99" $b_builder_invalid_tx_execution_attempts $f_builder_invalid_tx_execution_attempts p99)
         (do $nonzero_count_row "Invalid Tx Skips" $b_builder_invalid_tx_skips $f_builder_invalid_tx_skips)
         (do $nonzero_count_row "Nonce Too Low Skips" $b_builder_nonce_too_low_skips $f_builder_nonce_too_low_skips)
-        (do $nonzero_stat_row "Fill Overhead P50 [ms]" $b_builder_fill_overhead $f_builder_fill_overhead p50)
-        (do $nonzero_stat_row "Fill Overhead P99 [ms]" $b_builder_fill_overhead $f_builder_fill_overhead p99)
         (do $nonzero_stat_row "Fill Idle P50 [ms]" $b_builder_fill_idle $f_builder_fill_idle p50)
         (do $nonzero_stat_row "Fill Idle P99 [ms]" $b_builder_fill_idle $f_builder_fill_idle p99)
         ""
@@ -1497,20 +1464,11 @@ def generate-summary [
                 builder_finish_p50: $b_builder_finish.p50
                 builder_finish_p90: $b_builder_finish.p90
                 builder_finish_p99: $b_builder_finish.p99
-                builder_included_tx_execution_p50: $b_builder_included_tx.p50
-                builder_included_tx_execution_p90: $b_builder_included_tx.p90
-                builder_included_tx_execution_p99: $b_builder_included_tx.p99
-                builder_invalid_tx_execution_p50: $b_builder_invalid_tx.p50
-                builder_invalid_tx_execution_p90: $b_builder_invalid_tx.p90
-                builder_invalid_tx_execution_p99: $b_builder_invalid_tx.p99
                 builder_invalid_tx_execution_attempts_p50: $b_builder_invalid_tx_execution_attempts.p50
                 builder_invalid_tx_execution_attempts_p90: $b_builder_invalid_tx_execution_attempts.p90
                 builder_invalid_tx_execution_attempts_p99: $b_builder_invalid_tx_execution_attempts.p99
                 builder_invalid_tx_skips: $b_builder_invalid_tx_skips
                 builder_nonce_too_low_skips: $b_builder_nonce_too_low_skips
-                builder_fill_overhead_p50: $b_builder_fill_overhead.p50
-                builder_fill_overhead_p90: $b_builder_fill_overhead.p90
-                builder_fill_overhead_p99: $b_builder_fill_overhead.p99
                 builder_fill_idle_p50: $b_builder_fill_idle.p50
                 builder_fill_idle_p90: $b_builder_fill_idle.p90
                 builder_fill_idle_p99: $b_builder_fill_idle.p99
@@ -1537,20 +1495,11 @@ def generate-summary [
                 builder_finish_p50: $f_builder_finish.p50
                 builder_finish_p90: $f_builder_finish.p90
                 builder_finish_p99: $f_builder_finish.p99
-                builder_included_tx_execution_p50: $f_builder_included_tx.p50
-                builder_included_tx_execution_p90: $f_builder_included_tx.p90
-                builder_included_tx_execution_p99: $f_builder_included_tx.p99
-                builder_invalid_tx_execution_p50: $f_builder_invalid_tx.p50
-                builder_invalid_tx_execution_p90: $f_builder_invalid_tx.p90
-                builder_invalid_tx_execution_p99: $f_builder_invalid_tx.p99
                 builder_invalid_tx_execution_attempts_p50: $f_builder_invalid_tx_execution_attempts.p50
                 builder_invalid_tx_execution_attempts_p90: $f_builder_invalid_tx_execution_attempts.p90
                 builder_invalid_tx_execution_attempts_p99: $f_builder_invalid_tx_execution_attempts.p99
                 builder_invalid_tx_skips: $f_builder_invalid_tx_skips
                 builder_nonce_too_low_skips: $f_builder_nonce_too_low_skips
-                builder_fill_overhead_p50: $f_builder_fill_overhead.p50
-                builder_fill_overhead_p90: $f_builder_fill_overhead.p90
-                builder_fill_overhead_p99: $f_builder_fill_overhead.p99
                 builder_fill_idle_p50: $f_builder_fill_idle.p50
                 builder_fill_idle_p90: $f_builder_fill_idle.p90
                 builder_fill_idle_p99: $f_builder_fill_idle.p99
@@ -1577,20 +1526,11 @@ def generate-summary [
                 builder_finish_p50: (do $delta $b_builder_finish.p50 $f_builder_finish.p50)
                 builder_finish_p90: (do $delta $b_builder_finish.p90 $f_builder_finish.p90)
                 builder_finish_p99: (do $delta $b_builder_finish.p99 $f_builder_finish.p99)
-                builder_included_tx_execution_p50: (do $delta $b_builder_included_tx.p50 $f_builder_included_tx.p50)
-                builder_included_tx_execution_p90: (do $delta $b_builder_included_tx.p90 $f_builder_included_tx.p90)
-                builder_included_tx_execution_p99: (do $delta $b_builder_included_tx.p99 $f_builder_included_tx.p99)
-                builder_invalid_tx_execution_p50: (do $delta $b_builder_invalid_tx.p50 $f_builder_invalid_tx.p50)
-                builder_invalid_tx_execution_p90: (do $delta $b_builder_invalid_tx.p90 $f_builder_invalid_tx.p90)
-                builder_invalid_tx_execution_p99: (do $delta $b_builder_invalid_tx.p99 $f_builder_invalid_tx.p99)
                 builder_invalid_tx_execution_attempts_p50: (do $delta $b_builder_invalid_tx_execution_attempts.p50 $f_builder_invalid_tx_execution_attempts.p50)
                 builder_invalid_tx_execution_attempts_p90: (do $delta $b_builder_invalid_tx_execution_attempts.p90 $f_builder_invalid_tx_execution_attempts.p90)
                 builder_invalid_tx_execution_attempts_p99: (do $delta $b_builder_invalid_tx_execution_attempts.p99 $f_builder_invalid_tx_execution_attempts.p99)
                 builder_invalid_tx_skips: (do $delta $b_builder_invalid_tx_skips $f_builder_invalid_tx_skips)
                 builder_nonce_too_low_skips: (do $delta $b_builder_nonce_too_low_skips $f_builder_nonce_too_low_skips)
-                builder_fill_overhead_p50: (do $delta $b_builder_fill_overhead.p50 $f_builder_fill_overhead.p50)
-                builder_fill_overhead_p90: (do $delta $b_builder_fill_overhead.p90 $f_builder_fill_overhead.p90)
-                builder_fill_overhead_p99: (do $delta $b_builder_fill_overhead.p99 $f_builder_fill_overhead.p99)
                 builder_fill_idle_p50: (do $delta $b_builder_fill_idle.p50 $f_builder_fill_idle.p50)
                 builder_fill_idle_p90: (do $delta $b_builder_fill_idle.p90 $f_builder_fill_idle.p90)
                 builder_fill_idle_p99: (do $delta $b_builder_fill_idle.p99 $f_builder_fill_idle.p99)


### PR DESCRIPTION
Payload building recorded normal transaction execution durations inside the hot loop, adding clock reads and Prometheus histogram writes for every pool transaction.

Removes those per-transaction execution and derived overhead metrics, and drops the matching benchmark-summary consumers so high-throughput blocks no longer pay that observability cost.