### PR TITLE
bench: drop removed payload execution metric

### DIFF
--- a/contrib/bench/grafana/dashboards/tempo-benchmarking.json
+++ b/contrib/bench/grafana/dashboards/tempo-benchmarking.json
@@ -561,13 +561,13 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "label_replace(avg(reth_tempo_payload_builder_total_transaction_execution_duration_seconds{namespace=\"$namespace\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
+          "expr": "label_replace(avg(reth_tempo_payload_builder_total_subblock_transaction_execution_duration_seconds{namespace=\"$namespace\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
           "legendFormat": "{{job}} p{{quantile}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Execution Latency",
+      "title": "Subblock Execution Latency",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
## Summary
- replace the removed `reth_tempo_payload_builder_total_transaction_execution_duration_seconds` benchmark dashboard query
- use the still-existing `reth_tempo_payload_builder_total_subblock_transaction_execution_duration_seconds` metric and retitle the panel
- verified the other recently removed builder timing metrics from #4402 are already gone from `main` bench summary collection

## Test
- jq empty contrib/bench/grafana/dashboards/tempo-benchmarking.json
- nu -c 'source tempo.nu; print ok'
- rg check for removed metric names returned no matches

Prompted by: @shekhirin
