### PR TITLE
ci(bench): remove e2e default local builder args

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -26,10 +26,6 @@ const E2E_LOCAL_RETH_ARGS = [
     "--trusted-only"
     "--tempo.bootnodes-endpoint" "none"
     "--consensus.no-legacy-archive"
-    "--builder.max-tasks" "1"
-    "--engine.share-sparse-trie-with-payload-builder"
-    "--engine.share-execution-cache-with-payload-builder"
-    "--builder.enable-prewarming"
 ]
 
 def run-bench-schelk [...args: string] {


### PR DESCRIPTION
Removes the local reth builder/cache prewarming args from the e2e benchmark defaults (`E2E_LOCAL_RETH_ARGS`).

Prompted by: @shekhirin