### PR TITLE
bench(evm): run TIP20 benches for current and latest hardforks

### DIFF
--- a/crates/evm/benches/tip20_execution.rs
+++ b/crates/evm/benches/tip20_execution.rs
@@ -303,13 +303,22 @@ fn latest_known_hardfork() -> TempoHardfork {
 fn hardfork_bench_cases() -> Vec<TempoHardfork> {
     let current = current_active_hardfork();
     let latest = latest_known_hardfork();
-    let mut cases = vec![current];
+    let variants = TempoHardfork::VARIANTS;
+    let current_idx = variants
+        .iter()
+        .position(|&hardfork| hardfork == current)
+        .expect("current hardfork must be a known Tempo hardfork");
+    let latest_idx = variants
+        .iter()
+        .position(|&hardfork| hardfork == latest)
+        .expect("latest hardfork must be a known Tempo hardfork");
 
-    if latest != current {
-        cases.push(latest);
-    }
-
-    cases
+    variants
+        .iter()
+        .skip(current_idx)
+        .take(latest_idx.saturating_sub(current_idx) + 1)
+        .copied()
+        .collect()
 }
 
 fn bench_env(

--- a/crates/evm/benches/tip20_execution.rs
+++ b/crates/evm/benches/tip20_execution.rs
@@ -300,25 +300,16 @@ fn latest_known_hardfork() -> TempoHardfork {
         .expect("TempoHardfork must define at least one variant")
 }
 
-fn hardfork_bench_cases() -> Vec<TempoHardfork> {
+fn hardfork_bench_cases() -> Vec<(&'static str, TempoHardfork)> {
     let current = current_active_hardfork();
     let latest = latest_known_hardfork();
-    let variants = TempoHardfork::VARIANTS;
-    let current_idx = variants
-        .iter()
-        .position(|&hardfork| hardfork == current)
-        .expect("current hardfork must be a known Tempo hardfork");
-    let latest_idx = variants
-        .iter()
-        .position(|&hardfork| hardfork == latest)
-        .expect("latest hardfork must be a known Tempo hardfork");
+    let mut cases = vec![("current", current)];
 
-    variants
-        .iter()
-        .skip(current_idx)
-        .take(latest_idx.saturating_sub(current_idx) + 1)
-        .copied()
-        .collect()
+    if latest != current {
+        cases.push(("latest", latest));
+    }
+
+    cases
 }
 
 fn bench_env(
@@ -913,7 +904,7 @@ fn tip20_execution(c: &mut Criterion) {
     let hardfork_cases = hardfork_bench_cases();
     let config = TempoEvmConfig::new(Arc::new(TempoChainSpec::moderato()));
 
-    for &hardfork in &hardfork_cases {
+    for &(label, hardfork) in &hardfork_cases {
         let fixture = setup_fixed_cache_state(
             &workload.participants,
             workload.block_timestamp,
@@ -928,7 +919,7 @@ fn tip20_execution(c: &mut Criterion) {
             hardfork,
         );
 
-        let mut group = c.benchmark_group(format!("{hardfork}/tip20_execution"));
+        let mut group = c.benchmark_group(format!("{label}/tip20_execution"));
         group.throughput(Throughput::Elements(workload.transactions.len() as u64));
         group.bench_function("txgen_tip20_pure_execution", |b| {
             b.iter_batched(
@@ -950,7 +941,7 @@ fn tip20_execution(c: &mut Criterion) {
     }
 
     let reward_workloads = reward_bench_workloads();
-    for &hardfork in &hardfork_cases {
+    for &(label, hardfork) in &hardfork_cases {
         for reward_workload in &reward_workloads {
             let fixture = setup_fixed_cache_state(
                 &reward_workload.participants,
@@ -966,7 +957,7 @@ fn tip20_execution(c: &mut Criterion) {
                 hardfork,
             );
 
-            let mut group = c.benchmark_group(format!("{hardfork}/tip20_rewards"));
+            let mut group = c.benchmark_group(format!("{label}/tip20_rewards"));
             group.throughput(Throughput::Elements(
                 reward_workload.transactions.len() as u64
             ));

--- a/crates/evm/benches/tip20_execution.rs
+++ b/crates/evm/benches/tip20_execution.rs
@@ -94,17 +94,6 @@ struct Workload {
 }
 
 #[derive(Clone, Copy)]
-struct HardforkBenchCase {
-    hardfork: TempoHardfork,
-}
-
-impl HardforkBenchCase {
-    fn bench_label(self) -> String {
-        self.hardfork.to_string()
-    }
-}
-
-#[derive(Clone, Copy)]
 enum RewardSeedMode {
     None,
     SelfRecipient,
@@ -311,13 +300,13 @@ fn latest_known_hardfork() -> TempoHardfork {
         .expect("TempoHardfork must define at least one variant")
 }
 
-fn hardfork_bench_cases() -> Vec<HardforkBenchCase> {
+fn hardfork_bench_cases() -> Vec<TempoHardfork> {
     let current = current_active_hardfork();
     let latest = latest_known_hardfork();
-    let mut cases = vec![HardforkBenchCase { hardfork: current }];
+    let mut cases = vec![current];
 
     if latest != current {
-        cases.push(HardforkBenchCase { hardfork: latest });
+        cases.push(latest);
     }
 
     cases
@@ -915,23 +904,22 @@ fn tip20_execution(c: &mut Criterion) {
     let hardfork_cases = hardfork_bench_cases();
     let config = TempoEvmConfig::new(Arc::new(TempoChainSpec::moderato()));
 
-    for hardfork_case in &hardfork_cases {
+    for &hardfork in &hardfork_cases {
         let fixture = setup_fixed_cache_state(
             &workload.participants,
             workload.block_timestamp,
             None,
-            hardfork_case.hardfork,
+            hardfork,
         );
         execute_txs(
             &config,
             fixture.prewarm_state_db(),
             &workload.transactions,
             workload.block_timestamp,
-            hardfork_case.hardfork,
+            hardfork,
         );
 
-        let mut group =
-            c.benchmark_group(format!("{}/tip20_execution", hardfork_case.bench_label()));
+        let mut group = c.benchmark_group(format!("{hardfork}/tip20_execution"));
         group.throughput(Throughput::Elements(workload.transactions.len() as u64));
         group.bench_function("txgen_tip20_pure_execution", |b| {
             b.iter_batched(
@@ -942,7 +930,7 @@ fn tip20_execution(c: &mut Criterion) {
                         db,
                         &workload.transactions,
                         workload.block_timestamp,
-                        hardfork_case.hardfork,
+                        hardfork,
                     );
                     black_box(stats.gas_used);
                 },
@@ -953,24 +941,23 @@ fn tip20_execution(c: &mut Criterion) {
     }
 
     let reward_workloads = reward_bench_workloads();
-    for hardfork_case in &hardfork_cases {
+    for &hardfork in &hardfork_cases {
         for reward_workload in &reward_workloads {
             let fixture = setup_fixed_cache_state(
                 &reward_workload.participants,
                 DEFAULT_BLOCK_TIMESTAMP,
                 Some((&reward_workload.delegates, reward_workload.kind)),
-                hardfork_case.hardfork,
+                hardfork,
             );
             execute_txs(
                 &config,
                 fixture.prewarm_state_db(),
                 &reward_workload.transactions,
                 DEFAULT_BLOCK_TIMESTAMP,
-                hardfork_case.hardfork,
+                hardfork,
             );
 
-            let mut group =
-                c.benchmark_group(format!("{}/tip20_rewards", hardfork_case.bench_label()));
+            let mut group = c.benchmark_group(format!("{hardfork}/tip20_rewards"));
             group.throughput(Throughput::Elements(
                 reward_workload.transactions.len() as u64
             ));
@@ -983,7 +970,7 @@ fn tip20_execution(c: &mut Criterion) {
                             db,
                             &reward_workload.transactions,
                             DEFAULT_BLOCK_TIMESTAMP,
-                            hardfork_case.hardfork,
+                            hardfork,
                         );
                         black_box(stats.gas_used);
                     },

--- a/crates/evm/benches/tip20_execution.rs
+++ b/crates/evm/benches/tip20_execution.rs
@@ -38,8 +38,20 @@ use revm::{
     context::{BlockEnv, CfgEnv, JournalTr},
     database::{CacheDB, DbAccount, EmptyDB},
 };
-use std::{collections::BTreeSet, fs, hint::black_box, num::NonZeroU64, path::Path, sync::Arc};
-use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork, spec::TEMPO_T1_BASE_FEE};
+use std::{
+    collections::BTreeSet,
+    fs,
+    hint::black_box,
+    num::NonZeroU64,
+    path::Path,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tempo_chainspec::{
+    TempoChainSpec,
+    hardfork::{TempoHardfork, TempoHardforks},
+    spec::TEMPO_T1_BASE_FEE,
+};
 use tempo_contracts::precompiles::ITIP20;
 use tempo_evm::{
     TempoBlockEnv, TempoBlockExecutionCtx, TempoEvmConfig, TempoEvmFactory, evm::TempoEvm,
@@ -79,6 +91,17 @@ struct Workload {
     transactions: Vec<Recovered<TempoTxEnvelope>>,
     participants: Vec<Address>,
     block_timestamp: u64,
+}
+
+#[derive(Clone, Copy)]
+struct HardforkBenchCase {
+    hardfork: TempoHardfork,
+}
+
+impl HardforkBenchCase {
+    fn bench_label(self) -> String {
+        self.hardfork.to_string()
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -274,8 +297,37 @@ impl HashedPostStateProvider for InMemoryStateProvider {
     }
 }
 
-fn bench_env(block_timestamp: u64) -> EvmEnv<TempoHardfork, TempoBlockEnv> {
-    let spec = TempoHardfork::T5;
+fn current_active_hardfork() -> TempoHardfork {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is before UNIX_EPOCH")
+        .as_secs();
+    TempoChainSpec::mainnet().tempo_hardfork_at(now)
+}
+
+fn latest_known_hardfork() -> TempoHardfork {
+    *TempoHardfork::VARIANTS
+        .last()
+        .expect("TempoHardfork must define at least one variant")
+}
+
+fn hardfork_bench_cases() -> Vec<HardforkBenchCase> {
+    let current = current_active_hardfork();
+    let latest = latest_known_hardfork();
+    let mut cases = vec![HardforkBenchCase { hardfork: current }];
+
+    if latest != current {
+        cases.push(HardforkBenchCase { hardfork: latest });
+    }
+
+    cases
+}
+
+fn bench_env(
+    hardfork: TempoHardfork,
+    block_timestamp: u64,
+) -> EvmEnv<TempoHardfork, TempoBlockEnv> {
+    let spec = hardfork;
     let amsterdam_eip8037_enabled = false;
     let mut cfg_env = CfgEnv::default();
     cfg_env.chain_id = CHAIN_ID;
@@ -303,11 +355,14 @@ fn seed_in_memory_cache_db(
     participants: &[Address],
     block_timestamp: u64,
     reward_seed: Option<(&[Address], RewardBenchKind)>,
+    hardfork: TempoHardfork,
 ) -> CacheDB<EmptyDB> {
     // This setup database only materializes the benchmark fixture in memory. The measured
     // execution path below uses Reth's fixed-cache execution provider, not CacheDB.
-    let mut evm = TempoEvmFactory::default()
-        .create_evm(CacheDB::new(EmptyDB::default()), bench_env(block_timestamp));
+    let mut evm = TempoEvmFactory::default().create_evm(
+        CacheDB::new(EmptyDB::default()),
+        bench_env(hardfork, block_timestamp),
+    );
     let admin = participants
         .first()
         .copied()
@@ -363,8 +418,9 @@ fn setup_fixed_cache_state(
     participants: &[Address],
     block_timestamp: u64,
     reward_seed: Option<(&[Address], RewardBenchKind)>,
+    hardfork: TempoHardfork,
 ) -> ExecutionFixture {
-    let seeded = seed_in_memory_cache_db(participants, block_timestamp, reward_seed);
+    let seeded = seed_in_memory_cache_db(participants, block_timestamp, reward_seed, hardfork);
     let state_cache = seeded.cache;
     let execution_cache = ExecutionCache::new(EXECUTION_CACHE_BYTES);
 
@@ -803,11 +859,13 @@ fn execute_txs<DB>(
     db: DB,
     txs: &[Recovered<TempoTxEnvelope>],
     block_timestamp: u64,
+    hardfork: TempoHardfork,
 ) -> ExecutionStats
 where
     DB: StateDB,
 {
-    let evm: TempoEvm<_, _> = TempoEvmFactory::default().create_evm(db, bench_env(block_timestamp));
+    let evm: TempoEvm<_, _> =
+        TempoEvmFactory::default().create_evm(db, bench_env(hardfork, block_timestamp));
     let ctx = TempoBlockExecutionCtx {
         inner: EthBlockExecutionCtx {
             parent_hash: B256::ZERO,
@@ -854,61 +912,37 @@ where
 
 fn tip20_execution(c: &mut Criterion) {
     let workload = workload();
+    let hardfork_cases = hardfork_bench_cases();
     let config = TempoEvmConfig::new(Arc::new(TempoChainSpec::moderato()));
-    let fixture = setup_fixed_cache_state(&workload.participants, workload.block_timestamp, None);
-    execute_txs(
-        &config,
-        fixture.prewarm_state_db(),
-        &workload.transactions,
-        workload.block_timestamp,
-    );
 
-    let mut group = c.benchmark_group("tip20_execution");
-    group.throughput(Throughput::Elements(workload.transactions.len() as u64));
-    group.bench_function("txgen_tip20_pure_execution", |b| {
-        b.iter_batched(
-            || fixture.state_db(),
-            |db| {
-                let stats = execute_txs(
-                    &config,
-                    db,
-                    &workload.transactions,
-                    workload.block_timestamp,
-                );
-                black_box(stats.gas_used);
-            },
-            BatchSize::SmallInput,
-        )
-    });
-    group.finish();
-
-    let reward_workloads = reward_bench_workloads();
-    for reward_workload in reward_workloads {
+    for hardfork_case in &hardfork_cases {
         let fixture = setup_fixed_cache_state(
-            &reward_workload.participants,
-            DEFAULT_BLOCK_TIMESTAMP,
-            Some((&reward_workload.delegates, reward_workload.kind)),
+            &workload.participants,
+            workload.block_timestamp,
+            None,
+            hardfork_case.hardfork,
         );
         execute_txs(
             &config,
             fixture.prewarm_state_db(),
-            &reward_workload.transactions,
-            DEFAULT_BLOCK_TIMESTAMP,
+            &workload.transactions,
+            workload.block_timestamp,
+            hardfork_case.hardfork,
         );
 
-        let mut group = c.benchmark_group("tip20_rewards");
-        group.throughput(Throughput::Elements(
-            reward_workload.transactions.len() as u64
-        ));
-        group.bench_function(reward_workload.name, |b| {
+        let mut group =
+            c.benchmark_group(format!("{}/tip20_execution", hardfork_case.bench_label()));
+        group.throughput(Throughput::Elements(workload.transactions.len() as u64));
+        group.bench_function("txgen_tip20_pure_execution", |b| {
             b.iter_batched(
                 || fixture.state_db(),
                 |db| {
                     let stats = execute_txs(
                         &config,
                         db,
-                        &reward_workload.transactions,
-                        DEFAULT_BLOCK_TIMESTAMP,
+                        &workload.transactions,
+                        workload.block_timestamp,
+                        hardfork_case.hardfork,
                     );
                     black_box(stats.gas_used);
                 },
@@ -916,6 +950,48 @@ fn tip20_execution(c: &mut Criterion) {
             )
         });
         group.finish();
+    }
+
+    let reward_workloads = reward_bench_workloads();
+    for hardfork_case in &hardfork_cases {
+        for reward_workload in &reward_workloads {
+            let fixture = setup_fixed_cache_state(
+                &reward_workload.participants,
+                DEFAULT_BLOCK_TIMESTAMP,
+                Some((&reward_workload.delegates, reward_workload.kind)),
+                hardfork_case.hardfork,
+            );
+            execute_txs(
+                &config,
+                fixture.prewarm_state_db(),
+                &reward_workload.transactions,
+                DEFAULT_BLOCK_TIMESTAMP,
+                hardfork_case.hardfork,
+            );
+
+            let mut group =
+                c.benchmark_group(format!("{}/tip20_rewards", hardfork_case.bench_label()));
+            group.throughput(Throughput::Elements(
+                reward_workload.transactions.len() as u64
+            ));
+            group.bench_function(reward_workload.name, |b| {
+                b.iter_batched(
+                    || fixture.state_db(),
+                    |db| {
+                        let stats = execute_txs(
+                            &config,
+                            db,
+                            &reward_workload.transactions,
+                            DEFAULT_BLOCK_TIMESTAMP,
+                            hardfork_case.hardfork,
+                        );
+                        black_box(stats.gas_used);
+                    },
+                    BatchSize::SmallInput,
+                )
+            });
+            group.finish();
+        }
     }
 }
 


### PR DESCRIPTION
Runs TIP20 execution and reward benches for the currently active mainnet hardfork and the latest known hardfork, labeling groups as `current/...` and `latest/...`. When both resolve to the same hardfork, the matrix is deduplicated; otherwise the selected hardfork is threaded through fixture seeding, prewarm, and measured execution so each bench reflects that fork's protocol rules.