### PR TITLE
fix(consensus): tolerate experimental BAL hash mismatch

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -41,14 +41,25 @@ pub const TEMPO_MAXIMUM_EXTRA_DATA_SIZE: usize = 10 * 1_024; // 10KiB
 pub struct TempoConsensus {
     /// Inner Ethereum consensus.
     inner: EthBeaconConsensus<TempoChainSpec>,
+    /// Whether to tolerate BAL hash mismatches while BAL support is experimental.
+    ignore_bal_hash_mismatch: bool,
 }
 
 impl TempoConsensus {
     /// Creates a new [`TempoConsensus`] with the given chain spec.
     pub fn new(chain_spec: Arc<TempoChainSpec>) -> Self {
+        Self::new_with_bal_hash_mismatch_ignored(chain_spec, false)
+    }
+
+    /// Creates a new [`TempoConsensus`] with optional BAL hash mismatch tolerance.
+    pub fn new_with_bal_hash_mismatch_ignored(
+        chain_spec: Arc<TempoChainSpec>,
+        ignore_bal_hash_mismatch: bool,
+    ) -> Self {
         Self {
             inner: EthBeaconConsensus::new(chain_spec)
                 .with_max_extra_data_size(TEMPO_MAXIMUM_EXTRA_DATA_SIZE),
+            ignore_bal_hash_mismatch,
         }
     }
 
@@ -232,13 +243,21 @@ impl FullConsensus<TempoPrimitives> for TempoConsensus {
         receipt_root_bloom: Option<ReceiptRootBloom>,
         block_access_list_hash: Option<alloy_primitives::B256>,
     ) -> Result<(), ConsensusError> {
-        FullConsensus::<TempoPrimitives>::validate_block_post_execution(
+        let result = FullConsensus::<TempoPrimitives>::validate_block_post_execution(
             &self.inner,
             block,
             result,
             receipt_root_bloom,
             block_access_list_hash,
-        )
+        );
+
+        if self.ignore_bal_hash_mismatch
+            && matches!(result, Err(ConsensusError::BlockAccessListHashMismatch(_)))
+        {
+            return Ok(());
+        }
+
+        result
     }
 }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -159,7 +159,9 @@ impl TempoNode {
             .executor(TempoExecutorBuilder::default())
             .payload(BasicPayloadServiceBuilder::new(payload_builder_builder))
             .network(EthereumNetworkBuilder::default())
-            .consensus(TempoConsensusBuilder::default())
+            .consensus(TempoConsensusBuilder {
+                ignore_bal_hash_mismatch: payload_builder_builder.enable_bal,
+            })
     }
 
     pub fn provider_factory_builder() -> ProviderFactoryBuilder<Self> {
@@ -377,7 +379,10 @@ where
 /// Builder for [`TempoConsensus`].
 #[derive(Debug, Default, Clone, Copy)]
 #[non_exhaustive]
-pub struct TempoConsensusBuilder;
+pub struct TempoConsensusBuilder {
+    /// Whether to tolerate BAL hash mismatches while BAL support is experimental.
+    pub ignore_bal_hash_mismatch: bool,
+}
 
 impl<Node> ConsensusBuilder<Node> for TempoConsensusBuilder
 where
@@ -386,7 +391,10 @@ where
     type Consensus = TempoConsensus;
 
     async fn build_consensus(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Consensus> {
-        Ok(TempoConsensus::new(ctx.chain_spec()))
+        Ok(TempoConsensus::new_with_bal_hash_mismatch_ignored(
+            ctx.chain_spec(),
+            self.ignore_bal_hash_mismatch,
+        ))
     }
 }
 


### PR DESCRIPTION
Stacked on #4026.

Propagates the experimental BAL builder flag into `TempoConsensus` and uses it to ignore only `ConsensusError::BlockAccessListHashMismatch`. The default `TempoConsensus::new` path remains strict.

Validation:
- `cargo fmt`
- `cargo check -p tempo-consensus -p tempo-node`

Prompted by: @klkvr