### PR TITLE
Add Cyclops audit comment trigger

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -3,13 +3,15 @@ name: Pull request audit
 on:
   pull_request:
     types: [labeled]
+  issue_comment:
+    types: [created]
 
 permissions: {}
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'cyclops' || github.event.label.name == 'agentic-audit'
+    if: github.event_name == 'pull_request' && (github.event.label.name == 'cyclops' || github.event.label.name == 'agentic-audit')
     steps:
       - name: Publish event
         run: |
@@ -31,3 +33,271 @@ jobs:
                 "sha": "${{ github.event.pull_request.head.sha }}"
               }
             }'
+
+  publish-comment:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      (
+        startsWith(github.event.comment.body, 'cyclops audit') ||
+        startsWith(github.event.comment.body, '@decofe cyclops audit') ||
+        startsWith(github.event.comment.body, 'derek audit')
+      )
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Check org membership
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.DEREK_BENCH_ACK_TOKEN || github.token }}
+          script: |
+            const org = 'tempoxyz';
+            const checkMembership = async (username) => {
+              try {
+                const { status } = await github.rest.orgs.checkMembershipForUser({ org, username });
+                return status === 204 || status === 302;
+              } catch {
+                return false;
+              }
+            };
+
+            const commenter = context.payload.comment.user.login;
+            if (!await checkMembership(commenter)) {
+              core.setFailed(`@${commenter} is not a member of ${org}`);
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const prAuthor = pr.user.login;
+            if (!await checkMembership(prAuthor)) {
+              core.setFailed(`PR author @${prAuthor} is not a member of ${org}`);
+            }
+
+      - name: Parse arguments
+        id: args
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
+          script: |
+            const usage = [
+              '**Usage:** `cyclops audit [fast] [iterations=N] [hours=N] [config=pr-review.yaml] ',
+              '[models="anthropic/claude-opus-4-7,openai/gpt-5.5"] [run-label=LABEL] ',
+              '[dry-run] [note="per-run audit guidance"]`',
+            ].join('');
+            const body = context.payload.comment.body.trim();
+            const prefix = /^(?:@decofe\s+)?(?:cyclops\s+audit|derek\s+audit)\b/i;
+            const args = body.replace(prefix, '').trim();
+            const parts = [];
+            const argRegex = /(\S+?[=:]"[^"]*"|\S+?[=:]'[^']*'|\S+?[=:]\S+|\S+)/g;
+            let match;
+            while ((match = argRegex.exec(args)) !== null) parts.push(match[1]);
+
+            const defaults = {
+              config: '',
+              iterations: '',
+              hours: '',
+              models: '',
+              'run-label': '',
+              'dry-run': 'false',
+              note: '',
+            };
+            const intArgs = new Set(['iterations', 'hours']);
+            const stringArgs = new Set(['config', 'models', 'run-label', 'note']);
+            const boolArgs = new Set(['dry-run']);
+            const unknown = [];
+            const invalid = [];
+
+            for (const part of parts) {
+              if (part === 'fast') {
+                defaults.iterations = '1';
+                continue;
+              }
+
+              const eq = part.indexOf('=');
+              const colon = part.indexOf(':');
+              const sep = eq === -1 ? colon : colon === -1 ? eq : Math.min(eq, colon);
+              if (sep === -1) {
+                if (boolArgs.has(part)) {
+                  defaults[part] = 'true';
+                } else {
+                  unknown.push(part);
+                }
+                continue;
+              }
+
+              const key = part.slice(0, sep);
+              let value = part.slice(sep + 1);
+              if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+                value = value.slice(1, -1);
+              }
+
+              if (intArgs.has(key)) {
+                if (!/^[1-9]\d*$/.test(value)) {
+                  invalid.push(`\`${key}=${value}\` (must be a positive integer)`);
+                } else {
+                  defaults[key] = value;
+                }
+              } else if (boolArgs.has(key)) {
+                if (value === 'true' || value === 'false') {
+                  defaults[key] = value;
+                } else {
+                  invalid.push(`\`${key}=${value}\` (must be true or false)`);
+                }
+              } else if (stringArgs.has(key)) {
+                if (!value) {
+                  invalid.push(`\`${key}=\` (must not be empty)`);
+                } else {
+                  defaults[key] = value;
+                }
+              } else {
+                unknown.push(key);
+              }
+            }
+
+            const errors = [];
+            if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
+            if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
+            if (errors.length) {
+              const msg = `Invalid cyclops audit command\n\n${errors.join('\n')}\n\n${usage}`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: msg,
+              });
+              core.setFailed(msg);
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            const data = {
+              pr_number: context.issue.number,
+              sha: pr.head.sha,
+              source: 'comment',
+              actor: context.payload.comment.user.login,
+              comment_id: context.payload.comment.id,
+              dry_run: defaults['dry-run'] === 'true',
+            };
+            if (defaults.config) data.config = defaults.config;
+            if (defaults.iterations) data.max_iterations = Number(defaults.iterations);
+            if (defaults.hours) data.max_hours = Number(defaults.hours);
+            if (defaults.models) data.models = defaults.models;
+            if (defaults['run-label']) data.run_label = defaults['run-label'];
+            if (defaults.note) data.audit_note_b64 = Buffer.from(defaults.note, 'utf8').toString('base64');
+
+            const payload = {
+              repository: `${context.repo.owner}/${context.repo.repo}`,
+              event: 'pr_audit',
+              data,
+            };
+
+            const summaryParts = [
+              defaults.config ? `config: \`${defaults.config}\`` : 'config: `default`',
+              defaults.iterations ? `iterations: \`${defaults.iterations}\`` : 'iterations: `default`',
+              defaults.hours ? `hours: \`${defaults.hours}\`` : 'hours: `default`',
+            ];
+            if (defaults.models) summaryParts.push(`models: \`${defaults.models}\``);
+            if (defaults['run-label']) summaryParts.push(`run-label: \`${defaults['run-label']}\``);
+            if (defaults['dry-run'] === 'true') summaryParts.push('dry-run: `true`');
+            if (defaults.note) {
+              const note = defaults.note.replace(/`/g, "'").slice(0, 160);
+              summaryParts.push(`note: \`${note}${defaults.note.length > 160 ? '...' : ''}\``);
+            }
+
+            core.setOutput('actor', context.payload.comment.user.login);
+            core.setOutput('payload-b64', Buffer.from(JSON.stringify(payload), 'utf8').toString('base64'));
+            core.setOutput('summary', `**Config:** ${summaryParts.join(', ')}`);
+
+      - name: Acknowledge request
+        id: ack
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ACTOR: ${{ steps.args.outputs.actor }}
+          SUMMARY: ${{ steps.args.outputs.summary }}
+        with:
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
+          script: |
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes',
+              });
+            } catch (error) {
+              core.warning(`Could not add acknowledgement reaction: ${error.message}`);
+            }
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { data: comment } = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `cc @${process.env.ACTOR}\n\nCyclops audit event queued. [View workflow run](${runUrl})\n\n${process.env.SUMMARY}`,
+            });
+            core.setOutput('comment-id', String(comment.id));
+
+      - name: Publish event
+        id: publish
+        continue-on-error: true
+        env:
+          PAYLOAD_B64: ${{ steps.args.outputs.payload-b64 }}
+        run: |
+          set -euo pipefail
+
+          printf '%s' '${{ secrets.EVENTS_KEY }}' > "${RUNNER_TEMP}/key"
+          printf '%s' '${{ secrets.EVENTS_CERT }}' > "${RUNNER_TEMP}/cert"
+          printf '%s' "$PAYLOAD_B64" | base64 --decode > "${RUNNER_TEMP}/pr-audit-event.json"
+
+          # EVENTS_ARGS may contain additional curl arguments, not just a URL.
+          curl -sf -o /dev/null -X POST ${{ secrets.EVENTS_ARGS }} \
+            -H "Content-Type: application/json" \
+            --key "${RUNNER_TEMP}/key" \
+            --cert "${RUNNER_TEMP}/cert" \
+            -d @"${RUNNER_TEMP}/pr-audit-event.json"
+
+      - name: Update status
+        if: always()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COMMENT_ID: ${{ steps.ack.outputs.comment-id }}
+          PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+          ACTOR: ${{ steps.args.outputs.actor }}
+          SUMMARY: ${{ steps.args.outputs.summary }}
+        with:
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const success = process.env.PUBLISH_OUTCOME === 'success';
+            const body = success
+              ? `cc @${process.env.ACTOR}\n\nCyclops audit event published. [View workflow run](${runUrl})\n\n${process.env.SUMMARY}`
+              : `cc @${process.env.ACTOR}\n\nCyclops audit event failed to publish. [View workflow run](${runUrl})\n\n${process.env.SUMMARY}`;
+
+            if (process.env.COMMENT_ID) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: Number(process.env.COMMENT_ID),
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+            if (!success) core.setFailed('Failed to publish pr_audit event');


### PR DESCRIPTION
Extend the existing PR audit workflow so authorized PR comments can publish the same pr_audit event used by the label-triggered Cyclops audit path.

Supports iterations/hours/models/config/run-label/dry-run/note. The `cyclops audit fast` alias sets iterations=1.

Depends on tempoxyz/dev-infra#1668 for the Argo Events sensor to pass these optional fields into the Cyclops PR-review workflow.