### PR TITLE
fix(perf): add enable builder flags

### DIFF
--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -211,7 +211,7 @@ fn init_engine_defaults() {
         .with_always_process_payload_attributes_on_canonical_head(true)
         // Defer persistence I/O during active payload builds.
         .with_suppress_persistence_during_build(true)
-        .with_share_execution_cache_with_payload_builder(true)
+        .with_share_execution_cache_with_payload_builder(false)
         .with_share_sparse_trie_with_payload_builder(true)
         .try_init()
         .expect("failed to initialize engine defaults");

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -357,6 +357,8 @@ fn main() -> eyre::Result<()> {
         }
     };
 
+    apply_builder_disable_flags(&mut cli);
+
     if let Commands::Node(node_cmd) = &cli.command
         && node_cmd.engine.share_sparse_trie_with_payload_builder
         && node_cmd.builder.max_payload_tasks != 1
@@ -750,13 +752,29 @@ fn main() -> eyre::Result<()> {
     Ok(())
 }
 
+fn apply_builder_disable_flags(cli: &mut TempoCli) {
+    let Commands::Node(node_cmd) = &mut cli.command else {
+        return;
+    };
+
+    if node_cmd.ext.node_args.builder_disable_prewarming {
+        node_cmd.ext.node_args.builder_enable_prewarming = false;
+    }
+    if node_cmd.ext.node_args.builder_disable_execution_cache {
+        node_cmd.engine.share_execution_cache_with_payload_builder = false;
+    }
+    if node_cmd.ext.node_args.builder_disable_sparse_trie {
+        node_cmd.engine.share_sparse_trie_with_payload_builder = false;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{sync::Once, time::Duration};
 
     use clap::Parser;
 
-    use super::{Commands, TempoCli, defaults};
+    use super::{Commands, TempoCli, apply_builder_disable_flags, defaults};
 
     fn init_defaults_once() {
         static INIT: Once = Once::new();
@@ -775,6 +793,9 @@ mod tests {
         assert!(node_cmd.engine.share_sparse_trie_with_payload_builder);
         assert_eq!(node_cmd.builder.max_payload_tasks, 1);
         assert!(node_cmd.ext.node_args.builder_enable_prewarming);
+        assert!(!node_cmd.ext.node_args.builder_disable_prewarming);
+        assert!(!node_cmd.ext.node_args.builder_disable_execution_cache);
+        assert!(!node_cmd.ext.node_args.builder_disable_sparse_trie);
         assert_eq!(
             node_cmd.ext.consensus.target_block_time.into_duration(),
             Duration::from_millis(550)
@@ -811,5 +832,30 @@ mod tests {
             node_cmd.ext.consensus.network_budget.into_duration(),
             Duration::from_millis(50)
         );
+    }
+
+    #[test]
+    fn builder_disable_flags_parse() {
+        init_defaults_once();
+
+        let mut cli = TempoCli::try_parse_from([
+            "tempo",
+            "node",
+            "--dev",
+            "--builder.disable-prewarming",
+            "--builder.disable-execution-cache",
+            "--builder.disable-sparse-trie",
+        ])
+        .unwrap();
+        apply_builder_disable_flags(&mut cli);
+        let Commands::Node(node_cmd) = cli.command else {
+            panic!("expected node command");
+        };
+        assert!(node_cmd.ext.node_args.builder_disable_prewarming);
+        assert!(node_cmd.ext.node_args.builder_disable_execution_cache);
+        assert!(node_cmd.ext.node_args.builder_disable_sparse_trie);
+        assert!(!node_cmd.ext.node_args.builder_enable_prewarming);
+        assert!(!node_cmd.engine.share_execution_cache_with_payload_builder);
+        assert!(!node_cmd.engine.share_sparse_trie_with_payload_builder);
     }
 }

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -793,14 +793,6 @@ mod tests {
         assert!(!node_cmd.ext.node_args.builder_enable_prewarming);
         assert!(!node_cmd.ext.node_args.builder_enable_execution_cache);
         assert!(!node_cmd.ext.node_args.builder_disable_sparse_trie);
-        assert!(!node_cmd.ext.node_args.builder_enable_elastic_payload_budget);
-        assert!(
-            !node_cmd
-                .ext
-                .node_args
-                .payload_builder_builder()
-                .enable_elastic_payload_budget
-        );
         assert_eq!(
             node_cmd.ext.consensus.target_block_time.into_duration(),
             Duration::from_millis(550)
@@ -850,7 +842,6 @@ mod tests {
             "--builder.enable-prewarming",
             "--builder.enable-execution-cache",
             "--builder.disable-sparse-trie",
-            "--builder.enable-elastic-payload-budget",
         ])
         .unwrap();
         apply_builder_feature_flags(&mut cli);
@@ -860,15 +851,7 @@ mod tests {
         assert!(node_cmd.ext.node_args.builder_enable_prewarming);
         assert!(node_cmd.ext.node_args.builder_enable_execution_cache);
         assert!(node_cmd.ext.node_args.builder_disable_sparse_trie);
-        assert!(node_cmd.ext.node_args.builder_enable_elastic_payload_budget);
         assert!(node_cmd.engine.share_execution_cache_with_payload_builder);
         assert!(!node_cmd.engine.share_sparse_trie_with_payload_builder);
-        assert!(
-            node_cmd
-                .ext
-                .node_args
-                .payload_builder_builder()
-                .enable_elastic_payload_budget
-        );
     }
 }

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -357,7 +357,7 @@ fn main() -> eyre::Result<()> {
         }
     };
 
-    apply_builder_disable_flags(&mut cli);
+    apply_builder_feature_flags(&mut cli);
 
     if let Commands::Node(node_cmd) = &cli.command
         && node_cmd.engine.share_sparse_trie_with_payload_builder
@@ -752,16 +752,13 @@ fn main() -> eyre::Result<()> {
     Ok(())
 }
 
-fn apply_builder_disable_flags(cli: &mut TempoCli) {
+fn apply_builder_feature_flags(cli: &mut TempoCli) {
     let Commands::Node(node_cmd) = &mut cli.command else {
         return;
     };
 
-    if node_cmd.ext.node_args.builder_disable_prewarming {
-        node_cmd.ext.node_args.builder_enable_prewarming = false;
-    }
-    if node_cmd.ext.node_args.builder_disable_execution_cache {
-        node_cmd.engine.share_execution_cache_with_payload_builder = false;
+    if node_cmd.ext.node_args.builder_enable_execution_cache {
+        node_cmd.engine.share_execution_cache_with_payload_builder = true;
     }
     if node_cmd.ext.node_args.builder_disable_sparse_trie {
         node_cmd.engine.share_sparse_trie_with_payload_builder = false;
@@ -774,7 +771,7 @@ mod tests {
 
     use clap::Parser;
 
-    use super::{Commands, TempoCli, apply_builder_disable_flags, defaults};
+    use super::{Commands, TempoCli, apply_builder_feature_flags, defaults};
 
     fn init_defaults_once() {
         static INIT: Once = Once::new();
@@ -785,17 +782,25 @@ mod tests {
     fn consensus_block_budget_defaults_are_stable() {
         init_defaults_once();
 
-        let cli = TempoCli::try_parse_from(["tempo", "node", "--dev"]).unwrap();
+        let mut cli = TempoCli::try_parse_from(["tempo", "node", "--dev"]).unwrap();
+        apply_builder_feature_flags(&mut cli);
         let Commands::Node(node_cmd) = cli.command else {
             panic!("expected node command");
         };
-        assert!(node_cmd.engine.share_execution_cache_with_payload_builder);
+        assert!(!node_cmd.engine.share_execution_cache_with_payload_builder);
         assert!(node_cmd.engine.share_sparse_trie_with_payload_builder);
         assert_eq!(node_cmd.builder.max_payload_tasks, 1);
-        assert!(node_cmd.ext.node_args.builder_enable_prewarming);
-        assert!(!node_cmd.ext.node_args.builder_disable_prewarming);
-        assert!(!node_cmd.ext.node_args.builder_disable_execution_cache);
+        assert!(!node_cmd.ext.node_args.builder_enable_prewarming);
+        assert!(!node_cmd.ext.node_args.builder_enable_execution_cache);
         assert!(!node_cmd.ext.node_args.builder_disable_sparse_trie);
+        assert!(!node_cmd.ext.node_args.builder_enable_elastic_payload_budget);
+        assert!(
+            !node_cmd
+                .ext
+                .node_args
+                .payload_builder_builder()
+                .enable_elastic_payload_budget
+        );
         assert_eq!(
             node_cmd.ext.consensus.target_block_time.into_duration(),
             Duration::from_millis(550)
@@ -835,27 +840,35 @@ mod tests {
     }
 
     #[test]
-    fn builder_disable_flags_parse() {
+    fn builder_feature_flags_parse() {
         init_defaults_once();
 
         let mut cli = TempoCli::try_parse_from([
             "tempo",
             "node",
             "--dev",
-            "--builder.disable-prewarming",
-            "--builder.disable-execution-cache",
+            "--builder.enable-prewarming",
+            "--builder.enable-execution-cache",
             "--builder.disable-sparse-trie",
+            "--builder.enable-elastic-payload-budget",
         ])
         .unwrap();
-        apply_builder_disable_flags(&mut cli);
+        apply_builder_feature_flags(&mut cli);
         let Commands::Node(node_cmd) = cli.command else {
             panic!("expected node command");
         };
-        assert!(node_cmd.ext.node_args.builder_disable_prewarming);
-        assert!(node_cmd.ext.node_args.builder_disable_execution_cache);
+        assert!(node_cmd.ext.node_args.builder_enable_prewarming);
+        assert!(node_cmd.ext.node_args.builder_enable_execution_cache);
         assert!(node_cmd.ext.node_args.builder_disable_sparse_trie);
-        assert!(!node_cmd.ext.node_args.builder_enable_prewarming);
-        assert!(!node_cmd.engine.share_execution_cache_with_payload_builder);
+        assert!(node_cmd.ext.node_args.builder_enable_elastic_payload_budget);
+        assert!(node_cmd.engine.share_execution_cache_with_payload_builder);
         assert!(!node_cmd.engine.share_sparse_trie_with_payload_builder);
+        assert!(
+            node_cmd
+                .ext
+                .node_args
+                .payload_builder_builder()
+                .enable_elastic_payload_budget
+        );
     }
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -68,16 +68,12 @@ pub struct TempoNodeArgs {
     pub builder_state_provider_metrics: bool,
 
     /// Enable prewarming for the payload builder.
-    #[arg(long = "builder.enable-prewarming", default_value_t = true)]
+    #[arg(long = "builder.enable-prewarming", default_value_t = false)]
     pub builder_enable_prewarming: bool,
 
-    /// Disable prewarming for the payload builder.
-    #[arg(long = "builder.disable-prewarming", default_value_t = false)]
-    pub builder_disable_prewarming: bool,
-
-    /// Disable sharing the execution cache with the payload builder.
-    #[arg(long = "builder.disable-execution-cache", default_value_t = false)]
-    pub builder_disable_execution_cache: bool,
+    /// Enable sharing the execution cache with the payload builder.
+    #[arg(long = "builder.enable-execution-cache", default_value_t = false)]
+    pub builder_enable_execution_cache: bool,
 
     /// Disable sharing the sparse trie with the payload builder.
     #[arg(long = "builder.disable-sparse-trie", default_value_t = false)]
@@ -89,6 +85,13 @@ pub struct TempoNodeArgs {
         default_value_t = DEFAULT_BUILD_TIME_MULTIPLIER
     )]
     pub builder_build_time_multiplier: f64,
+
+    /// Enable the elastic payload build budget.
+    #[arg(
+        long = "builder.enable-elastic-payload-budget",
+        default_value_t = false
+    )]
+    pub builder_enable_elastic_payload_budget: bool,
 }
 
 impl Default for TempoNodeArgs {
@@ -98,10 +101,10 @@ impl Default for TempoNodeArgs {
             max_tempo_authorizations: DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
             builder_state_provider_metrics: false,
             builder_enable_prewarming: false,
-            builder_disable_prewarming: false,
-            builder_disable_execution_cache: false,
+            builder_enable_execution_cache: false,
             builder_disable_sparse_trie: false,
             builder_build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
+            builder_enable_elastic_payload_budget: false,
         }
     }
 }
@@ -119,8 +122,9 @@ impl TempoNodeArgs {
     pub fn payload_builder_builder(&self) -> TempoPayloadBuilderBuilder {
         TempoPayloadBuilderBuilder {
             state_provider_metrics: self.builder_state_provider_metrics,
-            enable_prewarming: self.builder_enable_prewarming && !self.builder_disable_prewarming,
+            enable_prewarming: self.builder_enable_prewarming,
             build_time_multiplier: self.builder_build_time_multiplier,
+            enable_elastic_payload_budget: self.builder_enable_elastic_payload_budget,
         }
     }
 }
@@ -531,6 +535,8 @@ pub struct TempoPayloadBuilderBuilder {
     pub enable_prewarming: bool,
     /// Initial multiplier for predicting replayable payload build work.
     pub build_time_multiplier: f64,
+    /// Enable the elastic payload build budget.
+    pub enable_elastic_payload_budget: bool,
 }
 
 impl Default for TempoPayloadBuilderBuilder {
@@ -539,6 +545,7 @@ impl Default for TempoPayloadBuilderBuilder {
             state_provider_metrics: false,
             enable_prewarming: false,
             build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
+            enable_elastic_payload_budget: false,
         }
     }
 }
@@ -566,6 +573,7 @@ where
                 state_provider_metrics: self.state_provider_metrics,
                 enable_prewarming: self.enable_prewarming,
                 build_time_multiplier: self.build_time_multiplier,
+                enable_elastic_payload_budget: self.enable_elastic_payload_budget,
             },
         ))
     }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -85,13 +85,6 @@ pub struct TempoNodeArgs {
         default_value_t = DEFAULT_BUILD_TIME_MULTIPLIER
     )]
     pub builder_build_time_multiplier: f64,
-
-    /// Enable the elastic payload build budget.
-    #[arg(
-        long = "builder.enable-elastic-payload-budget",
-        default_value_t = false
-    )]
-    pub builder_enable_elastic_payload_budget: bool,
 }
 
 impl Default for TempoNodeArgs {
@@ -104,7 +97,6 @@ impl Default for TempoNodeArgs {
             builder_enable_execution_cache: false,
             builder_disable_sparse_trie: false,
             builder_build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
-            builder_enable_elastic_payload_budget: false,
         }
     }
 }
@@ -124,7 +116,6 @@ impl TempoNodeArgs {
             state_provider_metrics: self.builder_state_provider_metrics,
             enable_prewarming: self.builder_enable_prewarming,
             build_time_multiplier: self.builder_build_time_multiplier,
-            enable_elastic_payload_budget: self.builder_enable_elastic_payload_budget,
         }
     }
 }
@@ -535,8 +526,6 @@ pub struct TempoPayloadBuilderBuilder {
     pub enable_prewarming: bool,
     /// Initial multiplier for predicting replayable payload build work.
     pub build_time_multiplier: f64,
-    /// Enable the elastic payload build budget.
-    pub enable_elastic_payload_budget: bool,
 }
 
 impl Default for TempoPayloadBuilderBuilder {
@@ -545,7 +534,6 @@ impl Default for TempoPayloadBuilderBuilder {
             state_provider_metrics: false,
             enable_prewarming: false,
             build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
-            enable_elastic_payload_budget: false,
         }
     }
 }
@@ -573,7 +561,6 @@ where
                 state_provider_metrics: self.state_provider_metrics,
                 enable_prewarming: self.enable_prewarming,
                 build_time_multiplier: self.build_time_multiplier,
-                enable_elastic_payload_budget: self.enable_elastic_payload_budget,
             },
         ))
     }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -71,6 +71,18 @@ pub struct TempoNodeArgs {
     #[arg(long = "builder.enable-prewarming", default_value_t = true)]
     pub builder_enable_prewarming: bool,
 
+    /// Disable prewarming for the payload builder.
+    #[arg(long = "builder.disable-prewarming", default_value_t = false)]
+    pub builder_disable_prewarming: bool,
+
+    /// Disable sharing the execution cache with the payload builder.
+    #[arg(long = "builder.disable-execution-cache", default_value_t = false)]
+    pub builder_disable_execution_cache: bool,
+
+    /// Disable sharing the sparse trie with the payload builder.
+    #[arg(long = "builder.disable-sparse-trie", default_value_t = false)]
+    pub builder_disable_sparse_trie: bool,
+
     /// Initial multiplier for predicting replayable payload build work.
     #[arg(
         long = "builder.build-time-multiplier",
@@ -86,6 +98,9 @@ impl Default for TempoNodeArgs {
             max_tempo_authorizations: DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
             builder_state_provider_metrics: false,
             builder_enable_prewarming: false,
+            builder_disable_prewarming: false,
+            builder_disable_execution_cache: false,
+            builder_disable_sparse_trie: false,
             builder_build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
         }
     }
@@ -104,7 +119,7 @@ impl TempoNodeArgs {
     pub fn payload_builder_builder(&self) -> TempoPayloadBuilderBuilder {
         TempoPayloadBuilderBuilder {
             state_provider_metrics: self.builder_state_provider_metrics,
-            enable_prewarming: self.builder_enable_prewarming,
+            enable_prewarming: self.builder_enable_prewarming && !self.builder_disable_prewarming,
             build_time_multiplier: self.builder_build_time_multiplier,
         }
     }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -104,6 +104,8 @@ pub struct TempoPayloadBuilder<Provider> {
     state_provider_metrics: bool,
     /// Whether to enable prewarming of best transactions.
     enable_prewarming: bool,
+    /// Whether to apply the local elastic payload build budget.
+    enable_elastic_payload_budget: bool,
     /// Conservative estimate of total replayable build work divided by work at tx cutoff.
     build_time_multiplier: Arc<AtomicU64>,
 }
@@ -117,6 +119,8 @@ pub struct TempoPayloadBuilderConfig {
     pub state_provider_metrics: bool,
     /// Whether to enable prewarming of best transactions.
     pub enable_prewarming: bool,
+    /// Whether to apply the local elastic payload build budget.
+    pub enable_elastic_payload_budget: bool,
     /// Initial estimate of total replayable build work divided by work at tx cutoff.
     pub build_time_multiplier: f64,
 }
@@ -127,6 +131,7 @@ impl Default for TempoPayloadBuilderConfig {
             is_dev: false,
             state_provider_metrics: false,
             enable_prewarming: false,
+            enable_elastic_payload_budget: false,
             build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
         }
     }
@@ -151,6 +156,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             is_dev: config.is_dev,
             state_provider_metrics: config.state_provider_metrics,
             enable_prewarming: config.enable_prewarming,
+            enable_elastic_payload_budget: config.enable_elastic_payload_budget,
             build_time_multiplier: Arc::new(AtomicU64::new(scaled_build_time_multiplier(
                 config.build_time_multiplier,
             ))),
@@ -520,7 +526,10 @@ where
         let mut skipped_oversized_block = false;
         let mut invalid_pool_transaction_execution_attempts = 0u64;
         let mut normal_transaction_fill_idle_elapsed = Duration::ZERO;
-        let payload_build_budget = attributes.payload_build_budget();
+        let payload_build_budget = self
+            .enable_elastic_payload_budget
+            .then(|| attributes.payload_build_budget())
+            .flatten();
         let build_time_multiplier = self.build_time_multiplier();
         let marshal_persist = marshal_persist_estimate();
         let block_build_stop_reason = loop {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -104,8 +104,6 @@ pub struct TempoPayloadBuilder<Provider> {
     state_provider_metrics: bool,
     /// Whether to enable prewarming of best transactions.
     enable_prewarming: bool,
-    /// Whether to apply the local elastic payload build budget.
-    enable_elastic_payload_budget: bool,
     /// Conservative estimate of total replayable build work divided by work at tx cutoff.
     build_time_multiplier: Arc<AtomicU64>,
 }
@@ -119,8 +117,6 @@ pub struct TempoPayloadBuilderConfig {
     pub state_provider_metrics: bool,
     /// Whether to enable prewarming of best transactions.
     pub enable_prewarming: bool,
-    /// Whether to apply the local elastic payload build budget.
-    pub enable_elastic_payload_budget: bool,
     /// Initial estimate of total replayable build work divided by work at tx cutoff.
     pub build_time_multiplier: f64,
 }
@@ -131,7 +127,6 @@ impl Default for TempoPayloadBuilderConfig {
             is_dev: false,
             state_provider_metrics: false,
             enable_prewarming: false,
-            enable_elastic_payload_budget: false,
             build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
         }
     }
@@ -156,7 +151,6 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             is_dev: config.is_dev,
             state_provider_metrics: config.state_provider_metrics,
             enable_prewarming: config.enable_prewarming,
-            enable_elastic_payload_budget: config.enable_elastic_payload_budget,
             build_time_multiplier: Arc::new(AtomicU64::new(scaled_build_time_multiplier(
                 config.build_time_multiplier,
             ))),
@@ -526,10 +520,7 @@ where
         let mut skipped_oversized_block = false;
         let mut invalid_pool_transaction_execution_attempts = 0u64;
         let mut normal_transaction_fill_idle_elapsed = Duration::ZERO;
-        let payload_build_budget = self
-            .enable_elastic_payload_budget
-            .then(|| attributes.payload_build_budget())
-            .flatten();
+        let payload_build_budget = attributes.payload_build_budget();
         let build_time_multiplier = self.build_time_multiplier();
         let marshal_persist = marshal_persist_estimate();
         let block_build_stop_reason = loop {


### PR DESCRIPTION
Adds builder-scoped enable flags for payload builder prewarming, shared execution cache.

Sparse trie enabled by default. 

These flags map onto the existing Tempo/reth builder and engine configuration after CLI parsing:
- --builder.enable-prewarming
- --builder.enable-execution-cache
- --builder.disable-sparse-trie

Validation:
- cargo fmt --check
- cargo test -p tempo --bin tempo builder_disable_flags_parse
- cargo test -p tempo --bin tempo consensus_block_budget_defaults_are_stable

Prompted by: @shekhirin