### PR TITLE
fix(bench): run feature side first

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -474,15 +474,15 @@ update_bench_status() {
 }
 
 # ============================================================================
-# Interleaved runs. For run-pairs=2 this preserves the previous B-F-F-B order.
+# Interleaved runs. For run-pairs=2 this uses F-B-B-F order.
 # ============================================================================
 
 build_run_order() {
   local run_pairs="$1"
   if [ $((run_pairs % 2)) -eq 0 ]; then
-    printf 'BFFB%.0s' $(seq 1 $((run_pairs / 2)))
+    printf 'FBBF%.0s' $(seq 1 $((run_pairs / 2)))
   else
-    printf 'BF%.0s' $(seq 1 "$run_pairs")
+    printf 'FB%.0s' $(seq 1 "$run_pairs")
   fi
   echo
 }

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1045,11 +1045,11 @@ def e2e-run-sides [run_pairs: int] {
     mut sides = []
     if ($run_pairs mod 2) == 0 {
         for _ in 0..<($run_pairs // 2) {
-            $sides = ($sides | append ["baseline" "feature" "feature" "baseline"])
+            $sides = ($sides | append ["feature" "baseline" "baseline" "feature"])
         }
     } else {
         for _ in 0..<$run_pairs {
-            $sides = ($sides | append ["baseline" "feature"])
+            $sides = ($sides | append ["feature" "baseline"])
         }
     }
     $sides


### PR DESCRIPTION
Starts e2e and replay benchmark run ordering with the feature side. Even run-pair sequences now use FBBF ordering and odd sequences use FB ordering.