### PR TITLE
docs: align payment classification TIPs

### DIFF
--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -290,7 +290,9 @@ Channel reserve operations MUST be treated as payment-lane transactions in conse
 
 ### Classification Rules
 
-Implementations MUST define a strict classifier `is_channel_reserve_payment(to, input)` that returns true iff:
+Implementations MUST classify channel reserve calls using the
+`ITIP20ChannelReserveCalls::is_payment_with_valid_signature(input, validate_signature)` predicate
+after checking that:
 
 1. `to == TIP20_CHANNEL_RESERVE`.
 2. `input` selector is one of `{open, settle, topUp, close, requestClose, withdraw}`.
@@ -305,15 +307,15 @@ For AA transactions, payment classification MUST satisfy all of:
 
 1. `calls.length > 0`.
 2. `tempo_authorization_list.length == 0`.
-3. `key_authorization` is absent.
-4. Every call satisfies either TIP-20 strict payment classification or `is_channel_reserve_payment`.
+3. If `key_authorization` is present, `len(rlp(key_authorization)) <= 1024` bytes.
+4. Every call satisfies either TIP-20 strict payment classification or the channel reserve payment predicate.
 
 An AA transaction with an empty `calls` array MUST be classified as non-payment.
 
 ### Required Integration Points
 
 1. The consensus-level payment classifier (`is_payment`) MUST include TIP-20 channel reserve calls and MUST enforce the same authorization-side-effect exclusions above.
-2. The strict builder/pool classifier (`is_payment_v2`) MUST include `is_channel_reserve_payment` and MUST enforce the same authorization-side-effect exclusions above.
+2. The strict builder/pool classifier (`is_payment_v2`) MUST include the channel reserve payment predicate and MUST enforce the same authorization-side-effect exclusions above.
 3. The transaction pool payment flag MUST be computed from the strict classifier, so channel reserve calls are admitted in the payment lane path.
 4. The payload builder non-payment gate (`general_gas_limit` enforcement) MUST treat channel reserve calls as payment, so they are not rejected by the non-payment overflow path.
 
@@ -338,7 +340,7 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 11. Reopening the same logical channel in a later transaction MUST yield a different `channelId` because the replay-protected context hash is different.
 12. Reopening the same `channelId` within one top-level transaction MUST be impossible.
 13. Fund conservation MUST hold at all terminal states.
-14. Channel reserve calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
+14. Channel reserve calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, unbounded authorization sidecars MUST be classified as non-payment, and bounded `key_authorization` handling MUST follow TIP-1045.
 15. `open` and `topUp` MUST not require a prior user `approve` transaction.
 16. `withdraw` MUST require an active close request whose grace period has elapsed.
 17. Channel spend authorization MUST follow the logical `payer -> payee` path: funding operations require an authorized recipient payee, and new payee payouts require an authorized sender payer.

--- a/tips/tip-1045.md
+++ b/tips/tip-1045.md
@@ -47,6 +47,8 @@ Calldata MUST satisfy the ABI encoding constraints for the entry's signature. Ad
 - **Static-only entries**: calldata MUST have no trailing bytes; equivalently, its length MUST be the 4-byte selector plus one 32-byte ABI word per parameter.
 - **Entries with any dynamic type**: calldata MUST be valid ABI-decodable calldata for the matched signature and its total length MUST be `<= 2048` bytes.
 
+For TIP20ChannelReserve `settle` and `close`, the dynamic `signature` parameter MUST also be valid Tempo transaction signature byte encoding. Invalid signature bytes do not match the payment call allow-list, even if the outer ABI encoding is otherwise valid.
+
 The initial payment call allow-list is:
 
 | Target | Selector | Function |


### PR DESCRIPTION
## Summary
- update TIP-1034 so AA payment classification follows TIP-1045's bounded key_authorization rule
- clarify that is_channel_reserve_payment is a spec predicate rather than a required code symbol
- document TIP20ChannelReserve settle/close signature-byte validation in TIP-1045

## Testing
- git diff --check