### PR TITLE
perf: use direct BTree first-entry access

### DIFF
--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -229,9 +229,7 @@ impl BlockCache {
 
     fn evict(&mut self) {
         while self.by_number.len() as u64 > self.capacity {
-            if let Some((&oldest_num, _)) = self.by_number.iter().next()
-                && let Some(block) = self.by_number.remove(&oldest_num)
-            {
+            if let Some((_, block)) = self.by_number.pop_first() {
                 self.by_hash.remove(&block.hash);
             }
         }

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -1043,8 +1043,7 @@ impl AA2dPool {
 
         let worst_expiring = self
             .expiring_nonce_eviction_order
-            .iter()
-            .next()
+            .first()
             .map(|key| (key.expiring_hash, key.priority.clone(), key.submission_id));
 
         match (worst_2d, worst_expiring) {


### PR DESCRIPTION
Uses direct first-entry APIs for ordered B-tree collections when evicting transactions and cached blocks. This avoids iterator setup and, for block cache eviction, removes the oldest entry in a single map operation.