### PR TITLE
perf(transaction-pool): batch expiring nonce state updates

### DIFF
--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -2,7 +2,7 @@
 use crate::{metrics::AA2dPoolMetrics, transaction::TempoPooledTransaction};
 use alloy_primitives::{
     Address, B256, TxHash, U256,
-    map::{AddressMap, B256Map, HashMap, HashSet, U256Map},
+    map::{AddressMap, B256Map, B256Set, HashMap, HashSet, U256Map},
 };
 use reth_primitives_traits::transaction::error::InvalidTransactionError;
 use reth_tracing::tracing::trace;
@@ -31,6 +31,7 @@ use tempo_precompiles::NONCE_PRECOMPILE_ADDRESS;
 use tokio::sync::broadcast;
 
 type TxOrdering = CoinbaseTipOrdering<TempoPooledTransaction>;
+
 /// A sub-pool that keeps track of 2D nonce transactions.
 ///
 /// It maintains both pending and queued transactions.
@@ -70,6 +71,8 @@ pub struct AA2dPool {
     ///
     /// Used to track inclusion of expiring nonce transactions.
     slot_to_expiring_nonce_hash: U256Map<B256>,
+    /// Scratch set reused while processing included expiring nonce transactions.
+    included_expiring_nonce_hashes: B256Set,
     /// Reverse index for the storage slot of an account's nonce
     ///
     /// ```solidity
@@ -119,6 +122,7 @@ impl AA2dPool {
             expiring_nonce_txs: Default::default(),
             expiring_nonce_eviction_order: Default::default(),
             slot_to_expiring_nonce_hash: Default::default(),
+            included_expiring_nonce_hashes: Default::default(),
             slot_to_seq_id: Default::default(),
             config,
             metrics: AA2dPoolMetrics::default(),
@@ -1145,6 +1149,29 @@ impl AA2dPool {
         Some(self.remove_expiring_nonce_pending_tx(pending_tx))
     }
 
+    /// Removes included expiring nonce transactions with one `extract_if` pass
+    /// and cleans the eviction index with one retain pass.
+    fn remove_expiring_nonce_txs_by_hashes(
+        &mut self,
+        expiring_hashes: &B256Set,
+        mined: &mut Vec<Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
+    ) {
+        if expiring_hashes.is_empty() {
+            return;
+        }
+
+        let mut expiring_nonce_txs = core::mem::take(&mut self.expiring_nonce_txs);
+        for (_, pending_tx) in expiring_nonce_txs
+            .extract_if(|expiring_hash, _| expiring_hashes.contains(expiring_hash))
+        {
+            mined.push(self.remove_expiring_nonce_pending_tx(pending_tx));
+        }
+        self.expiring_nonce_txs = expiring_nonce_txs;
+
+        self.expiring_nonce_eviction_order
+            .retain(|key| !expiring_hashes.contains(&key.expiring_hash));
+    }
+
     /// Removes secondary state for an already-detached expiring nonce transaction.
     ///
     /// Call only after removing the transaction from `expiring_nonce_txs` and
@@ -1232,7 +1259,9 @@ impl AA2dPool {
         };
 
         let mut changes = HashMap::default();
-        let mut included_expiring_nonce_hashes = Vec::new();
+        let mut included_expiring_nonce_hashes =
+            core::mem::take(&mut self.included_expiring_nonce_hashes);
+        included_expiring_nonce_hashes.clear();
 
         // Process known 2D nonce slot changes.
         for (slot, value) in nonce_state.storage.iter() {
@@ -1244,18 +1273,16 @@ impl AA2dPool {
             if !value.present_value.is_zero()
                 && let Some(expiring_nonce_hash) = self.slot_to_expiring_nonce_hash.get(slot)
             {
-                included_expiring_nonce_hashes.push(*expiring_nonce_hash);
+                included_expiring_nonce_hashes.insert(*expiring_nonce_hash);
             }
         }
 
         let (promoted, mut mined) = self.on_nonce_changes(changes);
 
         // Remove included expiring nonce transactions
-        for expiring_nonce_hash in included_expiring_nonce_hashes {
-            if let Some(tx) = self.remove_expiring_nonce_tx(&expiring_nonce_hash) {
-                mined.push(tx);
-            }
-        }
+        self.remove_expiring_nonce_txs_by_hashes(&included_expiring_nonce_hashes, &mut mined);
+        included_expiring_nonce_hashes.clear();
+        self.included_expiring_nonce_hashes = included_expiring_nonce_hashes;
 
         // Record metrics for all changes
         if !promoted.is_empty() {


### PR DESCRIPTION
Replaces per-hash expiring nonce removals during state updates with a reusable hash set, one `extract_if` over `expiring_nonce_txs`, and one `retain` over the eviction order.

This avoids a BTreeSet keyed removal for every mined expiring nonce tx. The benchmarked implementation variant was the hash-based `extract_if` path; the PR additionally keeps the hash set allocation reusable across state updates.

Local Criterion medians:

| case | current | extract_if hash | speedup |
|---|---:|---:|---:|
| 1k/1k | 0.147ms | 0.133ms | 1.11x |
| 2k/2k | 0.794ms | 0.303ms | 2.62x |
| 3k/3k | 0.552ms | 0.432ms | 1.28x |
| 4k/4k | 0.725ms | 0.574ms | 1.26x |
| 5k/5k | 0.974ms | 0.756ms | 1.29x |
| 6k/6k | 1.223ms | 0.936ms | 1.31x |
| 7k/7k | 1.409ms | 1.107ms | 1.27x |
| 8k/8k | 1.660ms | 1.334ms | 1.24x |
| 9k/9k | 1.928ms | 1.488ms | 1.30x |
| 10k/10k | 2.281ms | 1.772ms | 1.29x |
| 15k/15k | 4.409ms | 3.162ms | 1.39x |
| 20k/20k | 6.766ms | 4.558ms | 1.48x |
| 25k/25k | 9.763ms | 5.860ms | 1.67x |
| 30k/30k | 11.770ms | 8.899ms | 1.32x |
| 35k/35k | 15.046ms | 10.105ms | 1.49x |
| 40k/40k | 16.947ms | 12.170ms | 1.39x |
| 45k/45k | 21.173ms | 14.993ms | 1.41x |
| 50k/50k | 23.581ms | 15.222ms | 1.55x |
| 55k/55k | 26.871ms | 16.487ms | 1.63x |
| 60k/60k | 30.440ms | 25.091ms | 1.21x |
| 10k/5k | 1.134ms | 0.969ms | 1.17x |
| 10k/8k | 2.347ms | 1.491ms | 1.57x |
| 20k/10k | 3.154ms | 2.690ms | 1.17x |
| 20k/16k | 5.109ms | 3.725ms | 1.37x |
| 30k/15k | 6.869ms | 4.966ms | 1.38x |
| 30k/24k | 10.577ms | 7.048ms | 1.50x |
| 40k/20k | 9.502ms | 6.989ms | 1.36x |
| 40k/32k | 14.798ms | 10.060ms | 1.47x |
| 50k/25k | 12.102ms | 8.624ms | 1.40x |
| 50k/40k | 19.732ms | 12.982ms | 1.52x |
| 60k/30k | 16.671ms | 11.977ms | 1.39x |
| 60k/48k | 25.389ms | 16.622ms | 1.53x |