### PR TITLE
perf(transaction-pool): cache aa pool read in retain_contains

### DIFF
--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -942,7 +942,8 @@ where
         if announcement.is_empty() {
             return;
         }
-        announcement.retain_by_hash(|tx| self.contains(tx))
+        let aa_pool = self.aa_2d_pool.read();
+        announcement.retain_by_hash(|tx| self.protocol_pool.contains(tx) || aa_pool.contains(tx))
     }
 
     fn contains(&self, tx_hash: &B256) -> bool {


### PR DESCRIPTION
Caches the AA 2D pool read guard in the transaction pool `retain_contains` implementation. This avoids reacquiring the AA pool lock for each announced hash while preserving combined protocol-pool and AA-pool membership semantics.