### PR TITLE
TIP-1067: Duplicate access key authorization tolerance

### DIFF
--- a/tips/tip-1067.md
+++ b/tips/tip-1067.md
@@ -1,0 +1,79 @@
+---
+id: TIP-1067
+title: Duplicate Access Key Authorization Tolerance
+description: Treats duplicate transaction-level access key authorization for an active key as a successful no-op.
+authors: Tony D'Addeo (@amdaddeo)
+status: Draft
+related: TIP-0001, TIP-1011, TIP-1049, TIP-1053
+protocolVersion: TBD
+---
+
+# TIP-1067: Duplicate Access Key Authorization Tolerance
+
+## Abstract
+
+This TIP makes transaction-level access key authorization tolerant of duplicate submissions. If a transaction carries a `key_authorization` for an already-active `(account, key_id)`, the authorization step succeeds as a no-op instead of failing with `KeyAlreadyExists`. The existing key state remains authoritative and is not mutated.
+
+## Motivation
+
+Applications often prepare a `key_authorization` before the access key is needed and only register the key onchain with the first transaction that uses it.
+
+Transactions are not necessarily causally ordered, so multiple transactions may race to be the first one that registers the key. Treating redundant authorization as a no-op removes the need for stateful retry logic. This is especially important for flows like MPP pull, where one party signs the transaction and another submits it.
+
+## Assumptions
+
+- Access keys are identified by `(account, key_id)`, where `key_id` is the address derived from the access key's public key.
+- Applications relying on duplicate tolerance generate one authorization policy per `(account, key_id)`. If they submit different policies for the same key, the first policy that lands defines the key.
+- Relayers and submitters are untrusted and may replay, delay, or race signed transactions. They cannot expand authority because duplicate success never rewrites existing key state.
+- TIP-1053 verifiers remain responsible for offchain witness/challenge semantics. The protocol only checks whether a submitted witness has been manually burned.
+- This TIP only changes transaction-level `key_authorization`. Direct AccountKeychain precompile calls keep the existing duplicate-key behavior.
+
+---
+
+# Specification
+
+## Activation
+
+This TIP activates at `protocolVersion`. Before activation, duplicate transaction-level `key_authorization` behavior is unchanged and MUST reject with the existing duplicate-key error.
+
+No storage migration is required.
+
+This TIP introduces no new persistent storage.
+
+## Active Key
+
+A key is active at block timestamp `t` if:
+
+1. `keys[account][key_id].expiry > 0`,
+2. `keys[account][key_id].is_revoked == false`, and
+3. `t < keys[account][key_id].expiry`.
+
+Missing, revoked, and expired keys are not active.
+
+## Protocol Changes
+
+When processing a transaction-level `key_authorization`, the protocol:
+
+- MUST apply the existing decoding, chain-id, signer, protocol-version, and same-transaction authorize-and-use checks.
+- MUST apply TIP-1053 witness burn checks; if a duplicate authorization carries a burned witness, validation MUST reject.
+- MUST create the key as before when no key exists and the key was not previously revoked.
+- MUST reject with the existing revoked-key error when the key was previously revoked.
+- MUST reject with the existing expired-key error when the key exists but is expired.
+- MUST accept the authorization step as a no-op when the key is active.
+- MUST NOT mutate key state, spending-limit state, call-scope state, expiry, witness state, or emit `KeyAuthorized` or `KeyAuthorizationWitness` for an accepted duplicate no-op.
+
+For an active duplicate, the protocol does not compare the submitted authorization's limits, expiry, call scopes, selector rules, recipients, witness, or signature type against the live key configuration. The live key configuration controls later validation and execution.
+
+For same-block ordering, the rule is evaluated against state produced by earlier transactions in the block. If transaction A creates an active `(account, key_id)`, later transaction B in the same block carrying authorization for the same `(account, key_id)` treats the authorization step as already satisfied.
+
+# Invariants
+
+1. **Transaction-level scope.** Duplicate tolerance MUST apply only to transaction-level `key_authorization`. Duplicate direct calls to AccountKeychain authorization methods MUST keep the existing duplicate-key behavior.
+
+2. **Active-key condition.** After activation, a transaction-level `key_authorization` for `(account, key_id)` MUST no-op only when `keys[account][key_id]` is active at the block timestamp. Revoked and expired keys MUST NOT satisfy duplicate tolerance.
+
+3. **No state mutation.** A duplicate no-op MUST NOT write `keys[account][key_id]`, spending-limit state, call-scope state, expiry, witness state, or authorization events.
+
+4. **Live key authority.** When duplicate authorization succeeds, later validation and execution MUST use the existing key configuration and MUST NOT use fields from the duplicate authorization to set expiry, limits, call scopes, selector rules, recipients, witness behavior, or signature type.
+
+5. **Witness burn preservation.** If a transaction-level `key_authorization` includes a `witness` and `witnesses[account][witness]` is burned, validation MUST reject even when `(account, key_id)` is active.


### PR DESCRIPTION
## Summary
- add TIP-1067 for duplicate transaction-level access key authorization tolerance
- define active-key duplicate authorization as a no-op with no new persistent storage
- preserve TIP-1053 witness burn checks and direct AccountKeychain duplicate-key behavior

## Testing
- git diff --check origin/main...HEAD