### PR TITLE
fix: adapt reth clippy to revm api

### DIFF
--- a/crates/e2e/src/execution_runtime.rs
+++ b/crates/e2e/src/execution_runtime.rs
@@ -12,7 +12,7 @@ use alloy::{
     signers::{local::MnemonicBuilder, utils::secret_key_to_address},
     transports::http::reqwest::Url,
 };
-use alloy_evm::{EvmFactory as _, revm::inspector::JournalExt as _};
+use alloy_evm::{EvmFactory as _, revm::context_interface::JournalTr as _};
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{Address, B256, Keccak256, U256};
 use commonware_codec::Encode;

--- a/crates/evm/benches/tip20_execution.rs
+++ b/crates/evm/benches/tip20_execution.rs
@@ -35,9 +35,8 @@ use reth_trie::{
 };
 use revm::{
     DatabaseCommit,
-    context::{BlockEnv, CfgEnv},
+    context::{BlockEnv, CfgEnv, JournalTr},
     database::{CacheDB, DbAccount, EmptyDB},
-    inspector::JournalExt,
 };
 use std::{collections::BTreeSet, fs, hint::black_box, num::NonZeroU64, path::Path, sync::Arc};
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork, spec::TEMPO_T1_BASE_FEE};

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -114,13 +114,7 @@ impl TempoTxResult {
 
     /// Returns the state gas consumed by this transaction.
     pub fn state_gas_used(&self) -> u64 {
-        self.inner
-            .result
-            .result
-            .gas()
-            .state_gas_spent()
-            .try_into()
-            .expect("state gas spent is non-negative")
+        self.inner.result.result.gas().state_gas_spent_final()
     }
 
     /// Returns the validator-credited fee amount (post-feeAMM haircut) for this transaction.
@@ -210,7 +204,7 @@ where
             new_info.code_hash = code.hash_slow();
             new_info.code = Some(code);
             let mut account: Account = new_info.into();
-            account.original_info = Box::new(original_info);
+            *account.original_info_mut() = original_info;
             account.mark_touch();
             let state = EvmState::from_iter([(address, account)]);
             self.inner.system_caller.on_state(
@@ -1752,7 +1746,7 @@ mod tests {
             "state hook should contain the deployed address"
         );
         assert_eq!(
-            *calls[0].1[&addr].original_info,
+            calls[0].1[&addr].original_info(),
             Default::default(),
             "state hook account should preserve original_info"
         );
@@ -1793,7 +1787,8 @@ mod tests {
         let calls = hook_calls.lock().unwrap();
         assert_eq!(calls.len(), 1, "state hook should be called exactly once");
         assert_eq!(
-            *calls[0].1[&addr].original_info, original_info,
+            calls[0].1[&addr].original_info(),
+            original_info,
             "state hook account should preserve existing original_info"
         );
     }

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -3,6 +3,7 @@ use alloy_evm::{
     precompiles::PrecompilesMap,
     revm::{
         Context, ExecuteEvm, InspectEvm, Inspector, SystemCallEvm,
+        context::DBErrorMarker,
         context::result::{EVMError, ResultAndState, ResultGas},
         inspector::NoOpInspector,
     },
@@ -29,7 +30,7 @@ impl EvmFactory for TempoEvmFactory {
     type Evm<DB: Database, I: Inspector<Self::Context<DB>>> = TempoEvm<DB, I>;
     type Context<DB: Database> = TempoContext<DB>;
     type Tx = TempoTxEnv;
-    type Error<DBError: std::error::Error + Send + Sync + 'static> =
+    type Error<DBError: std::error::Error + Send + Sync + DBErrorMarker + 'static> =
         EVMError<DBError, TempoInvalidTransaction>;
     type HaltReason = TempoHaltReason;
     type Spec = TempoHardfork;

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -936,7 +936,7 @@ where
             "Built payload"
         );
 
-        let eth_payload = EthBuiltPayload::new(sealed_block, total_fees, requests, None);
+        let eth_payload = EthBuiltPayload::new(Arc::new(block.clone()), total_fees, requests, None);
 
         let execution_output = BlockExecutionOutput {
             result: execution_result,
@@ -1126,7 +1126,15 @@ mod tests {
             },
         };
         let sealed = Arc::new(SealedBlock::seal_slow(block));
-        let eth = EthBuiltPayload::new(sealed, U256::ZERO, None, None);
+        let eth = EthBuiltPayload::new(
+            Arc::new(reth_primitives_traits::RecoveredBlock::new_sealed(
+                Arc::unwrap_or_clone(sealed),
+                vec![TEMPO_SYSTEM_TX_SENDER],
+            )),
+            U256::ZERO,
+            None,
+            None,
+        );
         TempoBuiltPayload::new(eth, None)
     }
 

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -98,14 +98,11 @@ impl<DB: Database, I> TempoEvm<DB, I> {
         // Pre-T0 it could happen that the initial gas spending is greater than the gas limit due to faulty validation.
         //
         // Before that it would overflow, so we are reproducing this behavior here by setting the gas limit to u64::MAX and the reservoir to 0.
-        if !self.cfg.spec.is_t0() && init_and_floor_gas.initial_total_gas > self.tx.gas_limit {
+        if !self.cfg.spec.is_t0() && init_and_floor_gas.initial_total_gas() > self.tx.gas_limit {
             (u64::MAX, 0)
         } else {
-            init_and_floor_gas.initial_gas_and_reservoir(
-                self.tx.gas_limit,
-                self.cfg.tx_gas_limit_cap(),
-                self.cfg.is_amsterdam_eip8037_enabled(),
-            )
+            init_and_floor_gas
+                .initial_gas_and_reservoir(self.tx.gas_limit, self.cfg.tx_gas_limit_cap())
         }
     }
 }
@@ -1679,10 +1676,10 @@ mod tests {
             let gas = result.unwrap();
             // Verify floor_gas > initial_total_gas for this calldata (EIP-7623 scenario)
             assert!(
-                gas.floor_gas > gas.initial_total_gas,
+                gas.floor_gas > gas.initial_total_gas(),
                 "Expected floor_gas ({}) > initial_total_gas ({}) for large calldata",
                 gas.floor_gas,
-                gas.initial_total_gas
+                gas.initial_total_gas()
             );
         }
 
@@ -1700,7 +1697,7 @@ mod tests {
 
             let gas = result.unwrap();
             assert!(
-                gas.initial_total_gas >= 21_000,
+                gas.initial_total_gas() >= 21_000,
                 "Initial gas should be at least 21k base"
             );
         }

--- a/crates/revm/src/gas_params.rs
+++ b/crates/revm/src/gas_params.rs
@@ -109,7 +109,7 @@ fn amsterdam_gas_params() -> GasParams {
             T4_EIP7702_PER_AUTH_TOTAL,
         ),
         (
-            GasId::tx_eip7702_per_auth_state_gas(),
+            GasId::new_account_state_gas(),
             T4_NEW_ACCOUNT_STATE, // 225,000
         ),
         // Auth refund is zeroed by apply_eip7702_auth_list override (TIP-1000:
@@ -287,13 +287,12 @@ mod tests {
             "EIP-7702 per auth total = 25k regular + 225k state per spec"
         );
         assert_eq!(
-            gas_params.tx_eip7702_per_auth_state_gas(),
+            gas_params.tx_eip7702_state_gas(),
             225_000,
             "EIP-7702 per auth state gas per spec"
         );
         assert_eq!(
-            gas_params.tx_eip7702_per_empty_account_cost()
-                - gas_params.tx_eip7702_per_auth_state_gas(),
+            gas_params.tx_eip7702_per_empty_account_cost() - gas_params.tx_eip7702_state_gas(),
             25_000,
             "EIP-7702 per auth regular gas = total - state = 25k"
         );
@@ -369,8 +368,8 @@ mod tests {
 
         // EIP-7702: 25,000 regular + 225,000 state = 250,000 per auth
         assert_eq!(
-            (t4.tx_eip7702_per_empty_account_cost() - t4.tx_eip7702_per_auth_state_gas())
-                + t4.tx_eip7702_per_auth_state_gas(),
+            (t4.tx_eip7702_per_empty_account_cost() - t4.tx_eip7702_state_gas())
+                + t4.tx_eip7702_state_gas(),
             250_000,
             "EIP-7702 per auth total must be 250,000"
         );

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -260,11 +260,11 @@ fn call_scope_extra_gas(auth: &tempo_primitives::transaction::KeyAuthorization) 
 fn normalize_failed_batch_result_gas(
     frame_result: &mut FrameResult,
     final_gas_limit: u64,
-    accumulated_state_gas_spent: u64,
+    accumulated_state_gas_spent: i64,
 ) {
     // Create new Gas with correct limit, because Gas does not have a set_limit method
     // (the frame_result limit only covers the failed step).
-    let mut corrected_gas = Gas::new_spent(final_gas_limit);
+    let mut corrected_gas = Gas::new_spent_with_reservoir(final_gas_limit, 0);
     if frame_result.instruction_result().is_revert() {
         corrected_gas.erase_cost(frame_result.gas().remaining());
     }
@@ -275,10 +275,15 @@ fn normalize_failed_batch_result_gas(
     // Reservoir and state gas are refunded on failure
     corrected_gas.set_reservoir(
         frame_result.gas().reservoir()
-            + frame_result.gas().state_gas_spent()
-            + accumulated_state_gas_spent,
+            + frame_result.gas().state_gas_spent().max(0) as u64
+            + accumulated_state_gas_spent.max(0) as u64,
     );
     *frame_result.gas_mut() = corrected_gas;
+}
+
+#[inline]
+fn add_initial_regular_gas(gas: &mut InitialAndFloorGas, amount: u64) {
+    gas.set_initial_regular_gas(gas.initial_regular_gas().saturating_add(amount));
 }
 
 fn translate_allowed_calls_for_precompile(
@@ -551,7 +556,7 @@ where
         let mut frame_result = run_loop(self, evm, first_frame_input)?;
 
         // Handle last frame result
-        self.last_frame_result(evm, &mut frame_result)?;
+        self.last_frame_result(evm, reservoir, &mut frame_result)?;
 
         Ok(frame_result)
     }
@@ -602,7 +607,7 @@ where
         // Create checkpoint for atomic execution - captures state before any calls
         let checkpoint = evm.ctx().journal_mut().checkpoint();
         let mut accumulated_gas_refund = 0i64;
-        let mut accumulated_state_gas_spent = 0u64;
+        let mut accumulated_state_gas_spent = 0i64;
 
         // Store original TxEnv values to restore after batch execution
         let original_kind = evm.ctx().tx().kind();
@@ -857,16 +862,20 @@ where
         let refunded_gas = if has_aa_auth_list {
             let tempo_tx_env = ctx.tx.tempo_tx_env.as_ref().unwrap();
 
-            apply_auth_list::<_, Self::Error>(
+            let (refunded_accounts, refunded_bytecodes) = apply_auth_list::<_, Self::Error>(
                 ctx.cfg.chain_id,
-                ctx.cfg.gas_params.tx_eip7702_auth_refund(),
                 tempo_tx_env
                     .tempo_authorization_list
                     .iter()
                     // T0 hardfork: skip keychain signatures in auth list processing
                     .filter(|auth| !(spec.is_t0() && auth.signature().is_keychain())),
                 &mut ctx.journaled_state,
-            )?
+            )?;
+            refunded_accounts * ctx.cfg.gas_params.tx_eip7702_auth_refund_regular()
+                + ctx
+                    .cfg
+                    .gas_params
+                    .tx_eip7702_state_refund(refunded_accounts, refunded_bytecodes)
         } else {
             // For standard EIP-7702 transactions, use the default implementation
             pre_execution::apply_eip7702_auth_list::<_, Self::Error>(evm.ctx(), init_and_floor_gas)?
@@ -952,14 +961,14 @@ where
         {
             let account_cost = cfg.gas_params.get(GasId::new_account_cost());
             let account_state_gas = cfg.gas_params.new_account_state_gas();
-            init_gas.initial_total_gas += account_cost + account_state_gas;
+            add_initial_regular_gas(init_gas, account_cost + account_state_gas);
             init_gas.initial_state_gas += account_state_gas;
 
             // do the gas limit check again (include state gas for T4+).
-            if tx.gas_limit() < init_gas.initial_total_gas {
+            if tx.gas_limit() < init_gas.initial_total_gas() {
                 return Err(InvalidTransaction::CallGasCostMoreThanGasLimit {
                     gas_limit: tx.gas_limit(),
-                    initial_gas: init_gas.initial_total_gas,
+                    initial_gas: init_gas.initial_total_gas(),
                 }
                 .into());
             }
@@ -1288,7 +1297,7 @@ where
             // unlimited gas also eliminates the OOG path that caused the CREATE
             // nonce replay vulnerability (protocol nonce not bumped on OOG).
             let gas_limit = if spec.is_t1() && !spec.is_t1b() {
-                tx.gas_limit() - init_gas.initial_total_gas
+                tx.gas_limit() - init_gas.initial_total_gas()
             } else {
                 u64::MAX
             };
@@ -1406,10 +1415,10 @@ where
                 if spec.is_t1b() {
                     journal.checkpoint_commit();
                 } else if out_of_gas {
-                    init_gas.initial_total_gas = u64::MAX;
+                    init_gas.set_initial_regular_gas(u64::MAX);
                     journal.checkpoint_revert(keychain_checkpoint);
                 } else {
-                    init_gas.initial_total_gas += gas_used;
+                    add_initial_regular_gas(init_gas, gas_used);
                     journal.checkpoint_commit();
                 };
             }
@@ -1764,7 +1773,7 @@ where
                     let auth_state_gas = gas_params.tx_tip1000_auth_account_creation_state_gas();
                     // Add both execution and state portions to initial_total_gas
                     // (revm's invariant: initial_total_gas >= initial_state_gas)
-                    init_gas.initial_total_gas += auth_cost + auth_state_gas;
+                    add_initial_regular_gas(&mut init_gas, auth_cost + auth_state_gas);
                     init_gas.initial_state_gas += auth_state_gas;
                 }
             }
@@ -1776,15 +1785,15 @@ where
                 let account_state_gas = gas_params.new_account_state_gas();
                 // Add both execution and state portions to initial_total_gas
                 // (revm's invariant: initial_total_gas >= initial_state_gas)
-                init_gas.initial_total_gas += account_cost + account_state_gas;
+                add_initial_regular_gas(&mut init_gas, account_cost + account_state_gas);
                 init_gas.initial_state_gas += account_state_gas;
             }
 
             // Validate gas limit is sufficient for initial gas
-            if gas_limit < init_gas.initial_total_gas {
+            if gas_limit < init_gas.initial_total_gas() {
                 return Err(InvalidTransaction::CallGasCostMoreThanGasLimit {
                     gas_limit,
-                    initial_gas: init_gas.initial_total_gas,
+                    initial_gas: init_gas.initial_total_gas(),
                 }
                 .into());
             }
@@ -1793,7 +1802,7 @@ where
         };
 
         if evm.ctx.cfg.is_eip7623_disabled() {
-            init_gas.floor_gas = 0u64;
+            init_gas.set_floor_gas(0u64);
         }
 
         // Validate floor gas (Prague+)
@@ -1925,34 +1934,42 @@ pub fn calculate_aa_batch_intrinsic_gas<'a>(
     let mut gas = InitialAndFloorGas::default();
 
     // 1. Base stipend (21k, once per transaction)
-    gas.initial_total_gas += gas_params.tx_base_stipend();
+    add_initial_regular_gas(&mut gas, gas_params.tx_base_stipend());
 
     // 2. Signature verification gas
-    gas.initial_total_gas += tempo_signature_verification_gas(signature);
+    add_initial_regular_gas(&mut gas, tempo_signature_verification_gas(signature));
 
     let cold_account_cost =
         gas_params.warm_storage_read_cost() + gas_params.cold_account_additional_cost();
 
     // 3. Per-call overhead: cold account access
     // if the `to` address has not appeared in the call batch before.
-    gas.initial_total_gas += cold_account_cost * calls.len().saturating_sub(1) as u64;
+    add_initial_regular_gas(
+        &mut gas,
+        cold_account_cost * calls.len().saturating_sub(1) as u64,
+    );
 
     // 4. Authorization list costs (EIP-7702)
     let num_auths = authorization_list.len() as u64;
-    gas.initial_total_gas += num_auths * gas_params.tx_eip7702_per_empty_account_cost();
+    add_initial_regular_gas(
+        &mut gas,
+        num_auths * gas_params.tx_eip7702_per_empty_account_cost(),
+    );
     // TIP-1016: Track state gas portion of per-auth cost (225k on T4, 0 pre-T4).
-    gas.initial_state_gas += num_auths * gas_params.tx_eip7702_per_auth_state_gas();
+    gas.initial_state_gas += num_auths * gas_params.tx_eip7702_state_gas();
 
     // Add signature verification costs for each authorization
     // No need for v1 fork check as gas_params would be zero
     for auth in authorization_list {
-        gas.initial_total_gas += tempo_signature_verification_gas(auth.signature());
+        add_initial_regular_gas(&mut gas, tempo_signature_verification_gas(auth.signature()));
         // TIP-1000: Storage pricing updates for launch
         // EIP-7702 authorisation list entries with `auth_list.nonce == 0` require an additional 250,000 gas.
         if auth.nonce == 0 {
             let auth_state_gas = gas_params.tx_tip1000_auth_account_creation_state_gas();
-            gas.initial_total_gas +=
-                gas_params.tx_tip1000_auth_account_creation_cost() + auth_state_gas;
+            add_initial_regular_gas(
+                &mut gas,
+                gas_params.tx_tip1000_auth_account_creation_cost() + auth_state_gas,
+            );
             // TIP-1016: Track state gas for auth account creation
             gas.initial_state_gas += auth_state_gas;
         }
@@ -1962,7 +1979,7 @@ pub fn calculate_aa_batch_intrinsic_gas<'a>(
     if let Some(key_auth) = key_authorization {
         let (key_auth_gas, key_auth_state_gas) =
             calculate_key_authorization_gas(key_auth, gas_params, spec);
-        gas.initial_total_gas += key_auth_gas;
+        add_initial_regular_gas(&mut gas, key_auth_gas);
         gas.initial_state_gas += key_auth_state_gas;
     }
 
@@ -1978,10 +1995,10 @@ pub fn calculate_aa_batch_intrinsic_gas<'a>(
         if call.to.is_create() {
             let create_state_gas = gas_params.create_state_gas();
             // CREATE costs 500,000 gas in TIP-1000 (T1), 32,000 before
-            gas.initial_total_gas += gas_params.create_cost() + create_state_gas;
+            add_initial_regular_gas(&mut gas, gas_params.create_cost() + create_state_gas);
 
             // EIP-3860: Initcode analysis gas using revm helper
-            gas.initial_total_gas += gas_params.tx_initcode_cost(call.input.len());
+            add_initial_regular_gas(&mut gas, gas_params.tx_initcode_cost(call.input.len()));
 
             // TIP-1016: Track predictable state gas for CREATE calls
             gas.initial_state_gas += create_state_gas;
@@ -1996,23 +2013,29 @@ pub fn calculate_aa_batch_intrinsic_gas<'a>(
         // 4c. Value transfer cost using revm constant
         // left here for future reference.
         if !call.value.is_zero() && call.to.is_call() {
-            gas.initial_total_gas += gas_params.get(GasId::transfer_value_cost()); // 9000 gas
+            add_initial_regular_gas(&mut gas, gas_params.get(GasId::transfer_value_cost())); // 9000 gas
         }
     }
 
-    gas.initial_total_gas += total_tokens * gas_params.tx_token_cost();
+    add_initial_regular_gas(&mut gas, total_tokens * gas_params.tx_token_cost());
 
     // 5. Access list costs using revm constants
     if let Some(access_list) = access_list {
         let (accounts, storages) = access_list.fold((0, 0), |(acc_count, storage_count), item| {
             (acc_count + 1, storage_count + item.storage_slots().count())
         });
-        gas.initial_total_gas += accounts * gas_params.tx_access_list_address_cost(); // 2400 per account
-        gas.initial_total_gas += storages as u64 * gas_params.tx_access_list_storage_key_cost(); // 1900 per storage
+        add_initial_regular_gas(
+            &mut gas,
+            accounts * gas_params.tx_access_list_address_cost(),
+        ); // 2400 per account
+        add_initial_regular_gas(
+            &mut gas,
+            storages as u64 * gas_params.tx_access_list_storage_key_cost(),
+        ); // 1900 per storage
     }
 
     // 6. Floor gas using revm helper
-    gas.floor_gas = gas_params.tx_floor_cost(total_tokens); // tokens * 10 + 21000
+    gas.set_floor_gas(gas_params.tx_floor_cost_with_tokens(total_tokens)); // tokens * 10 + 21000
 
     Ok(gas)
 }
@@ -2063,18 +2086,18 @@ where
             // - Expiring nonce (nonce_key == MAX, T1 active): ring buffer + seen mapping operations
             // - 2D nonce (nonce_key != 0): SLOAD + SSTORE for nonce increment
             // - Regular nonce (nonce_key == 0): no additional gas
-            batch_gas.initial_total_gas += EXPIRING_NONCE_GAS;
+            add_initial_regular_gas(&mut batch_gas, EXPIRING_NONCE_GAS);
         } else if tx.nonce == 0 {
             // TIP-1000: Storage pricing updates for launch
             // Tempo transactions with any `nonce_key` and `nonce == 0` require an additional 250,000 gas
             let account_cost = gas_params.get(GasId::new_account_cost());
             let account_state_gas = gas_params.new_account_state_gas();
-            batch_gas.initial_total_gas += account_cost + account_state_gas;
+            add_initial_regular_gas(&mut batch_gas, account_cost + account_state_gas);
             batch_gas.initial_state_gas += account_state_gas;
         } else if !aa_env.nonce_key.is_zero() {
             // Existing 2D nonce key usage (nonce > 0)
             // TIP-1000 Invariant 3: existing state updates must charge +5,000 gas
-            batch_gas.initial_total_gas += spec.gas_existing_nonce_key();
+            add_initial_regular_gas(&mut batch_gas, spec.gas_existing_nonce_key());
         }
     } else if let Some(aa_env) = &tx.tempo_tx_env
         && !aa_env.nonce_key.is_zero()
@@ -2091,16 +2114,16 @@ where
     // with gas_limit < intrinsic + nonce_2d_gas to pass validation, but the gas is still
     // charged during execution via init_and_floor_gas (not evm.initial_gas)
     if spec.is_t0() {
-        batch_gas.initial_total_gas += nonce_2d_gas;
+        add_initial_regular_gas(&mut batch_gas, nonce_2d_gas);
     }
 
     // Validate gas limit is sufficient for initial gas.
     // initial_total_gas already includes initial_state_gas as a subset,
     // so no need to add state gas separately.
-    if gas_limit < batch_gas.initial_total_gas {
+    if gas_limit < batch_gas.initial_total_gas() {
         return Err(InvalidTransaction::CallGasCostMoreThanGasLimit {
             gas_limit,
-            initial_gas: batch_gas.initial_total_gas,
+            initial_gas: batch_gas.initial_total_gas(),
         }
         .into());
     }
@@ -2108,7 +2131,7 @@ where
     // For pre-T0 (Genesis), add 2D nonce gas after validation
     // This gas will be charged via init_and_floor_gas, not evm.initial_gas
     if !spec.is_t0() {
-        batch_gas.initial_total_gas += nonce_2d_gas;
+        add_initial_regular_gas(&mut batch_gas, nonce_2d_gas);
     }
 
     Ok(batch_gas)
@@ -2172,9 +2195,9 @@ where
 #[inline]
 fn oog_frame_result(kind: TxKind, gas_limit: u64) -> FrameResult {
     if kind.is_call() {
-        FrameResult::new_call_oog(gas_limit, 0..0)
+        FrameResult::new_call_oog(gas_limit, 0..0, 0)
     } else {
-        FrameResult::new_create_oog(gas_limit)
+        FrameResult::new_create_oog(gas_limit, 0)
     }
 }
 
@@ -2188,7 +2211,7 @@ fn check_gas_limit(
     tx: &TempoTxEnv,
     adjusted_gas: &InitialAndFloorGas,
 ) -> Option<FrameResult> {
-    if spec.is_t0() && tx.gas_limit() < adjusted_gas.initial_total_gas {
+    if spec.is_t0() && tx.gas_limit() < adjusted_gas.initial_total_gas() {
         let kind = *tx
             .first_call()
             .expect("we already checked that there is at least one call in aa tx")
@@ -2634,7 +2657,10 @@ mod tests {
         );
 
         // AA with secp256k1 + single call should match normal tx exactly
-        assert_eq!(aa_gas.initial_total_gas, normal_tx_gas.initial_total_gas);
+        assert_eq!(
+            aa_gas.initial_total_gas(),
+            normal_tx_gas.initial_total_gas()
+        );
     }
 
     #[test]
@@ -2688,11 +2714,11 @@ mod tests {
 
         // For 3 calls: base (21k) + 3*calldata + 2*per-call overhead (calls 2 and 3)
         // = 21k + 2*(calldata cost) + 2*COLD_ACCOUNT_ACCESS_COST
-        let expected = base_tx_gas.initial_total_gas
+        let expected = base_tx_gas.initial_total_gas()
             + 2 * (calldata.len() as u64 * 16)
             + 2 * COLD_ACCOUNT_ACCESS_COST;
         // Should charge per-call overhead for calls beyond the first
-        assert_eq!(gas.initial_total_gas, expected,);
+        assert_eq!(gas.initial_total_gas(), expected,);
     }
 
     #[test]
@@ -2741,8 +2767,8 @@ mod tests {
         let base_gas = calculate_initial_tx_gas(spec, &calldata, false, 0, 0, 0);
 
         // Expected: normal tx + P256_VERIFY_GAS
-        let expected = base_gas.initial_total_gas + P256_VERIFY_GAS;
-        assert_eq!(gas.initial_total_gas, expected,);
+        let expected = base_gas.initial_total_gas() + P256_VERIFY_GAS;
+        assert_eq!(gas.initial_total_gas(), expected,);
     }
 
     #[test]
@@ -2786,7 +2812,7 @@ mod tests {
         );
 
         // AA CREATE should match normal CREATE exactly
-        assert_eq!(gas.initial_total_gas, base_gas.initial_total_gas,);
+        assert_eq!(gas.initial_total_gas(), base_gas.initial_total_gas(),);
     }
 
     #[test]
@@ -2865,7 +2891,7 @@ mod tests {
         let base_gas = calculate_initial_tx_gas(spec, &calldata, false, 0, 0, 0);
 
         // Expected: normal tx
-        assert_eq!(gas.initial_total_gas, base_gas.initial_total_gas,);
+        assert_eq!(gas.initial_total_gas(), base_gas.initial_total_gas(),);
     }
 
     #[test]
@@ -3411,7 +3437,7 @@ mod tests {
         let expected_key_auth_gas = KEY_AUTH_BASE_GAS + ECRECOVER_GAS + 2 * KEY_AUTH_PER_LIMIT_GAS;
 
         assert_eq!(
-            gas_with_key_auth.initial_total_gas - gas_without_key_auth.initial_total_gas,
+            gas_with_key_auth.initial_total_gas() - gas_without_key_auth.initial_total_gas(),
             expected_key_auth_gas,
             "Key authorization should add exactly {expected_key_auth_gas} gas to batch",
         );
@@ -3419,15 +3445,17 @@ mod tests {
         // Also verify absolute values
         let spec = tempo_chainspec::hardfork::TempoHardfork::default();
         let base_tx_gas = calculate_initial_tx_gas(spec.into(), &calldata, false, 0, 0, 0);
-        let expected_without = base_tx_gas.initial_total_gas; // no cold access for single call
+        let expected_without = base_tx_gas.initial_total_gas(); // no cold access for single call
         let expected_with = expected_without + expected_key_auth_gas;
 
         assert_eq!(
-            gas_without_key_auth.initial_total_gas, expected_without,
+            gas_without_key_auth.initial_total_gas(),
+            expected_without,
             "Gas without key auth should match expected"
         );
         assert_eq!(
-            gas_with_key_auth.initial_total_gas, expected_with,
+            gas_with_key_auth.initial_total_gas(),
+            expected_with,
             "Gas with key auth should match expected"
         );
     }
@@ -3486,7 +3514,8 @@ mod tests {
                 let mut evm = make_evm(5, U256::ZERO);
                 let gas = handler.validate_initial_tx_gas(&mut evm).unwrap();
                 assert_eq!(
-                    gas.initial_total_gas, BASE_INTRINSIC_GAS,
+                    gas.initial_total_gas(),
+                    BASE_INTRINSIC_GAS,
                     "{spec:?}: protocol nonce (nonce_key=0, nonce>0) should have no extra gas"
                 );
             }
@@ -3503,7 +3532,8 @@ mod tests {
                 let mut evm = make_evm(0, U256::ONE);
                 let gas = handler.validate_initial_tx_gas(&mut evm).unwrap();
                 assert_eq!(
-                    gas.initial_total_gas, expected,
+                    gas.initial_total_gas(),
+                    expected,
                     "{spec:?}: nonce_key!=0, nonce==0 gas mismatch"
                 );
             }
@@ -3513,7 +3543,7 @@ mod tests {
                 let mut evm = make_evm(5, U256::ONE);
                 let gas = handler.validate_initial_tx_gas(&mut evm).unwrap();
                 assert_eq!(
-                    gas.initial_total_gas,
+                    gas.initial_total_gas(),
                     BASE_INTRINSIC_GAS + spec.gas_existing_nonce_key(),
                     "{spec:?}: existing 2D nonce key gas mismatch"
                 );
@@ -3698,11 +3728,11 @@ mod tests {
 
         let init_gas = test.validate_initial_tx_gas();
         assert!(
-            init_gas.floor_gas <= init_gas.initial_total_gas,
+            init_gas.floor_gas <= init_gas.initial_total_gas(),
             "test requires floor gas to not exceed intrinsic gas"
         );
 
-        test.evm.inner.ctx.tx.inner.gas_limit = init_gas.initial_total_gas;
+        test.evm.inner.ctx.tx.inner.gas_limit = init_gas.initial_total_gas();
 
         test.validate_against_state_and_deduct_caller()
             .expect("scope validation no longer runs during state validation");
@@ -3719,12 +3749,12 @@ mod tests {
         );
         assert_eq!(
             result.gas().limit(),
-            init_gas.initial_total_gas,
+            init_gas.initial_total_gas(),
             "batch OOG should report the full tx gas budget"
         );
         assert_eq!(
             result.gas().total_gas_spent(),
-            init_gas.initial_total_gas,
+            init_gas.initial_total_gas(),
             "batch OOG should consume the full tx gas budget"
         );
         assert_eq!(result.gas().refunded(), 0);
@@ -4136,13 +4166,13 @@ mod tests {
             let gas2 = compute_aa_gas(&make_single_call_env(Bytes::from(vec![1u8; calldata_len2])));
 
             if calldata_len1 <= calldata_len2 {
-                prop_assert!(gas1.initial_total_gas <= gas2.initial_total_gas,
+                prop_assert!(gas1.initial_total_gas() <= gas2.initial_total_gas(),
                     "More calldata should mean more gas: len1={}, gas1={}, len2={}, gas2={}",
-                    calldata_len1, gas1.initial_total_gas, calldata_len2, gas2.initial_total_gas);
+                    calldata_len1, gas1.initial_total_gas(), calldata_len2, gas2.initial_total_gas());
             } else {
-                prop_assert!(gas1.initial_total_gas >= gas2.initial_total_gas,
+                prop_assert!(gas1.initial_total_gas() >= gas2.initial_total_gas(),
                     "Less calldata should mean less gas: len1={}, gas1={}, len2={}, gas2={}",
-                    calldata_len1, gas1.initial_total_gas, calldata_len2, gas2.initial_total_gas);
+                    calldata_len1, gas1.initial_total_gas(), calldata_len2, gas2.initial_total_gas());
             }
         }
 
@@ -4157,13 +4187,13 @@ mod tests {
             let gas2 = compute_aa_gas(&make_single_call_env(Bytes::from(vec![0u8; calldata_len2])));
 
             if calldata_len1 <= calldata_len2 {
-                prop_assert!(gas1.initial_total_gas <= gas2.initial_total_gas,
+                prop_assert!(gas1.initial_total_gas() <= gas2.initial_total_gas(),
                     "More zero-byte calldata should mean more gas: len1={}, gas1={}, len2={}, gas2={}",
-                    calldata_len1, gas1.initial_total_gas, calldata_len2, gas2.initial_total_gas);
+                    calldata_len1, gas1.initial_total_gas(), calldata_len2, gas2.initial_total_gas());
             } else {
-                prop_assert!(gas1.initial_total_gas >= gas2.initial_total_gas,
+                prop_assert!(gas1.initial_total_gas() >= gas2.initial_total_gas(),
                     "Less zero-byte calldata should mean less gas: len1={}, gas1={}, len2={}, gas2={}",
-                    calldata_len1, gas1.initial_total_gas, calldata_len2, gas2.initial_total_gas);
+                    calldata_len1, gas1.initial_total_gas(), calldata_len2, gas2.initial_total_gas());
             }
         }
 
@@ -4174,9 +4204,9 @@ mod tests {
             let zero_gas = compute_aa_gas(&make_single_call_env(Bytes::from(vec![0u8; calldata_len])));
             let nonzero_gas = compute_aa_gas(&make_single_call_env(Bytes::from(vec![1u8; calldata_len])));
 
-            prop_assert!(zero_gas.initial_total_gas < nonzero_gas.initial_total_gas,
+            prop_assert!(zero_gas.initial_total_gas() < nonzero_gas.initial_total_gas(),
                 "Zero-byte calldata should cost less: len={}, zero_gas={}, nonzero_gas={}",
-                calldata_len, zero_gas.initial_total_gas, nonzero_gas.initial_total_gas);
+                calldata_len, zero_gas.initial_total_gas(), nonzero_gas.initial_total_gas());
         }
 
         /// Property: mixed calldata gas is bounded by all-zero and all-nonzero extremes.
@@ -4195,12 +4225,12 @@ mod tests {
             let zero_gas = compute_aa_gas(&make_single_call_env(Bytes::from(vec![0u8; calldata_len])));
             let nonzero_gas = compute_aa_gas(&make_single_call_env(Bytes::from(vec![1u8; calldata_len])));
 
-            prop_assert!(mixed_gas.initial_total_gas >= zero_gas.initial_total_gas,
+            prop_assert!(mixed_gas.initial_total_gas() >= zero_gas.initial_total_gas(),
                 "Mixed calldata gas should be >= all-zero gas: mixed={}, zero={}",
-                mixed_gas.initial_total_gas, zero_gas.initial_total_gas);
-            prop_assert!(mixed_gas.initial_total_gas <= nonzero_gas.initial_total_gas,
+                mixed_gas.initial_total_gas(), zero_gas.initial_total_gas());
+            prop_assert!(mixed_gas.initial_total_gas() <= nonzero_gas.initial_total_gas(),
                 "Mixed calldata gas should be <= all-nonzero gas: mixed={}, nonzero={}",
-                mixed_gas.initial_total_gas, nonzero_gas.initial_total_gas);
+                mixed_gas.initial_total_gas(), nonzero_gas.initial_total_gas());
         }
 
         /// Property: gas calculation monotonicity - more calls means more gas
@@ -4213,13 +4243,13 @@ mod tests {
             let gas2 = compute_aa_gas(&make_multi_call_env(num_calls2));
 
             if num_calls1 <= num_calls2 {
-                prop_assert!(gas1.initial_total_gas <= gas2.initial_total_gas,
+                prop_assert!(gas1.initial_total_gas() <= gas2.initial_total_gas(),
                     "More calls should mean more gas: calls1={}, gas1={}, calls2={}, gas2={}",
-                    num_calls1, gas1.initial_total_gas, num_calls2, gas2.initial_total_gas);
+                    num_calls1, gas1.initial_total_gas(), num_calls2, gas2.initial_total_gas());
             } else {
-                prop_assert!(gas1.initial_total_gas >= gas2.initial_total_gas,
+                prop_assert!(gas1.initial_total_gas() >= gas2.initial_total_gas(),
                     "Fewer calls should mean less gas: calls1={}, gas1={}, calls2={}, gas2={}",
-                    num_calls1, gas1.initial_total_gas, num_calls2, gas2.initial_total_gas);
+                    num_calls1, gas1.initial_total_gas(), num_calls2, gas2.initial_total_gas());
             }
         }
 
@@ -4238,9 +4268,9 @@ mod tests {
 
             // Expected exactly: 21k base + cold account access for each additional call
             let expected = 21_000 + COLD_ACCOUNT_ACCESS_COST * (num_calls.saturating_sub(1) as u64);
-            prop_assert_eq!(gas.initial_total_gas, expected,
+            prop_assert_eq!(gas.initial_total_gas(), expected,
                 "Gas {} should equal expected {} for {} calls (21k + {}*COLD_ACCOUNT_ACCESS_COST)",
-                gas.initial_total_gas, expected, num_calls, num_calls.saturating_sub(1));
+                gas.initial_total_gas(), expected, num_calls, num_calls.saturating_sub(1));
         }
 
         /// Property: first_call returns the first call for AA transactions with any number of calls
@@ -4496,7 +4526,7 @@ mod tests {
 
         // Delta-based assertion: the difference should be new_account_cost - EXISTING_NONCE_KEY_GAS
         // nonce=0 charges 250k (new account), nonce>0 charges 5k (existing key update)
-        let gas_delta = gas_nonce_zero.initial_total_gas - gas_nonce_five.initial_total_gas;
+        let gas_delta = gas_nonce_zero.initial_total_gas() - gas_nonce_five.initial_total_gas();
         let expected_delta = new_account_cost - EXISTING_NONCE_KEY_GAS;
         assert_eq!(
             gas_delta, expected_delta,
@@ -4516,7 +4546,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            gas_nonce_zero.initial_total_gas, gas_regular.initial_total_gas,
+            gas_nonce_zero.initial_total_gas(),
+            gas_regular.initial_total_gas(),
             "nonce=0 should charge the same regardless of nonce_key (2D vs regular)"
         );
     }
@@ -4582,7 +4613,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            gas_existing.initial_total_gas,
+            gas_existing.initial_total_gas(),
             BASE_INTRINSIC_GAS + EXISTING_NONCE_KEY_GAS,
             "T1 existing 2D nonce key (nonce>0) should charge BASE + EXISTING_NONCE_KEY_GAS ({EXISTING_NONCE_KEY_GAS})"
         );
@@ -4592,12 +4623,13 @@ mod tests {
         let gas_regular = handler.validate_initial_tx_gas(&mut evm_regular).unwrap();
 
         assert_eq!(
-            gas_regular.initial_total_gas, BASE_INTRINSIC_GAS,
+            gas_regular.initial_total_gas(),
+            BASE_INTRINSIC_GAS,
             "T1 regular nonce (nonce_key=0, nonce>0) should only charge BASE intrinsic gas"
         );
 
         // Verify the delta between 2D and regular nonce is exactly EXISTING_NONCE_KEY_GAS
-        let gas_delta = gas_existing.initial_total_gas - gas_regular.initial_total_gas;
+        let gas_delta = gas_existing.initial_total_gas() - gas_regular.initial_total_gas();
         assert_eq!(
             gas_delta, EXISTING_NONCE_KEY_GAS,
             "Difference between existing 2D nonce and regular nonce should be EXISTING_NONCE_KEY_GAS ({EXISTING_NONCE_KEY_GAS})"
@@ -5307,7 +5339,11 @@ mod tests {
                     TX_GAS_LIMIT,
                     CAP,
                 );
-                assert_eq!(gas.state_gas_spent(), 0, "halt reports zero state gas");
+                assert_eq!(
+                    gas.state_gas_spent_final(),
+                    0,
+                    "halt reports zero state gas"
+                );
             }
             other => panic!("expected ExecutionResult::Halt, got {other:?}"),
         }
@@ -5352,7 +5388,11 @@ mod tests {
                     "expected SubblockTxFeePayment halt, got {reason:?}"
                 );
                 assert_eq!(gas.total_gas_spent(), 100_000);
-                assert_eq!(gas.state_gas_spent(), 0, "halt reports zero state gas");
+                assert_eq!(
+                    gas.state_gas_spent_final(),
+                    0,
+                    "halt reports zero state gas"
+                );
             }
             other => panic!("expected ExecutionResult::Halt, got {other:?}"),
         }
@@ -5515,11 +5555,11 @@ mod tests {
     fn test_state_gas_multi_call_corrected_gas_success_preserves_state_gas() {
         let gas_limit: u64 = 1_000_000;
         let total_gas_spent: u64 = 400_000;
-        let accumulated_state_gas: u64 = 150_000;
+        let accumulated_state_gas: i64 = 150_000;
         let accumulated_refund: i64 = 5_000;
 
         // Simulate flattened gas reconstruction (same pattern as execute_multi_call_with)
-        let mut corrected_gas = Gas::new_spent(gas_limit);
+        let mut corrected_gas = Gas::new_spent_with_reservoir(gas_limit, 0);
         corrected_gas.erase_cost(gas_limit - total_gas_spent);
         corrected_gas.set_refund(accumulated_refund);
         corrected_gas.set_state_gas_spent(accumulated_state_gas);
@@ -5743,9 +5783,9 @@ mod tests {
         .unwrap();
 
         assert!(
-            gas.initial_total_gas >= gas.initial_state_gas,
+            gas.initial_total_gas() >= gas.initial_state_gas,
             "invariant violated: initial_total_gas ({}) < initial_state_gas ({})",
-            gas.initial_total_gas,
+            gas.initial_total_gas(),
             gas.initial_state_gas,
         );
     }
@@ -5789,9 +5829,9 @@ mod tests {
         .unwrap();
 
         assert!(
-            gas.initial_total_gas >= gas.initial_state_gas,
+            gas.initial_total_gas() >= gas.initial_state_gas,
             "invariant violated: initial_total_gas ({}) < initial_state_gas ({})",
-            gas.initial_total_gas,
+            gas.initial_total_gas(),
             gas.initial_state_gas,
         );
     }
@@ -5860,7 +5900,7 @@ mod tests {
             .expect("execute_multi_call_with should return a failed frame result");
 
         let expected_spent =
-            init_gas.initial_total_gas + call_results.iter().map(|(_, spent)| spent).sum::<u64>();
+            init_gas.initial_total_gas() + call_results.iter().map(|(_, spent)| spent).sum::<u64>();
 
         // Pays CREATE state gas + both call costs. CREATE is charged upfront via intrinsic gas, and NOT refunded.
         assert_eq!(result.instruction_result(), InstructionResult::Revert);

--- a/crates/revm/src/instructions.rs
+++ b/crates/revm/src/instructions.rs
@@ -2,7 +2,9 @@ use crate::evm::TempoContext;
 use alloy_evm::Database;
 use revm::{
     handler::instructions::EthInstructions,
-    interpreter::{Instruction, InstructionContext, interpreter::EthInterpreter, push},
+    interpreter::{
+        Instruction, InstructionContext, InstructionExecResult, interpreter::EthInterpreter, push,
+    },
 };
 use tempo_chainspec::hardfork::TempoHardfork;
 
@@ -16,8 +18,11 @@ const MILLIS_TIMESTAMP_GAS_COST: u64 = 2;
 type TempoInstructionContext<'a, DB> = InstructionContext<'a, TempoContext<DB>, EthInterpreter>;
 
 /// Opcode returning current timestamp in milliseconds.
-fn millis_timestamp<DB: Database>(context: TempoInstructionContext<'_, DB>) {
+fn millis_timestamp<DB: Database>(
+    context: TempoInstructionContext<'_, DB>,
+) -> InstructionExecResult {
     push!(context.interpreter, context.host.block.timestamp_millis());
+    Ok(())
 }
 
 /// Returns configured instructions table for Tempo.
@@ -28,7 +33,8 @@ pub(crate) fn tempo_instructions<DB: Database>(
     if !spec.is_t1c() {
         instructions.insert_instruction(
             MILLIS_TIMESTAMP,
-            Instruction::new(millis_timestamp, MILLIS_TIMESTAMP_GAS_COST),
+            Instruction::new(millis_timestamp),
+            MILLIS_TIMESTAMP_GAS_COST as u16,
         );
     }
     instructions

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -18,7 +18,7 @@ use reth_provider::{ChangedAccount, StateProviderFactory};
 use reth_storage_api::StateProvider;
 use reth_transaction_pool::{
     AddedTransactionOutcome, AllPoolTransactions, BestTransactions, BestTransactionsAttributes,
-    BlockInfo, CanonicalStateUpdate, CoinbaseTipOrdering, GetPooledTransactionLimit,
+    BlobStore, BlockInfo, CanonicalStateUpdate, CoinbaseTipOrdering, GetPooledTransactionLimit,
     NewBlobSidecar, Pool, PoolResult, PoolSize, PoolTransaction, PropagatedTransactions,
     TransactionEvents, TransactionOrigin, TransactionPool, TransactionPoolExt,
     TransactionValidationOutcome, TransactionValidationTaskExecutor, TransactionValidator,
@@ -936,6 +936,13 @@ where
         announcement.retain_by_hash(|tx| !aa_pool.contains(tx))
     }
 
+    fn retain_contains<A: HandleMempoolData>(&self, announcement: &mut A) {
+        if announcement.is_empty() {
+            return;
+        }
+        announcement.retain_by_hash(|tx| self.contains(tx))
+    }
+
     fn contains(&self, tx_hash: &B256) -> bool {
         self.protocol_pool.contains(tx_hash) || self.aa_2d_pool.read().contains(tx_hash)
     }
@@ -954,6 +961,10 @@ where
 
     fn on_propagated(&self, txs: PropagatedTransactions) {
         self.protocol_pool.on_propagated(txs);
+    }
+
+    fn blob_store(&self) -> Box<dyn BlobStore> {
+        Box::new(self.protocol_pool.blob_store().clone())
     }
 
     fn get_transactions_by_sender(

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -27,7 +27,6 @@ use reth_evm::{
         DatabaseCommit,
         context_interface::JournalTr as _,
         database::{CacheDB, EmptyDB},
-        inspector::JournalExt,
         state::{AccountInfo, Bytecode},
     },
 };


### PR DESCRIPTION
## Summary
- adapt Tempo EVM/revm code to the updated revm gas, journal, and recovered-block APIs
- implement new transaction-pool trait requirements from the reth bump
- update tests/benches/imports for the new APIs

## Testing
- cargo clippy --all-targets --all-features --locked

Prompted by: @mattsse