### PR TITLE
perf(txgen): use secp256k1 signing backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,9 @@ dependencies = [
  "coins-bip39",
  "k256",
  "rand 0.8.6",
+ "secp256k1 0.30.0",
  "thiserror 2.0.18",
+ "yubihsm",
  "zeroize",
 ]
 
@@ -2614,6 +2616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,6 +2800,17 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmac"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+dependencies = [
+ "cipher",
+ "dbl",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "cmake"
@@ -3829,6 +3851,15 @@ checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dbl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -7367,6 +7398,18 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "serdect",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
  "sha2 0.10.9",
 ]
 
@@ -12430,6 +12473,18 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+ "signature_derive",
+]
+
+[[package]]
+name = "signature_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0381d1913eeaf4c7bc4094016c9a8de6c1120663afe32a90ff268ad7f80486"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14514,6 +14569,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -15521,6 +15577,37 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "yubihsm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467a4c054be41ff657a6823246b0194cd727fadc3c539b265d7bc125ac6d4884"
+dependencies = [
+ "aes",
+ "bitflags 2.11.1",
+ "cbc",
+ "cmac",
+ "ecdsa",
+ "ed25519",
+ "hmac",
+ "k256",
+ "log",
+ "p256",
+ "p384",
+ "pbkdf2",
+ "rand_core 0.6.4",
+ "rusb",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "signature",
+ "subtle",
+ "thiserror 1.0.69",
+ "time",
+ "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 alloy-eips.workspace = true
 alloy-primitives = { workspace = true, features = ["asm-keccak"] }
 alloy-signer.workspace = true
-alloy-signer-local = { workspace = true, features = ["mnemonic"] }
+alloy-signer-local = { workspace = true, features = ["mnemonic", "secp256k1"] }
 alloy-sol-types.workspace = true
 criterion.workspace = true
 revm.workspace = true

--- a/crates/evm/benches/tip20_execution.rs
+++ b/crates/evm/benches/tip20_execution.rs
@@ -16,7 +16,7 @@ use alloy_primitives::{
     map::{AddressMap, B256Map, HashMap},
 };
 use alloy_signer::SignerSync;
-use alloy_signer_local::{MnemonicBuilder, PrivateKeySigner};
+use alloy_signer_local::{MnemonicBuilder, Secp256k1Signer};
 use alloy_sol_types::SolCall;
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use reth_execution_cache::{
@@ -558,7 +558,7 @@ fn apply_seed_reward_mode(
     Ok(())
 }
 
-fn txgen_signers(account_count: usize) -> Vec<PrivateKeySigner> {
+fn txgen_signers(account_count: usize) -> Vec<Secp256k1Signer> {
     (0..account_count)
         .map(|idx| {
             MnemonicBuilder::from_phrase(TXGEN_MNEMONIC)
@@ -566,12 +566,13 @@ fn txgen_signers(account_count: usize) -> Vec<PrivateKeySigner> {
                 .expect("valid txgen account index")
                 .build()
                 .expect("valid txgen mnemonic")
+                .to_secp256k1()
         })
         .collect()
 }
 
 fn sign_tip20_transfer(
-    signer: &PrivateKeySigner,
+    signer: &Secp256k1Signer,
     recipient: Address,
     amount: U256,
 ) -> Recovered<TempoTxEnvelope> {
@@ -587,7 +588,7 @@ fn sign_tip20_transfer(
     )
 }
 
-fn sign_tip20_call(signer: &PrivateKeySigner, input: Bytes) -> Recovered<TempoTxEnvelope> {
+fn sign_tip20_call(signer: &Secp256k1Signer, input: Bytes) -> Recovered<TempoTxEnvelope> {
     let tx = TempoTransaction {
         chain_id: CHAIN_ID,
         fee_token: Some(PATH_USD_ADDRESS),
@@ -739,7 +740,7 @@ fn reward_bench_workloads() -> Vec<RewardBenchWorkload> {
 
 fn transfer_reward_workload(
     name: &'static str,
-    signers: &[PrivateKeySigner],
+    signers: &[Secp256k1Signer],
     sender: RewardSeedMode,
     recipient: RewardSeedMode,
     reward_delta: bool,


### PR DESCRIPTION
Switches the txgen-style TIP20 execution benchmark to build mnemonic accounts as Alloy secp256k1-backed signers and enables the signer feature on the tempo-evm bench dev-dependency.

Generated signatures stay compatible while high-volume txgen signing uses the faster backend.