### PR TITLE
feat: enable builder prewarming by default

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -764,6 +764,7 @@ mod tests {
         };
         assert!(node_cmd.engine.share_sparse_trie_with_payload_builder);
         assert_eq!(node_cmd.builder.max_payload_tasks, 1);
+        assert!(node_cmd.ext.node_args.builder_enable_prewarming);
         assert_eq!(
             node_cmd
                 .ext

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -67,7 +67,7 @@ pub struct TempoNodeArgs {
     pub builder_state_provider_metrics: bool,
 
     /// Enable prewarming for the payload builder.
-    #[arg(long = "builder.enable-prewarming", default_value_t = false)]
+    #[arg(long = "builder.enable-prewarming", default_value_t = true)]
     pub builder_enable_prewarming: bool,
 }
 


### PR DESCRIPTION
## Summary
- enable `--builder.enable-prewarming` by default for Tempo nodes
- assert the parsed node default in the existing CLI defaults test

## Testing
- `cargo fmt --check`
- `cargo test -p tempo transaction_execution_wait_default_depends_on_sparse_trie_sharing`

Prompted by: @shekhirin