### PR TITLE
bench: remove no-slack from manual dispatch inputs

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -7,6 +7,7 @@ name: bench-e2e
 
 on:
   workflow_dispatch:
+    # GitHub Actions supports at most 25 workflow_dispatch inputs; keep this UI-only list capped.
     inputs:
       baseline:
         description: Git ref for the baseline run. Empty = merge-base with main.
@@ -147,21 +148,6 @@ on:
         default: true
       bench-args:
         description: Extra bench args.
-        type: string
-        required: false
-        default: ""
-      bench-env:
-        description: Extra env vars for the bench sender process.
-        type: string
-        required: false
-        default: ""
-      baseline-env:
-        description: Extra env vars for the baseline node process.
-        type: string
-        required: false
-        default: ""
-      feature-env:
-        description: Extra env vars for the feature node process.
         type: string
         required: false
         default: ""


### PR DESCRIPTION
Removes the rarely used env-var fields (`bench-env`, `baseline-env`, `feature-env`) from the `bench-e2e` manual `workflow_dispatch` UI so the workflow stays under GitHub Actions' 25-input limit.

The env-var inputs remain available through `workflow_call`, so Derek comment-triggered benches can still pass them through. `valscope` and `no-slack` remain available in the manual UI.

Prompted by: @mattsse