### PR TITLE
perf(txgen): use secp256k1 signing backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,9 @@ dependencies = [
  "coins-bip39",
  "k256",
  "rand 0.8.6",
+ "secp256k1 0.30.0",
  "thiserror 2.0.18",
+ "yubihsm",
  "zeroize",
 ]
 
@@ -2614,6 +2616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,6 +2800,17 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmac"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+dependencies = [
+ "cipher",
+ "dbl",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "cmake"
@@ -3829,6 +3851,15 @@ checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dbl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -7367,6 +7398,18 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "serdect",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
  "sha2 0.10.9",
 ]
 
@@ -12430,6 +12473,18 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+ "signature_derive",
+]
+
+[[package]]
+name = "signature_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0381d1913eeaf4c7bc4094016c9a8de6c1120663afe32a90ff268ad7f80486"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14514,6 +14569,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -15521,6 +15577,37 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "yubihsm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467a4c054be41ff657a6823246b0194cd727fadc3c539b265d7bc125ac6d4884"
+dependencies = [
+ "aes",
+ "bitflags 2.11.1",
+ "cbc",
+ "cmac",
+ "ecdsa",
+ "ed25519",
+ "hmac",
+ "k256",
+ "log",
+ "p256",
+ "p384",
+ "pbkdf2",
+ "rand_core 0.6.4",
+ "rusb",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "signature",
+ "subtle",
+ "thiserror 1.0.69",
+ "time",
+ "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,9 +203,12 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "aec6ba0", feat
   "std",
   "optional-checks",
 ] }
-revm = { version = "40.0.3", features = ["optional_fee_charge"], default-features = false }
+revm = { version = "40.0.3", features = [
+  "optional_fee_charge",
+  "secp256k1",
+], default-features = false }
 
-alloy = { version = "2.0.5", default-features = false }
+alloy = { version = "2.0.5", default-features = false, features = ["secp256k1"] }
 alloy-consensus = { version = "2.0.5", default-features = false }
 alloy-contract = { version = "2.0.5", default-features = false }
 alloy-eips = { version = "2.0.5", default-features = false }
@@ -227,7 +230,7 @@ alloy-signer = "2.0.5"
 alloy-signer-aws = "2.0.5"
 alloy-signer-gcp = "2.0.5"
 alloy-signer-ledger = "2.0.5"
-alloy-signer-local = "2.0.5"
+alloy-signer-local = { version = "2.0.5", features = ["secp256k1"] }
 alloy-signer-trezor = "2.0.5"
 
 alloy-sol-types = { version = "1.6.0", default-features = false }

--- a/bin/tempo-sidecar/src/cmd/simple_arb.rs
+++ b/bin/tempo-sidecar/src/cmd/simple_arb.rs
@@ -3,7 +3,7 @@ use alloy::{
     primitives::{Address, U256},
     providers::{Provider, ProviderBuilder},
     rpc::types::Filter,
-    signers::local::PrivateKeySigner,
+    signers::local::Secp256k1Signer,
     sol_types::SolEvent,
 };
 use clap::Parser;
@@ -108,7 +108,7 @@ impl SimpleArbArgs {
                 .context("failed to run poem server")
         });
 
-        let signer = PrivateKeySigner::from_slice(
+        let signer = Secp256k1Signer::from_slice(
             &hex::decode(&self.private_key).context("failed to decode private key")?,
         )
         .context("failed to parse private key")?;

--- a/bin/tempo-sidecar/src/synthetic_load/mod.rs
+++ b/bin/tempo-sidecar/src/synthetic_load/mod.rs
@@ -56,7 +56,8 @@ impl SyntheticLoadGenerator {
         let mut wallet = EthereumWallet::default();
         let mut addresses = Vec::new();
         for index in 0..self.wallet_count {
-            let signer = MnemonicBuilder::from_phrase_nth(&self.mnemonic, index as u32);
+            let signer =
+                MnemonicBuilder::from_phrase_nth(&self.mnemonic, index as u32).to_secp256k1();
             addresses.push(signer.address());
             wallet.register_signer(signer);
         }

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -15,7 +15,7 @@ use alloy_rpc_types_eth::TransactionRequest;
 use alloy_signer_aws::{AwsSigner, aws_config, aws_sdk_kms};
 use alloy_signer_gcp::{GcpKeyRingRef, GcpSigner, KeySpecifier, gcloud_sdk};
 use alloy_signer_ledger::{HDPath as LedgerHDPath, LedgerSigner};
-use alloy_signer_local::PrivateKeySigner;
+use alloy_signer_local::Secp256k1Signer;
 use alloy_signer_trezor::{HDPath as TrezorHDPath, TrezorSigner};
 use alloy_sol_types::SolCall;
 use clap::Subcommand;
@@ -1359,10 +1359,10 @@ impl Info {
     }
 }
 
-fn key_from_file<P: AsRef<Path>>(p: P) -> eyre::Result<PrivateKeySigner> {
+fn key_from_file<P: AsRef<Path>>(p: P) -> eyre::Result<Secp256k1Signer> {
     let raw = std::fs::read(p).wrap_err("failed reading key from file")?;
     let bytes = alloy::hex::decode(&raw).wrap_err("failed decoding file contents from hex")?;
-    PrivateKeySigner::from_slice(&bytes)
+    Secp256k1Signer::from_slice(&bytes)
         .wrap_err("failed converting file decoded hex bytes to private key")
 }
 

--- a/crates/alloy/src/network.rs
+++ b/crates/alloy/src/network.rs
@@ -12,7 +12,7 @@ use alloy_provider::fillers::{
     ChainIdFiller, GasFiller, JoinFill, NonceFiller, RecommendedFillers,
 };
 use alloy_rpc_types_eth::{AccessList, Block, Transaction};
-use alloy_signer_local::PrivateKeySigner;
+use alloy_signer_local::{PrivateKeySigner, Secp256k1Signer};
 use tempo_primitives::{
     TempoHeader, TempoReceipt, TempoTxEnvelope, TempoTxType, transaction::TempoTypedTransaction,
 };
@@ -299,6 +299,14 @@ impl RecommendedFillers for TempoNetwork {
 }
 
 impl IntoWallet<TempoNetwork> for PrivateKeySigner {
+    type NetworkWallet = EthereumWallet;
+
+    fn into_wallet(self) -> Self::NetworkWallet {
+        self.into()
+    }
+}
+
+impl IntoWallet<TempoNetwork> for Secp256k1Signer {
     type NetworkWallet = EthereumWallet;
 
     fn into_wallet(self) -> Self::NetworkWallet {

--- a/crates/evm/benches/tip20_execution.rs
+++ b/crates/evm/benches/tip20_execution.rs
@@ -16,7 +16,7 @@ use alloy_primitives::{
     map::{AddressMap, B256Map, HashMap},
 };
 use alloy_signer::SignerSync;
-use alloy_signer_local::{MnemonicBuilder, PrivateKeySigner};
+use alloy_signer_local::{MnemonicBuilder, Secp256k1Signer};
 use alloy_sol_types::SolCall;
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use reth_execution_cache::{
@@ -558,7 +558,7 @@ fn apply_seed_reward_mode(
     Ok(())
 }
 
-fn txgen_signers(account_count: usize) -> Vec<PrivateKeySigner> {
+fn txgen_signers(account_count: usize) -> Vec<Secp256k1Signer> {
     (0..account_count)
         .map(|idx| {
             MnemonicBuilder::from_phrase(TXGEN_MNEMONIC)
@@ -566,12 +566,13 @@ fn txgen_signers(account_count: usize) -> Vec<PrivateKeySigner> {
                 .expect("valid txgen account index")
                 .build()
                 .expect("valid txgen mnemonic")
+                .to_secp256k1()
         })
         .collect()
 }
 
 fn sign_tip20_transfer(
-    signer: &PrivateKeySigner,
+    signer: &Secp256k1Signer,
     recipient: Address,
     amount: U256,
 ) -> Recovered<TempoTxEnvelope> {
@@ -587,7 +588,7 @@ fn sign_tip20_transfer(
     )
 }
 
-fn sign_tip20_call(signer: &PrivateKeySigner, input: Bytes) -> Recovered<TempoTxEnvelope> {
+fn sign_tip20_call(signer: &Secp256k1Signer, input: Bytes) -> Recovered<TempoTxEnvelope> {
     let tx = TempoTransaction {
         chain_id: CHAIN_ID,
         fee_token: Some(PATH_USD_ADDRESS),
@@ -739,7 +740,7 @@ fn reward_bench_workloads() -> Vec<RewardBenchWorkload> {
 
 fn transfer_reward_workload(
     name: &'static str,
-    signers: &[PrivateKeySigner],
+    signers: &[Secp256k1Signer],
     sender: RewardSeedMode,
     recipient: RewardSeedMode,
     reward_delta: bool,

--- a/crates/faucet/src/args.rs
+++ b/crates/faucet/src/args.rs
@@ -2,7 +2,7 @@ use alloy::{
     network::EthereumWallet,
     primitives::{Address, B256, U256},
     providers::{DynProvider, Provider, ProviderBuilder},
-    signers::local::PrivateKeySigner,
+    signers::local::Secp256k1Signer,
 };
 use clap::Args;
 use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderBuilderExt};
@@ -50,10 +50,9 @@ pub struct FaucetArgs {
 
 impl FaucetArgs {
     pub fn wallet(&self) -> EthereumWallet {
-        let signer: PrivateKeySigner = PrivateKeySigner::from_bytes(
-            &self.private_key.expect("No faucet private key provided"),
-        )
-        .expect("Failed to decode private key");
+        let signer: Secp256k1Signer =
+            Secp256k1Signer::from_bytes(&self.private_key.expect("No faucet private key provided"))
+                .expect("Failed to decode private key");
         EthereumWallet::new(signer)
     }
 


### PR DESCRIPTION
Switches the txgen-style TIP20 execution benchmark to build mnemonic accounts as Alloy secp256k1-backed signers and enables the signer feature on the tempo-evm bench dev-dependency.

Generated signatures stay compatible while high-volume txgen signing uses the faster backend.