### PR TITLE
test: add tip20 user state invariants

### DIFF
--- a/tips/verify/test/invariants/TIP20.t.sol
+++ b/tips/verify/test/invariants/TIP20.t.sol
@@ -1496,9 +1496,7 @@ contract TIP20InvariantTest is InvariantBaseTest {
         (address rewardRecipient,,) = token.userRewardInfo(account);
 
         assertEq(
-            decodedBalance,
-            exposedBalance,
-            "TIP-1065: low 128 bits must equal balanceOf(account)"
+            decodedBalance, exposedBalance, "TIP-1065: low 128 bits must equal balanceOf(account)"
         );
         assertLe(
             exposedBalance,
@@ -1508,9 +1506,8 @@ contract TIP20InvariantTest is InvariantBaseTest {
         assertEq(reservedBits, 0, "TIP-1065: reserved user-state bits must remain zero");
 
         if (rewardFlag != RewardFlag.Uninitialized) {
-            RewardFlag expectedFlag = rewardRecipient == address(0)
-                ? RewardFlag.OptedOut
-                : RewardFlag.OptedIn;
+            RewardFlag expectedFlag =
+                rewardRecipient == address(0) ? RewardFlag.OptedOut : RewardFlag.OptedIn;
             assertEq(
                 uint256(rewardFlag),
                 uint256(expectedFlag),
@@ -1528,9 +1525,8 @@ contract TIP20InvariantTest is InvariantBaseTest {
         view
     {
         (, RewardFlag rewardFlag,) = _userState(address(token), account);
-        RewardFlag expectedFlag = rewardRecipient == address(0)
-            ? RewardFlag.OptedOut
-            : RewardFlag.OptedIn;
+        RewardFlag expectedFlag =
+            rewardRecipient == address(0) ? RewardFlag.OptedOut : RewardFlag.OptedIn;
         assertEq(
             uint256(rewardFlag),
             uint256(expectedFlag),

--- a/tips/verify/test/invariants/TIP20.t.sol
+++ b/tips/verify/test/invariants/TIP20.t.sol
@@ -38,7 +38,7 @@ contract TIP20InvariantTest is InvariantBaseTest {
     uint256 internal constant USER_STATE_BALANCE_MASK = type(uint128).max;
     uint256 internal constant USER_STATE_REWARD_FLAG_MASK = uint256(3) << 128;
     uint256 internal constant USER_STATE_RESERVED_MASK = type(uint256).max << 130;
-    uint256 internal constant USER_STATE_BALANCES_SLOT = 10;
+    uint256 internal constant USER_STATE_BALANCES_SLOT = 9;
 
     enum RewardFlag {
         Uninitialized,

--- a/tips/verify/test/invariants/TIP20.t.sol
+++ b/tips/verify/test/invariants/TIP20.t.sol
@@ -1428,19 +1428,18 @@ contract TIP20InvariantTest is InvariantBaseTest {
             assertEq(totalSupply, expectedSupply, "TEMPO-TIP18: Supply conservation violated");
 
             // TEMPO-TIP20: Balance sum equals supply
-            address[] storage holders = _tokenHolders[tokenAddr];
-            uint256 balanceSum = 0;
-            for (uint256 j = 0; j < holders.length; j++) {
-                balanceSum += token.balanceOf(holders[j]);
-            }
-            assertEq(balanceSum, totalSupply, "TEMPO-TIP20: Balance sum does not equal totalSupply");
-
             // TIP-1065: T6 packed user-state balance slots must expose only low 128-bit balances
             // through balanceOf, keep reserved bits zero, and keep initialized rewardFlag values
             // consistent with rewardRecipient, which remains the source of truth.
+            address[] storage holders = _tokenHolders[tokenAddr];
+            uint256 balanceSum = 0;
             for (uint256 j = 0; j < holders.length; j++) {
-                _assertTip1065UserState(token, holders[j]);
+                address holder = holders[j];
+                uint256 exposedBalance = token.balanceOf(holder);
+                balanceSum += exposedBalance;
+                _assertTip1065UserState(token, holder, exposedBalance);
             }
+            assertEq(balanceSum, totalSupply, "TEMPO-TIP20: Balance sum does not equal totalSupply");
 
             // Rewards conservation: claimed <= distributed, dust bounded
             uint256 distributed = _tokenRewardsDistributed[tokenAddr];
@@ -1489,11 +1488,16 @@ contract TIP20InvariantTest is InvariantBaseTest {
         );
     }
 
-    function _assertTip1065UserState(ITIP20 token, address account) internal view {
+    function _assertTip1065UserState(
+        ITIP20 token,
+        address account,
+        uint256 exposedBalance
+    )
+        internal
+        view
+    {
         (uint256 decodedBalance, RewardFlag rewardFlag, uint256 reservedBits) =
             _userState(address(token), account);
-        uint256 exposedBalance = token.balanceOf(account);
-        (address rewardRecipient,,) = token.userRewardInfo(account);
 
         assertEq(
             decodedBalance, exposedBalance, "TIP-1065: low 128 bits must equal balanceOf(account)"
@@ -1506,6 +1510,7 @@ contract TIP20InvariantTest is InvariantBaseTest {
         assertEq(reservedBits, 0, "TIP-1065: reserved user-state bits must remain zero");
 
         if (rewardFlag != RewardFlag.Uninitialized) {
+            (address rewardRecipient,,) = token.userRewardInfo(account);
             RewardFlag expectedFlag =
                 rewardRecipient == address(0) ? RewardFlag.OptedOut : RewardFlag.OptedIn;
             assertEq(

--- a/tips/verify/test/invariants/TIP20.t.sol
+++ b/tips/verify/test/invariants/TIP20.t.sol
@@ -35,6 +35,17 @@ contract TIP20InvariantTest is InvariantBaseTest {
 
     /// @dev Constants
     uint256 internal constant ACC_PRECISION = 1e18;
+    uint256 internal constant USER_STATE_BALANCE_MASK = type(uint128).max;
+    uint256 internal constant USER_STATE_REWARD_FLAG_MASK = uint256(3) << 128;
+    uint256 internal constant USER_STATE_RESERVED_MASK = type(uint256).max << 130;
+    uint256 internal constant USER_STATE_BALANCES_SLOT = 10;
+
+    enum RewardFlag {
+        Uninitialized,
+        OptedOut,
+        OptedIn
+    }
+
     bytes32 internal constant PERMIT_TYPEHASH = keccak256(
         "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
     );
@@ -576,6 +587,7 @@ contract TIP20InvariantTest is InvariantBaseTest {
             (address storedRecipient,,) = token.userRewardInfo(actor);
 
             assertEq(storedRecipient, newRecipient, "Reward recipient not set correctly");
+            _assertTip1065RewardFlagMatchesRecipient(token, actor, newRecipient);
 
             // Opted-in supply should update correctly
             uint128 optedInSupplyAfter = token.optedInSupply();
@@ -1423,6 +1435,13 @@ contract TIP20InvariantTest is InvariantBaseTest {
             }
             assertEq(balanceSum, totalSupply, "TEMPO-TIP20: Balance sum does not equal totalSupply");
 
+            // TIP-1065: T6 packed user-state balance slots must expose only low 128-bit balances
+            // through balanceOf, keep reserved bits zero, and keep initialized rewardFlag values
+            // consistent with rewardRecipient, which remains the source of truth.
+            for (uint256 j = 0; j < holders.length; j++) {
+                _assertTip1065UserState(token, holders[j]);
+            }
+
             // Rewards conservation: claimed <= distributed, dust bounded
             uint256 distributed = _tokenRewardsDistributed[tokenAddr];
             uint256 claimed = _tokenRewardsClaimed[tokenAddr];
@@ -1444,6 +1463,79 @@ contract TIP20InvariantTest is InvariantBaseTest {
                 }
             }
         }
+    }
+
+    function _userState(
+        address token,
+        address account
+    )
+        internal
+        view
+        returns (uint256 balance, RewardFlag rewardFlag, uint256 reservedBits)
+    {
+        uint256 stateWord =
+            uint256(vm.load(token, keccak256(abi.encode(account, USER_STATE_BALANCES_SLOT))));
+        uint256 rewardFlagValue = (stateWord & USER_STATE_REWARD_FLAG_MASK) >> 128;
+        assertLe(
+            rewardFlagValue,
+            uint256(type(RewardFlag).max),
+            "TIP-1065: invalid rewardFlag value in user-state slot"
+        );
+
+        return (
+            stateWord & USER_STATE_BALANCE_MASK,
+            RewardFlag(rewardFlagValue),
+            stateWord & USER_STATE_RESERVED_MASK
+        );
+    }
+
+    function _assertTip1065UserState(ITIP20 token, address account) internal view {
+        (uint256 decodedBalance, RewardFlag rewardFlag, uint256 reservedBits) =
+            _userState(address(token), account);
+        uint256 exposedBalance = token.balanceOf(account);
+        (address rewardRecipient,,) = token.userRewardInfo(account);
+
+        assertEq(
+            decodedBalance,
+            exposedBalance,
+            "TIP-1065: low 128 bits must equal balanceOf(account)"
+        );
+        assertLe(
+            exposedBalance,
+            USER_STATE_BALANCE_MASK,
+            "TIP-1065: account balance exceeds uint128::MAX"
+        );
+        assertEq(reservedBits, 0, "TIP-1065: reserved user-state bits must remain zero");
+
+        if (rewardFlag != RewardFlag.Uninitialized) {
+            RewardFlag expectedFlag = rewardRecipient == address(0)
+                ? RewardFlag.OptedOut
+                : RewardFlag.OptedIn;
+            assertEq(
+                uint256(rewardFlag),
+                uint256(expectedFlag),
+                "TIP-1065: initialized rewardFlag stale vs rewardRecipient"
+            );
+        }
+    }
+
+    function _assertTip1065RewardFlagMatchesRecipient(
+        ITIP20 token,
+        address account,
+        address rewardRecipient
+    )
+        internal
+        view
+    {
+        (, RewardFlag rewardFlag,) = _userState(address(token), account);
+        RewardFlag expectedFlag = rewardRecipient == address(0)
+            ? RewardFlag.OptedOut
+            : RewardFlag.OptedIn;
+        assertEq(
+            uint256(rewardFlag),
+            uint256(expectedFlag),
+            "TIP-1065: rewardRecipient update must atomically update rewardFlag"
+        );
     }
 
     // Helper function to select key associated with seed


### PR DESCRIPTION
this PR adds new TIP20 tests to verify the `UserState` invariants defined in TIP-1065