### PR TITLE
fix(cli): restore deprecated consensus budget flags

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -367,6 +367,10 @@ fn main() -> eyre::Result<()> {
         );
     }
 
+    if let Commands::Node(node_cmd) = &cli.command {
+        node_cmd.ext.consensus.warn_deprecated_flags();
+    }
+
     // If telemetry is enabled, set logs OTLP (conflicts_with in TelemetryArgs prevents both being set)
     let mut telemetry_config = None;
     if let Commands::Node(node_cmd) = &cli.command
@@ -810,6 +814,58 @@ mod tests {
         assert_eq!(
             node_cmd.ext.consensus.network_budget.into_duration(),
             Duration::from_millis(50)
+        );
+    }
+
+    #[test]
+    fn deprecated_consensus_budget_flags_are_still_accepted() {
+        init_defaults_once();
+
+        let cli = TempoCli::try_parse_from([
+            "tempo",
+            "node",
+            "--dev",
+            "--consensus.time-to-prepare-proposal-transactions",
+            "350ms",
+            "--consensus.minimum-time-before-propose",
+            "450ms",
+        ])
+        .unwrap();
+        let Commands::Node(node_cmd) = cli.command else {
+            panic!("expected node command");
+        };
+        assert!(
+            node_cmd
+                .ext
+                .consensus
+                .deprecated_time_to_prepare_proposal_transactions
+                .is_some()
+        );
+        assert!(
+            node_cmd
+                .ext
+                .consensus
+                .deprecated_minimum_time_before_propose
+                .is_some()
+        );
+
+        let cli = TempoCli::try_parse_from([
+            "tempo",
+            "node",
+            "--dev",
+            "--consensus.time-to-build-proposal",
+            "450ms",
+        ])
+        .unwrap();
+        let Commands::Node(node_cmd) = cli.command else {
+            panic!("expected node command");
+        };
+        assert!(
+            node_cmd
+                .ext
+                .consensus
+                .deprecated_minimum_time_before_propose
+                .is_some()
         );
     }
 }

--- a/crates/commonware-node/src/args.rs
+++ b/crates/commonware-node/src/args.rs
@@ -138,6 +138,21 @@ pub struct Args {
     #[arg(long = "consensus.network-budget", default_value = "50ms")]
     pub network_budget: PositiveDuration,
 
+    /// DEPRECATED: This flag is accepted for compatibility but is no longer used.
+    #[arg(
+        long = "consensus.time-to-prepare-proposal-transactions",
+        help = "DEPRECATED: accepted for compatibility but no longer used"
+    )]
+    pub deprecated_time_to_prepare_proposal_transactions: Option<PositiveDuration>,
+
+    /// DEPRECATED: This flag is accepted for compatibility but is no longer used.
+    #[arg(
+        long = "consensus.minimum-time-before-propose",
+        alias = "consensus.time-to-build-proposal",
+        help = "DEPRECATED: accepted for compatibility but no longer used"
+    )]
+    pub deprecated_minimum_time_before_propose: Option<PositiveDuration>,
+
     /// The amount of time this node will use to construct a subblock before
     /// sending it to the next proposer.
     #[arg(long = "consensus.time-to-build-subblock", default_value = "100ms")]
@@ -318,6 +333,23 @@ impl FromStr for PositiveDuration {
 }
 
 impl Args {
+    pub fn warn_deprecated_flags(&self) {
+        if self
+            .deprecated_time_to_prepare_proposal_transactions
+            .is_some()
+        {
+            eprintln!(
+                "warning: --consensus.time-to-prepare-proposal-transactions is deprecated and no longer used"
+            );
+        }
+
+        if self.deprecated_minimum_time_before_propose.is_some() {
+            eprintln!(
+                "warning: --consensus.minimum-time-before-propose/--consensus.time-to-build-proposal is deprecated and no longer used"
+            );
+        }
+    }
+
     /// Returns the signing key loaded from the configured file.
     ///
     /// When `--consensus.secret` is set, tries to decrypt the signing key.


### PR DESCRIPTION
## Summary
- restore removed consensus budget CLI flags as accepted-but-unused deprecated options
- emit a startup warning when either deprecated option is supplied
- cover the restored flags and alias with a parser test

Prompted by: @joshieDo

## Tests
- cargo fmt --all --check
- cargo test -p tempo --bin tempo deprecated_consensus_budget_flags_are_still_accepted