### PR TITLE
perf(payload): precompute pending payment prewarm hints

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod budget;
 mod metrics;
+mod pending_hints;
 mod prewarming;
 
 pub use budget::DEFAULT_BUILD_TIME_MULTIPLIER;
@@ -15,6 +16,7 @@ use crate::{
         payload_budget_exhausted, scaled_build_time_multiplier,
     },
     metrics::{BlockBuildStopReason, InstrumentedFinishProvider, TempoPayloadBuilderMetrics},
+    pending_hints::PendingPaymentPrewarmHints,
     prewarming::BestTransactionsPrewarming,
 };
 use alloy_consensus::{BlockHeader as _, Signed, Transaction, TxLegacy};
@@ -104,6 +106,8 @@ pub struct TempoPayloadBuilder<Provider> {
     state_provider_metrics: bool,
     /// Whether to enable prewarming of best transactions.
     enable_prewarming: bool,
+    /// Background pending payment prewarm hint computation service.
+    pending_prewarm_hints: Option<PendingPaymentPrewarmHints<Provider>>,
     /// Conservative estimate of total replayable build work divided by work at tx cutoff.
     build_time_multiplier: Arc<AtomicU64>,
 }
@@ -132,7 +136,15 @@ impl Default for TempoPayloadBuilderConfig {
     }
 }
 
-impl<Provider> TempoPayloadBuilder<Provider> {
+impl<Provider> TempoPayloadBuilder<Provider>
+where
+    Provider: StateProviderFactory
+        + ChainSpecProvider<ChainSpec = TempoChainSpec>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
     pub fn new(
         pool: TempoTransactionPool<Provider>,
         provider: Provider,
@@ -140,17 +152,23 @@ impl<Provider> TempoPayloadBuilder<Provider> {
         evm_config: TempoEvmConfig,
         config: TempoPayloadBuilderConfig,
     ) -> Self {
+        let metrics = TempoPayloadBuilderMetrics::default();
+        let pending_prewarm_hints = config
+            .enable_prewarming
+            .then(|| PendingPaymentPrewarmHints::spawn(pool.clone(), metrics.clone()));
+
         Self {
             pool,
             provider,
             executor,
             evm_config,
-            metrics: TempoPayloadBuilderMetrics::default(),
+            metrics,
             cache_metrics: CachedStateMetrics::zeroed(CachedStateMetricsSource::Builder),
             highest_invalid_subblock: Default::default(),
             is_dev: config.is_dev,
             state_provider_metrics: config.state_provider_metrics,
             enable_prewarming: config.enable_prewarming,
+            pending_prewarm_hints,
             build_time_multiplier: Arc::new(AtomicU64::new(scaled_build_time_multiplier(
                 config.build_time_multiplier,
             ))),
@@ -223,8 +241,12 @@ impl<Provider: ChainSpecProvider<ChainSpec = TempoChainSpec>> TempoPayloadBuilde
 
 impl<Provider> PayloadBuilder for TempoPayloadBuilder<Provider>
 where
-    Provider:
-        StateProviderFactory + ChainSpecProvider<ChainSpec = TempoChainSpec> + Clone + 'static,
+    Provider: StateProviderFactory
+        + ChainSpecProvider<ChainSpec = TempoChainSpec>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     type Attributes = TempoPayloadAttributes;
     type BuiltPayload = TempoBuiltPayload;
@@ -270,8 +292,12 @@ where
 
 impl<Provider> TempoPayloadBuilder<Provider>
 where
-    Provider:
-        StateProviderFactory + ChainSpecProvider<ChainSpec = TempoChainSpec> + Clone + 'static,
+    Provider: StateProviderFactory
+        + ChainSpecProvider<ChainSpec = TempoChainSpec>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     #[instrument(
         target = "payload_builder",
@@ -307,6 +333,10 @@ where
             attributes,
             payload_id,
         } = config;
+        let _pending_prewarm_hints_pause = self
+            .pending_prewarm_hints
+            .as_ref()
+            .map(PendingPaymentPrewarmHints::pause);
         let build_once_with_shared_trie =
             // When trie handle is provided, we build the payload once so the shared trie can be reused.
             trie_handle.is_some()

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -156,6 +156,40 @@ impl TempoPayloadBuilderMetrics {
     pub(crate) fn inc_subblocks_expired(&self) {
         metrics::counter!("tempo_payload_builder_subblocks_expired_total").increment(1);
     }
+
+    /// Increments the queued pending payment prewarm hint counter.
+    #[inline]
+    pub(crate) fn inc_pending_prewarm_hint_queued(&self) {
+        metrics::counter!("tempo_payload_builder_pending_prewarm_hints_queued_total").increment(1);
+    }
+
+    /// Increments the computed pending payment prewarm hint counter.
+    #[inline]
+    pub(crate) fn inc_pending_prewarm_hint_computed(&self) {
+        metrics::counter!("tempo_payload_builder_pending_prewarm_hints_computed_total")
+            .increment(1);
+    }
+
+    /// Increments the skipped pending payment prewarm hint counter.
+    #[inline]
+    pub(crate) fn inc_pending_prewarm_hint_skipped(&self, reason: &'static str) {
+        metrics::counter!("tempo_payload_builder_pending_prewarm_hints_skipped_total", "reason" => reason)
+            .increment(1);
+    }
+
+    /// Increments the full-queue drop counter.
+    #[inline]
+    pub(crate) fn inc_pending_prewarm_hint_dropped_full_queue(&self) {
+        metrics::counter!("tempo_payload_builder_pending_prewarm_hints_dropped_full_queue_total")
+            .increment(1);
+    }
+
+    /// Sets the number of active pending payment prewarm hint workers.
+    #[inline]
+    pub(crate) fn set_pending_prewarm_hint_active_workers(&self, active_workers: usize) {
+        metrics::gauge!("tempo_payload_builder_pending_prewarm_hint_active_workers")
+            .set(active_workers as f64);
+    }
 }
 
 /// Wraps a [`StateProvider`] reference to instrument `hashed_post_state` and

--- a/crates/payload/builder/src/pending_hints.rs
+++ b/crates/payload/builder/src/pending_hints.rs
@@ -1,0 +1,544 @@
+use crate::{metrics::TempoPayloadBuilderMetrics, prewarming::prewarm_hint_for_pending_payment};
+use alloy_primitives::TxHash;
+use reth_chainspec::ChainSpecProvider;
+use reth_storage_api::StateProviderFactory;
+use reth_tasks::spawn_os_thread;
+use reth_transaction_pool::{
+    NewTransactionEvent, SubPool, TransactionListenerKind, TransactionPool,
+};
+use std::{
+    collections::HashSet,
+    fmt,
+    sync::{
+        Arc, Condvar, Mutex,
+        mpsc::{Receiver, SyncSender, TrySendError, sync_channel},
+    },
+};
+use tempo_chainspec::TempoChainSpec;
+use tempo_transaction_pool::{TempoTransactionPool, best::BestTransaction};
+use tracing::trace;
+
+const PENDING_PAYMENT_PREWARM_HINT_WORKERS: usize = 2;
+const PENDING_PAYMENT_PREWARM_HINT_QUEUE: usize = 256;
+
+/// Background service that computes opportunistic prewarm hints for pending payment transactions.
+#[derive(Clone)]
+pub(crate) struct PendingPaymentPrewarmHints<Provider> {
+    pool: TempoTransactionPool<Provider>,
+    jobs_tx: SyncSender<BestTransaction>,
+    state: Arc<PendingPaymentPrewarmHintState>,
+    metrics: TempoPayloadBuilderMetrics,
+}
+
+impl<Provider> fmt::Debug for PendingPaymentPrewarmHints<Provider> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PendingPaymentPrewarmHints")
+            .field("state", &self.state)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<Provider> PendingPaymentPrewarmHints<Provider>
+where
+    Provider: StateProviderFactory
+        + ChainSpecProvider<ChainSpec = TempoChainSpec>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    /// Spawns the listener and worker threads.
+    pub(crate) fn spawn(
+        pool: TempoTransactionPool<Provider>,
+        metrics: TempoPayloadBuilderMetrics,
+    ) -> Self {
+        let (jobs_tx, jobs_rx) = sync_channel(PENDING_PAYMENT_PREWARM_HINT_QUEUE);
+        let jobs_rx = Arc::new(Mutex::new(jobs_rx));
+        let state = Arc::new(PendingPaymentPrewarmHintState::default());
+
+        for _ in 0..PENDING_PAYMENT_PREWARM_HINT_WORKERS {
+            spawn_worker(jobs_rx.clone(), state.clone(), metrics.clone());
+        }
+
+        spawn_listener(
+            pool.clone(),
+            jobs_tx.clone(),
+            state.clone(),
+            metrics.clone(),
+        );
+
+        let this = Self {
+            pool,
+            jobs_tx,
+            state,
+            metrics,
+        };
+        this.scan_pending();
+        this
+    }
+
+    /// Pauses new scheduling and waits for already active workers to finish.
+    pub(crate) fn pause(&self) -> PendingPaymentPrewarmHintPauseGuard<Provider> {
+        self.state.pause(&self.metrics);
+        PendingPaymentPrewarmHintPauseGuard {
+            service: self.clone(),
+        }
+    }
+
+    fn resume(&self) {
+        self.state.resume();
+        self.scan_pending();
+    }
+
+    fn scan_pending(&self) {
+        for tx in self.pool.pending_transactions() {
+            self.schedule_transaction(tx);
+        }
+    }
+
+    fn schedule_event(
+        &self,
+        event: NewTransactionEvent<tempo_transaction_pool::transaction::TempoPooledTransaction>,
+    ) {
+        let _ = schedule_new_transaction_event(event, &self.jobs_tx, &self.state, &self.metrics);
+    }
+
+    fn schedule_transaction(&self, tx: BestTransaction) {
+        let _ = schedule_prewarm_hint_transaction(tx, &self.jobs_tx, &self.state, &self.metrics);
+    }
+}
+
+/// RAII pause guard for pending prewarm hints.
+pub(crate) struct PendingPaymentPrewarmHintPauseGuard<Provider>
+where
+    Provider: StateProviderFactory
+        + ChainSpecProvider<ChainSpec = TempoChainSpec>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    service: PendingPaymentPrewarmHints<Provider>,
+}
+
+impl<Provider> Drop for PendingPaymentPrewarmHintPauseGuard<Provider>
+where
+    Provider: StateProviderFactory
+        + ChainSpecProvider<ChainSpec = TempoChainSpec>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    fn drop(&mut self) {
+        self.service.resume();
+    }
+}
+
+#[derive(Debug, Default)]
+struct PendingPaymentPrewarmHintState {
+    inner: Mutex<PendingPaymentPrewarmHintStateInner>,
+    changed: Condvar,
+}
+
+#[derive(Debug, Default)]
+struct PendingPaymentPrewarmHintStateInner {
+    paused: bool,
+    active_workers: usize,
+    in_flight: HashSet<TxHash>,
+}
+
+impl PendingPaymentPrewarmHintState {
+    fn pause(&self, metrics: &TempoPayloadBuilderMetrics) {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("pending prewarm hint state poisoned");
+        inner.paused = true;
+        while inner.active_workers != 0 {
+            inner = self
+                .changed
+                .wait(inner)
+                .expect("pending prewarm hint state poisoned");
+        }
+        metrics.set_pending_prewarm_hint_active_workers(0);
+    }
+
+    fn resume(&self) {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("pending prewarm hint state poisoned");
+        inner.paused = false;
+        self.changed.notify_all();
+    }
+
+    fn try_mark_queued(&self, tx_hash: TxHash) -> Result<(), ScheduleSkip> {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("pending prewarm hint state poisoned");
+        if inner.paused {
+            return Err(ScheduleSkip::Paused);
+        }
+        if !inner.in_flight.insert(tx_hash) {
+            return Err(ScheduleSkip::Duplicate);
+        }
+        Ok(())
+    }
+
+    fn wait_for_worker(&self, metrics: &TempoPayloadBuilderMetrics) -> ActiveWorkerGuard<'_> {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("pending prewarm hint state poisoned");
+        while inner.paused {
+            inner = self
+                .changed
+                .wait(inner)
+                .expect("pending prewarm hint state poisoned");
+        }
+        inner.active_workers += 1;
+        metrics.set_pending_prewarm_hint_active_workers(inner.active_workers);
+        ActiveWorkerGuard {
+            state: self,
+            metrics: metrics.clone(),
+        }
+    }
+
+    fn finish_job(&self, tx_hash: TxHash) {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("pending prewarm hint state poisoned");
+        inner.in_flight.remove(&tx_hash);
+    }
+}
+
+struct ActiveWorkerGuard<'a> {
+    state: &'a PendingPaymentPrewarmHintState,
+    metrics: TempoPayloadBuilderMetrics,
+}
+
+impl Drop for ActiveWorkerGuard<'_> {
+    fn drop(&mut self) {
+        let mut inner = self
+            .state
+            .inner
+            .lock()
+            .expect("pending prewarm hint state poisoned");
+        inner.active_workers = inner.active_workers.saturating_sub(1);
+        self.metrics
+            .set_pending_prewarm_hint_active_workers(inner.active_workers);
+        if inner.active_workers == 0 {
+            self.state.changed.notify_all();
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScheduleSkip {
+    Paused,
+    Duplicate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScheduleOutcome {
+    Queued,
+    Skipped(&'static str),
+    DroppedFullQueue,
+    Disconnected,
+}
+
+fn schedule_new_transaction_event(
+    event: NewTransactionEvent<tempo_transaction_pool::transaction::TempoPooledTransaction>,
+    jobs_tx: &SyncSender<BestTransaction>,
+    state: &PendingPaymentPrewarmHintState,
+    metrics: &TempoPayloadBuilderMetrics,
+) -> ScheduleOutcome {
+    if event.subpool != SubPool::Pending {
+        metrics.inc_pending_prewarm_hint_skipped("non_pending");
+        return ScheduleOutcome::Skipped("non_pending");
+    }
+
+    schedule_prewarm_hint_transaction(event.transaction, jobs_tx, state, metrics)
+}
+
+fn schedule_prewarm_hint_transaction(
+    tx: BestTransaction,
+    jobs_tx: &SyncSender<BestTransaction>,
+    state: &PendingPaymentPrewarmHintState,
+    metrics: &TempoPayloadBuilderMetrics,
+) -> ScheduleOutcome {
+    if tx.transaction.prewarm_hint().is_some() {
+        metrics.inc_pending_prewarm_hint_skipped("already_hinted");
+        return ScheduleOutcome::Skipped("already_hinted");
+    }
+
+    if !tx.transaction.is_payment() {
+        metrics.inc_pending_prewarm_hint_skipped("non_payment");
+        return ScheduleOutcome::Skipped("non_payment");
+    }
+
+    let tx_hash = *tx.hash();
+    match state.try_mark_queued(tx_hash) {
+        Ok(()) => {}
+        Err(ScheduleSkip::Paused) => {
+            metrics.inc_pending_prewarm_hint_skipped("paused");
+            return ScheduleOutcome::Skipped("paused");
+        }
+        Err(ScheduleSkip::Duplicate) => {
+            metrics.inc_pending_prewarm_hint_skipped("duplicate");
+            return ScheduleOutcome::Skipped("duplicate");
+        }
+    }
+
+    match jobs_tx.try_send(tx) {
+        Ok(()) => {
+            metrics.inc_pending_prewarm_hint_queued();
+            ScheduleOutcome::Queued
+        }
+        Err(TrySendError::Full(tx)) => {
+            state.finish_job(*tx.hash());
+            metrics.inc_pending_prewarm_hint_dropped_full_queue();
+            ScheduleOutcome::DroppedFullQueue
+        }
+        Err(TrySendError::Disconnected(tx)) => {
+            state.finish_job(*tx.hash());
+            trace!(
+                target: "payload_builder",
+                tx_hash = ?tx.hash(),
+                "pending prewarm hint worker queue disconnected"
+            );
+            ScheduleOutcome::Disconnected
+        }
+    }
+}
+
+fn spawn_listener<Provider>(
+    pool: TempoTransactionPool<Provider>,
+    jobs_tx: SyncSender<BestTransaction>,
+    state: Arc<PendingPaymentPrewarmHintState>,
+    metrics: TempoPayloadBuilderMetrics,
+) where
+    Provider: StateProviderFactory
+        + ChainSpecProvider<ChainSpec = TempoChainSpec>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    spawn_os_thread("pending-prewarm-hint-listener", move || {
+        let service = PendingPaymentPrewarmHints {
+            pool: pool.clone(),
+            jobs_tx,
+            state,
+            metrics,
+        };
+        let mut new_txs = pool.new_transactions_listener_for(TransactionListenerKind::All);
+        while let Some(event) = new_txs.blocking_recv() {
+            service.schedule_event(event);
+        }
+    });
+}
+
+fn spawn_worker(
+    jobs_rx: Arc<Mutex<Receiver<BestTransaction>>>,
+    state: Arc<PendingPaymentPrewarmHintState>,
+    metrics: TempoPayloadBuilderMetrics,
+) {
+    spawn_os_thread("pending-prewarm-hint-worker", move || {
+        loop {
+            let tx = {
+                let jobs_rx = jobs_rx
+                    .lock()
+                    .expect("pending prewarm hint worker queue poisoned");
+                jobs_rx.recv()
+            };
+            let Ok(tx) = tx else {
+                return;
+            };
+
+            let tx_hash = *tx.hash();
+            let active_worker = state.wait_for_worker(&metrics);
+
+            if tx.transaction.prewarm_hint().is_none()
+                && let Some(hint) = prewarm_hint_for_pending_payment(&tx)
+                && tx.transaction.set_prewarm_hint(hint)
+            {
+                metrics.inc_pending_prewarm_hint_computed();
+            }
+
+            drop(active_worker);
+            state.finish_job(tx_hash);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{Signed, TxLegacy};
+    use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
+    use alloy_sol_types::SolCall;
+    use reth_transaction_pool::{
+        TransactionOrigin, ValidPoolTransaction, identifier::TransactionId,
+    };
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        thread,
+        time::{Duration, Instant},
+    };
+    use tempo_precompiles::{DEFAULT_FEE_TOKEN, tip20::ITIP20};
+    use tempo_primitives::TempoTxEnvelope;
+    use tempo_transaction_pool::transaction::{PrewarmHint, PrewarmTouch, TempoPooledTransaction};
+
+    fn payment_tx() -> BestTransaction {
+        let tx = TxLegacy {
+            chain_id: Some(42431),
+            nonce: 0,
+            gas_price: 20_000_000_000,
+            gas_limit: 21_000,
+            to: TxKind::Call(DEFAULT_FEE_TOKEN),
+            value: U256::ZERO,
+            input: Bytes::from(
+                ITIP20::transferCall {
+                    to: Address::random(),
+                    amount: U256::from(1),
+                }
+                .abi_encode(),
+            ),
+        };
+        let envelope =
+            TempoTxEnvelope::Legacy(Signed::new_unhashed(tx, Signature::test_signature()));
+        let pooled = TempoPooledTransaction::new(reth_primitives_traits::Recovered::new_unchecked(
+            envelope,
+            Address::random(),
+        ));
+        Arc::new(ValidPoolTransaction {
+            transaction_id: TransactionId::new(0u64.into(), 0),
+            transaction: pooled,
+            propagate: true,
+            timestamp: Instant::now(),
+            origin: TransactionOrigin::External,
+            authority_ids: None,
+        })
+    }
+
+    fn non_payment_tx() -> BestTransaction {
+        let tx = TxLegacy {
+            chain_id: Some(42431),
+            nonce: 0,
+            gas_price: 20_000_000_000,
+            gas_limit: 21_000,
+            to: TxKind::Call(Address::random()),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        };
+        let envelope =
+            TempoTxEnvelope::Legacy(Signed::new_unhashed(tx, Signature::test_signature()));
+        let pooled = TempoPooledTransaction::new(reth_primitives_traits::Recovered::new_unchecked(
+            envelope,
+            Address::random(),
+        ));
+        Arc::new(ValidPoolTransaction {
+            transaction_id: TransactionId::new(0u64.into(), 0),
+            transaction: pooled,
+            propagate: true,
+            timestamp: Instant::now(),
+            origin: TransactionOrigin::External,
+            authority_ids: None,
+        })
+    }
+
+    #[test]
+    fn prewarm_hint_scheduling_filters_and_enqueues_pending_payments() {
+        let (jobs_tx, jobs_rx) = sync_channel(1);
+        let state = PendingPaymentPrewarmHintState::default();
+        let metrics = TempoPayloadBuilderMetrics::default();
+
+        let non_pending = NewTransactionEvent {
+            subpool: SubPool::BaseFee,
+            transaction: payment_tx(),
+        };
+        assert_eq!(
+            schedule_new_transaction_event(non_pending, &jobs_tx, &state, &metrics),
+            ScheduleOutcome::Skipped("non_pending")
+        );
+        assert!(jobs_rx.try_recv().is_err());
+
+        assert_eq!(
+            schedule_prewarm_hint_transaction(non_payment_tx(), &jobs_tx, &state, &metrics),
+            ScheduleOutcome::Skipped("non_payment")
+        );
+        assert!(jobs_rx.try_recv().is_err());
+
+        let hinted = payment_tx();
+        assert!(hinted.transaction.set_prewarm_hint(PrewarmHint::new(vec![
+            PrewarmTouch::Account(Address::random())
+        ])));
+        assert_eq!(
+            schedule_prewarm_hint_transaction(hinted, &jobs_tx, &state, &metrics),
+            ScheduleOutcome::Skipped("already_hinted")
+        );
+        assert!(jobs_rx.try_recv().is_err());
+
+        let pending = payment_tx();
+        let pending_hash = *pending.hash();
+        assert_eq!(
+            schedule_new_transaction_event(
+                NewTransactionEvent::pending(pending),
+                &jobs_tx,
+                &state,
+                &metrics
+            ),
+            ScheduleOutcome::Queued
+        );
+        assert_eq!(
+            *jobs_rx.try_recv().expect("queued transaction").hash(),
+            pending_hash
+        );
+    }
+
+    #[test]
+    fn prewarm_hint_state_rejects_duplicate_and_paused_work() {
+        let state = PendingPaymentPrewarmHintState::default();
+        let metrics = TempoPayloadBuilderMetrics::default();
+        let tx_hash = *payment_tx().hash();
+
+        assert_eq!(state.try_mark_queued(tx_hash), Ok(()));
+        assert_eq!(state.try_mark_queued(tx_hash), Err(ScheduleSkip::Duplicate));
+
+        state.finish_job(tx_hash);
+        state.pause(&metrics);
+        assert_eq!(state.try_mark_queued(tx_hash), Err(ScheduleSkip::Paused));
+        state.resume();
+        assert_eq!(state.try_mark_queued(tx_hash), Ok(()));
+    }
+
+    #[test]
+    fn prewarm_hint_pause_waits_for_active_workers() {
+        let state = Arc::new(PendingPaymentPrewarmHintState::default());
+        let metrics = TempoPayloadBuilderMetrics::default();
+        let active = state.wait_for_worker(&metrics);
+        let paused = Arc::new(AtomicBool::new(false));
+
+        let state_for_thread = state.clone();
+        let paused_for_thread = paused.clone();
+        let metrics_for_thread = metrics.clone();
+        let handle = thread::spawn(move || {
+            state_for_thread.pause(&metrics_for_thread);
+            paused_for_thread.store(true, Ordering::Relaxed);
+        });
+
+        thread::sleep(Duration::from_millis(20));
+        assert!(!paused.load(Ordering::Relaxed));
+
+        drop(active);
+        handle.join().unwrap();
+        assert!(paused.load(Ordering::Relaxed));
+    }
+}

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -1,7 +1,11 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-    mpsc::{self, Receiver, Sender},
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        mpsc::{self, Receiver, Sender},
+    },
 };
 
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
@@ -23,10 +27,20 @@ use tempo_precompiles::{
     tip20::{ITIP20, tip20_slots},
 };
 use tempo_primitives::TempoAddressExt;
-use tempo_transaction_pool::best::BestTransaction;
+use tempo_transaction_pool::{
+    best::BestTransaction,
+    transaction::{PrewarmHint, PrewarmTouch},
+};
 use tracing::trace;
 
 type PrewarmEvmState = Option<TempoEvm<StateProviderDatabase<StateProviderBox>>>;
+
+thread_local! {
+    static PREWARM_EVM_STATES: RefCell<HashMap<usize, PrewarmEvmState>> =
+        RefCell::new(HashMap::new());
+}
+
+static NEXT_PREWARM_EVM_CACHE_ID: AtomicUsize = AtomicUsize::new(1);
 
 /// Prewarming orchestrator that consumes source [`BestTransactions`] with bounded
 /// lookahead, prewarms buffered transactions in parallel, and produces a new
@@ -61,6 +75,7 @@ impl BestTransactionsPrewarming {
             cache,
             evm_env,
             stop: stop.clone(),
+            cache_id: NEXT_PREWARM_EVM_CACHE_ID.fetch_add(1, Ordering::Relaxed),
         };
 
         let this = Self {
@@ -99,11 +114,6 @@ impl BestTransactionsPrewarming {
         let pool = executor.prewarming_pool();
 
         pool.in_place_scope(|scope| {
-            let prewarm = ctx.prewarm.clone();
-            scope.spawn(move |_| {
-                pool.init::<PrewarmEvmState>(|_| prewarm.evm_for_ctx());
-            });
-
             let advance = |ctx: &mut BestTransactionsPrewarmingContext<Txs, Provider>| {
                 let Some(tx) = ctx.best_txs.next() else {
                     let _ = ctx.transactions_tx.send(None);
@@ -161,7 +171,7 @@ impl BestTransactionsPrewarming {
             }
         });
 
-        pool.clear();
+        ctx.prewarm.clear_worker_evms(pool);
     }
 
     fn prewarm_transaction<Provider>(
@@ -174,14 +184,34 @@ impl BestTransactionsPrewarming {
             return;
         }
 
-        WorkerPool::with_worker_mut(|worker| {
-            let Some(evm) = worker.get_or_init::<PrewarmEvmState>(|| prewarm.evm_for_ctx()) else {
-                return;
-            };
-
+        let _ = prewarm.with_evm(|evm| {
             let tx_hash = *tx.hash();
 
-            let touched = if is_tip20_transfer_transaction(&tx) {
+            let touched = if let Some(hint) = tx.transaction.prewarm_hint() {
+                let mut touches = hint.touches().to_vec();
+                add_fee_manager_touches_for_transaction(
+                    &mut touches,
+                    &tx,
+                    prewarm.evm_env.block_env.beneficiary,
+                );
+
+                for touch in &touches {
+                    if prewarm.is_stopped() {
+                        return;
+                    }
+                    if let Err(err) = warm_prewarm_touch(touch, evm) {
+                        trace!(
+                            target: "payload_builder",
+                            %err,
+                            ?tx_hash,
+                            "Failed to prewarm hinted transaction storage"
+                        );
+                        return;
+                    }
+                }
+
+                Some(touches.len())
+            } else if is_tip20_static_prewarm_transaction(&tx) {
                 let touches =
                     storage_touches_for_transaction(&tx, prewarm.evm_env.block_env.beneficiary);
 
@@ -189,7 +219,7 @@ impl BestTransactionsPrewarming {
                     if prewarm.is_stopped() {
                         return;
                     }
-                    if let Err(err) = touch.warm(evm) {
+                    if let Err(err) = warm_prewarm_touch(touch, evm) {
                         trace!(
                             target: "payload_builder",
                             %err,
@@ -292,6 +322,7 @@ struct PrewarmingExecutionContext<Provider> {
     cache: Option<SavedCache>,
     evm_env: EvmEnvFor<TempoEvmConfig>,
     stop: Arc<AtomicBool>,
+    cache_id: usize,
 }
 
 impl<Provider> PrewarmingExecutionContext<Provider>
@@ -329,6 +360,31 @@ where
         Some(TempoEvm::new(state_provider, evm_env))
     }
 
+    fn with_evm<R>(
+        &self,
+        f: impl FnOnce(&mut TempoEvm<StateProviderDatabase<StateProviderBox>>) -> R,
+    ) -> Option<R> {
+        PREWARM_EVM_STATES.with_borrow_mut(|states| {
+            let evm = states
+                .entry(self.cache_id)
+                .or_insert_with(|| self.evm_for_ctx())
+                .as_mut()?;
+            Some(f(evm))
+        })
+    }
+
+    fn clear_worker_evms(&self, pool: &WorkerPool) {
+        let cache_id = self.cache_id;
+        pool.broadcast(pool.current_num_threads(), move |_| {
+            PREWARM_EVM_STATES.with_borrow_mut(|states| {
+                states.remove(&cache_id);
+            });
+        });
+        PREWARM_EVM_STATES.with_borrow_mut(|states| {
+            states.remove(&cache_id);
+        });
+    }
+
     fn is_stopped(&self) -> bool {
         self.stop.load(Ordering::Relaxed)
     }
@@ -338,43 +394,43 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum StorageTouch {
-    Account(Address),
-    Storage { address: Address, slot: U256 },
-}
-
-impl StorageTouch {
-    fn warm<DB: Database>(&self, evm: &mut TempoEvm<DB>) -> Result<(), DB::Error> {
-        match *self {
-            Self::Account(address) => {
-                let _ = evm.db_mut().basic(address)?;
-            }
-            Self::Storage { address, slot } => {
-                let _ = evm.db_mut().storage(address, slot)?;
-            }
+fn warm_prewarm_touch<DB: Database>(
+    touch: &PrewarmTouch,
+    evm: &mut TempoEvm<DB>,
+) -> Result<(), DB::Error> {
+    match *touch {
+        PrewarmTouch::Account(address) => {
+            let _ = evm.db_mut().basic(address)?;
         }
-
-        Ok(())
+        PrewarmTouch::Storage { address, slot } => {
+            let _ = evm.db_mut().storage(address, slot)?;
+        }
     }
+
+    Ok(())
 }
 
-fn is_tip20_transfer_transaction(tx: &BestTransaction) -> bool {
-    tx.transaction.is_payment() && is_tip20_transfer_calls(tx.transaction.inner().calls())
+pub(crate) fn prewarm_hint_for_pending_payment(tx: &BestTransaction) -> Option<PrewarmHint> {
+    is_tip20_static_prewarm_transaction(tx)
+        .then(|| PrewarmHint::new(storage_touches_for_transaction_without_fee_recipient(tx)))
 }
 
-fn is_tip20_transfer_calls<'a>(calls: impl IntoIterator<Item = (TxKind, &'a Bytes)>) -> bool {
+fn is_tip20_static_prewarm_transaction(tx: &BestTransaction) -> bool {
+    tx.transaction.is_payment() && is_tip20_static_prewarm_calls(tx.transaction.inner().calls())
+}
+
+fn is_tip20_static_prewarm_calls<'a>(calls: impl IntoIterator<Item = (TxKind, &'a Bytes)>) -> bool {
     let mut has_call = false;
     for (kind, input) in calls {
         has_call = true;
-        if !is_tip20_transfer_call(kind, input) {
+        if !is_tip20_static_prewarm_call(kind, input) {
             return false;
         }
     }
     has_call
 }
 
-fn is_tip20_transfer_call(kind: TxKind, input: &[u8]) -> bool {
+fn is_tip20_static_prewarm_call(kind: TxKind, input: &[u8]) -> bool {
     let Some(token) = kind.to().copied() else {
         return false;
     };
@@ -387,14 +443,27 @@ fn is_tip20_transfer_call(kind: TxKind, input: &[u8]) -> bool {
         Ok(ITIP20::ITIP20Calls::transfer(_)
             | ITIP20::ITIP20Calls::transferWithMemo(_)
             | ITIP20::ITIP20Calls::transferFrom(_)
-            | ITIP20::ITIP20Calls::transferFromWithMemo(_))
+            | ITIP20::ITIP20Calls::transferFromWithMemo(_)
+            | ITIP20::ITIP20Calls::approve(_)
+            | ITIP20::ITIP20Calls::mint(_)
+            | ITIP20::ITIP20Calls::mintWithMemo(_)
+            | ITIP20::ITIP20Calls::burn(_)
+            | ITIP20::ITIP20Calls::burnWithMemo(_))
     )
 }
 
 fn storage_touches_for_transaction(
     tx: &BestTransaction,
     fee_recipient: Address,
-) -> Vec<StorageTouch> {
+) -> Vec<PrewarmTouch> {
+    let mut touches = storage_touches_for_transaction_without_fee_recipient(tx);
+    add_fee_manager_touches_for_transaction(&mut touches, tx, fee_recipient);
+    touches
+}
+
+fn storage_touches_for_transaction_without_fee_recipient(
+    tx: &BestTransaction,
+) -> Vec<PrewarmTouch> {
     let mut touches = Vec::new();
     let sender = tx.transaction.sender();
     let fee_payer = tx.transaction.inner().fee_payer(sender).unwrap_or(sender);
@@ -406,7 +475,6 @@ fn storage_touches_for_transaction(
     });
 
     add_tip20_fee_touches(&mut touches, fee_token, fee_payer);
-    add_fee_manager_touches(&mut touches, fee_recipient, fee_token);
 
     if tx.transaction.is_payment() {
         for (kind, input) in tx.transaction.inner().calls() {
@@ -419,7 +487,21 @@ fn storage_touches_for_transaction(
     touches
 }
 
-fn add_tip20_fee_touches(touches: &mut Vec<StorageTouch>, fee_token: Address, fee_payer: Address) {
+fn add_fee_manager_touches_for_transaction(
+    touches: &mut Vec<PrewarmTouch>,
+    tx: &BestTransaction,
+    fee_recipient: Address,
+) {
+    let fee_token = tx.transaction.resolved_fee_token().unwrap_or_else(|| {
+        tx.transaction
+            .inner()
+            .fee_token()
+            .unwrap_or(DEFAULT_FEE_TOKEN)
+    });
+    add_fee_manager_touches(touches, fee_recipient, fee_token);
+}
+
+fn add_tip20_fee_touches(touches: &mut Vec<PrewarmTouch>, fee_token: Address, fee_payer: Address) {
     if !fee_token.is_tip20() {
         return;
     }
@@ -431,7 +513,7 @@ fn add_tip20_fee_touches(touches: &mut Vec<StorageTouch>, fee_token: Address, fe
 }
 
 fn add_tip20_call_touches(
-    touches: &mut Vec<StorageTouch>,
+    touches: &mut Vec<PrewarmTouch>,
     sender: Address,
     kind: TxKind,
     input: &[u8],
@@ -494,7 +576,7 @@ fn add_tip20_call_touches(
     }
 }
 
-fn add_tip20_common_touches(touches: &mut Vec<StorageTouch>, token: Address) {
+fn add_tip20_common_touches(touches: &mut Vec<PrewarmTouch>, token: Address) {
     add_account_touch(touches, token);
     add_storage_touch(touches, token, tip20_slots::CURRENCY);
     add_storage_touch(touches, token, tip20_slots::PAUSED);
@@ -503,12 +585,12 @@ fn add_tip20_common_touches(touches: &mut Vec<StorageTouch>, token: Address) {
     add_storage_touch(touches, token, tip20_slots::OPTED_IN_SUPPLY);
 }
 
-fn add_tip20_balance_touch(touches: &mut Vec<StorageTouch>, token: Address, account: Address) {
+fn add_tip20_balance_touch(touches: &mut Vec<PrewarmTouch>, token: Address, account: Address) {
     add_storage_touch(touches, token, account.mapping_slot(tip20_slots::BALANCES));
 }
 
 fn add_tip20_allowance_touch(
-    touches: &mut Vec<StorageTouch>,
+    touches: &mut Vec<PrewarmTouch>,
     token: Address,
     owner: Address,
     spender: Address,
@@ -520,7 +602,7 @@ fn add_tip20_allowance_touch(
     );
 }
 
-fn add_tip20_reward_touches(touches: &mut Vec<StorageTouch>, token: Address, account: Address) {
+fn add_tip20_reward_touches(touches: &mut Vec<PrewarmTouch>, token: Address, account: Address) {
     let base_slot = account.mapping_slot(tip20_slots::USER_REWARD_INFO);
     add_storage_touch(touches, token, base_slot);
     add_storage_touch(touches, token, base_slot + U256::from(1));
@@ -528,7 +610,7 @@ fn add_tip20_reward_touches(touches: &mut Vec<StorageTouch>, token: Address, acc
 }
 
 fn add_fee_manager_touches(
-    touches: &mut Vec<StorageTouch>,
+    touches: &mut Vec<PrewarmTouch>,
     fee_recipient: Address,
     fee_token: Address,
 ) {
@@ -545,7 +627,7 @@ fn add_fee_manager_touches(
     );
 }
 
-fn add_expiring_nonce_touches(touches: &mut Vec<StorageTouch>, tx: &BestTransaction) {
+fn add_expiring_nonce_touches(touches: &mut Vec<PrewarmTouch>, tx: &BestTransaction) {
     let Some(expiring_nonce_slot) = tx.transaction.expiring_nonce_slot() else {
         return;
     };
@@ -559,16 +641,16 @@ fn add_expiring_nonce_touches(touches: &mut Vec<StorageTouch>, tx: &BestTransact
     );
 }
 
-fn add_account_touch(touches: &mut Vec<StorageTouch>, address: Address) {
-    add_unique_touch(touches, StorageTouch::Account(address));
+fn add_account_touch(touches: &mut Vec<PrewarmTouch>, address: Address) {
+    add_unique_touch(touches, PrewarmTouch::Account(address));
 }
 
-fn add_storage_touch(touches: &mut Vec<StorageTouch>, address: Address, slot: U256) {
+fn add_storage_touch(touches: &mut Vec<PrewarmTouch>, address: Address, slot: U256) {
     add_account_touch(touches, address);
-    add_unique_touch(touches, StorageTouch::Storage { address, slot });
+    add_unique_touch(touches, PrewarmTouch::Storage { address, slot });
 }
 
-fn add_unique_touch(touches: &mut Vec<StorageTouch>, touch: StorageTouch) {
+fn add_unique_touch(touches: &mut Vec<PrewarmTouch>, touch: PrewarmTouch) {
     if !touches.contains(&touch) {
         touches.push(touch);
     }
@@ -853,19 +935,19 @@ mod tests {
             );
         }
 
-        assert!(touches.contains(&StorageTouch::Account(token)));
-        assert!(touches.contains(&StorageTouch::Storage {
+        assert!(touches.contains(&PrewarmTouch::Account(token)));
+        assert!(touches.contains(&PrewarmTouch::Storage {
             address: token,
             slot: sender.mapping_slot(tip20_slots::BALANCES)
         }));
-        assert!(touches.contains(&StorageTouch::Storage {
+        assert!(touches.contains(&PrewarmTouch::Storage {
             address: token,
             slot: recipient.mapping_slot(tip20_slots::BALANCES)
         }));
     }
 
     #[test]
-    fn tip20_fast_path_is_limited_to_transfers() {
+    fn tip20_static_prewarm_path_accepts_payment_calls() {
         let token = DEFAULT_FEE_TOKEN;
         let transfer = Bytes::from(
             ITIP20::transferCall {
@@ -889,19 +971,74 @@ mod tests {
             }
             .abi_encode(),
         );
+        let burn = Bytes::from(
+            ITIP20::burnCall {
+                amount: U256::from(1),
+            }
+            .abi_encode(),
+        );
 
-        assert!(is_tip20_transfer_call(TxKind::Call(token), &transfer));
-        assert!(is_tip20_transfer_calls(
-            [&transfer, &transfer_from]
+        assert!(is_tip20_static_prewarm_call(TxKind::Call(token), &transfer));
+        assert!(is_tip20_static_prewarm_calls(
+            [&transfer, &transfer_from, &approve, &burn]
                 .into_iter()
                 .map(|input| (TxKind::Call(token), input)),
         ));
-        assert!(!is_tip20_transfer_call(TxKind::Call(token), &approve));
-        assert!(!is_tip20_transfer_calls(
-            [&transfer, &approve]
+        assert!(!is_tip20_static_prewarm_calls(
+            [&transfer, &Bytes::new()]
                 .into_iter()
                 .map(|input| (TxKind::Call(token), input)),
         ));
+    }
+
+    #[test]
+    fn pending_payment_hint_excludes_fee_recipient_touches() {
+        let sender = Address::random();
+        let recipient = Address::random();
+        let token = DEFAULT_FEE_TOKEN;
+        let tx = TxLegacy {
+            chain_id: Some(42431),
+            nonce: 0,
+            gas_price: 20_000_000_000,
+            gas_limit: 21_000,
+            to: TxKind::Call(token),
+            value: U256::ZERO,
+            input: Bytes::from(
+                ITIP20::transferCall {
+                    to: recipient,
+                    amount: U256::from(1),
+                }
+                .abi_encode(),
+            ),
+        };
+        let envelope =
+            TempoTxEnvelope::Legacy(Signed::new_unhashed(tx, Signature::test_signature()));
+        let pooled = TempoPooledTransaction::new(Recovered::new_unchecked(envelope, sender));
+        let best = Arc::new(ValidPoolTransaction {
+            transaction_id: TransactionId::new(0u64.into(), 0),
+            transaction: pooled,
+            propagate: true,
+            timestamp: Instant::now(),
+            origin: TransactionOrigin::External,
+            authority_ids: None,
+        });
+
+        let hint = prewarm_hint_for_pending_payment(&best).expect("hint");
+
+        assert!(hint.touches().contains(&PrewarmTouch::Storage {
+            address: token,
+            slot: sender.mapping_slot(tip20_slots::BALANCES)
+        }));
+        assert!(hint.touches().contains(&PrewarmTouch::Storage {
+            address: token,
+            slot: recipient.mapping_slot(tip20_slots::BALANCES)
+        }));
+        assert!(
+            !hint
+                .touches()
+                .iter()
+                .any(|touch| matches!(touch, PrewarmTouch::Storage { address, .. } if *address == TIP_FEE_MANAGER_ADDRESS))
+        );
     }
 
     #[test]

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -27,6 +27,38 @@ use tempo_primitives::{TempoTxEnvelope, transaction::calc_gas_balance_spending};
 use tempo_revm::{TempoInvalidTransaction, TempoTxEnv};
 use thiserror::Error;
 
+/// A state location that can be prefetched before executing a pooled transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrewarmTouch {
+    /// An account touch.
+    Account(Address),
+    /// A storage touch.
+    Storage { address: Address, slot: U256 },
+}
+
+/// Opportunistic prewarming hint attached to a pooled transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrewarmHint {
+    touches: Vec<PrewarmTouch>,
+}
+
+impl PrewarmHint {
+    /// Creates a new prewarming hint from the given touches.
+    pub fn new(touches: Vec<PrewarmTouch>) -> Self {
+        Self { touches }
+    }
+
+    /// Returns the touched accounts and storage slots.
+    pub fn touches(&self) -> &[PrewarmTouch] {
+        &self.touches
+    }
+
+    /// Consumes the hint and returns the touched accounts and storage slots.
+    pub fn into_touches(self) -> Vec<PrewarmTouch> {
+        self.touches
+    }
+}
+
 /// Tempo pooled transaction representation.
 ///
 /// This is a wrapper around the regular ethereum [`EthPooledTransaction`], but with tempo specific implementations.
@@ -60,6 +92,8 @@ pub struct TempoPooledTransaction {
     /// Stores `(fee_token, balance_slot)` so the payload builder's state-aware iterator
     /// can check if the fee payer's balance was modified without recomputing the keccak.
     fee_balance_slot: OnceLock<Option<(Address, U256)>>,
+    /// Opportunistic storage prewarm hint computed while the transaction is pending.
+    prewarm_hint: OnceLock<Arc<PrewarmHint>>,
 }
 
 impl TempoPooledTransaction {
@@ -93,6 +127,7 @@ impl TempoPooledTransaction {
             key_expiry: OnceLock::new(),
             resolved_fee_token: OnceLock::new(),
             fee_balance_slot: OnceLock::new(),
+            prewarm_hint: OnceLock::new(),
         }
     }
 
@@ -341,6 +376,18 @@ impl TempoPooledTransaction {
             let hash = self.expiring_nonce_hash()?;
             Some(NonceManager::new().expiring_nonce_seen[hash].slot())
         })
+    }
+
+    /// Attaches an opportunistic prewarming hint to this pooled transaction.
+    ///
+    /// Returns true if the hint was stored by this call. Existing hints are kept.
+    pub fn set_prewarm_hint(&self, hint: PrewarmHint) -> bool {
+        self.prewarm_hint.set(Arc::new(hint)).is_ok()
+    }
+
+    /// Returns the opportunistic prewarming hint, if one has been computed.
+    pub fn prewarm_hint(&self) -> Option<Arc<PrewarmHint>> {
+        self.prewarm_hint.get().cloned()
     }
 }
 
@@ -756,6 +803,50 @@ mod tests {
         tt_signature::{PrimitiveSignature, TempoSignature},
         tt_signed::AASigned,
     };
+
+    #[test]
+    fn prewarm_hint_storage_is_single_assignment_and_cloned() {
+        let tx = TxEip1559 {
+            to: TxKind::Call(PATH_USD_ADDRESS),
+            gas_limit: 21000,
+            ..Default::default()
+        };
+        let envelope = TempoTxEnvelope::Eip1559(alloy_consensus::Signed::new_unchecked(
+            tx,
+            Signature::test_signature(),
+            B256::ZERO,
+        ));
+        let pooled_tx = TempoPooledTransaction::new(Recovered::new_unchecked(
+            envelope,
+            address!("0000000000000000000000000000000000000001"),
+        ));
+
+        assert!(pooled_tx.prewarm_hint().is_none());
+
+        let first_touch = PrewarmTouch::Account(Address::repeat_byte(0x11));
+        assert!(pooled_tx.set_prewarm_hint(PrewarmHint::new(vec![first_touch])));
+        assert_eq!(
+            pooled_tx.prewarm_hint().expect("hint").touches(),
+            &[first_touch]
+        );
+
+        let second_touch = PrewarmTouch::Account(Address::repeat_byte(0x22));
+        assert!(!pooled_tx.set_prewarm_hint(PrewarmHint::new(vec![second_touch])));
+        assert_eq!(
+            pooled_tx.prewarm_hint().expect("hint").touches(),
+            &[first_touch]
+        );
+
+        let cloned = pooled_tx.clone();
+        assert_eq!(
+            cloned.prewarm_hint().expect("cloned hint").touches(),
+            &[first_touch]
+        );
+        assert_eq!(
+            pooled_tx.prewarm_hint().expect("original hint").touches(),
+            &[first_touch]
+        );
+    }
 
     #[test]
     fn test_payment_classification_positive() {


### PR DESCRIPTION
Adds opportunistic prewarm hint storage to pooled transactions and a payload-builder-owned background service that derives static hints for pending payment transactions. The service is enabled by the existing prewarming flag, uses two dedicated workers, pauses during payload builds, and falls back to existing prewarming paths when no hint is available.

This moves deterministic payment storage-touch discovery out of the hot payload build path while keeping fee-recipient-dependent touches tied to the actual builder block environment.