### PR TITLE
Fix existing recipients txgen env propagation

### DIFF
--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -120,7 +120,7 @@ def txgen-bloat-accounts-per-token [bloat_mib: int, token_count: int] {
     (($available_for_balances / 64) / $token_count) | into int
 }
 
-def txgen-configure-existing-recipients-env [preset_path: string, bloat_mib: int, token_count: int] {
+def --env txgen-configure-existing-recipients-env [preset_path: string, bloat_mib: int, token_count: int] {
     let preset_name = ($preset_path | path basename | str replace --regex '\.yml$' '')
     if $preset_name != $TXGEN_HELPER_EXISTING_RECIPIENTS_PRESET {
         return


### PR DESCRIPTION
## Summary
- make the existing recipients txgen env helper preserve env vars for downstream txgen commands

## Verification
- `nu --commands 'source contrib/bench/txgen/helpers.nu; txgen-configure-existing-recipients-env contrib/bench/txgen/presets/tip20_existing_recipients.yml 100 4; print $env.TXGEN_EXISTING_RECIPIENTS_START; print $env.TXGEN_EXISTING_RECIPIENTS_END'`\n\nPrompted by: @onbjerg