### PR TITLE
feat(payload): restore aggregate builder duration metrics

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -623,6 +623,9 @@ where
             .inc_block_build_stop_reason(block_build_stop_reason);
         let normal_transaction_fill_elapsed = execution_start.elapsed();
         self.metrics
+            .total_normal_transaction_fill_duration_seconds
+            .record(normal_transaction_fill_elapsed);
+        self.metrics
             .normal_transaction_fill_idle_duration_seconds
             .record(normal_transaction_fill_idle_elapsed);
         self.metrics
@@ -716,6 +719,13 @@ where
         self.metrics
             .system_transactions_execution_duration_seconds
             .record(system_txs_execution_elapsed);
+
+        let total_transaction_execution_elapsed = normal_transaction_fill_elapsed
+            + total_subblock_transaction_execution_elapsed
+            + system_txs_execution_elapsed;
+        self.metrics
+            .total_transaction_execution_duration_seconds
+            .record(total_transaction_execution_elapsed);
 
         let payload_finalization_start = Instant::now();
         let _finish_span = debug_span!(target: "payload_builder", "finish_block").entered();
@@ -894,6 +904,8 @@ where
             ?normal_transaction_fill_elapsed,
             ?normal_transaction_fill_idle_elapsed,
             ?total_subblock_transaction_execution_elapsed,
+            ?system_txs_execution_elapsed,
+            ?total_transaction_execution_elapsed,
             ?sparse_trie_state_root_wait_elapsed,
             ?builder_finish_elapsed,
             "Built payload"

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -75,8 +75,12 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) state_setup_duration_seconds: Histogram,
     /// The time it took to prepare system transactions in seconds.
     pub(crate) prepare_system_transactions_duration_seconds: Histogram,
+    /// Total wall-clock time spent filling the block with normal pool transactions.
+    pub(crate) total_normal_transaction_fill_duration_seconds: Histogram,
     /// Time spent waiting for more normal transactions during block fill.
     pub(crate) normal_transaction_fill_idle_duration_seconds: Histogram,
+    /// Total wall-clock time spent in transaction execution phases.
+    pub(crate) total_transaction_execution_duration_seconds: Histogram,
     /// The time it took to execute subblock transactions in seconds.
     pub(crate) total_subblock_transaction_execution_duration_seconds: Histogram,
     /// Execution time for a single subblock.


### PR DESCRIPTION
Restores aggregate payload builder duration metrics that were removed with the per-transaction timing cleanup, without reintroducing clock reads or histogram records inside the transaction hot loop.

Adds:
- total normal transaction fill wall-clock duration
- total transaction execution phase wall-clock duration across normal fill, subblocks, and system txs

Validation:
- `cargo fmt -p tempo-payload-builder --check`
- `cargo test -p tempo-payload-builder`

Note: `cargo +nightly fmt -p tempo-payload-builder --check` could not run because the sandbox nightly toolchain is missing `rustfmt`; stable `cargo fmt` passed with the repo config warning about nightly-only import granularity.

Prompted by: @mattsse