### PR TITLE
perf(transaction-pool): skip AMM math for accepted fee tokens

### DIFF
--- a/crates/transaction-pool/src/amm.rs
+++ b/crates/transaction-pool/src/amm.rs
@@ -73,16 +73,20 @@ impl AmmLiquidityCache {
             let inner = self.inner.read();
             hardfork = inner.hardfork;
 
+            if inner.unique_tokens.is_empty() {
+                return Ok(false);
+            }
+
+            // Validators always accept fees in their own token, so no swap math is needed.
+            if inner.unique_tokens.contains(&user_token) {
+                return Ok(true);
+            }
+
             let calc_swap = |input| compute_amount_out(input).map_err(ProviderError::other);
             let out1 = calc_swap(fee)?;
-            let out2 = hardfork.is_t5().then(|| calc_swap(out1)).transpose()?;
+            let mut out2 = None;
 
             for &validator_token in &inner.unique_tokens {
-                // Validators always accept fees in their own token.
-                if validator_token == user_token {
-                    return Ok(true);
-                }
-
                 let direct = inner
                     .pool_cache
                     .get(&(user_token, validator_token))
@@ -94,9 +98,17 @@ impl AmmLiquidityCache {
                     None => true,     // Direct reserve is missing.
                 };
 
-                if let Some(out2) = out2 {
+                if hardfork.is_t5() {
                     if let Some(hop) = inner.quote_token_cache.get(&user_token).copied() {
                         if !hop.is_zero() && hop != validator_token {
+                            let out2 = match out2 {
+                                Some(out2) => out2,
+                                None => {
+                                    let computed = calc_swap(out1)?;
+                                    out2 = Some(computed);
+                                    computed
+                                }
+                            };
                             let r1 = inner.pool_cache.get(&(user_token, hop)).copied();
                             let r2 = inner.pool_cache.get(&(hop, validator_token)).copied();
                             match (r1, r2) {
@@ -428,6 +440,20 @@ mod tests {
         assert!(
             result.unwrap(),
             "Should return true when user token matches validator token"
+        );
+
+        let result = cache.has_enough_liquidity(user_token, U256::MAX, &state);
+        assert!(result.is_ok());
+        assert!(
+            result.unwrap(),
+            "Accepted validator tokens should not require AMM swap math"
+        );
+
+        let non_validator_token = address!("2222222222222222222222222222222222222222");
+        let result = cache.has_enough_liquidity(non_validator_token, U256::MAX, &state);
+        assert!(
+            result.is_err(),
+            "AMM-routed tokens should still validate swap arithmetic"
         );
     }
 


### PR DESCRIPTION
Skips AMM route math in `AmmLiquidityCache::has_enough_liquidity` when the user's fee token is already an active validator token, and only computes the T5 two-hop output after the route lookup needs it. This keeps the txpool validation fast path on simple membership checks for accepted fee tokens and adds a regression test covering an overflow-prone accepted-token amount.

P2P profiles on exact refs (`22a4f8c12` vs `effe4d607`, 9000 AA txs, 1000 accounts, concurrency 200, 3 pairs) sampled `compute_amount_out` in baseline `[4, 8, 3]` times and feature `[0, 0, 0]`; `has_enough_liquidity` moved from `[4, 8, 3]` to `[1, 3, 1]`. Submit time and pending/queued counts stayed within harness noise, so this is a targeted txpool validation hot-path cleanup.

Firefox profiles: [baseline r1](https://share.firefox.dev/3PDZoDh), [feature r1](https://share.firefox.dev/3PZGlmL), [baseline r2](https://share.firefox.dev/4e2PPFS), [feature r2](https://share.firefox.dev/4x531CT), [baseline r3](https://share.firefox.dev/49yXgU6), [feature r3](https://share.firefox.dev/4eldfHW).