### PR TITLE
ci(bench): update Slack user mapping

### DIFF
--- a/.github/scripts/bench-slack-users.json
+++ b/.github/scripts/bench-slack-users.json
@@ -22,7 +22,7 @@
   "zerosnacks": "U09FARPMN74",
   "samczsun": "U096R14E4H3",
   "laibe": "U09FARE0B9Q",
-  "0xrusowsky": "U09LQG6KXRD",
+  "0xrusowsky": "U09FFDPBZ52",
   "howydev": "U09FB21B7FP",
   "decofe": "U09FATLPC30",
   "Zygimantass": "U09FQNBAG11"


### PR DESCRIPTION
Updates the bench Slack user mapping for `0xrusowsky` to ping `U09FFDPBZ52` instead of `U09LQG6KXRD`.

Validation:
- `jq empty .github/scripts/bench-slack-users.json`

Prompted by: @shekhirin