### PR TITLE
perf(precompile): non-std Handler hasher

### DIFF
--- a/crates/precompiles/src/storage/types/mod.rs
+++ b/crates/precompiles/src/storage/types/mod.rs
@@ -22,8 +22,11 @@ use crate::{
     error::Result,
     storage::{StorageOps, packing},
 };
-use alloy::primitives::{Address, U256, keccak256};
-use std::{cell::RefCell, collections::HashMap, hash::Hash};
+use alloy::primitives::{
+    Address, U256, keccak256,
+    map::{DefaultHashBuilder, HashMap},
+};
+use std::{cell::RefCell, hash::Hash};
 
 /// Describes how a type is laid out in EVM storage.
 ///
@@ -386,7 +389,7 @@ impl<K, H> HandlerCache<K, H> {
     #[inline]
     pub(super) fn new() -> Self {
         Self {
-            inner: RefCell::new(HashMap::new()),
+            inner: RefCell::new(HashMap::with_hasher(DefaultHashBuilder::default())),
         }
     }
 }


### PR DESCRIPTION
## Summary
- switch precompile `HandlerCache` from `std::collections::HashMap` to `alloy_primitives::map::HashMap`
- construct the cache with alloy/reth-style `DefaultHashBuilder`

## Testing
- `cargo fmt --check`
- `cargo test -p tempo-precompiles --features test-utils storage::types`