### PR TITLE
fix(builder): default payload features off

### DIFF
--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -211,7 +211,7 @@ fn init_engine_defaults() {
         .with_always_process_payload_attributes_on_canonical_head(true)
         // Defer persistence I/O during active payload builds.
         .with_suppress_persistence_during_build(true)
-        .with_share_execution_cache_with_payload_builder(true)
+        .with_share_execution_cache_with_payload_builder(false)
         .with_share_sparse_trie_with_payload_builder(true)
         .try_init()
         .expect("failed to initialize engine defaults");

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -771,10 +771,18 @@ mod tests {
         let Commands::Node(node_cmd) = cli.command else {
             panic!("expected node command");
         };
-        assert!(node_cmd.engine.share_execution_cache_with_payload_builder);
+        assert!(!node_cmd.engine.share_execution_cache_with_payload_builder);
         assert!(node_cmd.engine.share_sparse_trie_with_payload_builder);
         assert_eq!(node_cmd.builder.max_payload_tasks, 1);
-        assert!(node_cmd.ext.node_args.builder_enable_prewarming);
+        assert!(!node_cmd.ext.node_args.builder_enable_prewarming);
+        assert!(!node_cmd.ext.node_args.builder_enable_elastic_payload_budget);
+        assert!(
+            !node_cmd
+                .ext
+                .node_args
+                .payload_builder_builder()
+                .enable_elastic_payload_budget
+        );
         assert_eq!(
             node_cmd.ext.consensus.target_block_time.into_duration(),
             Duration::from_millis(550)
@@ -810,6 +818,30 @@ mod tests {
         assert_eq!(
             node_cmd.ext.consensus.network_budget.into_duration(),
             Duration::from_millis(50)
+        );
+    }
+
+    #[test]
+    fn builder_enable_elastic_payload_budget_parses() {
+        init_defaults_once();
+
+        let cli = TempoCli::try_parse_from([
+            "tempo",
+            "node",
+            "--dev",
+            "--builder.enable-elastic-payload-budget",
+        ])
+        .unwrap();
+        let Commands::Node(node_cmd) = cli.command else {
+            panic!("expected node command");
+        };
+        assert!(node_cmd.ext.node_args.builder_enable_elastic_payload_budget);
+        assert!(
+            node_cmd
+                .ext
+                .node_args
+                .payload_builder_builder()
+                .enable_elastic_payload_budget
         );
     }
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -68,7 +68,7 @@ pub struct TempoNodeArgs {
     pub builder_state_provider_metrics: bool,
 
     /// Enable prewarming for the payload builder.
-    #[arg(long = "builder.enable-prewarming", default_value_t = true)]
+    #[arg(long = "builder.enable-prewarming", default_value_t = false)]
     pub builder_enable_prewarming: bool,
 
     /// Initial multiplier for predicting replayable payload build work.
@@ -77,6 +77,13 @@ pub struct TempoNodeArgs {
         default_value_t = DEFAULT_BUILD_TIME_MULTIPLIER
     )]
     pub builder_build_time_multiplier: f64,
+
+    /// Enable the elastic payload build budget.
+    #[arg(
+        long = "builder.enable-elastic-payload-budget",
+        default_value_t = false
+    )]
+    pub builder_enable_elastic_payload_budget: bool,
 }
 
 impl Default for TempoNodeArgs {
@@ -87,6 +94,7 @@ impl Default for TempoNodeArgs {
             builder_state_provider_metrics: false,
             builder_enable_prewarming: false,
             builder_build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
+            builder_enable_elastic_payload_budget: false,
         }
     }
 }
@@ -106,6 +114,7 @@ impl TempoNodeArgs {
             state_provider_metrics: self.builder_state_provider_metrics,
             enable_prewarming: self.builder_enable_prewarming,
             build_time_multiplier: self.builder_build_time_multiplier,
+            enable_elastic_payload_budget: self.builder_enable_elastic_payload_budget,
         }
     }
 }
@@ -516,6 +525,8 @@ pub struct TempoPayloadBuilderBuilder {
     pub enable_prewarming: bool,
     /// Initial multiplier for predicting replayable payload build work.
     pub build_time_multiplier: f64,
+    /// Enable the elastic payload build budget.
+    pub enable_elastic_payload_budget: bool,
 }
 
 impl Default for TempoPayloadBuilderBuilder {
@@ -524,6 +535,7 @@ impl Default for TempoPayloadBuilderBuilder {
             state_provider_metrics: false,
             enable_prewarming: false,
             build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
+            enable_elastic_payload_budget: false,
         }
     }
 }
@@ -551,6 +563,7 @@ where
                 state_provider_metrics: self.state_provider_metrics,
                 enable_prewarming: self.enable_prewarming,
                 build_time_multiplier: self.build_time_multiplier,
+                enable_elastic_payload_budget: self.enable_elastic_payload_budget,
             },
         ))
     }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -104,6 +104,8 @@ pub struct TempoPayloadBuilder<Provider> {
     state_provider_metrics: bool,
     /// Whether to enable prewarming of best transactions.
     enable_prewarming: bool,
+    /// Whether to apply the local elastic payload build budget.
+    enable_elastic_payload_budget: bool,
     /// Conservative estimate of total replayable build work divided by work at tx cutoff.
     build_time_multiplier: Arc<AtomicU64>,
 }
@@ -117,6 +119,8 @@ pub struct TempoPayloadBuilderConfig {
     pub state_provider_metrics: bool,
     /// Whether to enable prewarming of best transactions.
     pub enable_prewarming: bool,
+    /// Whether to apply the local elastic payload build budget.
+    pub enable_elastic_payload_budget: bool,
     /// Initial estimate of total replayable build work divided by work at tx cutoff.
     pub build_time_multiplier: f64,
 }
@@ -127,6 +131,7 @@ impl Default for TempoPayloadBuilderConfig {
             is_dev: false,
             state_provider_metrics: false,
             enable_prewarming: false,
+            enable_elastic_payload_budget: false,
             build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
         }
     }
@@ -151,6 +156,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             is_dev: config.is_dev,
             state_provider_metrics: config.state_provider_metrics,
             enable_prewarming: config.enable_prewarming,
+            enable_elastic_payload_budget: config.enable_elastic_payload_budget,
             build_time_multiplier: Arc::new(AtomicU64::new(scaled_build_time_multiplier(
                 config.build_time_multiplier,
             ))),
@@ -520,7 +526,10 @@ where
         let mut skipped_oversized_block = false;
         let mut invalid_pool_transaction_execution_attempts = 0u64;
         let mut normal_transaction_fill_idle_elapsed = Duration::ZERO;
-        let payload_build_budget = attributes.payload_build_budget();
+        let payload_build_budget = self
+            .enable_elastic_payload_budget
+            .then(|| attributes.payload_build_budget())
+            .flatten();
         let build_time_multiplier = self.build_time_multiplier();
         let marshal_persist = marshal_persist_estimate();
         let block_build_stop_reason = loop {


### PR DESCRIPTION
Keeps shared sparse trie enabled while making payload prewarming, shared execution cache, and elastic payload budget opt-in.

This gives operators a safer default profile while preserving explicit flags for bisecting and re-enabling each path.