### PR TITLE
docs: clarify elastic proposal budget model

### DIFF
--- a/crates/commonware-node/src/args.rs
+++ b/crates/commonware-node/src/args.rs
@@ -106,7 +106,10 @@ pub struct Args {
     #[arg(long = "consensus.wait-for-notarizations", default_value = "2s")]
     pub wait_for_notarizations: PositiveDuration,
 
-    /// Target wall-clock time between blocks.
+    /// Target wall-clock time between blocks in healthy network conditions.
+    ///
+    /// Local proposal work is paced against this value minus
+    /// `--consensus.network-budget`.
     #[arg(long = "consensus.target-block-time", default_value = "550ms")]
     pub target_block_time: PositiveDuration,
 
@@ -135,6 +138,9 @@ pub struct Args {
     pub inactive_views_until_leader_skip: u64,
 
     /// Time reserved for proposal propagation before the target block boundary.
+    ///
+    /// The remaining `target-block-time - network-budget` is the local proposal
+    /// return budget used by consensus and the payload builder.
     #[arg(long = "consensus.network-budget", default_value = "50ms")]
     pub network_budget: PositiveDuration,
 

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -214,6 +214,7 @@ where
 struct Inner<TState> {
     public_key: PublicKey,
     epoch_strategy: FixedEpocher,
+    // Local proposal window after reserving network propagation time.
     proposal_return_budget: Duration,
 
     my_mailbox: Mailbox,
@@ -675,6 +676,9 @@ impl Inner<Init> {
         let parent_hash = parent.block_hash();
         let proposer_public_key = crate::utils::public_key_to_b256(&self.public_key);
         let marshal_persist = marshal_persist_estimate();
+        // Give the builder only the proposal window that remains when payload
+        // construction is requested. This accounts for a late `handle_propose`
+        // start instead of resetting the budget at builder entry.
         let build_budget = self
             .proposal_return_budget
             .saturating_sub(propose_start.elapsed());
@@ -734,8 +738,9 @@ impl Inner<Init> {
         let block_size_bytes = payload.rlp_block_size_bytes();
         let validator_marshal_persist = marshal_persist.estimate(block_size_bytes);
         let proposal_elapsed = propose_start.elapsed();
-        // Pace proposal return from the original propose start, leaving enough
-        // budget for validators to replay the payload and persist the block.
+        // Pace proposal return from the original propose start. Validators still
+        // need to repeat replayable build work and marshal persistence, so leave
+        // room for those costs before returning the proposal.
         let return_delay = self
             .proposal_return_budget
             .saturating_sub(proposal_elapsed)

--- a/crates/commonware-node/src/consensus/application/mod.rs
+++ b/crates/commonware-node/src/consensus/application/mod.rs
@@ -58,6 +58,10 @@ pub(super) struct Config<TContext> {
     pub(crate) subblocks: Option<subblocks::Mailbox>,
 
     /// Local proposal return budget, excluding the network propagation allowance.
+    ///
+    /// Starts at `target_block_time - network_budget`; `handle_propose`
+    /// subtracts time already spent in the view before handing the remaining
+    /// budget to the payload builder.
     pub(super) proposal_return_budget: Duration,
 
     /// The epoch strategy used by tempo, to map block heights to epochs.

--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -73,8 +73,8 @@ pub struct Builder<TBlocker, TPeerManager> {
     pub views_until_leader_skip: u64,
     /// Local proposal return budget after reserving network propagation time.
     ///
-    /// The leader uses this window for payload building, local persistence, and
-    /// any final wait before returning the proposal.
+    /// The leader uses this window for payload building, local marshal
+    /// persistence, and any final wait before returning the proposal.
     pub proposal_return_budget: Duration,
     pub time_to_build_subblock: Duration,
     pub subblock_broadcast_interval: Duration,

--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -62,12 +62,19 @@ pub struct Builder<TBlocker, TPeerManager> {
     pub mailbox_size: usize,
     pub deque_size: usize,
 
+    /// Maximum time to wait for the leader's proposal before timing out a view.
+    ///
+    /// This is a liveness timeout, not the normal block pacing target.
     pub time_to_propose: Duration,
     pub time_to_collect_notarizations: Duration,
     pub time_to_retry_nullify_broadcast: Duration,
     pub time_for_peer_response: Duration,
     pub views_to_track: u64,
     pub views_until_leader_skip: u64,
+    /// Local proposal return budget after reserving network propagation time.
+    ///
+    /// The leader uses this window for payload building, local persistence, and
+    /// any final wait before returning the proposal.
     pub proposal_return_budget: Duration,
     pub time_to_build_subblock: Duration,
     pub subblock_broadcast_interval: Duration,

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -98,6 +98,9 @@ pub async fn run_consensus_stack(
     let subblocks = network.register(SUBBLOCKS_CHANNEL_IDENT, SUBBLOCKS_LIMIT, message_backlog);
 
     let target_block_time = config.target_block_time.into_duration();
+    // Consensus owns the end-to-end local proposal window. The network budget
+    // is reserved for propagation, and the remaining time is passed down to
+    // proposal handling and local payload building.
     let proposal_return_budget =
         target_block_time.saturating_sub(config.network_budget.into_duration());
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -75,7 +75,7 @@ pub struct TempoNodeArgs {
     /// at transaction cutoff.
     ///
     /// The builder updates this at runtime. Higher values stop pool transaction
-    /// execution earlier to leave more room for builder finish work.
+    /// execution earlier to leave more room for `builder_finish`.
     #[arg(
         long = "builder.build-time-multiplier",
         default_value_t = DEFAULT_BUILD_TIME_MULTIPLIER

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -71,7 +71,11 @@ pub struct TempoNodeArgs {
     #[arg(long = "builder.enable-prewarming", default_value_t = true)]
     pub builder_enable_prewarming: bool,
 
-    /// Initial multiplier for predicting replayable payload build work.
+    /// Initial estimate of total replayable payload build work divided by work
+    /// at transaction cutoff.
+    ///
+    /// The builder updates this at runtime. Higher values stop pool transaction
+    /// execution earlier to leave more room for builder finish work.
     #[arg(
         long = "builder.build-time-multiplier",
         default_value_t = DEFAULT_BUILD_TIME_MULTIPLIER
@@ -514,7 +518,8 @@ pub struct TempoPayloadBuilderBuilder {
     pub state_provider_metrics: bool,
     /// Enable prewarming for the payload builder.
     pub enable_prewarming: bool,
-    /// Initial multiplier for predicting replayable payload build work.
+    /// Initial estimate of total replayable payload build work divided by work
+    /// at transaction cutoff.
     pub build_time_multiplier: f64,
 }
 

--- a/crates/payload/builder/src/budget.rs
+++ b/crates/payload/builder/src/budget.rs
@@ -75,7 +75,7 @@ pub(crate) fn payload_budget_exhausted(
 ///
 /// `work_at_tx_cutoff` is measured when pool transaction execution stops.
 /// `total_work` is measured after finalization finishes. Their ratio captures
-/// builder finish work without needing a separate fixed reserve.
+/// `builder_finish` without needing a separate fixed reserve.
 pub(crate) fn observed_build_time_multiplier(
     total_work: Duration,
     work_at_tx_cutoff: Duration,

--- a/crates/payload/builder/src/budget.rs
+++ b/crates/payload/builder/src/budget.rs
@@ -52,6 +52,8 @@ fn scaled_duration(elapsed: Duration, multiplier: u64) -> Duration {
 /// `elapsed` is wall-clock time spent in the builder so far. `idle_elapsed` is
 /// the proposer-only time spent waiting for more transactions, which is not
 /// replayed by validators and therefore counts once.
+/// `budget` is the remaining consensus payload build budget. `block_size_bytes`
+/// is the current encoded-size estimate used for marshal persistence.
 pub(crate) fn payload_budget_exhausted(
     elapsed: Duration,
     idle_elapsed: Duration,

--- a/crates/payload/builder/src/budget.rs
+++ b/crates/payload/builder/src/budget.rs
@@ -54,6 +54,10 @@ fn scaled_duration(elapsed: Duration, multiplier: u64) -> Duration {
 /// replayed by validators and therefore counts once.
 /// `budget` is the remaining consensus payload build budget. `block_size_bytes`
 /// is the current encoded-size estimate used for marshal persistence.
+///
+/// The budget is not split into fixed leader/validator buckets. Instead, we
+/// charge proposer idle once, projected replayable work once for the proposer
+/// and once for validators, and marshal persistence once for each side.
 pub(crate) fn payload_budget_exhausted(
     elapsed: Duration,
     idle_elapsed: Duration,

--- a/crates/payload/builder/src/budget.rs
+++ b/crates/payload/builder/src/budget.rs
@@ -5,6 +5,11 @@
 //! block assembly, and marshal persistence. These helpers learn the relation
 //! between tx execution cutoff time, total replayable build work, and the
 //! size-dependent cost of persisting large blocks through consensus.
+//!
+//! The decision model is:
+//! `leader_idle + 2 * predicted_replayable_work + 2 * marshal_persist >= budget`.
+//! Idle waiting only happens on the proposer, while replayable work and marshal
+//! persistence happen on both proposer and validators.
 
 use std::time::Duration;
 
@@ -19,6 +24,9 @@ const MAX_BUILD_TIME_MULTIPLIER: u64 = 1_700_000;
 const BUILD_TIME_MULTIPLIER_DECAY: u64 = 8;
 
 /// Initial estimate of total replayable build work divided by work at tx cutoff.
+///
+/// For example, `1.35` means "when cutoff work is 100 ms, expect the completed
+/// replayable build work to be about 135 ms".
 pub const DEFAULT_BUILD_TIME_MULTIPLIER: f64 = 1.35;
 
 /// Converts a human-readable build-work multiplier into the fixed-point representation.
@@ -39,7 +47,11 @@ fn scaled_duration(elapsed: Duration, multiplier: u64) -> Duration {
     )
 }
 
-/// Returns true when leader build plus validator work has exhausted `budget`.
+/// Returns true when the shared proposer/validator budget is exhausted.
+///
+/// `elapsed` is wall-clock time spent in the builder so far. `idle_elapsed` is
+/// the proposer-only time spent waiting for more transactions, which is not
+/// replayed by validators and therefore counts once.
 pub(crate) fn payload_budget_exhausted(
     elapsed: Duration,
     idle_elapsed: Duration,
@@ -60,6 +72,10 @@ pub(crate) fn payload_budget_exhausted(
 }
 
 /// Computes the observed total-work to tx-cutoff-work multiplier.
+///
+/// `work_at_tx_cutoff` is measured when pool transaction execution stops.
+/// `total_work` is measured after finalization finishes. Their ratio captures
+/// builder finish work without needing a separate fixed reserve.
 pub(crate) fn observed_build_time_multiplier(
     total_work: Duration,
     work_at_tx_cutoff: Duration,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -527,6 +527,9 @@ where
         let mut skipped_oversized_block = false;
         let mut invalid_pool_transaction_execution_attempts = 0u64;
         let mut normal_transaction_fill_idle_elapsed = Duration::ZERO;
+        // Consensus builds carry a remaining proposal budget. When present, the
+        // builder stops pool tx execution before projected proposer and validator
+        // work would consume that window.
         let payload_build_budget = attributes.payload_build_budget();
         let build_time_multiplier = self.build_time_multiplier();
         let marshal_persist = marshal_persist_estimate();

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -106,8 +106,8 @@ pub struct TempoPayloadBuilder<Provider> {
     enable_prewarming: bool,
     /// Learned estimate of total replayable build work divided by work at tx cutoff.
     ///
-    /// This lets the builder reserve time for non-interruptible finish work
-    /// without a fixed builder-finish duration.
+    /// This lets the builder reserve time for non-interruptible
+    /// `builder_finish` without a fixed duration.
     build_time_multiplier: Arc<AtomicU64>,
 }
 
@@ -123,8 +123,8 @@ pub struct TempoPayloadBuilderConfig {
     /// Initial estimate of total replayable build work divided by work at tx cutoff.
     ///
     /// `1.0` means no finish-work headroom beyond observed work so far. Values
-    /// above `1.0` stop transaction execution earlier to leave room for builder
-    /// finish work that validators also repeat.
+    /// above `1.0` stop transaction execution earlier to leave room for
+    /// `builder_finish`, which validators also repeat.
     pub build_time_multiplier: f64,
 }
 

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -104,7 +104,10 @@ pub struct TempoPayloadBuilder<Provider> {
     state_provider_metrics: bool,
     /// Whether to enable prewarming of best transactions.
     enable_prewarming: bool,
-    /// Conservative estimate of total replayable build work divided by work at tx cutoff.
+    /// Learned estimate of total replayable build work divided by work at tx cutoff.
+    ///
+    /// This lets the builder reserve time for non-interruptible finish work
+    /// without a fixed builder-finish duration.
     build_time_multiplier: Arc<AtomicU64>,
 }
 
@@ -118,6 +121,10 @@ pub struct TempoPayloadBuilderConfig {
     /// Whether to enable prewarming of best transactions.
     pub enable_prewarming: bool,
     /// Initial estimate of total replayable build work divided by work at tx cutoff.
+    ///
+    /// `1.0` means no finish-work headroom beyond observed work so far. Values
+    /// above `1.0` stop transaction execution earlier to leave room for builder
+    /// finish work that validators also repeat.
     pub build_time_multiplier: f64,
 }
 

--- a/crates/payload/types/src/attrs.rs
+++ b/crates/payload/types/src/attrs.rs
@@ -20,7 +20,11 @@ pub struct TempoPayloadAttributes {
     #[deref_mut]
     #[serde(flatten)]
     inner: EthPayloadAttributes,
-    /// Local payload build budget.
+    /// Remaining local proposal budget available to this payload build.
+    ///
+    /// Consensus sets this to the proposal return budget left when it dispatches
+    /// the build. `None` means the build was not requested by consensus, so the
+    /// builder should not stop early for block pacing.
     #[serde(skip)]
     payload_build_budget: Option<Duration>,
     /// Milliseconds portion of the timestamp.
@@ -90,11 +94,21 @@ impl TempoPayloadAttributes {
         self.proposer_public_key.as_ref()
     }
 
+    /// Sets the remaining local proposal budget for a consensus payload build.
+    ///
+    /// The value should already account for any time spent before the build was
+    /// requested. The builder treats it as a shared budget for leader
+    /// build/persist work and validator replay/persist work.
     pub fn with_payload_build_budget(mut self, budget: Duration) -> Self {
         self.payload_build_budget = Some(budget);
         self
     }
 
+    /// Returns the consensus-provided build budget, if this is a paced build.
+    ///
+    /// `None` is intentional for non-consensus builds such as dev or external
+    /// payload requests; those builds are not constrained by the consensus
+    /// block-time budget.
     pub fn payload_build_budget(&self) -> Option<Duration> {
         self.payload_build_budget
     }

--- a/crates/payload/types/src/budget.rs
+++ b/crates/payload/types/src/budget.rs
@@ -56,10 +56,6 @@ pub fn observe_marshal_persist(block_size_bytes: usize, elapsed: Duration) {
 }
 
 /// Point-in-time marshal persistence cost per encoded block byte.
-///
-/// The estimator is deliberately small and copyable so consensus can capture a
-/// stable rate at the start of a budget decision and pass it through without
-/// re-reading the global atomic mid-decision.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct MarshalPersistEstimator {
     ns_per_byte: u64,

--- a/crates/payload/types/src/budget.rs
+++ b/crates/payload/types/src/budget.rs
@@ -11,12 +11,20 @@ const MIN_SAMPLE_BYTES: usize = 128 * 1024;
 
 static MARSHAL_PERSIST_NS_PER_BYTE: AtomicU64 = AtomicU64::new(0);
 
-/// Returns the current marshal persistence estimator.
+/// Returns the current estimate of consensus marshal persistence cost.
+///
+/// This is a point-in-time snapshot. Callers use it before building or
+/// returning a proposal so the same estimate is applied consistently to that
+/// decision.
 pub fn marshal_persist_estimate() -> MarshalPersistEstimator {
     MarshalPersistEstimator::from_ns_per_byte(MARSHAL_PERSIST_NS_PER_BYTE.load(Ordering::Relaxed))
 }
 
 /// Records time spent persisting an encoded block through consensus marshal.
+///
+/// The observation is stored as nanoseconds per encoded block byte. Large
+/// blocks teach future build and return budgets how much size-dependent
+/// persistence time to reserve for both proposers and validators.
 pub fn observe_marshal_persist(block_size_bytes: usize, elapsed: Duration) {
     if block_size_bytes < MIN_SAMPLE_BYTES || elapsed == Duration::ZERO {
         return;
@@ -48,6 +56,10 @@ pub fn observe_marshal_persist(block_size_bytes: usize, elapsed: Duration) {
 }
 
 /// Point-in-time marshal persistence cost per encoded block byte.
+///
+/// The estimator is deliberately small and copyable so consensus can capture a
+/// stable rate at the start of a budget decision and pass it through without
+/// re-reading the global atomic mid-decision.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct MarshalPersistEstimator {
     ns_per_byte: u64,

--- a/crates/payload/types/src/budget.rs
+++ b/crates/payload/types/src/budget.rs
@@ -25,6 +25,8 @@ pub fn marshal_persist_estimate() -> MarshalPersistEstimator {
 /// The observation is stored as nanoseconds per encoded block byte. Large
 /// blocks teach future build and return budgets how much size-dependent
 /// persistence time to reserve for both proposers and validators.
+/// Consensus records this from local `marshal.proposed` time after persisting a
+/// proposal.
 pub fn observe_marshal_persist(block_size_bytes: usize, elapsed: Duration) {
     if block_size_bytes < MIN_SAMPLE_BYTES || elapsed == Duration::ZERO {
         return;

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -39,9 +39,10 @@ pub struct TempoBuiltPayload {
     /// Time validators are expected to spend reproducing this payload's build work.
     ///
     /// This excludes proposer-only idle waiting, but includes replayable work
-    /// such as transaction execution and non-interruptible builder finish work.
+    /// such as transaction execution and non-interruptible `builder_finish`.
     validation_work_duration: Duration,
-    /// RLP-encoded block size in bytes, cached for marshal persistence estimates.
+    /// RLP-encoded block size used to estimate marshal persistence duration in
+    /// the builder and proposal return budgets.
     rlp_block_size_bytes: usize,
 }
 

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -41,8 +41,8 @@ pub struct TempoBuiltPayload {
     /// This excludes proposer-only idle waiting, but includes replayable work
     /// such as transaction execution and non-interruptible `builder_finish`.
     validation_work_duration: Duration,
-    /// RLP-encoded block size used to estimate marshal persistence duration in
-    /// the builder and proposal return budgets.
+    /// RLP-encoded block size used for proposal return marshal estimates and
+    /// learning the rate used by future builder budgets.
     rlp_block_size_bytes: usize,
 }
 

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -36,9 +36,12 @@ pub struct TempoBuiltPayload {
     inner: EthBuiltPayload<TempoPrimitives>,
     /// The executed block data, used to skip re-execution in the engine tree.
     executed_block: Option<BuiltPayloadExecutedBlock<TempoPrimitives>>,
-    /// Estimated time validators spend reproducing the build work.
+    /// Time validators are expected to spend reproducing this payload's build work.
+    ///
+    /// This excludes proposer-only idle waiting, but includes replayable work
+    /// such as transaction execution and non-interruptible builder finish work.
     validation_work_duration: Duration,
-    /// RLP-encoded block size in bytes.
+    /// RLP-encoded block size in bytes, cached for marshal persistence estimates.
     rlp_block_size_bytes: usize,
 }
 
@@ -58,12 +61,15 @@ impl TempoBuiltPayload {
         }
     }
 
-    /// Returns the estimated validation work duration for this payload.
+    /// Returns the time validators are expected to spend reproducing this payload's build work.
     pub fn validation_work_duration(&self) -> Duration {
         self.validation_work_duration
     }
 
     /// Returns the RLP-encoded block size in bytes.
+    ///
+    /// Consensus uses this with the learned marshal persistence rate to reserve
+    /// time for validators to persist similarly sized proposals.
     pub fn rlp_block_size_bytes(&self) -> usize {
         self.rlp_block_size_bytes
     }


### PR DESCRIPTION
Clarifies the elastic proposal budget docs added in #4277, especially what value flows into `payload_build_budget`, how the proposal return budget is derived, and how replayable work, marshal persistence, and the build multiplier fit together.

This is docs-only and does not change budget behavior.

Tested with `cargo fmt --check` and `cargo check -p tempo-payload-types -p tempo-payload-builder -p tempo-commonware-node -p tempo-node --all-targets`.