### PR TITLE
fix: enforce secp256k1 feature propagation

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -12,7 +12,7 @@ workflows:
         # Check that `A` activates the features of `B`.
         "propagate-feature",
         # These are the features to check:
-        "--features=std,op,asm-keccak,jemalloc,jemalloc-prof,jemalloc-symbols,serde-bincode-compat,serde,test-utils,arbitrary,bench,reth-codec,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs,otlp,js-tracer,keccak-cache-global",
+        "--features=std,op,asm-keccak,jemalloc,jemalloc-prof,jemalloc-symbols,serde-bincode-compat,serde,test-utils,arbitrary,bench,reth-codec,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs,otlp,js-tracer,keccak-cache-global,secp256k1",
         # Do not try to add a new section to `[features]` of `A` only because `B` exposes that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
         # Ignore the case that `A` is outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.


### PR DESCRIPTION
Adds `secp256k1` to the zepter propagate-feature workflow so missing secp256k1 forwarding is caught by the standard feature lint.