### PR TITLE
Bump tempo workspace version to 1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12812,7 +12812,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -12959,7 +12959,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13020,7 +13020,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node-config"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13037,7 +13037,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -13068,7 +13068,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13082,7 +13082,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13133,7 +13133,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13171,7 +13171,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13190,7 +13190,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "eyre",
  "indenter",
@@ -13198,7 +13198,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13211,7 +13211,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13280,7 +13280,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13314,7 +13314,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13333,7 +13333,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13365,7 +13365,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13413,7 +13413,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13447,7 +13447,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "clap",
@@ -13472,7 +13472,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "eyre",
  "jiff",
@@ -13481,7 +13481,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13520,7 +13520,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13532,7 +13532,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-json-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps the workspace package version from 1.7.1 to 1.8.0.

Ran `cargo update -n tempo`; Cargo completed successfully and reported this was a dry-run, so `Cargo.lock` was not updated.

Prompted by: @jenpaff