### PR TITLE
Add observability requirements to TIP template

### DIFF
--- a/tips/tip-0000.md
+++ b/tips/tip-0000.md
@@ -56,7 +56,7 @@ Goal: Turn an idea into a complete, reviewable specification.
 2. Assign one TIP owner who is accountable for moving the TIP forward.
 3. Pick the lowest available TIP number and create branch `tip/xxxx`.
 4. Create `tip-xxxx.md` using the [TIP Template](./tip_template.md) and open a draft PR.
-5. Complete the draft with: problem statement, design, assumptions, alternatives considered, threat model, expected tooling/user impact, and success criteria.
+5. Complete the draft with: problem statement, design, assumptions, alternatives considered, threat model, expected tooling/user impact, observability requirements, and success criteria.
 6. When ready, set status to `In Review` and request stakeholder review.
 
 ## 2. Review the TIP

--- a/tips/tip_template.md
+++ b/tips/tip_template.md
@@ -39,6 +39,10 @@ For features that do not introduce a precompile, this section should define the 
 
 Where a feature involves multiple processes, state diagrams / flowcharts should be considered when helpful.
 
+# Observability
+
+Describe the events needed to monitor and debug this TIP in production. List each event that MUST be emitted, its fields, and the operational question it answers. If no new events are required, write `N/A` and explain why existing observability is sufficient.
+
 # Invariants
 
 This section should describe invariants that must always hold, and outline the critical cases that the test suite must cover. 


### PR DESCRIPTION
## Summary
- add an Observability section to the canonical TIP template
- include observability requirements in the TIP-0000 draft checklist

Prompted by: @grandizzy