### PR TITLE
ci: use CodSpeed macro runner

### DIFF
--- a/.github/workflows/codspeed-microbench.yml
+++ b/.github/workflows/codspeed-microbench.yml
@@ -45,7 +45,7 @@ env:
 jobs:
   codspeed:
     name: CodSpeed microbenchmarks
-    runs-on: depot-ubuntu-latest-4
+    runs-on: codspeed-macro
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Switch the CodSpeed microbenchmarks workflow to run on the CodSpeed macro runner label.

Prompted by: @shekhirin