### PR TITLE
perf(txpool): optimize expiring nonce eviction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13490,6 +13490,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
+ "codspeed-criterion-compat",
  "futures",
  "itertools 0.14.0",
  "metrics",

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -68,5 +68,11 @@ alloy-eips.workspace = true
 alloy-consensus.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true
+criterion.workspace = true
 tokio.workspace = true
 test-case.workspace = true
+
+[[bench]]
+name = "txpool"
+harness = false
+required-features = ["test-utils"]

--- a/crates/transaction-pool/benches/txpool.rs
+++ b/crates/transaction-pool/benches/txpool.rs
@@ -1,0 +1,78 @@
+//! Criterion benchmarks for txgen-style TIP20 expiring nonce transaction-pool load.
+//!
+//! Run with:
+//! `cargo bench -p tempo-transaction-pool --features test-utils --bench txpool`
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use reth_transaction_pool::TransactionPool;
+use std::hint::black_box;
+use tempo_transaction_pool::bench_utils::{
+    TxpoolBenchConfig, add_validated_transaction_for_bench, fresh_pool,
+    populated_pool_with_expiry_state, txgen_tip20_expiring_nonce_workload,
+};
+
+fn txpool_tip20_expiring_nonce(c: &mut Criterion) {
+    let config = config_from_env();
+    let workload = txgen_tip20_expiring_nonce_workload(&config);
+
+    let mut group = c.benchmark_group("txpool/tip20_expiring_nonce");
+    group.throughput(Throughput::Elements(config.tx_count as u64));
+
+    group.bench_function(BenchmarkId::new("add_transactions", config.tx_count), |b| {
+        b.iter_batched(
+            || (fresh_pool(&config), workload.transactions.clone()),
+            |(pool, txs)| {
+                for tx in txs {
+                    black_box(
+                        add_validated_transaction_for_bench(&pool, tx)
+                            .expect("benchmark transaction should be admitted"),
+                    );
+                }
+                black_box(pool.pool_size());
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function(
+        BenchmarkId::new("maintain_expiry_tick", config.tx_count),
+        |b| {
+            b.iter_batched(
+                || populated_pool_with_expiry_state(&workload, &config),
+                |(pool, mut state)| {
+                    let tip_timestamp = config.block_timestamp + config.valid_for_secs;
+                    black_box(state.evict_expired(&pool, tip_timestamp));
+                    black_box(pool.pool_size());
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
+
+    group.finish();
+}
+
+fn config_from_env() -> TxpoolBenchConfig {
+    let mut config = TxpoolBenchConfig::default();
+    config.account_count = env_usize("TEMPO_TXPOOL_BENCH_ACCOUNTS", config.account_count);
+    config.tx_count = env_usize("TEMPO_TXPOOL_BENCH_TXS", config.tx_count);
+    config.valid_for_secs = env_u64("TEMPO_TXPOOL_BENCH_VALID_FOR_SECS", config.valid_for_secs);
+    config
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+criterion_group!(benches, txpool_tip20_expiring_nonce);
+criterion_main!(benches);

--- a/crates/transaction-pool/src/bench_utils.rs
+++ b/crates/transaction-pool/src/bench_utils.rs
@@ -1,0 +1,288 @@
+//! Test-feature utilities for Criterion transaction-pool benchmarks.
+
+use crate::{
+    AA2dPool, AA2dPoolConfig, TempoTransactionPool,
+    amm::AmmLiquidityCache,
+    maintain::{EVICTION_BUFFER_SECS, TempoPoolState},
+    transaction::TempoPooledTransaction,
+    validator::{
+        DEFAULT_AA_VALID_AFTER_MAX_SECS, DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
+        TempoTransactionValidator,
+    },
+};
+use alloy_consensus::{Header, Transaction};
+use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256};
+use alloy_sol_types::SolCall;
+use core::num::NonZeroU64;
+use reth_primitives_traits::Recovered;
+use reth_provider::test_utils::MockEthProvider;
+use reth_transaction_pool::{
+    AddedTransactionOutcome, CoinbaseTipOrdering, Pool, PoolConfig, PoolResult, PoolTransaction,
+    SubPoolLimit, TransactionOrigin, TransactionPool, TransactionValidationOutcome,
+    TransactionValidationTaskExecutor,
+    blobstore::InMemoryBlobStore,
+    validate::{EthTransactionValidatorBuilder, ValidTransaction},
+};
+use std::sync::Arc;
+use tempo_chainspec::{
+    TempoChainSpec,
+    spec::{DEV, TEMPO_T1_TX_GAS_LIMIT_CAP},
+};
+use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, ITIP20};
+use tempo_evm::TempoEvmConfig;
+use tempo_primitives::{
+    AASigned, Block, TempoHeader, TempoPrimitives, TempoSignature, TempoTransaction,
+    TempoTxEnvelope,
+    transaction::{Call, PrimitiveSignature, TEMPO_EXPIRING_NONCE_KEY},
+};
+
+/// Default account count used by the txgen-style TIP20 workload.
+pub const DEFAULT_TXGEN_ACCOUNT_COUNT: usize = 1_024;
+/// Default transaction count used by the txgen-style TIP20 workload.
+pub const DEFAULT_TXGEN_TX_COUNT: usize = 4_096;
+/// Timestamp used for the synthetic pool tip and transaction validity window.
+pub const DEFAULT_BLOCK_TIMESTAMP: u64 = 1_700_000_000;
+/// `valid_for_secs` from `contrib/bench/txgen/presets/tip20.yml`.
+pub const TXGEN_TIP20_VALID_FOR_SECS: u64 = 10;
+/// Gas limit from `contrib/bench/txgen/presets/tip20.yml`.
+pub const TXGEN_TIP20_GAS_LIMIT: u64 = 300_000;
+/// Fee settings from the txgen TIP20 preset.
+pub const TXGEN_FEE_PER_GAS: u128 = 100_000_000_000;
+/// Chain id from the txgen TIP20 preset.
+pub const TXGEN_CHAIN_ID: u64 = 1337;
+
+/// Mock provider type used by the transaction-pool benches.
+pub type BenchProvider = MockEthProvider<TempoPrimitives, TempoChainSpec>;
+/// Tempo transaction pool type used by the transaction-pool benches.
+pub type BenchPool = TempoTransactionPool<BenchProvider>;
+
+/// Configuration for the txgen-style TIP20 expiring nonce pool benchmarks.
+#[derive(Debug, Clone)]
+pub struct TxpoolBenchConfig {
+    pub account_count: usize,
+    pub tx_count: usize,
+    pub block_timestamp: u64,
+    pub valid_for_secs: u64,
+    pub chain_id: u64,
+    pub gas_limit: u64,
+    pub max_fee_per_gas: u128,
+    pub max_priority_fee_per_gas: u128,
+}
+
+impl Default for TxpoolBenchConfig {
+    fn default() -> Self {
+        Self {
+            account_count: DEFAULT_TXGEN_ACCOUNT_COUNT,
+            tx_count: DEFAULT_TXGEN_TX_COUNT,
+            block_timestamp: DEFAULT_BLOCK_TIMESTAMP,
+            valid_for_secs: TXGEN_TIP20_VALID_FOR_SECS,
+            chain_id: TXGEN_CHAIN_ID,
+            gas_limit: TXGEN_TIP20_GAS_LIMIT,
+            max_fee_per_gas: TXGEN_FEE_PER_GAS,
+            max_priority_fee_per_gas: TXGEN_FEE_PER_GAS,
+        }
+    }
+}
+
+/// Pre-generated txgen-style workload used as input to timed pool operations.
+#[derive(Debug, Clone)]
+pub struct TxpoolWorkload {
+    pub transactions: Vec<TempoPooledTransaction>,
+    pub participants: Vec<Address>,
+}
+
+/// Maintenance state wrapper that exposes the expiry path used by
+/// `maintain_tempo_pool` without running the infinite async event loop.
+#[derive(Default)]
+pub struct ExpiryMaintenanceState {
+    inner: TempoPoolState,
+}
+
+impl ExpiryMaintenanceState {
+    /// Seed expiry tracking from the current pool contents, matching
+    /// `maintain_tempo_pool` startup behavior.
+    pub fn from_pool(pool: &BenchPool) -> Self {
+        let mut inner = TempoPoolState::default();
+        let all_txs = pool.all_transactions();
+        for tx in all_txs.pending.iter().chain(all_txs.queued.iter()) {
+            inner.track(&tx.transaction);
+        }
+        Self { inner }
+    }
+
+    /// Run the expiring-transaction eviction portion of one maintenance tick.
+    pub fn evict_expired(&mut self, pool: &BenchPool, tip_timestamp: u64) -> usize {
+        let max_expiry = tip_timestamp.saturating_add(EVICTION_BUFFER_SECS);
+        let expired: Vec<_> = self
+            .inner
+            .drain_expired(max_expiry)
+            .into_iter()
+            .filter(|hash| pool.contains(hash))
+            .collect();
+        if expired.is_empty() {
+            return 0;
+        }
+        pool.remove_transactions(expired).len()
+    }
+}
+
+/// Build deterministic TIP20 expiring nonce transactions with the same pool-relevant shape as
+/// the txgen TIP20 preset: AA transaction, TIP20 transfer call, explicit fee token, expiring
+/// nonce key, nonce 0, and a 10s validity window. Like txgen, the fee fields are bumped by a
+/// per-transaction counter so deterministic expiring-nonce hashes stay unique.
+pub fn txgen_tip20_expiring_nonce_workload(config: &TxpoolBenchConfig) -> TxpoolWorkload {
+    assert!(config.account_count > 0, "account_count must be non-zero");
+
+    let participants = (0..config.account_count)
+        .map(indexed_user_address)
+        .collect::<Vec<_>>();
+    let transactions = (0..config.tx_count)
+        .map(|idx| {
+            let sender = participants[idx % participants.len()];
+            let recipient = participants
+                [(idx.wrapping_mul(17) + 1 + idx / participants.len()) % participants.len()];
+            tip20_expiring_nonce_tx(config, sender, recipient, idx as u128 + 1)
+        })
+        .collect();
+
+    TxpoolWorkload {
+        transactions,
+        participants,
+    }
+}
+
+/// Create a fresh mock-backed Tempo transaction pool sized for the benchmark workload.
+pub fn fresh_pool(config: &TxpoolBenchConfig) -> BenchPool {
+    let provider = provider_with_tip(config.block_timestamp);
+    let inner = EthTransactionValidatorBuilder::new(provider.clone(), TempoEvmConfig::mainnet())
+        .disable_balance_check()
+        .build(InMemoryBlobStore::default());
+    let amm_cache = AmmLiquidityCache::new(provider).expect("failed to setup AmmLiquidityCache");
+    let validator = TempoTransactionValidator::new(
+        inner,
+        DEFAULT_AA_VALID_AFTER_MAX_SECS,
+        DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
+        amm_cache,
+    );
+
+    let (executor, _task) = TransactionValidationTaskExecutor::new(validator);
+    let protocol_pool = Pool::new(
+        executor,
+        CoinbaseTipOrdering::default(),
+        InMemoryBlobStore::default(),
+        PoolConfig::default(),
+    );
+    let aa_config = AA2dPoolConfig {
+        pending_limit: SubPoolLimit::max(),
+        queued_limit: SubPoolLimit::max(),
+        max_txs_per_sender: config.tx_count.max(1),
+        ..Default::default()
+    };
+    TempoTransactionPool::new(protocol_pool, AA2dPool::new(aa_config))
+}
+
+/// Insert a transaction through the validated transaction path, bypassing expensive EVM
+/// validation so the benchmark isolates pool admission and indexing.
+pub fn add_validated_transaction_for_bench(
+    pool: &BenchPool,
+    pooled: TempoPooledTransaction,
+) -> PoolResult<AddedTransactionOutcome> {
+    let state_nonce = pooled.nonce();
+    let validated = TransactionValidationOutcome::Valid {
+        balance: *pooled.cost(),
+        state_nonce,
+        bytecode_hash: None,
+        transaction: ValidTransaction::new(pooled, None),
+        propagate: true,
+        authorities: None,
+    };
+    pool.add_validated_transaction(TransactionOrigin::External, validated)
+}
+
+/// Create a fully populated pool and matching expiry-maintenance state.
+pub fn populated_pool_with_expiry_state(
+    workload: &TxpoolWorkload,
+    config: &TxpoolBenchConfig,
+) -> (BenchPool, ExpiryMaintenanceState) {
+    let pool = fresh_pool(config);
+    for tx in workload.transactions.iter().cloned() {
+        add_validated_transaction_for_bench(&pool, tx)
+            .expect("benchmark transaction should be admitted");
+    }
+    let state = ExpiryMaintenanceState::from_pool(&pool);
+    (pool, state)
+}
+
+fn tip20_expiring_nonce_tx(
+    config: &TxpoolBenchConfig,
+    sender: Address,
+    recipient: Address,
+    uniqueness_bump: u128,
+) -> TempoPooledTransaction {
+    let input = Bytes::from(
+        ITIP20::transferCall {
+            to: recipient,
+            amount: U256::from(1),
+        }
+        .abi_encode(),
+    );
+    let max_priority_fee_per_gas = config
+        .max_priority_fee_per_gas
+        .checked_add(uniqueness_bump)
+        .expect("benchmark priority fee overflow");
+    let max_fee_per_gas = config
+        .max_fee_per_gas
+        .checked_add(uniqueness_bump)
+        .expect("benchmark max fee overflow");
+    let tx = TempoTransaction {
+        chain_id: config.chain_id,
+        max_priority_fee_per_gas,
+        max_fee_per_gas,
+        gas_limit: config.gas_limit,
+        calls: vec![Call {
+            to: TxKind::Call(DEFAULT_FEE_TOKEN),
+            value: U256::ZERO,
+            input,
+        }],
+        nonce_key: TEMPO_EXPIRING_NONCE_KEY,
+        nonce: 0,
+        fee_token: Some(DEFAULT_FEE_TOKEN),
+        fee_payer_signature: None,
+        valid_after: None,
+        valid_before: NonZeroU64::new(config.block_timestamp + config.valid_for_secs),
+        access_list: Default::default(),
+        tempo_authorization_list: Vec::new(),
+        key_authorization: None,
+    };
+    let signature =
+        TempoSignature::Primitive(PrimitiveSignature::Secp256k1(Signature::test_signature()));
+    let envelope: TempoTxEnvelope = AASigned::new_unhashed(tx, signature).into();
+    TempoPooledTransaction::new(Recovered::new_unchecked(envelope, sender))
+}
+
+fn provider_with_tip(block_timestamp: u64) -> BenchProvider {
+    let provider = MockEthProvider::<TempoPrimitives>::new()
+        .with_chain_spec(Arc::unwrap_or_clone(DEV.clone()));
+    provider.add_block(
+        B256::with_last_byte(1),
+        Block {
+            header: TempoHeader {
+                inner: Header {
+                    gas_limit: TEMPO_T1_TX_GAS_LIMIT_CAP,
+                    timestamp: block_timestamp,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
+    provider
+}
+
+fn indexed_user_address(index: usize) -> Address {
+    let mut bytes = [0u8; 20];
+    bytes[0] = 0x10;
+    bytes[12..].copy_from_slice(&(index as u64).to_be_bytes());
+    Address::from(bytes)
+}

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -27,5 +27,9 @@ pub use maintain::TempoPoolUpdates;
 pub use metrics::{AA2dPoolMetrics, TempoPoolMaintenanceMetrics};
 pub use tt_2d_pool::{AA2dPool, AA2dPoolConfig, AASequenceId, DEFAULT_MAX_TXS_PER_SENDER};
 
+#[cfg(feature = "test-utils")]
+#[doc(hidden)]
+pub mod bench_utils;
+
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -32,7 +32,7 @@ use tracing::{debug, error};
 
 /// Evict transactions this many seconds before they expire to reduce propagation
 /// of near-expiry transactions that are likely to fail validation on peers.
-const EVICTION_BUFFER_SECS: u64 = 3;
+pub(crate) const EVICTION_BUFFER_SECS: u64 = 3;
 
 /// Aggregated block-level invalidation events for the transaction pool.
 ///
@@ -394,7 +394,7 @@ fn decode_event<T: SolEvent>(log: &Log) -> Option<T> {
 /// when we check `pool.contains()` before eviction. This avoids the overhead of
 /// subscribing to all transaction lifecycle events.
 #[derive(Default)]
-struct TempoPoolState {
+pub(crate) struct TempoPoolState {
     /// Maps timestamp to transactions that are going to be invalidated at that time (due to `valid_after` or keychain-related expiry).
     expiry_map: BTreeMap<u64, B256Set>,
     /// Reverse mapping: tx_hash -> valid_before timestamp (for cleanup during drain).
@@ -407,7 +407,7 @@ struct TempoPoolState {
 
 impl TempoPoolState {
     /// Tracks an AA transaction with a `valid_before` timestamp.
-    fn track(&mut self, tx: &TempoPooledTransaction) {
+    pub(crate) fn track(&mut self, tx: &TempoPooledTransaction) {
         let valid_before = tx
             .inner()
             .as_aa()
@@ -467,7 +467,7 @@ impl TempoPoolState {
 
     /// Collects and removes all expired transactions up to the given timestamp.
     /// Returns the list of expired transaction hashes.
-    fn drain_expired(&mut self, tip_timestamp: u64) -> Vec<TxHash> {
+    pub(crate) fn drain_expired(&mut self, tip_timestamp: u64) -> Vec<TxHash> {
         let mut expired = Vec::new();
         while let Some(entry) = self.expiry_map.first_entry()
             && *entry.key() <= tip_timestamp

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -480,7 +480,7 @@ where
     /// [`TempoPooledTransaction::is_aa_2d`] routes AA transactions with non-zero
     /// nonce keys, including expiring nonces, to the 2D nonce pool. Everything else
     /// stays in the protocol pool.
-    fn add_validated_transaction(
+    pub(crate) fn add_validated_transaction(
         &self,
         origin: TransactionOrigin,
         transaction: TransactionValidationOutcome<TempoPooledTransaction>,

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -15,8 +15,9 @@ use reth_transaction_pool::{
 };
 use revm::database::BundleAccount;
 use std::{
+    cmp::Reverse,
     collections::{
-        BTreeMap, BTreeSet,
+        BTreeMap, BTreeSet, BinaryHeap,
         Bound::{Excluded, Unbounded},
         btree_map::Entry,
         hash_map,
@@ -31,6 +32,10 @@ use tempo_precompiles::NONCE_PRECOMPILE_ADDRESS;
 use tokio::sync::broadcast;
 
 type TxOrdering = CoinbaseTipOrdering<TempoPooledTransaction>;
+
+/// Minimum stale entries before rebuilding the expiring nonce eviction heap.
+const EXPIRING_NONCE_EVICTION_HEAP_REBUILD_MIN_STALE: usize = 16_384;
+
 /// A sub-pool that keeps track of 2D nonce transactions.
 ///
 /// It maintains both pending and queued transactions.
@@ -62,10 +67,10 @@ pub struct AA2dPool {
     /// Regular 2D transactions use `by_eviction_order`, which is keyed by
     /// `AA2dTransactionId`. Expiring nonce transactions are keyed by their
     /// expiring nonce hash instead and are always pending, so they need a
-    /// separate ordered index. The first entry is the expiring nonce transaction
-    /// that should be evicted next: lowest priority first, then newest
-    /// submission first when priorities tie.
-    expiring_nonce_eviction_order: BTreeSet<ExpiringNonceEvictionKey>,
+    /// separate ordered index. This heap is lazy: hash-based removals leave
+    /// stale candidates behind, and eviction prunes them before selecting the
+    /// worst live transaction.
+    expiring_nonce_eviction_heap: BinaryHeap<Reverse<ExpiringNonceEvictionKey>>,
     /// A mapping of `expiring_nonce_seen` slot to expiring nonce hash.
     ///
     /// Used to track inclusion of expiring nonce transactions.
@@ -117,7 +122,7 @@ impl AA2dPool {
             by_id: Default::default(),
             by_hash: Default::default(),
             expiring_nonce_txs: Default::default(),
-            expiring_nonce_eviction_order: Default::default(),
+            expiring_nonce_eviction_heap: Default::default(),
             slot_to_expiring_nonce_hash: Default::default(),
             slot_to_seq_id: Default::default(),
             config,
@@ -399,7 +404,9 @@ impl AA2dPool {
         // Insert into expiring nonce map and by_hash
         self.expiring_nonce_txs
             .insert(expiring_nonce_hash, pending_tx);
-        self.expiring_nonce_eviction_order.insert(eviction_key);
+        self.expiring_nonce_eviction_heap
+            .push(Reverse(eviction_key));
+        self.maybe_compact_expiring_nonce_eviction_heap();
         if let Some(slot) = transaction.transaction.expiring_nonce_slot() {
             self.slot_to_expiring_nonce_hash
                 .insert(slot, expiring_nonce_hash);
@@ -1077,9 +1084,8 @@ impl AA2dPool {
             .map(|key| (key.tx_id, key.priority().clone(), key.submission_id()));
 
         let worst_expiring = self
-            .expiring_nonce_eviction_order
-            .first()
-            .map(|key| (key.priority.clone(), key.submission_id));
+            .worst_expiring_nonce_key()
+            .map(|key| (key.priority, key.submission_id));
 
         match (worst_2d, worst_expiring) {
             (Some((id, pri_2d, sid_2d)), Some((pri_exp, sid_exp))) => {
@@ -1110,39 +1116,100 @@ impl AA2dPool {
         Some(tx)
     }
 
+    /// Returns the worst live expiring nonce eviction key, pruning stale heap
+    /// entries left behind by hash-based removals.
+    fn worst_expiring_nonce_key(&mut self) -> Option<ExpiringNonceEvictionKey> {
+        self.maybe_compact_expiring_nonce_eviction_heap();
+
+        loop {
+            let eviction_key = self.expiring_nonce_eviction_heap.peek()?.0.clone();
+
+            if self.is_live_expiring_nonce_eviction_key(&eviction_key) {
+                return Some(eviction_key);
+            }
+
+            self.expiring_nonce_eviction_heap.pop();
+        }
+    }
+
     /// Evicts the worst expiring nonce transaction.
-    ///
-    /// Use when eviction has selected the front of
-    /// `expiring_nonce_eviction_order`; this pops it directly instead of doing a
-    /// keyed removal.
     fn evict_worst_expiring_nonce_tx(
         &mut self,
     ) -> Option<Arc<ValidPoolTransaction<TempoPooledTransaction>>> {
-        let eviction_key = self.expiring_nonce_eviction_order.pop_first()?;
-        let pending_tx = self
-            .expiring_nonce_txs
-            .remove(&eviction_key.expiring_hash)?;
+        self.maybe_compact_expiring_nonce_eviction_heap();
 
-        Some(self.remove_expiring_nonce_pending_tx(pending_tx))
+        loop {
+            let eviction_key = self.expiring_nonce_eviction_heap.pop()?.0;
+
+            if !self.is_live_expiring_nonce_eviction_key(&eviction_key) {
+                continue;
+            }
+
+            let pending_tx = self
+                .expiring_nonce_txs
+                .remove(&eviction_key.expiring_hash)?;
+
+            let removed = self.remove_expiring_nonce_pending_tx(pending_tx);
+            if self.expiring_nonce_txs.is_empty() {
+                self.expiring_nonce_eviction_heap.clear();
+            }
+
+            return Some(removed);
+        }
     }
 
     /// Removes an expiring nonce transaction by hash.
     ///
     /// Use when removal starts from a hash, such as direct removal, sender
-    /// removal, or nonce-state inclusion. This path removes the matching
-    /// eviction key by lookup.
+    /// removal, or nonce-state inclusion. This path leaves a stale eviction
+    /// candidate in the heap; eviction prunes stale candidates lazily.
     fn remove_expiring_nonce_tx(
         &mut self,
         expiring_hash: &B256,
     ) -> Option<Arc<ValidPoolTransaction<TempoPooledTransaction>>> {
         let pending_tx = self.expiring_nonce_txs.remove(expiring_hash)?;
-        let eviction_key = ExpiringNonceEvictionKey::new(
-            *expiring_hash,
-            pending_tx.priority.clone(),
-            pending_tx.submission_id,
-        );
-        self.expiring_nonce_eviction_order.remove(&eviction_key);
-        Some(self.remove_expiring_nonce_pending_tx(pending_tx))
+        let removed = self.remove_expiring_nonce_pending_tx(pending_tx);
+
+        if self.expiring_nonce_txs.is_empty() {
+            self.expiring_nonce_eviction_heap.clear();
+        }
+
+        Some(removed)
+    }
+
+    fn is_live_expiring_nonce_eviction_key(&self, key: &ExpiringNonceEvictionKey) -> bool {
+        self.expiring_nonce_txs
+            .get(&key.expiring_hash)
+            .is_some_and(|pending_tx| pending_tx.submission_id == key.submission_id)
+    }
+
+    fn maybe_compact_expiring_nonce_eviction_heap(&mut self) {
+        let live = self.expiring_nonce_txs.len();
+        if live == 0 {
+            self.expiring_nonce_eviction_heap.clear();
+            return;
+        }
+
+        let heap_len = self.expiring_nonce_eviction_heap.len();
+        let stale = heap_len.saturating_sub(live);
+        if stale > EXPIRING_NONCE_EVICTION_HEAP_REBUILD_MIN_STALE && stale.saturating_mul(2) > live
+        {
+            self.rebuild_expiring_nonce_eviction_heap();
+        }
+    }
+
+    fn rebuild_expiring_nonce_eviction_heap(&mut self) {
+        self.expiring_nonce_eviction_heap = self
+            .expiring_nonce_txs
+            .iter()
+            .map(|(expiring_hash, pending_tx)| {
+                Reverse(ExpiringNonceEvictionKey::new(
+                    *expiring_hash,
+                    pending_tx.priority.clone(),
+                    pending_tx.submission_id,
+                ))
+            })
+            .collect();
     }
 
     /// Removes secondary state for an already-detached expiring nonce transaction.
@@ -1288,12 +1355,11 @@ impl AA2dPool {
             self.expiring_nonce_txs.len(),
             self.by_hash.len()
         );
-        assert_eq!(
+        assert!(
+            self.expiring_nonce_txs.len() <= self.expiring_nonce_eviction_heap.len(),
+            "expiring_nonce_txs.len() ({}) > expiring_nonce_eviction_heap.len() ({})",
             self.expiring_nonce_txs.len(),
-            self.expiring_nonce_eviction_order.len(),
-            "expiring_nonce_txs.len() ({}) != expiring_nonce_eviction_order.len() ({})",
-            self.expiring_nonce_txs.len(),
-            self.expiring_nonce_eviction_order.len()
+            self.expiring_nonce_eviction_heap.len()
         );
 
         // All independent transactions must exist in by_id
@@ -1448,14 +1514,16 @@ impl AA2dPool {
                 self.by_hash.contains_key(&tx_hash),
                 "Expiring nonce tx {tx_hash:?} not in by_hash (expiring hash {hash:?})"
             );
+            let eviction_key = ExpiringNonceEvictionKey::new(
+                *hash,
+                pending_tx.priority.clone(),
+                pending_tx.submission_id,
+            );
             assert!(
-                self.expiring_nonce_eviction_order
-                    .contains(&ExpiringNonceEvictionKey::new(
-                        *hash,
-                        pending_tx.priority.clone(),
-                        pending_tx.submission_id,
-                    )),
-                "Expiring nonce tx {tx_hash:?} not in expiring_nonce_eviction_order"
+                self.expiring_nonce_eviction_heap
+                    .iter()
+                    .any(|key| key.0 == eviction_key),
+                "Expiring nonce tx {tx_hash:?} not in expiring_nonce_eviction_heap"
             );
             assert!(
                 pending_tx.transaction.transaction.is_expiring_nonce(),
@@ -1463,12 +1531,16 @@ impl AA2dPool {
             );
         }
 
-        for key in &self.expiring_nonce_eviction_order {
-            assert!(
-                self.expiring_nonce_txs.contains_key(&key.expiring_hash),
-                "Expiring nonce eviction key {:?} not in expiring_nonce_txs",
-                key.expiring_hash
-            );
+        for Reverse(key) in &self.expiring_nonce_eviction_heap {
+            if let Some(pending_tx) = self.expiring_nonce_txs.get(&key.expiring_hash)
+                && pending_tx.submission_id == key.submission_id
+            {
+                assert_eq!(
+                    pending_tx.priority, key.priority,
+                    "Live expiring nonce eviction key priority mismatch for {:?}",
+                    key.expiring_hash
+                );
+            }
         }
     }
 }
@@ -1532,12 +1604,12 @@ impl AA2dInternalTransaction {
     }
 }
 
-/// Ordering key for `AA2dPool::expiring_nonce_eviction_order`.
+/// Ordering key for `AA2dPool::expiring_nonce_eviction_heap`.
 ///
 /// This mirrors `EvictionKey` for expiring nonce transactions, which are not
 /// stored in `by_id` and therefore cannot use `AA2dTransactionId`. The key keeps
 /// a copy of the transaction's immutable eviction fields so pending eviction can
-/// select the worst expiring nonce transaction from the front of the set.
+/// select the worst expiring nonce transaction from the top of the heap.
 ///
 /// Order:
 /// 1. Priority ascending (lowest priority evicted first)
@@ -5594,8 +5666,8 @@ mod tests {
             "expiring_nonce_txs not cleaned up"
         );
         assert!(
-            pool.expiring_nonce_eviction_order.is_empty(),
-            "expiring_nonce_eviction_order not cleaned up"
+            pool.expiring_nonce_eviction_heap.is_empty(),
+            "expiring_nonce_eviction_heap not cleaned up"
         );
         assert!(
             !pool.by_hash.contains_key(&tx_hash),
@@ -5678,25 +5750,38 @@ mod tests {
 
     fn assert_expiring_eviction_index_len(pool: &AA2dPool, len: usize) {
         assert_eq!(pool.expiring_nonce_txs.len(), len);
-        assert_eq!(pool.expiring_nonce_eviction_order.len(), len);
+        assert!(
+            pool.expiring_nonce_eviction_heap.len() >= len,
+            "expiring_nonce_eviction_heap.len() ({}) < live len ({len})",
+            pool.expiring_nonce_eviction_heap.len()
+        );
+        assert_eq!(
+            pool.expiring_nonce_eviction_heap
+                .iter()
+                .filter(|key| pool.is_live_expiring_nonce_eviction_key(&key.0))
+                .count(),
+            len
+        );
         pool.assert_invariants();
     }
 
     fn assert_expiring_eviction_index_contains(pool: &AA2dPool, expiring_hash: B256) {
         assert!(
-            pool.expiring_nonce_eviction_order
+            pool.expiring_nonce_eviction_heap
                 .iter()
-                .any(|key| key.expiring_hash == expiring_hash),
-            "expiring_nonce_eviction_order should contain {expiring_hash:?}"
+                .any(|key| key.0.expiring_hash == expiring_hash
+                    && pool.is_live_expiring_nonce_eviction_key(&key.0)),
+            "expiring_nonce_eviction_heap should contain live {expiring_hash:?}"
         );
     }
 
     fn assert_expiring_eviction_index_missing(pool: &AA2dPool, expiring_hash: B256) {
         assert!(
-            pool.expiring_nonce_eviction_order
+            pool.expiring_nonce_eviction_heap
                 .iter()
-                .all(|key| key.expiring_hash != expiring_hash),
-            "expiring_nonce_eviction_order should not contain {expiring_hash:?}"
+                .all(|key| key.0.expiring_hash != expiring_hash
+                    || !pool.is_live_expiring_nonce_eviction_key(&key.0)),
+            "expiring_nonce_eviction_heap should not contain live {expiring_hash:?}"
         );
     }
 
@@ -5888,7 +5973,7 @@ mod tests {
     }
 
     #[test]
-    fn expiring_nonce_eviction_order_evicts_lowest_priority() {
+    fn expiring_nonce_eviction_heap_evicts_lowest_priority() {
         let mut pool = eviction_test_pool();
 
         let tx_low = TxBuilder::aa(Address::random())
@@ -5952,7 +6037,78 @@ mod tests {
     }
 
     #[test]
-    fn expiring_nonce_eviction_order_evicts_newer_same_priority() {
+    fn expiring_nonce_eviction_heap_skips_stale_removed_tx() {
+        let mut pool = eviction_test_pool();
+
+        let tx_low = TxBuilder::aa(Address::random())
+            .nonce_key(U256::MAX)
+            .max_priority_fee(1_000_000_000)
+            .max_fee(30_000_000_000)
+            .build();
+        let tx_mid = TxBuilder::aa(Address::random())
+            .nonce_key(U256::MAX)
+            .max_priority_fee(2_000_000_000)
+            .max_fee(30_000_000_000)
+            .build();
+        let tx_high = TxBuilder::aa(Address::random())
+            .nonce_key(U256::MAX)
+            .max_priority_fee(3_000_000_000)
+            .max_fee(30_000_000_000)
+            .build();
+        let tx_new = TxBuilder::aa(Address::random())
+            .nonce_key(U256::MAX)
+            .max_priority_fee(4_000_000_000)
+            .max_fee(30_000_000_000)
+            .build();
+
+        pool.add_transaction(
+            Arc::new(wrap_valid_tx(tx_low.clone(), TransactionOrigin::Local)),
+            0,
+            TempoHardfork::T1,
+        )
+        .unwrap();
+        pool.add_transaction(
+            Arc::new(wrap_valid_tx(tx_mid.clone(), TransactionOrigin::Local)),
+            0,
+            TempoHardfork::T1,
+        )
+        .unwrap();
+
+        let removed = pool.remove_transactions(std::iter::once(tx_low.hash()));
+        assert_eq!(removed.len(), 1);
+        assert!(!pool.contains(tx_low.hash()));
+        assert!(
+            pool.expiring_nonce_eviction_heap.len() > pool.expiring_nonce_txs.len(),
+            "hash removal should leave a stale heap candidate"
+        );
+
+        pool.add_transaction(
+            Arc::new(wrap_valid_tx(tx_high.clone(), TransactionOrigin::Local)),
+            0,
+            TempoHardfork::T1,
+        )
+        .unwrap();
+        let result = pool
+            .add_transaction(
+                Arc::new(wrap_valid_tx(tx_new.clone(), TransactionOrigin::Local)),
+                0,
+                TempoHardfork::T1,
+            )
+            .unwrap();
+
+        let AddedTransaction::Pending(pending) = result else {
+            panic!("expected pending")
+        };
+        assert_eq!(pending.discarded.len(), 1);
+        assert_eq!(pending.discarded[0].hash(), tx_mid.hash());
+        assert!(pool.contains(tx_high.hash()));
+        assert!(pool.contains(tx_new.hash()));
+        assert!(!pool.contains(tx_mid.hash()));
+        pool.assert_invariants();
+    }
+
+    #[test]
+    fn expiring_nonce_eviction_heap_evicts_newer_same_priority() {
         let mut pool = eviction_test_pool();
 
         let tx_old_1 = TxBuilder::aa(Address::random())


### PR DESCRIPTION
Adds Criterion txpool benches for TIP-20 expiring nonce add/maintain load and replaces the expiring nonce eviction BTreeSet with a lazy BinaryHeap that rebuilds when stale entries accumulate.

On the 20k maintain benchmark, median improved from about 19.5ms to 16.5ms; the maintain profile no longer shows BTreeSet removal in the expiry path and is now dominated by removal/drop work.