### PR TITLE
fix(pool): exclude mined txs from expiry eviction

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -6,7 +6,6 @@ use crate::{
     paused::{PausedEntry, PausedFeeTokenPool},
     transaction::TempoPooledTransaction,
 };
-use alloy_consensus::transaction::TxHashRef;
 use alloy_primitives::{
     Address, B256, Log, TxHash,
     map::{AddressMap, AddressSet, B256Map, B256Set},
@@ -612,10 +611,7 @@ where
                 let mut updates = TempoPoolUpdates::from_chain(tip);
 
                 // Remove expiry tracking for mined transactions.
-                let mined_hashes = tip.blocks_iter()
-                    .flat_map(|block| block.body().transactions())
-                    .map(|tx| tx.tx_hash());
-                state.untrack_many(mined_hashes);
+                state.untrack_many(tip.transaction_hashes());
 
                 // Evict transactions slightly before they expire to prevent
                 // broadcasting near-expiry txs that peers would reject.
@@ -623,7 +619,13 @@ where
 
                 // Add expired transactions (from local tracking state)
                 let expired = state.drain_expired(max_expiry);
-                updates.expired_txs = expired.into_iter().filter(|h| pool.contains(h)).collect();
+                if !expired.is_empty() {
+                    let mined_hashes: B256Set = tip.transaction_hashes().copied().collect();
+                    updates.expired_txs = expired
+                        .into_iter()
+                        .filter(|hash| !mined_hashes.contains(hash) && pool.contains(hash))
+                        .collect();
+                }
 
                 // 4. Evict expired AA transactions
                 let expired_start = Instant::now();


### PR DESCRIPTION
Ensures expiry eviction explicitly filters out transactions included in the committed chain before checking pool membership.

This keeps mined transactions from being reported as expired if pool pruning and local expiry tracking disagree.