### PR TITLE
test: benchmark legacy `TempoStreamChannel` contract gas

### DIFF
--- a/crates/node/tests/it/gas/legacy_stream_channel_contract.rs
+++ b/crates/node/tests/it/gas/legacy_stream_channel_contract.rs
@@ -1,0 +1,434 @@
+use std::{fs, path::Path, process::Command};
+
+use alloy::{
+    hex,
+    primitives::{Address, B256, Bytes, U256},
+    providers::Provider,
+    signers::{SignerSync, local::PrivateKeySigner},
+    sol,
+};
+use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
+use tempo_contracts::{CREATEX_ADDRESS, CreateX, precompiles::ITIP20};
+use tempo_precompiles::PATH_USD_ADDRESS;
+
+use super::helpers::{
+    GAS_LIMIT, GasSnapshot, Receipt, TempoTxSender, fixed_signer, print_gas_snapshot, test_signer,
+};
+use crate::utils::TestNodeBuilder;
+
+const DEPOSIT: u64 = 1_000_000;
+const FUNDING: u64 = 20_000_000;
+const LEGACY_STREAM_CHANNEL_SOURCE: &str =
+    include_str!("../../../../../tips/verify/src/LegacyTempoStreamChannel.sol");
+
+sol! {
+    #[sol(rpc)]
+    interface ITempoStreamChannel {
+        function open(
+            address payee,
+            address token,
+            uint128 deposit,
+            bytes32 salt,
+            address authorizedSigner
+        ) external returns (bytes32 channelId);
+        function settle(bytes32 channelId, uint128 cumulativeAmount, bytes calldata signature) external;
+        function topUp(bytes32 channelId, uint256 additionalDeposit) external;
+        function close(bytes32 channelId, uint128 cumulativeAmount, bytes calldata signature) external;
+        function requestClose(bytes32 channelId) external;
+        function computeChannelId(
+            address payer,
+            address payee,
+            address token,
+            bytes32 salt,
+            address authorizedSigner
+        ) external view returns (bytes32);
+        function getVoucherDigest(bytes32 channelId, uint128 cumulativeAmount) external view returns (bytes32);
+    }
+}
+
+struct ChannelEnv<P> {
+    address: Address,
+    contract: ITempoStreamChannel::ITempoStreamChannelInstance<P>,
+    id: B256,
+    open_gas_used: u64,
+}
+
+impl<P: Provider + Clone> ChannelEnv<P> {
+    async fn open(
+        address: Address,
+        sender: &mut TempoTxSender<P>,
+        payee: Address,
+        salt: u8,
+    ) -> eyre::Result<Self> {
+        let contract = ITempoStreamChannel::new(address, sender.provider.clone());
+        let salt = B256::with_last_byte(salt);
+        let id = contract
+            .computeChannelId(
+                sender.address(),
+                payee,
+                PATH_USD_ADDRESS,
+                salt,
+                Address::ZERO,
+            )
+            .call()
+            .await?;
+        sender
+            .send_call(
+                PATH_USD_ADDRESS,
+                ITIP20::approveCall {
+                    spender: address,
+                    amount: U256::from(DEPOSIT),
+                },
+            )
+            .await?;
+        let sent = sender
+            .send_call(
+                address,
+                ITempoStreamChannel::openCall {
+                    payee,
+                    token: PATH_USD_ADDRESS,
+                    deposit: DEPOSIT as u128,
+                    salt,
+                    authorizedSigner: Address::ZERO,
+                },
+            )
+            .await?;
+        Ok(Self {
+            address,
+            contract,
+            id,
+            open_gas_used: sent.gas_used,
+        })
+    }
+
+    fn gas_used(&self) -> u64 {
+        self.open_gas_used
+    }
+
+    async fn top_up(
+        &self,
+        gas: &mut GasSnapshot,
+        name: impl Into<String>,
+        sender: &mut TempoTxSender<P>,
+        amount: u64,
+    ) -> eyre::Result<Receipt> {
+        sender
+            .send_call(
+                PATH_USD_ADDRESS,
+                ITIP20::approveCall {
+                    spender: self.address,
+                    amount: U256::from(amount),
+                },
+            )
+            .await?;
+        gas.call(
+            name,
+            sender,
+            self.address,
+            ITempoStreamChannel::topUpCall {
+                channelId: self.id,
+                additionalDeposit: U256::from(amount),
+            },
+        )
+        .await
+    }
+
+    async fn settle(
+        &self,
+        gas: &mut GasSnapshot,
+        name: impl Into<String>,
+        submitter: &mut TempoTxSender<P>,
+        payer: &PrivateKeySigner,
+        amount: u64,
+    ) -> eyre::Result<Receipt> {
+        let signature = self.voucher_signature(payer, amount).await?;
+        gas.call(
+            name,
+            submitter,
+            self.address,
+            ITempoStreamChannel::settleCall {
+                channelId: self.id,
+                cumulativeAmount: amount as u128,
+                signature,
+            },
+        )
+        .await
+    }
+
+    async fn settle_unrecorded(
+        &self,
+        submitter: &mut TempoTxSender<P>,
+        payer: &PrivateKeySigner,
+        amount: u64,
+    ) -> eyre::Result<Receipt> {
+        let signature = self.voucher_signature(payer, amount).await?;
+        submitter
+            .send_call(
+                self.address,
+                ITempoStreamChannel::settleCall {
+                    channelId: self.id,
+                    cumulativeAmount: amount as u128,
+                    signature,
+                },
+            )
+            .await
+    }
+
+    async fn close(
+        &self,
+        gas: &mut GasSnapshot,
+        name: impl Into<String>,
+        submitter: &mut TempoTxSender<P>,
+        payer: &PrivateKeySigner,
+        amount: u64,
+    ) -> eyre::Result<Receipt> {
+        let signature = self.voucher_signature(payer, amount).await?;
+        gas.call(
+            name,
+            submitter,
+            self.address,
+            ITempoStreamChannel::closeCall {
+                channelId: self.id,
+                cumulativeAmount: amount as u128,
+                signature,
+            },
+        )
+        .await
+    }
+
+    async fn request_close(
+        &self,
+        gas: &mut GasSnapshot,
+        name: impl Into<String>,
+        sender: &mut TempoTxSender<P>,
+    ) -> eyre::Result<Receipt> {
+        gas.call(
+            name,
+            sender,
+            self.address,
+            ITempoStreamChannel::requestCloseCall { channelId: self.id },
+        )
+        .await
+    }
+
+    async fn voucher_signature(
+        &self,
+        payer: &PrivateKeySigner,
+        amount: u64,
+    ) -> eyre::Result<Bytes> {
+        let digest = self
+            .contract
+            .getVoucherDigest(self.id, amount as u128)
+            .call()
+            .await?;
+        Ok(Bytes::copy_from_slice(
+            &payer.sign_hash_sync(&digest)?.as_bytes(),
+        ))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_legacy_stream_channel_contract_gas_snapshots() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let http_url = setup.http_url;
+
+    let mut funder = TempoTxSender::connect(http_url.clone(), test_signer(0)?).await?;
+    let mut payer =
+        TempoTxSender::connect_with_zero_nonce(http_url.clone(), fixed_signer(0x11)).await?;
+    let mut payee =
+        TempoTxSender::connect_with_zero_nonce(http_url.clone(), fixed_signer(0x12)).await?;
+    let mut new_payee =
+        TempoTxSender::connect_with_zero_nonce(http_url, fixed_signer(0x13)).await?;
+    let legacy_contract = deploy_legacy_stream_channel(&mut funder).await?;
+
+    funder
+        .fund_tip20(
+            PATH_USD_ADDRESS,
+            [payer.address(), payee.address(), new_payee.address()],
+            U256::from(FUNDING),
+        )
+        .await?;
+
+    let mut gas = GasSnapshot::new();
+
+    let first = ChannelEnv::open(legacy_contract, &mut payer, payee.address(), 1).await?;
+    gas.record("open_new_channel_first_reserve_balance", first.gas_used());
+
+    let second = ChannelEnv::open(legacy_contract, &mut payer, payee.address(), 2).await?;
+    gas.record(
+        "open_new_channel_existing_reserve_balance",
+        second.gas_used(),
+    );
+
+    second
+        .top_up(&mut gas, "top_up_existing_channel", &mut payer, 250_000)
+        .await?;
+
+    second
+        .settle(
+            &mut gas,
+            "settle_existing_channel_existing_payee_balance",
+            &mut payee,
+            &payer.signer,
+            400_000,
+        )
+        .await?;
+
+    let settle_new_payee =
+        ChannelEnv::open(legacy_contract, &mut payer, new_payee.address(), 3).await?;
+    settle_new_payee
+        .settle(
+            &mut gas,
+            "settle_existing_channel_new_payee_balance",
+            &mut new_payee,
+            &payer.signer,
+            300_000,
+        )
+        .await?;
+
+    let close_only = ChannelEnv::open(legacy_contract, &mut payer, payee.address(), 4).await?;
+    close_only
+        .close(
+            &mut gas,
+            "close_existing_channel_no_prior_settlement",
+            &mut payee,
+            &payer.signer,
+            700_000,
+        )
+        .await?;
+
+    let close_after_settle =
+        ChannelEnv::open(legacy_contract, &mut payer, payee.address(), 5).await?;
+    close_after_settle
+        .settle_unrecorded(&mut payee, &payer.signer, 250_000)
+        .await?;
+    close_after_settle
+        .close(
+            &mut gas,
+            "close_existing_channel_after_settlement",
+            &mut payee,
+            &payer.signer,
+            650_000,
+        )
+        .await?;
+
+    let request_close_channel =
+        ChannelEnv::open(legacy_contract, &mut payer, payee.address(), 6).await?;
+    request_close_channel
+        .request_close(&mut gas, "request_close_existing_channel", &mut payer)
+        .await?;
+
+    request_close_channel
+        .top_up(
+            &mut gas,
+            "top_up_existing_channel_cancel_close_request",
+            &mut payer,
+            100_000,
+        )
+        .await?;
+
+    print_gas_snapshot("Legacy TempoStreamChannel gas snapshot", &gas);
+
+    insta::assert_yaml_snapshot!(gas);
+
+    Ok(())
+}
+
+async fn deploy_legacy_stream_channel<P: Provider + Clone>(
+    sender: &mut TempoTxSender<P>,
+) -> eyre::Result<Address> {
+    let init_code = compile_legacy_stream_channel()?;
+    let createx = CreateX::new(CREATEX_ADDRESS, &sender.provider);
+
+    let deployed_address = createx
+        .deployCreate(init_code.clone())
+        .gas_price(TEMPO_T1_BASE_FEE as u128)
+        .gas(GAS_LIMIT)
+        .call()
+        .await?
+        .0;
+
+    let receipt = createx
+        .deployCreate(init_code)
+        .nonce(sender.nonce)
+        .gas_price(TEMPO_T1_BASE_FEE as u128)
+        .gas(GAS_LIMIT)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(receipt.status(), "legacy stream channel deploy failed");
+    sender.nonce += 1;
+
+    Ok(deployed_address.into())
+}
+
+fn compile_legacy_stream_channel() -> eyre::Result<Bytes> {
+    let root = std::env::temp_dir().join(format!(
+        "tempo-legacy-stream-channel-{}",
+        std::process::id()
+    ));
+    if root.exists() {
+        fs::remove_dir_all(&root)?;
+    }
+    fs::create_dir_all(root.join("src"))?;
+
+    let tempo_std = fs::canonicalize(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tips/verify/lib/tempo-std"),
+    )?;
+    eyre::ensure!(
+        tempo_std
+            .join("src/interfaces/ITempoStreamChannel.sol")
+            .exists(),
+        "tempo-std submodule is missing; run `git submodule update --init tips/verify/lib/tempo-std`"
+    );
+
+    write_file(
+        root.join("src/LegacyTempoStreamChannel.sol"),
+        LEGACY_STREAM_CHANNEL_SOURCE,
+    )?;
+    write_file(
+        root.join("foundry.toml"),
+        &format!(
+            r#"[profile.default]
+src = "{}/src"
+out = "{}/out"
+remappings = ["tempo-std/={}/src/"]
+via_ir = true
+optimizer = true
+evm_version = "cancun"
+"#,
+            root.display(),
+            root.display(),
+            tempo_std.display()
+        ),
+    )?;
+
+    let output = Command::new("forge")
+        .arg("build")
+        .arg("--config-path")
+        .arg(root.join("foundry.toml"))
+        .arg(root.join("src/LegacyTempoStreamChannel.sol"))
+        .output()?;
+    eyre::ensure!(
+        output.status.success(),
+        "forge build failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let artifact = fs::read_to_string(
+        root.join("out/LegacyTempoStreamChannel.sol/LegacyTempoStreamChannel.json"),
+    )?;
+    let artifact: serde_json::Value = serde_json::from_str(&artifact)?;
+    let bytecode = artifact["bytecode"]["object"]
+        .as_str()
+        .ok_or_else(|| eyre::eyre!("legacy stream channel artifact missing bytecode"))?;
+    Ok(Bytes::from(hex::decode(bytecode.trim_start_matches("0x"))?))
+}
+
+fn write_file(path: impl AsRef<Path>, contents: &str) -> eyre::Result<()> {
+    Ok(fs::write(path, contents)?)
+}

--- a/crates/node/tests/it/gas/legacy_stream_channel_contract.rs
+++ b/crates/node/tests/it/gas/legacy_stream_channel_contract.rs
@@ -20,6 +20,78 @@ const DEPOSIT: u64 = 1_000_000;
 const FUNDING: u64 = 20_000_000;
 const LEGACY_STREAM_CHANNEL_SOURCE: &str =
     include_str!("../../../../../tips/verify/src/LegacyTempoStreamChannel.sol");
+const ITIP20_SOURCE: &str = r#"// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface ITIP20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+}
+"#;
+const I_TEMPO_STREAM_CHANNEL_SOURCE: &str = r#"// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface ITempoStreamChannel {
+    struct Channel {
+        bool finalized;
+        uint64 closeRequestedAt;
+        address payer;
+        address payee;
+        address token;
+        address authorizedSigner;
+        uint128 deposit;
+        uint128 settled;
+    }
+
+    error AmountExceedsDeposit();
+    error AmountNotIncreasing();
+    error ChannelAlreadyExists();
+    error ChannelFinalized();
+    error ChannelNotFound();
+    error CloseNotReady();
+    error InvalidSignature();
+    error NotPayee();
+    error NotPayer();
+    error TransferFailed();
+
+    event ChannelOpened(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        address token,
+        address authorizedSigner,
+        bytes32 salt,
+        uint256 deposit
+    );
+    event Settled(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        uint256 cumulativeAmount,
+        uint256 deltaPaid,
+        uint256 newSettled
+    );
+    event TopUp(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        uint256 additionalDeposit,
+        uint256 newDeposit
+    );
+    event CloseRequested(
+        bytes32 indexed channelId, address indexed payer, address indexed payee, uint256 closeGraceEnd
+    );
+    event CloseRequestCancelled(bytes32 indexed channelId, address indexed payer, address indexed payee);
+    event ChannelClosed(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        uint256 settledToPayee,
+        uint256 refundedToPayer
+    );
+    event ChannelExpired(bytes32 indexed channelId, address indexed payer, address indexed payee);
+}
+"#;
 
 sol! {
     #[sol(rpc)]
@@ -374,20 +446,19 @@ fn compile_legacy_stream_channel() -> eyre::Result<Bytes> {
         fs::remove_dir_all(&root)?;
     }
     fs::create_dir_all(root.join("src"))?;
-
-    let tempo_std = fs::canonicalize(
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tips/verify/lib/tempo-std"),
-    )?;
-    eyre::ensure!(
-        tempo_std
-            .join("src/interfaces/ITempoStreamChannel.sol")
-            .exists(),
-        "tempo-std submodule is missing; run `git submodule update --init tips/verify/lib/tempo-std`"
-    );
+    fs::create_dir_all(root.join("tempo-std/src/interfaces"))?;
 
     write_file(
         root.join("src/LegacyTempoStreamChannel.sol"),
         LEGACY_STREAM_CHANNEL_SOURCE,
+    )?;
+    write_file(
+        root.join("tempo-std/src/interfaces/ITIP20.sol"),
+        ITIP20_SOURCE,
+    )?;
+    write_file(
+        root.join("tempo-std/src/interfaces/ITempoStreamChannel.sol"),
+        I_TEMPO_STREAM_CHANNEL_SOURCE,
     )?;
     write_file(
         root.join("foundry.toml"),
@@ -395,14 +466,15 @@ fn compile_legacy_stream_channel() -> eyre::Result<Bytes> {
             r#"[profile.default]
 src = "{}/src"
 out = "{}/out"
-remappings = ["tempo-std/={}/src/"]
+remappings = ["tempo-std/={}/tempo-std/src/"]
 via_ir = true
 optimizer = true
 evm_version = "cancun"
+bytecode_hash = "none"
 "#,
             root.display(),
             root.display(),
-            tempo_std.display()
+            root.display()
         ),
     )?;
 

--- a/crates/node/tests/it/gas/mod.rs
+++ b/crates/node/tests/it/gas/mod.rs
@@ -1,5 +1,6 @@
 mod helpers;
 
+mod legacy_stream_channel_contract;
 mod receive_policy_guard;
 mod stablecoin_dex;
 mod tip1016_storage;

--- a/crates/node/tests/it/gas/snapshots/it__gas__legacy_stream_channel_contract__legacy_stream_channel_contract_gas_snapshots.snap
+++ b/crates/node/tests/it/gas/snapshots/it__gas__legacy_stream_channel_contract__legacy_stream_channel_contract_gas_snapshots.snap
@@ -1,0 +1,14 @@
+---
+source: crates/node/tests/it/gas/legacy_stream_channel_contract.rs
+assertion_line: 408
+expression: gas
+---
+close_existing_channel_after_settlement: 85118
+close_existing_channel_no_prior_settlement: 85118
+open_new_channel_existing_reserve_balance: 1055229
+open_new_channel_first_reserve_balance: 1302429
+request_close_existing_channel: 31752
+settle_existing_channel_existing_payee_balance: 312037
+settle_existing_channel_new_payee_balance: 312037
+top_up_existing_channel: 53724
+top_up_existing_channel_cancel_close_request: 58785

--- a/crates/node/tests/it/gas/snapshots/it__gas__legacy_stream_channel_contract__legacy_stream_channel_contract_gas_snapshots.snap
+++ b/crates/node/tests/it/gas/snapshots/it__gas__legacy_stream_channel_contract__legacy_stream_channel_contract_gas_snapshots.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/node/tests/it/gas/legacy_stream_channel_contract.rs
-assertion_line: 408
 expression: gas
 ---
 close_existing_channel_after_settlement: 85118

--- a/tips/verify/src/LegacyTempoStreamChannel.sol
+++ b/tips/verify/src/LegacyTempoStreamChannel.sol
@@ -1,24 +1,34 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {ITempoStreamChannel} from "tempo-std/interfaces/ITempoStreamChannel.sol";
-import {ITIP20} from "tempo-std/interfaces/ITIP20.sol";
+import { ITIP20 } from "tempo-std/interfaces/ITIP20.sol";
+import { ITempoStreamChannel } from "tempo-std/interfaces/ITempoStreamChannel.sol";
 
 /// @title LegacyTempoStreamChannel
 /// @notice Legacy stream channel contract from the PaymentAuth session draft Appendix B.
 contract LegacyTempoStreamChannel is ITempoStreamChannel {
-    uint64 public constant CLOSE_GRACE_PERIOD = 15 minutes;
-    bytes32 public constant VOUCHER_TYPEHASH = keccak256("Voucher(bytes32 channelId,uint128 cumulativeAmount)");
-    bytes32 public constant CLOSE_REQUEST_TYPEHASH = keccak256("CloseRequest(bytes32 channelId,uint64 requestedAt)");
 
-    bytes32 internal constant _EIP712_DOMAIN_TYPEHASH =
-        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    uint64 public constant CLOSE_GRACE_PERIOD = 15 minutes;
+    bytes32 public constant VOUCHER_TYPEHASH =
+        keccak256("Voucher(bytes32 channelId,uint128 cumulativeAmount)");
+    bytes32 public constant CLOSE_REQUEST_TYPEHASH =
+        keccak256("CloseRequest(bytes32 channelId,uint64 requestedAt)");
+
+    bytes32 internal constant _EIP712_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
     bytes32 internal constant _NAME_HASH = keccak256("TempoStreamChannel");
     bytes32 internal constant _VERSION_HASH = keccak256("1");
 
     mapping(bytes32 => Channel) public channels;
 
-    function open(address payee, address token, uint128 deposit, bytes32 salt, address authorizedSigner)
+    function open(
+        address payee,
+        address token,
+        uint128 deposit,
+        bytes32 salt,
+        address authorizedSigner
+    )
         external
         returns (bytes32 channelId)
     {
@@ -42,7 +52,13 @@ contract LegacyTempoStreamChannel is ITempoStreamChannel {
         emit ChannelOpened(channelId, msg.sender, payee, token, authorizedSigner, salt, deposit);
     }
 
-    function settle(bytes32 channelId, uint128 cumulativeAmount, bytes calldata signature) external {
+    function settle(
+        bytes32 channelId,
+        uint128 cumulativeAmount,
+        bytes calldata signature
+    )
+        external
+    {
         Channel storage channel = _activeChannel(channelId);
         if (msg.sender != channel.payee) revert NotPayee();
         _settle(channelId, channel, cumulativeAmount, signature);
@@ -75,14 +91,19 @@ contract LegacyTempoStreamChannel is ITempoStreamChannel {
         if (msg.sender != channel.payer) revert NotPayer();
         if (channel.closeRequestedAt == 0) {
             channel.closeRequestedAt = uint64(block.timestamp);
-            emit CloseRequested(channelId, channel.payer, channel.payee, block.timestamp + CLOSE_GRACE_PERIOD);
+            emit CloseRequested(
+                channelId, channel.payer, channel.payee, block.timestamp + CLOSE_GRACE_PERIOD
+            );
         }
     }
 
     function withdraw(bytes32 channelId) external {
         Channel storage channel = _activeChannel(channelId);
         if (msg.sender != channel.payer) revert NotPayer();
-        if (channel.closeRequestedAt == 0 || block.timestamp < uint256(channel.closeRequestedAt) + CLOSE_GRACE_PERIOD) {
+        if (
+            channel.closeRequestedAt == 0
+                || block.timestamp < uint256(channel.closeRequestedAt) + CLOSE_GRACE_PERIOD
+        ) {
             revert CloseNotReady();
         }
         _finalize(channelId, channel);
@@ -92,22 +113,41 @@ contract LegacyTempoStreamChannel is ITempoStreamChannel {
         return channels[channelId];
     }
 
-    function getChannelsBatch(bytes32[] calldata channelIds) external view returns (Channel[] memory channelStates) {
+    function getChannelsBatch(bytes32[] calldata channelIds)
+        external
+        view
+        returns (Channel[] memory channelStates)
+    {
         channelStates = new Channel[](channelIds.length);
         for (uint256 i; i < channelIds.length; ++i) {
             channelStates[i] = channels[channelIds[i]];
         }
     }
 
-    function computeChannelId(address payer, address payee, address token, bytes32 salt, address authorizedSigner)
+    function computeChannelId(
+        address payer,
+        address payee,
+        address token,
+        bytes32 salt,
+        address authorizedSigner
+    )
         public
         view
         returns (bytes32)
     {
-        return keccak256(abi.encode(payer, payee, token, salt, authorizedSigner, address(this), block.chainid));
+        return keccak256(
+            abi.encode(payer, payee, token, salt, authorizedSigner, address(this), block.chainid)
+        );
     }
 
-    function getVoucherDigest(bytes32 channelId, uint128 cumulativeAmount) external view returns (bytes32) {
+    function getVoucherDigest(
+        bytes32 channelId,
+        uint128 cumulativeAmount
+    )
+        external
+        view
+        returns (bytes32)
+    {
         return _hashTypedData(keccak256(abi.encode(VOUCHER_TYPEHASH, channelId, cumulativeAmount)));
     }
 
@@ -115,7 +155,12 @@ contract LegacyTempoStreamChannel is ITempoStreamChannel {
         return _domainSeparator();
     }
 
-    function _settle(bytes32 channelId, Channel storage channel, uint128 cumulativeAmount, bytes calldata signature)
+    function _settle(
+        bytes32 channelId,
+        Channel storage channel,
+        uint128 cumulativeAmount,
+        bytes calldata signature
+    )
         internal
     {
         if (cumulativeAmount > channel.deposit) revert AmountExceedsDeposit();
@@ -125,7 +170,9 @@ contract LegacyTempoStreamChannel is ITempoStreamChannel {
         uint128 delta = cumulativeAmount - channel.settled;
         channel.settled = cumulativeAmount;
         if (!ITIP20(channel.token).transfer(channel.payee, delta)) revert TransferFailed();
-        emit Settled(channelId, channel.payer, channel.payee, cumulativeAmount, delta, channel.settled);
+        emit Settled(
+            channelId, channel.payer, channel.payee, cumulativeAmount, delta, channel.settled
+        );
     }
 
     function _finalize(bytes32 channelId, Channel storage channel) internal {
@@ -142,9 +189,14 @@ contract LegacyTempoStreamChannel is ITempoStreamChannel {
         bytes32 channelId,
         uint128 cumulativeAmount,
         bytes calldata signature
-    ) internal view {
-        bytes32 digest = _hashTypedData(keccak256(abi.encode(VOUCHER_TYPEHASH, channelId, cumulativeAmount)));
-        address expectedSigner = channel.authorizedSigner != address(0) ? channel.authorizedSigner : channel.payer;
+    )
+        internal
+        view
+    {
+        bytes32 digest =
+            _hashTypedData(keccak256(abi.encode(VOUCHER_TYPEHASH, channelId, cumulativeAmount)));
+        address expectedSigner =
+            channel.authorizedSigner != address(0) ? channel.authorizedSigner : channel.payer;
         (bytes32 r, bytes32 s, uint8 v) = _splitSignature(signature);
         address signer = ecrecover(digest, v, r, s);
         if (signer != expectedSigner) revert InvalidSignature();
@@ -157,14 +209,22 @@ contract LegacyTempoStreamChannel is ITempoStreamChannel {
     }
 
     function _domainSeparator() internal view returns (bytes32) {
-        return keccak256(abi.encode(_EIP712_DOMAIN_TYPEHASH, _NAME_HASH, _VERSION_HASH, block.chainid, address(this)));
+        return keccak256(
+            abi.encode(
+                _EIP712_DOMAIN_TYPEHASH, _NAME_HASH, _VERSION_HASH, block.chainid, address(this)
+            )
+        );
     }
 
     function _hashTypedData(bytes32 structHash) internal view returns (bytes32) {
         return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
     }
 
-    function _splitSignature(bytes calldata signature) internal pure returns (bytes32 r, bytes32 s, uint8 v) {
+    function _splitSignature(bytes calldata signature)
+        internal
+        pure
+        returns (bytes32 r, bytes32 s, uint8 v)
+    {
         if (signature.length != 65) revert InvalidSignature();
         assembly {
             r := calldataload(signature.offset)
@@ -173,4 +233,5 @@ contract LegacyTempoStreamChannel is ITempoStreamChannel {
         }
         if (v < 27) v += 27;
     }
+
 }

--- a/tips/verify/src/LegacyTempoStreamChannel.sol
+++ b/tips/verify/src/LegacyTempoStreamChannel.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ITempoStreamChannel} from "tempo-std/interfaces/ITempoStreamChannel.sol";
+import {ITIP20} from "tempo-std/interfaces/ITIP20.sol";
+
+/// @title LegacyTempoStreamChannel
+/// @notice Legacy stream channel contract from the PaymentAuth session draft Appendix B.
+contract LegacyTempoStreamChannel is ITempoStreamChannel {
+    uint64 public constant CLOSE_GRACE_PERIOD = 15 minutes;
+    bytes32 public constant VOUCHER_TYPEHASH = keccak256("Voucher(bytes32 channelId,uint128 cumulativeAmount)");
+    bytes32 public constant CLOSE_REQUEST_TYPEHASH = keccak256("CloseRequest(bytes32 channelId,uint64 requestedAt)");
+
+    bytes32 internal constant _EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 internal constant _NAME_HASH = keccak256("TempoStreamChannel");
+    bytes32 internal constant _VERSION_HASH = keccak256("1");
+
+    mapping(bytes32 => Channel) public channels;
+
+    function open(address payee, address token, uint128 deposit, bytes32 salt, address authorizedSigner)
+        external
+        returns (bytes32 channelId)
+    {
+        channelId = computeChannelId(msg.sender, payee, token, salt, authorizedSigner);
+        if (channels[channelId].payer != address(0)) revert ChannelAlreadyExists();
+
+        channels[channelId] = Channel({
+            payer: msg.sender,
+            payee: payee,
+            token: token,
+            authorizedSigner: authorizedSigner,
+            deposit: deposit,
+            settled: 0,
+            closeRequestedAt: 0,
+            finalized: false
+        });
+
+        if (!ITIP20(token).transferFrom(msg.sender, address(this), deposit)) {
+            revert TransferFailed();
+        }
+        emit ChannelOpened(channelId, msg.sender, payee, token, authorizedSigner, salt, deposit);
+    }
+
+    function settle(bytes32 channelId, uint128 cumulativeAmount, bytes calldata signature) external {
+        Channel storage channel = _activeChannel(channelId);
+        if (msg.sender != channel.payee) revert NotPayee();
+        _settle(channelId, channel, cumulativeAmount, signature);
+    }
+
+    function topUp(bytes32 channelId, uint256 additionalDeposit) external {
+        Channel storage channel = _activeChannel(channelId);
+        if (msg.sender != channel.payer) revert NotPayer();
+
+        channel.deposit += uint128(additionalDeposit);
+        if (!ITIP20(channel.token).transferFrom(msg.sender, address(this), additionalDeposit)) {
+            revert TransferFailed();
+        }
+        if (channel.closeRequestedAt != 0) {
+            channel.closeRequestedAt = 0;
+            emit CloseRequestCancelled(channelId, channel.payer, channel.payee);
+        }
+        emit TopUp(channelId, channel.payer, channel.payee, additionalDeposit, channel.deposit);
+    }
+
+    function close(bytes32 channelId, uint128 cumulativeAmount, bytes calldata signature) external {
+        Channel storage channel = _activeChannel(channelId);
+        if (msg.sender != channel.payee) revert NotPayee();
+        _settle(channelId, channel, cumulativeAmount, signature);
+        _finalize(channelId, channel);
+    }
+
+    function requestClose(bytes32 channelId) external {
+        Channel storage channel = _activeChannel(channelId);
+        if (msg.sender != channel.payer) revert NotPayer();
+        if (channel.closeRequestedAt == 0) {
+            channel.closeRequestedAt = uint64(block.timestamp);
+            emit CloseRequested(channelId, channel.payer, channel.payee, block.timestamp + CLOSE_GRACE_PERIOD);
+        }
+    }
+
+    function withdraw(bytes32 channelId) external {
+        Channel storage channel = _activeChannel(channelId);
+        if (msg.sender != channel.payer) revert NotPayer();
+        if (channel.closeRequestedAt == 0 || block.timestamp < uint256(channel.closeRequestedAt) + CLOSE_GRACE_PERIOD) {
+            revert CloseNotReady();
+        }
+        _finalize(channelId, channel);
+    }
+
+    function getChannel(bytes32 channelId) external view returns (Channel memory) {
+        return channels[channelId];
+    }
+
+    function getChannelsBatch(bytes32[] calldata channelIds) external view returns (Channel[] memory channelStates) {
+        channelStates = new Channel[](channelIds.length);
+        for (uint256 i; i < channelIds.length; ++i) {
+            channelStates[i] = channels[channelIds[i]];
+        }
+    }
+
+    function computeChannelId(address payer, address payee, address token, bytes32 salt, address authorizedSigner)
+        public
+        view
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(payer, payee, token, salt, authorizedSigner, address(this), block.chainid));
+    }
+
+    function getVoucherDigest(bytes32 channelId, uint128 cumulativeAmount) external view returns (bytes32) {
+        return _hashTypedData(keccak256(abi.encode(VOUCHER_TYPEHASH, channelId, cumulativeAmount)));
+    }
+
+    function domainSeparator() external view returns (bytes32) {
+        return _domainSeparator();
+    }
+
+    function _settle(bytes32 channelId, Channel storage channel, uint128 cumulativeAmount, bytes calldata signature)
+        internal
+    {
+        if (cumulativeAmount > channel.deposit) revert AmountExceedsDeposit();
+        if (cumulativeAmount <= channel.settled) revert AmountNotIncreasing();
+        _validateVoucher(channel, channelId, cumulativeAmount, signature);
+
+        uint128 delta = cumulativeAmount - channel.settled;
+        channel.settled = cumulativeAmount;
+        if (!ITIP20(channel.token).transfer(channel.payee, delta)) revert TransferFailed();
+        emit Settled(channelId, channel.payer, channel.payee, cumulativeAmount, delta, channel.settled);
+    }
+
+    function _finalize(bytes32 channelId, Channel storage channel) internal {
+        uint128 refund = channel.deposit - channel.settled;
+        channel.finalized = true;
+        if (refund > 0 && !ITIP20(channel.token).transfer(channel.payer, refund)) {
+            revert TransferFailed();
+        }
+        emit ChannelClosed(channelId, channel.payer, channel.payee, channel.settled, refund);
+    }
+
+    function _validateVoucher(
+        Channel storage channel,
+        bytes32 channelId,
+        uint128 cumulativeAmount,
+        bytes calldata signature
+    ) internal view {
+        bytes32 digest = _hashTypedData(keccak256(abi.encode(VOUCHER_TYPEHASH, channelId, cumulativeAmount)));
+        address expectedSigner = channel.authorizedSigner != address(0) ? channel.authorizedSigner : channel.payer;
+        (bytes32 r, bytes32 s, uint8 v) = _splitSignature(signature);
+        address signer = ecrecover(digest, v, r, s);
+        if (signer != expectedSigner) revert InvalidSignature();
+    }
+
+    function _activeChannel(bytes32 channelId) internal view returns (Channel storage channel) {
+        channel = channels[channelId];
+        if (channel.payer == address(0)) revert ChannelNotFound();
+        if (channel.finalized) revert ChannelFinalized();
+    }
+
+    function _domainSeparator() internal view returns (bytes32) {
+        return keccak256(abi.encode(_EIP712_DOMAIN_TYPEHASH, _NAME_HASH, _VERSION_HASH, block.chainid, address(this)));
+    }
+
+    function _hashTypedData(bytes32 structHash) internal view returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
+    }
+
+    function _splitSignature(bytes calldata signature) internal pure returns (bytes32 r, bytes32 s, uint8 v) {
+        if (signature.length != 65) revert InvalidSignature();
+        assembly {
+            r := calldataload(signature.offset)
+            s := calldataload(add(signature.offset, 32))
+            v := byte(0, calldataload(add(signature.offset, 64)))
+        }
+        if (v < 27) v += 27;
+    }
+}


### PR DESCRIPTION
## Summary
- add `LegacyTempoStreamChannel.sol` under `tips/verify/src`, importing `ITempoStreamChannel` and `ITIP20` from `tempo-std`
- add `legacy_stream_channel_contract` gas coverage and matching `legacy_stream_channel_contract` snapshot names
- benchmark analogous open/topUp/settle/close/requestClose flows using the legacy `bytes32 channelId`/`uint128` ABI

Prompted by: @0xrusowsky

## Notes
- Appendix B has no operator field or capture amount, so the legacy benchmark omits operator settlement and uses close-at-cumulative semantics.
- The integration test compiles against `tips/verify/lib/tempo-std`; initialize that submodule before running it in a fresh checkout.

## Test
- git submodule update --init tips/verify/lib/tempo-std
- cargo test -p tempo-node --test it gas::legacy_stream_channel_contract::test_legacy_stream_channel_contract_gas_snapshots -- --nocapture
- cargo fmt --check