### PR TITLE
ci(bench): enable builder cache & prewarming flags in bench-e2e

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -26,6 +26,8 @@ const E2E_LOCAL_RETH_ARGS = [
     "--trusted-only"
     "--tempo.bootnodes-endpoint" "none"
     "--consensus.no-legacy-archive"
+    "--engine.share-execution-cache-with-payload-builder"
+    "--builder.enable-prewarming"
 ]
 
 def tempo-node-help [tempo_bin: string] {


### PR DESCRIPTION
Summary:
- Add execution cache sharing and builder prewarming to `E2E_LOCAL_RETH_ARGS`.
- Keeps bench-e2e validator args flowing through the existing support-filtered local reth args path.

Validation:
- `nu --commands 'source bench-e2e.nu; help main e2e | ignore'`

Prompted by: @shekhirin