### PR TITLE
fix(tip-1059): discount based on gas limit

### DIFF
--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -9,7 +9,7 @@ pub mod token;
 
 pub use admin::{TempoAdminApi, TempoAdminApiServer};
 use alloy_primitives::B256;
-use alloy_rpc_types_eth::{Log, ReceiptWithBloom};
+use alloy_rpc_types_eth::{Log, ReceiptWithBloom, TransactionTrait};
 pub use consensus::{TempoConsensusApiServer, TempoConsensusRpc};
 pub use eth_ext::{TempoEthExt, TempoEthExtApiServer};
 pub use fork_schedule::{TempoForkScheduleApiServer, TempoForkScheduleRpc};
@@ -465,15 +465,12 @@ impl ReceiptConverter<TempoPrimitives> for TempoReceiptConverter {
         let is_t6 = receipts
             .first()
             .is_some_and(|r| self.chain_spec.is_t6_active_at_timestamp(r.meta.timestamp));
-        let receipt_context = receipts
-            .iter()
-            .map(|r| (r.tx, r.gas_used))
-            .collect::<Vec<_>>();
+        let receipt_context = receipts.iter().map(|r| r.tx).collect::<Vec<_>>();
         self.inner
             .convert_receipts(receipts)?
             .into_iter()
             .zip(receipt_context)
-            .map(|(inner, (tx, gas_used))| {
+            .map(|(inner, tx)| {
                 let mut receipt = TempoTransactionReceipt {
                     inner,
                     fee_token: None,
@@ -488,7 +485,7 @@ impl ReceiptConverter<TempoPrimitives> for TempoReceiptConverter {
                         matches!(to.to(), Some(to) if to.is_tip20())
                             && ITIP20::ITIP20Calls::is_discounted_payment_call(input)
                     })
-                    && gas_used <= SSTORE_SET_COST
+                    && tx.gas_limit() <= SSTORE_SET_COST
                 {
                     // Mirror execution settlement: subtract only the base-fee discount and keep
                     // the transaction-derived priority-fee component payable.

--- a/crates/node/tests/it/payment_lane.rs
+++ b/crates/node/tests/it/payment_lane.rs
@@ -230,7 +230,7 @@ async fn test_payment_lane_with_mixed_load() -> eyre::Result<()> {
                     .from(accounts[j])
                     .to(accounts[j]) // Send to self
                     .gas_price(TEMPO_T1_BASE_FEE as u128)
-                    .gas_limit(2_000_000)
+                    .gas_limit(250_000)
                     .value(U256::ZERO);
 
                 all_futures.push((provider.send_transaction(tx), "non-payment"));
@@ -244,7 +244,7 @@ async fn test_payment_lane_with_mixed_load() -> eyre::Result<()> {
                     .into_transaction_request()
                     .from(caller2)
                     .gas_price(TEMPO_T1_BASE_FEE as u128)
-                    .gas_limit(2_000_000);
+                    .gas_limit(250_000);
 
                 all_futures.push((provider2.send_transaction(tx), "payment"));
             }

--- a/crates/node/tests/it/tip20_gas_fees.rs
+++ b/crates/node/tests/it/tip20_gas_fees.rs
@@ -227,7 +227,7 @@ async fn test_tip1059_discounted_payment_receipts_and_fees() -> eyre::Result<()>
     let tx_hash = token
         .transfer(recipient, U256::from(1))
         .gas_price(TEMPO_T1_BASE_FEE as u128)
-        .gas(1_000_000)
+        .gas(250_000)
         .send()
         .await?
         .watch()
@@ -260,7 +260,7 @@ async fn test_tip1059_discounted_payment_receipts_and_fees() -> eyre::Result<()>
         .transfer(recipient, U256::from(1))
         .max_fee_per_gas(TEMPO_T1_BASE_FEE as u128 + PRIORITY_FEE)
         .max_priority_fee_per_gas(PRIORITY_FEE)
-        .gas(1_000_000)
+        .gas(250_000)
         .send()
         .await?
         .watch()

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -68,7 +68,6 @@ use crate::{
     common::TempoStateAccess,
     error::{FeePaymentError, TempoHaltReason},
     evm::TempoContext,
-    gas_params::SSTORE_SET_COST,
 };
 
 /// Additional gas for P256 signature verification
@@ -1463,7 +1462,7 @@ where
         let mut effective_gas_price = tx.effective_gas_price(basefee);
         let gas = exec_result.gas();
         let gas_used = gas.used().saturating_sub(gas.reservoir());
-        if context.cfg.spec.is_t6() && tx.is_discounted_payment() && gas_used <= SSTORE_SET_COST {
+        if context.cfg.spec.is_t6() && tx.is_discounted_payment() {
             // TIP-1059 subtracts only the base-fee discount. The transaction-derived priority-fee
             // component remains payable.
             // https://github.com/tempoxyz/tempo/blob/main/tips/tip-1059.md#applying-the-discount

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -1,4 +1,4 @@
-use crate::TempoInvalidTransaction;
+use crate::{TempoInvalidTransaction, gas_params::SSTORE_SET_COST};
 use alloy_consensus::{Typed2718, crypto::secp256k1};
 use alloy_evm::{FromRecoveredTx, FromTxWithEncoded, IntoTxEnv, TransactionEnvMut};
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
@@ -174,6 +174,10 @@ impl TempoTxEnv {
             .access_list()
             .is_some_and(|mut list| list.next().is_some())
         {
+            return false;
+        }
+
+        if self.gas_limit > SSTORE_SET_COST {
             return false;
         }
 
@@ -998,23 +1002,27 @@ mod tests {
             .abi_encode(),
         );
 
-        let tx = |to, input: Bytes| super::TempoTxEnv {
+        let tx = |to, input: Bytes, gas_limit: u64| super::TempoTxEnv {
             inner: TxEnv {
                 kind: to,
                 data: input,
+                gas_limit,
                 ..Default::default()
             },
             ..Default::default()
         };
 
-        assert!(tx(TxKind::Call(PAYMENT_TKN), transfer.clone()).is_discounted_payment());
-        assert!(tx(TxKind::Call(PAYMENT_TKN), burn).is_discounted_payment());
-        assert!(!tx(TxKind::Call(PAYMENT_TKN), approve.clone()).is_discounted_payment());
-        assert!(!tx(TxKind::Call(PAYMENT_TKN), mint).is_discounted_payment());
-        assert!(!tx(TxKind::Call(Address::random()), transfer.clone()).is_discounted_payment());
-        assert!(!tx(TxKind::Create, transfer.clone()).is_discounted_payment());
+        assert!(tx(TxKind::Call(PAYMENT_TKN), transfer.clone(), 250_000).is_discounted_payment());
+        assert!(!tx(TxKind::Call(PAYMENT_TKN), transfer.clone(), 250_001).is_discounted_payment());
+        assert!(tx(TxKind::Call(PAYMENT_TKN), burn, 250_000).is_discounted_payment());
+        assert!(!tx(TxKind::Call(PAYMENT_TKN), approve.clone(), 250_000).is_discounted_payment());
+        assert!(!tx(TxKind::Call(PAYMENT_TKN), mint, 250_000).is_discounted_payment());
+        assert!(
+            !tx(TxKind::Call(Address::random()), transfer.clone(), 250_000).is_discounted_payment()
+        );
+        assert!(!tx(TxKind::Create, transfer.clone(), 250_000).is_discounted_payment());
 
-        let mut access_list_tx = tx(TxKind::Call(PAYMENT_TKN), transfer.clone());
+        let mut access_list_tx = tx(TxKind::Call(PAYMENT_TKN), transfer.clone(), 250_000);
         access_list_tx.inner.access_list = AccessList(vec![AccessListItem {
             address: Address::random(),
             storage_keys: vec![],
@@ -1030,6 +1038,10 @@ mod tests {
                 }],
                 ..Default::default()
             })),
+            inner: TxEnv {
+                gas_limit: 250_000,
+                ..Default::default()
+            },
             ..Default::default()
         };
         assert!(aa_tx.is_discounted_payment());

--- a/tips/tip-1059.md
+++ b/tips/tip-1059.md
@@ -14,13 +14,13 @@ protocolVersion: T6
 
 This TIP lets simple TIP-20 payment and redemption operations settle at 12 billion attodollars per gas instead of the normal 20 billion attodollars per gas.
 
-The discount is intentionally narrow. It applies only to payment-lane transactions that call a small set of TIP-20 transfer or burn functions and use no more than 250,000 gas. Approvals, mints, arbitrary contract execution, mixed batches, and higher-gas transactions continue to pay the normal base fee.
+The discount is intentionally narrow. It applies only to payment-lane transactions that call a small set of TIP-20 transfer or burn functions and declare a gas limit of no more than 250,000 gas. Approvals, mints, arbitrary contract execution, mixed batches, and higher-gas-limit transactions continue to pay the normal base fee.
 
 ## Motivation
 
 Tempo keeps the fixed base fee high enough to price worst-case spam and state growth. That is the right default for arbitrary execution and state-creating transactions, but it overprices simple, low-gas payment flows.
 
-This TIP carves out a lower settlement price for those low-cost payment and redemption paths: TIP-20 transfers, delegated transfers, and burns. Wallets still authorize the normal base fee for reliable inclusion. After execution, if the transaction satisfies the payment-lane rules, uses only an eligible TIP-20 function, and stays under the gas-used threshold, the protocol charges the lower gas price and refunds the difference.
+This TIP carves out a lower settlement price for those low-cost payment and redemption paths: TIP-20 transfers, delegated transfers, and burns. Wallets still authorize the normal base fee for reliable inclusion. If the transaction satisfies the payment-lane rules, uses only an eligible TIP-20 function, and declares a gas limit at or below the discounted-payment cap, the protocol charges the lower gas price and refunds the difference after execution.
 
 The discount is a payment UX improvement, not a replacement for the normal base fee as the chain's main spam-resistance mechanism.
 
@@ -36,7 +36,7 @@ At the T6 hardfork, introduce the following parameters:
 | --- | ---: | --- |
 | Normal base fee | 20,000,000,000 | Existing gas price for ordinary transactions |
 | Discounted payment gas price | 12,000,000,000 | Gas price charged to eligible payment operations |
-| Maximum discounted payment gas used | TIP-1000 new-state-write gas cost, 250,000 gas at T6 | Per-transaction execution cap for the discount |
+| Maximum discounted payment gas limit | TIP-1000 new-state-write gas cost, 250,000 gas at T6 | Per-transaction authorized gas cap for the discount |
 
 All gas prices are denominated in attodollars per gas.
 
@@ -52,7 +52,7 @@ A transaction is eligible for the discounted payment gas price only if all of th
    - `transferFromWithMemo(address from, address to, uint256 amount, bytes32 memo)`
    - `burn(uint256 amount)`
    - `burnWithMemo(uint256 amount, bytes32 memo)`
-3. The transaction uses no more than the TIP-1000 new-state-write gas cost. At T6, this is 250,000 gas. This enforces the discount to apply only to transactions that do not create new state.
+3. The transaction gas limit is no more than the TIP-1000 new-state-write gas cost. At T6, this is 250,000 gas. This prevents transactions that authorize enough gas for state creation from receiving discounted settlement.
 
 For account-abstraction (type `0x76`) transactions, every call in `calls` must individually be classified as a TIP-20 payment. A transaction with any call that does not satisfy this constraint is not eligible for the discount.
 
@@ -72,6 +72,8 @@ A transaction that does not satisfy the eligibility rules receives no discount.
 
 Execution semantics are otherwise unchanged. In particular, execution uses the normal base fee as the transaction gas price. The discount affects post-execution fee settlement only.
 
+Eligibility is determined from transaction shape and gas limit, not from post-execution gas used. A transaction with a gas limit above the discounted-payment cap does not receive the discount even if it ultimately uses no more than 250,000 gas.
+
 ## Fee caps and refunds
 
 All transactions must authorize the normal base fee. A transaction with `max_fee_per_gas` below the normal base fee is not eligible for inclusion under this TIP.
@@ -88,7 +90,7 @@ The payload fee total used for builder comparison MUST use the same fee amount t
 
 Fee estimation for ordinary transactions is unchanged.
 
-Fee estimation for eligible pure TIP-20 payment operations SHOULD show the discounted settlement gas price when the transaction is expected to qualify. RPCs and wallets SHOULD make clear that transactions still authorize the normal base fee for reliable inclusion.
+Fee estimation for eligible pure TIP-20 payment operations SHOULD show the discounted settlement gas price when the transaction is expected to qualify, including the gas-limit cap. RPCs and wallets SHOULD make clear that transactions still authorize the normal base fee for reliable inclusion.
 
 ## Compatibility
 
@@ -110,9 +112,9 @@ This is the simplest change, but it makes storage creation and arbitrary contrac
 
 This is broader than the proposal in this TIP. Doing this risks making permanent state creation, approvals, and other non-transfer payment-lane activity too cheap.
 
-## Discount based only on gas limit
+## Discount based on actual gas used
 
-This would be simpler to validate before execution, but it would punish wallets that set conservative gas limits because they do not always know how much gas a transfer will use. This TIP uses actual gas used instead.
+This would be friendlier to wallets that set conservative gas limits because eligibility would depend on the gas actually consumed. It would also make discount eligibility a post-execution result, which is harder to reflect consistently across settlement, receipt conversion, and block-building fee accounting. This TIP uses the transaction gas limit instead so eligibility is deterministic before execution.
 
 ## Cap discounted gas per block
 


### PR DESCRIPTION
Changes TIP-1059 logic to apply discount based on transaction's gas limit instead of gas usage thus allowing for the discount classification to be fully stateless