### PR TITLE
perf(precompiles): remove handler cache

### DIFF
--- a/crates/precompiles/src/storage/types/array.rs
+++ b/crates/precompiles/src/storage/types/array.rs
@@ -19,7 +19,7 @@ use crate::{
     error::Result,
     storage::{
         Handler, LayoutCtx, Storable, StorableType, packing,
-        types::{HandlerCache, Slot},
+        types::{HandlerArena, Slot},
     },
 };
 
@@ -59,7 +59,7 @@ tempo_precompiles_macros::storable_nested_arrays!();
 pub struct ArrayHandler<T: StorableType, const N: usize> {
     base_slot: U256,
     address: Address,
-    cache: HandlerCache<usize, T::Handler>,
+    handlers: HandlerArena<T::Handler>,
 }
 
 impl<T: StorableType, const N: usize> ArrayHandler<T, N> {
@@ -69,7 +69,7 @@ impl<T: StorableType, const N: usize> ArrayHandler<T, N> {
         Self {
             base_slot,
             address,
-            cache: HandlerCache::new(),
+            handlers: HandlerArena::new(),
         }
     }
 
@@ -103,7 +103,7 @@ impl<T: StorableType, const N: usize> ArrayHandler<T, N> {
     /// Returns a `Handler` for the element at the given index.
     ///
     /// The returned handler automatically handles packing based on `T::BYTES`.
-    /// The handler is computed on first access and cached for subsequent accesses.
+    /// The handler is computed on every access.
     ///
     /// Returns `None` if the index is out of bounds (>= N).
     #[inline]
@@ -113,8 +113,8 @@ impl<T: StorableType, const N: usize> ArrayHandler<T, N> {
         }
         let (base_slot, address) = (self.base_slot, self.address);
         Some(
-            self.cache
-                .get_or_insert(&index, || Self::compute_handler(base_slot, address, index)),
+            self.handlers
+                .insert(Self::compute_handler(base_slot, address, index)),
         )
     }
 
@@ -139,28 +139,28 @@ impl<T: StorableType, const N: usize> ArrayHandler<T, N> {
 impl<T: StorableType, const N: usize> Index<usize> for ArrayHandler<T, N> {
     type Output = T::Handler;
 
-    /// Returns a reference to the cached handler for the given index.
+    /// Returns a reference to a computed handler for the given index.
     ///
     /// **WARNING:** Panics if OOB. Caller must ensure that the index is valid.
     /// For gracefully checked access use `.at(index)` instead.
     fn index(&self, index: usize) -> &Self::Output {
         assert!(index < N, "index out of bounds: {index} >= {N}");
         let (base_slot, address) = (self.base_slot, self.address);
-        self.cache
-            .get_or_insert(&index, || Self::compute_handler(base_slot, address, index))
+        self.handlers
+            .insert(Self::compute_handler(base_slot, address, index))
     }
 }
 
 impl<T: StorableType, const N: usize> IndexMut<usize> for ArrayHandler<T, N> {
-    /// Returns a mutable reference to the cached handler for the given index.
+    /// Returns a mutable reference to a computed handler for the given index.
     ///
     /// **WARNING:** Panics if OOB. Caller must ensure that the index is valid.
     /// For gracefully checked access use `.at(index)` instead.
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         assert!(index < N, "index out of bounds: {index} >= {N}");
         let (base_slot, address) = (self.base_slot, self.address);
-        self.cache
-            .get_or_insert_mut(&index, || Self::compute_handler(base_slot, address, index))
+        self.handlers
+            .insert_mut(Self::compute_handler(base_slot, address, index))
     }
 }
 

--- a/crates/precompiles/src/storage/types/mapping.rs
+++ b/crates/precompiles/src/storage/types/mapping.rs
@@ -3,10 +3,11 @@
 use alloy::primitives::{Address, U256};
 use std::{
     hash::Hash,
+    marker::PhantomData,
     ops::{Index, IndexMut},
 };
 
-use crate::storage::{Layout, LayoutCtx, StorableType, StorageKey, types::HandlerCache};
+use crate::storage::{Layout, LayoutCtx, StorableType, StorageKey, types::HandlerArena};
 
 /// Type-safe access wrapper for EVM storage mappings (hash-based key-value storage).
 ///
@@ -44,7 +45,8 @@ use crate::storage::{Layout, LayoutCtx, StorableType, StorageKey, types::Handler
 pub struct Mapping<K, V: StorableType> {
     base_slot: U256,
     address: Address,
-    cache: HandlerCache<K, V::Handler>,
+    handlers: HandlerArena<V::Handler>,
+    _key: PhantomData<K>,
 }
 
 impl<K, V: StorableType> Mapping<K, V> {
@@ -56,7 +58,8 @@ impl<K, V: StorableType> Mapping<K, V> {
         Self {
             base_slot,
             address,
-            cache: HandlerCache::new(),
+            handlers: HandlerArena::new(),
+            _key: PhantomData,
         }
     }
 
@@ -72,32 +75,34 @@ impl<K, V: StorableType> Mapping<K, V> {
     /// where the mapping slot computation happens once, and the resulting slot
     /// can be used for multiple operations.
     ///
-    /// The handler is computed on first access and cached for subsequent accesses.
-    /// Takes a reference to avoid cloning on cache hits.
+    /// The handler is computed on every access.
     pub fn at(&self, key: &K) -> &V::Handler
     where
         K: StorageKey + Hash + Eq + Clone,
     {
         let (base_slot, address) = (self.base_slot, self.address);
-        self.cache.get_or_insert(key, || {
-            V::handle(key.mapping_slot(base_slot), LayoutCtx::FULL, address)
-        })
+        self.handlers.insert(V::handle(
+            key.mapping_slot(base_slot),
+            LayoutCtx::FULL,
+            address,
+        ))
     }
 
     /// Returns a mutable `Handler` for the given key.
     ///
     /// Use this when you need to call mutable methods like `write()` or `delete()`.
     ///
-    /// The handler is computed on first access and cached for subsequent accesses.
-    /// Takes a reference to avoid cloning on cache hits.
+    /// The handler is computed on every access.
     pub fn at_mut(&mut self, key: &K) -> &mut V::Handler
     where
         K: StorageKey + Hash + Eq + Clone,
     {
         let (base_slot, address) = (self.base_slot, self.address);
-        self.cache.get_or_insert_mut(key, || {
-            V::handle(key.mapping_slot(base_slot), LayoutCtx::FULL, address)
-        })
+        self.handlers.insert_mut(V::handle(
+            key.mapping_slot(base_slot),
+            LayoutCtx::FULL,
+            address,
+        ))
     }
 }
 
@@ -113,14 +118,16 @@ where
 {
     type Output = V::Handler;
 
-    /// Returns a reference to the cached handler for the given key.
+    /// Returns a reference to a computed handler for the given key.
     ///
-    /// The handler is computed on first access and cached for subsequent accesses.
+    /// The handler is computed on every access.
     fn index(&self, key: K) -> &Self::Output {
         let (base_slot, address) = (self.base_slot, self.address);
-        self.cache.get_or_insert(&key, || {
-            V::handle(key.mapping_slot(base_slot), LayoutCtx::FULL, address)
-        })
+        self.handlers.insert(V::handle(
+            key.mapping_slot(base_slot),
+            LayoutCtx::FULL,
+            address,
+        ))
     }
 }
 
@@ -128,12 +135,14 @@ impl<K, V: StorableType> IndexMut<K> for Mapping<K, V>
 where
     K: StorageKey + Hash + Eq + Clone,
 {
-    /// Returns a mutable reference to the cached handler for the given key.
+    /// Returns a mutable reference to a computed handler for the given key.
     fn index_mut(&mut self, key: K) -> &mut Self::Output {
         let (base_slot, address) = (self.base_slot, self.address);
-        self.cache.get_or_insert_mut(&key, || {
-            V::handle(key.mapping_slot(base_slot), LayoutCtx::FULL, address)
-        })
+        self.handlers.insert_mut(V::handle(
+            key.mapping_slot(base_slot),
+            LayoutCtx::FULL,
+            address,
+        ))
     }
 }
 

--- a/crates/precompiles/src/storage/types/mod.rs
+++ b/crates/precompiles/src/storage/types/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     storage::{StorageOps, packing},
 };
 use alloy::primitives::{Address, U256, keccak256};
-use std::{cell::RefCell, collections::HashMap, hash::Hash};
+use std::cell::RefCell;
 
 /// Describes how a type is laid out in EVM storage.
 ///
@@ -369,61 +369,54 @@ pub trait StorageKey: sealed::OnlyPrimitives {
     }
 }
 
-/// Cache for computed handlers with stable references.
+/// Arena for computed handlers with stable references.
 ///
-/// Enables `Index` implementations on handlers by storing child handlers and
-/// returning references that remain valid across insertions.
+/// Enables `Index` implementations on handlers by storing returned handlers and
+/// returning references that remain valid across insertions. It does not perform
+/// key-based reuse; every access inserts a freshly computed handler.
 ///
 /// Uses `RefCell` for interior mutability with runtime borrow checking.
 /// Re-entrant access will panic rather than cause undefined behavior.
 #[derive(Debug, Default)]
-pub(super) struct HandlerCache<K, H> {
-    inner: RefCell<HashMap<K, Box<H>>>,
+pub(super) struct HandlerArena<H> {
+    inner: RefCell<Vec<Box<H>>>,
 }
 
-impl<K, H> HandlerCache<K, H> {
-    /// Creates a new empty handler cache.
+impl<H> HandlerArena<H> {
+    /// Creates a new empty handler arena.
     #[inline]
     pub(super) fn new() -> Self {
         Self {
-            inner: RefCell::new(HashMap::new()),
+            inner: RefCell::new(Vec::new()),
         }
     }
 }
 
-impl<K, H> Clone for HandlerCache<K, H> {
-    /// Creates a new empty cache (cached handlers are not cloned).
+impl<H> Clone for HandlerArena<H> {
+    /// Creates a new empty arena (stored handlers are not cloned).
     fn clone(&self) -> Self {
         Self::new()
     }
 }
 
-impl<K: Hash + Eq + Clone, H> HandlerCache<K, H> {
-    /// Returns a reference to a lazily initialized handler for the given key.
+impl<H> HandlerArena<H> {
+    /// Stores a computed handler and returns a stable reference to it.
     #[inline]
-    pub(super) fn get_or_insert(&self, key: &K, f: impl FnOnce() -> H) -> &H {
-        let mut cache = self.inner.borrow_mut();
-        // Lookup first to avoid cloning on cache hit
-        if let Some(boxed) = cache.get(key) {
-            // SAFETY: Box provides stable heap address. Cache is append-only.
-            return unsafe { &*(boxed.as_ref() as *const H) };
-        }
-        let boxed = cache.entry(key.clone()).or_insert_with(|| Box::new(f()));
-        // SAFETY: Box provides stable heap address. Cache is append-only.
+    pub(super) fn insert(&self, handler: H) -> &H {
+        let mut handlers = self.inner.borrow_mut();
+        handlers.push(Box::new(handler));
+        let boxed = handlers.last().expect("just inserted");
+        // SAFETY: Box provides stable heap address. Arena is append-only.
         unsafe { &*(boxed.as_ref() as *const H) }
     }
 
-    /// Returns a mutable reference to a lazily initialized handler for the given key.
+    /// Stores a computed handler and returns a stable mutable reference to it.
     #[inline]
-    pub(super) fn get_or_insert_mut(&mut self, key: &K, f: impl FnOnce() -> H) -> &mut H {
-        let mut cache = self.inner.borrow_mut();
-        // Lookup first to avoid cloning on cache hit
-        if let Some(boxed) = cache.get_mut(key) {
-            // SAFETY: Box provides stable heap address. Cache is append-only. `&mut self` ensures exclusive access.
-            return unsafe { &mut *(boxed.as_mut() as *mut H) };
-        }
-        let boxed = cache.entry(key.clone()).or_insert_with(|| Box::new(f()));
-        // SAFETY: Box provides stable heap address. Cache is append-only. `&mut self` ensures exclusive access.
+    pub(super) fn insert_mut(&mut self, handler: H) -> &mut H {
+        let mut handlers = self.inner.borrow_mut();
+        handlers.push(Box::new(handler));
+        let boxed = handlers.last_mut().expect("just inserted");
+        // SAFETY: Box provides stable heap address. Arena is append-only. `&mut self` ensures exclusive access.
         unsafe { &mut *(boxed.as_mut() as *mut H) }
     }
 }

--- a/crates/precompiles/src/storage/types/vec.rs
+++ b/crates/precompiles/src/storage/types/vec.rs
@@ -19,7 +19,7 @@ use crate::{
     storage::{
         Handler, Layout, LayoutCtx, Storable, StorableType, StorageCtx, StorageOps,
         packing::{PackedSlot, calc_element_loc, calc_packed_slot_count},
-        types::{HandlerCache, Slot},
+        types::{HandlerArena, Slot},
     },
 };
 
@@ -143,7 +143,7 @@ where
 pub struct VecHandler<T: Storable> {
     len_slot: U256,
     address: Address,
-    cache: HandlerCache<usize, T::Handler>,
+    handlers: HandlerArena<T::Handler>,
 }
 
 impl<T> Handler<Vec<T>> for VecHandler<T>
@@ -197,7 +197,7 @@ where
         Self {
             len_slot,
             address,
-            cache: HandlerCache::new(),
+            handlers: HandlerArena::new(),
         }
     }
 
@@ -263,7 +263,7 @@ where
 
     /// Returns a `Handler` for the element at the given index with bounds checking.
     ///
-    /// The handler is computed on first access and cached for subsequent accesses.
+    /// The handler is computed on every access.
     ///
     /// # Returns
     /// - If the SLOAD to read the length fails, returns an error.
@@ -275,9 +275,10 @@ where
         }
 
         let (data_start, address) = (self.data_slot(), self.address);
-        Ok(Some(self.cache.get_or_insert(&index, || {
-            Self::compute_handler(data_start, address, index)
-        })))
+        Ok(Some(
+            self.handlers
+                .insert(Self::compute_handler(data_start, address, index)),
+        ))
     }
 
     /// Pushes a new element to the end of the vector.
@@ -352,14 +353,14 @@ where
 {
     type Output = T::Handler;
 
-    /// Returns a reference to the cached handler for the given index (unchecked).
+    /// Returns a reference to a computed handler for the given index (unchecked).
     ///
     /// **WARNING:** Does not check bounds. Caller must ensure that the index is valid.
     /// For checked access use `.at(index)` instead.
     fn index(&self, index: usize) -> &Self::Output {
         let (data_start, address) = (self.data_slot(), self.address);
-        self.cache
-            .get_or_insert(&index, || Self::compute_handler(data_start, address, index))
+        self.handlers
+            .insert(Self::compute_handler(data_start, address, index))
     }
 }
 
@@ -367,14 +368,14 @@ impl<T> IndexMut<usize> for VecHandler<T>
 where
     T: Storable,
 {
-    /// Returns a mutable reference to the cached handler for the given index (unchecked).
+    /// Returns a mutable reference to a computed handler for the given index (unchecked).
     ///
     /// **WARNING:** Does not check bounds. Caller must ensure that the index is valid.
     /// For checked access use `.at(index)` instead.
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         let (data_start, address) = (self.data_slot(), self.address);
-        self.cache
-            .get_or_insert_mut(&index, || Self::compute_handler(data_start, address, index))
+        self.handlers
+            .insert_mut(Self::compute_handler(data_start, address, index))
     }
 }
 


### PR DESCRIPTION
## Summary
- remove keyed `HandlerCache` reuse from mapping, array, and vec handlers
- add a non-keyed append-only `HandlerArena` so existing reference-returning `Index` APIs remain stable
- recompute child handlers on every access for comparison against the cached variants

## Testing
- `cargo fmt --check`
- `cargo test -p tempo-precompiles --features test-utils storage::types`