### PR TITLE
ci: remove TPS percentile rows from bench Slack message

### DIFF
--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -105,9 +105,6 @@ function e2eChanges(summary) {
   const deltas = summary.results.deltas;
   return {
     tps: changeFromPct(deltas.tps, false),
-    tps_p50: changeFromPct(deltas.tps_p50, false),
-    tps_p90: changeFromPct(deltas.tps_p90, false),
-    tps_p99: changeFromPct(deltas.tps_p99, false),
     mgas_s: changeFromPct(deltas.mgas_s, false),
     block_time_mean: changeFromPct(deltas.block_time_mean, true),
     block_time_p50: changeFromPct(deltas.block_time_p50, true),
@@ -139,9 +136,6 @@ function buildMetricRows(summary) {
   const c = e2eChanges(summary);
   return [
     { label: 'TPS Mean',        baseline: fmtVal(b.tps, '', 0),     feature: fmtVal(f.tps, '', 0),     change: fmtChange(c.tps) },
-    { label: 'TPS P50',         baseline: fmtVal(b.tps_p50, '', 1), feature: fmtVal(f.tps_p50, '', 1), change: fmtChange(c.tps_p50) },
-    { label: 'TPS P90',         baseline: fmtVal(b.tps_p90, '', 1), feature: fmtVal(f.tps_p90, '', 1), change: fmtChange(c.tps_p90) },
-    { label: 'TPS P99',         baseline: fmtVal(b.tps_p99, '', 1), feature: fmtVal(f.tps_p99, '', 1), change: fmtChange(c.tps_p99) },
     { label: 'Gas/s',           baseline: fmtVal(b.mgas_s, ' Mgas/s', 1), feature: fmtVal(f.mgas_s, ' Mgas/s', 1), change: fmtChange(c.mgas_s) },
     { label: 'Block Time Mean', baseline: fmtMs(b.block_time_mean), feature: fmtMs(f.block_time_mean), change: fmtChange(c.block_time_mean) },
     { label: 'Block P50',       baseline: fmtMs(b.block_time_p50),  feature: fmtMs(f.block_time_p50),  change: fmtChange(c.block_time_p50) },


### PR DESCRIPTION
Removes TPS P50/P90/P99 rows from the e2e bench Slack notification while keeping TPS Mean. Throughput percentiles are still available in the generated benchmark summary/classification output if needed, but they no longer clutter Slack.

Validation:
- node --check .github/scripts/bench-slack-notify.js
- rg -n "TPS P50|TPS P90|TPS P99|tps_p50|tps_p90|tps_p99" .github/scripts/bench-slack-notify.js (no matches)
- git diff --check

Prompted by: @klkvr