### PR TITLE
fix(alloy): treat blank relay test env vars as absent

### DIFF
--- a/crates/alloy/tests/relay_transport.rs
+++ b/crates/alloy/tests/relay_transport.rs
@@ -24,9 +24,15 @@ const SPONSOR_URL: &str = "https://sponsor.moderato.tempo.xyz";
 const TEST_PRIVATE_KEY: &str = "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6";
 
 fn rpc_and_sponsor_urls() -> Option<(String, String)> {
-    let rpc = std::env::var("TEMPO_TESTNET_RPC_URL").ok()?;
-    let sponsor = std::env::var("TEMPO_SPONSOR_URL").unwrap_or_else(|_| SPONSOR_URL.to_string());
+    let rpc = non_empty_env_var("TEMPO_TESTNET_RPC_URL")?;
+    let sponsor = non_empty_env_var("TEMPO_SPONSOR_URL").unwrap_or_else(|| SPONSOR_URL.to_string());
     Some((rpc, sponsor))
+}
+
+fn non_empty_env_var(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
 }
 
 /// Test that the RelayTransport correctly routes reads to the default transport


### PR DESCRIPTION
Treats blank `TEMPO_TESTNET_RPC_URL` values as absent so fork PRs without secrets skip the relay transport test instead of passing an empty connection string to Alloy. Also applies the same blank-value fallback to `TEMPO_SPONSOR_URL`.

prevents failing ci for https://github.com/tempoxyz/tempo/blob/0b0a29cdcd1e2e155a760205681bfb426a172580/crates/alloy/tests/relay_transport.rs#L32-L35 when opened from a fork