### PR TITLE
bench: remove TPS quantiles from summary

### DIFF
--- a/tempo.nu
+++ b/tempo.nu
@@ -877,8 +877,6 @@ def generate-summary [
     mut feature_blocks = []
     mut baseline_intervals = []
     mut feature_intervals = []
-    mut baseline_tps_samples = []
-    mut feature_tps_samples = []
     mut baseline_builder_latency_values = []
     mut feature_builder_latency_values = []
     mut baseline_builder_finish_samples = []
@@ -899,15 +897,6 @@ def generate-summary [
     mut feature_builder_gas_values = []
     mut baseline_validation_gas_values = []
     mut feature_validation_gas_values = []
-
-    let compute_tps_stats = { |samples: list<any>|
-        let sorted_samples = ($samples | sort)
-        {
-            p50: (percentile $sorted_samples 50 | math round --precision 1)
-            p90: (percentile $sorted_samples 90 | math round --precision 1)
-            p99: (percentile $sorted_samples 99 | math round --precision 1)
-        }
-    }
 
     let compute_block_time_stats = { |intervals: list<any>|
         let sorted_intervals = ($intervals | sort)
@@ -1125,24 +1114,12 @@ def generate-summary [
         let timestamps = ($sorted_blocks | get timestamp)
         let block_intervals = ($sorted_blocks | where block_time_ms != null | get block_time_ms)
 
-        # Attribute each interval's throughput to the later block so TPS quantiles stay
-        # within a single run and avoid the inter-run gaps that skew merged samples.
-        let block_tps_samples = if ($sorted_blocks | length) > 1 {
-            $sorted_blocks | window 2 | each { |pair|
-                let earlier = ($pair | first)
-                let later = ($pair | last)
-                let interval_ms = [((($later | get timestamp) - ($earlier | get timestamp))) 1] | math max
-                (($later | get tx_count) / ($interval_ms / 1000.0))
-            }
-        } else { [] }
-        let run_tps = do $compute_tps_stats $block_tps_samples
         let run_bt = do $compute_block_time_stats $block_intervals
 
         # Collect blocks into baseline/feature groups
         if ($label | str starts-with "baseline") {
             $baseline_blocks = ($baseline_blocks | append $blocks)
             $baseline_intervals = ($baseline_intervals | append $block_intervals)
-            $baseline_tps_samples = ($baseline_tps_samples | append $block_tps_samples)
             $baseline_builder_latency_values = ($baseline_builder_latency_values | append $builder_latency_values)
             $baseline_builder_finish_samples = ($baseline_builder_finish_samples | append $builder_finish_samples)
             $baseline_builder_pool_fetch_samples = ($baseline_builder_pool_fetch_samples | append $builder_pool_fetch_samples)
@@ -1156,7 +1133,6 @@ def generate-summary [
         } else {
             $feature_blocks = ($feature_blocks | append $blocks)
             $feature_intervals = ($feature_intervals | append $block_intervals)
-            $feature_tps_samples = ($feature_tps_samples | append $block_tps_samples)
             $feature_builder_latency_values = ($feature_builder_latency_values | append $builder_latency_values)
             $feature_builder_finish_samples = ($feature_builder_finish_samples | append $builder_finish_samples)
             $feature_builder_pool_fetch_samples = ($feature_builder_pool_fetch_samples | append $builder_pool_fetch_samples)
@@ -1209,9 +1185,6 @@ def generate-summary [
             builder_latency_p99: $run_builder.p99
             builder_gas_s: $run_builder_gas
             tps: $actual_tps
-            tps_p50: $run_tps.p50
-            tps_p90: $run_tps.p90
-            tps_p99: $run_tps.p99
             mgas_s: $mgas_per_sec
             block_time_p50: $run_bt.p50
             block_time_p90: $run_bt.p90
@@ -1267,9 +1240,6 @@ def generate-summary [
 
     let b_bt = do $compute_block_time_stats $baseline_intervals
     let f_bt = do $compute_block_time_stats $feature_intervals
-    let b_tps_stats = do $compute_tps_stats $baseline_tps_samples
-    let f_tps_stats = do $compute_tps_stats $feature_tps_samples
-
     # Aggregate TPS and Mgas/s from per-run totals (total_tx / total_time)
     let baseline_runs = ($run_data | where { |r| $r.label | str starts-with "baseline" })
     let feature_runs = ($run_data | where { |r| $r.label | str starts-with "feature" })
@@ -1392,9 +1362,6 @@ def generate-summary [
         "| Metric | Baseline | Feature | Delta |"
         "|--------|----------|---------|-------|"
         $"| TPS Mean | ($b_tps) | ($f_tps) | (do $delta $b_tps $f_tps)% |"
-        $"| TPS P50 | ($b_tps_stats.p50) | ($f_tps_stats.p50) | (do $delta $b_tps_stats.p50 $f_tps_stats.p50)% |"
-        $"| TPS P90 | ($b_tps_stats.p90) | ($f_tps_stats.p90) | (do $delta $b_tps_stats.p90 $f_tps_stats.p90)% |"
-        $"| TPS P99 | ($b_tps_stats.p99) | ($f_tps_stats.p99) | (do $delta $b_tps_stats.p99 $f_tps_stats.p99)% |"
         $"| Gas Throughput [Mgas/s] | ($b_mgas) | ($f_mgas) | (do $delta $b_mgas $f_mgas)% |"
         $"| Block Time Mean [ms] | ($b_block_time.mean) | ($f_block_time.mean) | (do $delta $b_block_time.mean $f_block_time.mean)% |"
         $"| Block Time P50 [ms] | ($b_bt.p50) | ($f_bt.p50) | (do $delta $b_bt.p50 $f_bt.p50)% |"
@@ -1489,9 +1456,6 @@ def generate-summary [
                 builder_fill_idle_p99: $b_builder_fill_idle.p99
                 builder_gas_s: $b_builder_gas
                 tps: $b_tps
-                tps_p50: $b_tps_stats.p50
-                tps_p90: $b_tps_stats.p90
-                tps_p99: $b_tps_stats.p99
                 mgas_s: $b_mgas
                 block_time_p50: $b_bt.p50
                 block_time_p90: $b_bt.p90
@@ -1523,9 +1487,6 @@ def generate-summary [
                 builder_fill_idle_p99: $f_builder_fill_idle.p99
                 builder_gas_s: $f_builder_gas
                 tps: $f_tps
-                tps_p50: $f_tps_stats.p50
-                tps_p90: $f_tps_stats.p90
-                tps_p99: $f_tps_stats.p99
                 mgas_s: $f_mgas
                 block_time_p50: $f_bt.p50
                 block_time_p90: $f_bt.p90
@@ -1557,9 +1518,6 @@ def generate-summary [
                 builder_fill_idle_p99: (do $delta $b_builder_fill_idle.p99 $f_builder_fill_idle.p99)
                 builder_gas_s: (do $delta $b_builder_gas $f_builder_gas)
                 tps: (do $delta $b_tps $f_tps)
-                tps_p50: (do $delta $b_tps_stats.p50 $f_tps_stats.p50)
-                tps_p90: (do $delta $b_tps_stats.p90 $f_tps_stats.p90)
-                tps_p99: (do $delta $b_tps_stats.p99 $f_tps_stats.p99)
                 mgas_s: (do $delta $b_mgas $f_mgas)
                 block_time_p50: (do $delta $b_bt.p50 $f_bt.p50)
                 block_time_p90: (do $delta $b_bt.p90 $f_bt.p90)


### PR DESCRIPTION
## Summary
- Remove TPS percentile calculations from the bench summary
- Keep only mean TPS in markdown and JSON summary output

Prompted by: @onbjerg

## Testing
- `nu --commands 'source tempo.nu; help generate-summary | ignore'`