### PR TITLE
Enable T6 for invariant tests

### DIFF
--- a/tips/verify/README.md
+++ b/tips/verify/README.md
@@ -6,7 +6,7 @@ This directory contains Solidity spec verification tests and fuzz harnesses for 
 
 ## Profiles
 
-The checked-in `foundry.toml` uses two profiles, which default to the Tempo T5 hardfork and run against a Tempo-native EVM with enabled Rust precompiles:
+The checked-in `foundry.toml` uses two profiles, which default to the Tempo T6 hardfork and run against a Tempo-native EVM with enabled Rust precompiles:
 
 - `default`: config for standard Foundry build/fmt/ABI tasks. Lighter optimizer and fuzz/invariant settings, for quicker output.
 - `fuzz500`: config for extended invariant runs.

--- a/tips/verify/foundry.toml
+++ b/tips/verify/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-hardfork = "tempo:T5"
+hardfork = "tempo:T6"
 
 # layout and file system
 src = "src"


### PR DESCRIPTION
## Summary
- switch the default Foundry hardfork for tips/verify from tempo:T5 to tempo:T6
- update the specs README to match the new default

## Validation
- git diff --check
- forge config / forge build currently fail locally because the installed Forge binary rejects tempo:T6 as an unknown Tempo hardfork

Prompted by: @jenpaff