### PR TITLE
DNM: chore(payload): add build payload timing debug logs

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -80,6 +80,38 @@ fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> boo
     })
 }
 
+#[inline]
+fn duration_to_micros(duration: Duration) -> u64 {
+    u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
+}
+
+#[inline]
+fn debug_build_payload_timing(
+    payload_id: &impl std::fmt::Display,
+    phase: &'static str,
+    start_offset: Duration,
+    duration: Duration,
+) {
+    debug!(
+        target: "payload_builder::build_payload_timing",
+        id = %payload_id,
+        phase = phase,
+        start_offset_us = duration_to_micros(start_offset),
+        duration_us = duration_to_micros(duration),
+        end_offset_us = duration_to_micros(start_offset + duration),
+        "timed build_payload phase"
+    );
+}
+
+const fn block_build_stop_reason_label(reason: &BlockBuildStopReason) -> &'static str {
+    match reason {
+        BlockBuildStopReason::GasLimit => "gas_limit",
+        BlockBuildStopReason::RlpBlockSizeLimit => "rlp_block_size_limit",
+        BlockBuildStopReason::TxPoolEmpty => "tx_pool_empty",
+        BlockBuildStopReason::BuildBudget => "build_budget",
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TempoPayloadBuilder<Provider> {
     pool: TempoTransactionPool<Provider>,
@@ -357,9 +389,16 @@ where
             .with_bundle_update()
             .build();
         drop(_state_setup_span);
+        let state_setup_elapsed = state_setup_start.elapsed();
         self.metrics
             .state_setup_duration_seconds
-            .record(state_setup_start.elapsed());
+            .record(state_setup_elapsed);
+        debug_build_payload_timing(
+            &payload_id,
+            "state_setup",
+            state_setup_start.duration_since(start),
+            state_setup_elapsed,
+        );
 
         check_cancel!();
 
@@ -493,9 +532,16 @@ where
         self.metrics
             .prepare_system_transactions_duration_seconds
             .record(prepare_system_txs_elapsed);
+        debug_build_payload_timing(
+            &payload_id,
+            "prepare_system_txs",
+            prepare_system_txs_start.duration_since(start),
+            prepare_system_txs_elapsed,
+        );
 
         let base_fee = builder.evm_mut().block().basefee;
         let pool_fetch_start = Instant::now();
+        let best_txs_create_start = Instant::now();
         let best_txs = best_txs(BestTransactionsAttributes::new(
             base_fee,
             builder
@@ -504,6 +550,7 @@ where
                 .blob_gasprice()
                 .map(|gasprice| gasprice as u64),
         ));
+        let best_transactions_create_elapsed = best_txs_create_start.elapsed();
         // Wrap best transactions into state-aware wrapper to skip transactions that
         // get invalidated by already-executed ones.
         let mut best_txs = StateAwareBestTransactions::new(if self.enable_prewarming {
@@ -518,15 +565,39 @@ where
         } else {
             Box::new(best_txs)
         });
+        let pool_fetch_elapsed = pool_fetch_start.elapsed();
         self.metrics
             .pool_fetch_duration_seconds
-            .record(pool_fetch_start.elapsed());
+            .record(pool_fetch_elapsed);
+        debug_build_payload_timing(
+            &payload_id,
+            "best_txs_create",
+            best_txs_create_start.duration_since(start),
+            best_transactions_create_elapsed,
+        );
+        let pool_fetch_start_offset = pool_fetch_start.duration_since(start);
+        debug!(
+            target: "payload_builder::build_payload_timing",
+            id = %payload_id,
+            phase = "pool_fetch",
+            start_offset_us = duration_to_micros(pool_fetch_start_offset),
+            duration_us = duration_to_micros(pool_fetch_elapsed),
+            end_offset_us = duration_to_micros(pool_fetch_start_offset + pool_fetch_elapsed),
+            prewarming = self.enable_prewarming,
+            "timed build_payload operation"
+        );
 
         let execution_start = Instant::now();
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
         let mut skipped_oversized_block = false;
         let mut invalid_pool_transaction_execution_attempts = 0u64;
         let mut normal_transaction_fill_idle_elapsed = Duration::ZERO;
+        let mut best_transactions_next_calls = 0u64;
+        let mut total_best_transactions_next_elapsed = Duration::ZERO;
+        let mut max_best_transactions_next_elapsed = Duration::ZERO;
+        let mut execute_transaction_with_result_closure_calls = 0u64;
+        let mut total_execute_transaction_with_result_closure_elapsed = Duration::ZERO;
+        let mut max_execute_transaction_with_result_closure_elapsed = Duration::ZERO;
         // Consensus builds carry a remaining proposal budget. When present, the
         // builder stops pool tx execution before projected proposer and validator
         // work would consume that window.
@@ -562,23 +633,48 @@ where
                 }
             }
 
-            let Some(pool_tx) = best_txs.next() else {
-                if build_once_with_shared_trie
-                    && payload_build_budget.is_some()
-                    && cumulative_gas_used < non_shared_gas_limit
-                {
-                    std::thread::sleep(Duration::from_millis(1));
-                    normal_transaction_fill_idle_elapsed += Duration::from_millis(1);
-                    continue;
+            let best_txs_next_start = Instant::now();
+            let next_pool_tx = best_txs.next();
+            let best_txs_next_elapsed = best_txs_next_start.elapsed();
+            best_transactions_next_calls += 1;
+            total_best_transactions_next_elapsed += best_txs_next_elapsed;
+            max_best_transactions_next_elapsed =
+                max_best_transactions_next_elapsed.max(best_txs_next_elapsed);
+            let best_txs_next_start_offset = best_txs_next_start.duration_since(start);
+            debug!(
+                target: "payload_builder::build_payload_timing",
+                id = %payload_id,
+                phase = "best_txs.next",
+                call = best_transactions_next_calls,
+                yielded_transaction = next_pool_tx.is_some(),
+                start_offset_us = duration_to_micros(best_txs_next_start_offset),
+                duration_us = duration_to_micros(best_txs_next_elapsed),
+                end_offset_us = duration_to_micros(
+                    best_txs_next_start_offset + best_txs_next_elapsed
+                ),
+                "timed build_payload operation"
+            );
+
+            let pool_tx = match next_pool_tx {
+                Some(pool_tx) => pool_tx,
+                None => {
+                    if build_once_with_shared_trie
+                        && payload_build_budget.is_some()
+                        && cumulative_gas_used < non_shared_gas_limit
+                    {
+                        std::thread::sleep(Duration::from_millis(1));
+                        normal_transaction_fill_idle_elapsed += Duration::from_millis(1);
+                        continue;
+                    }
+                    let stop_reason = if cumulative_gas_used >= non_shared_gas_limit {
+                        BlockBuildStopReason::GasLimit
+                    } else if skipped_oversized_block {
+                        BlockBuildStopReason::RlpBlockSizeLimit
+                    } else {
+                        BlockBuildStopReason::TxPoolEmpty
+                    };
+                    break stop_reason;
                 }
-                let stop_reason = if cumulative_gas_used >= non_shared_gas_limit {
-                    BlockBuildStopReason::GasLimit
-                } else if skipped_oversized_block {
-                    BlockBuildStopReason::RlpBlockSizeLimit
-                } else {
-                    BlockBuildStopReason::TxPoolEmpty
-                };
-                break stop_reason;
             };
             pool_transactions_yielded += 1;
 
@@ -651,6 +747,8 @@ where
                 .unwrap_or_default();
 
             let tx_with_env = pool_tx.transaction.clone_into_with_tx_env();
+            execute_transaction_with_result_closure_calls += 1;
+            let execute_transaction_with_result_closure_start = Instant::now();
             let execution_result =
                 builder.execute_transaction_with_result_closure(tx_with_env, |result| {
                     cumulative_gas_used += result.block_gas_used();
@@ -666,6 +764,33 @@ where
                     // Notify transactions iterator about the new state.
                     best_txs.on_new_result(result);
                 });
+            let execute_transaction_with_result_closure_elapsed =
+                execute_transaction_with_result_closure_start.elapsed();
+            total_execute_transaction_with_result_closure_elapsed +=
+                execute_transaction_with_result_closure_elapsed;
+            max_execute_transaction_with_result_closure_elapsed =
+                max_execute_transaction_with_result_closure_elapsed
+                    .max(execute_transaction_with_result_closure_elapsed);
+            let execute_transaction_with_result_closure_start_offset =
+                execute_transaction_with_result_closure_start.duration_since(start);
+            debug!(
+                target: "payload_builder::build_payload_timing",
+                id = %payload_id,
+                phase = "execute_transaction_with_result_closure",
+                call = execute_transaction_with_result_closure_calls,
+                yielded_transaction_index = pool_transactions_yielded,
+                success = execution_result.is_ok(),
+                tx = %tx_debug_repr,
+                start_offset_us = duration_to_micros(
+                    execute_transaction_with_result_closure_start_offset
+                ),
+                duration_us = duration_to_micros(execute_transaction_with_result_closure_elapsed),
+                end_offset_us = duration_to_micros(
+                    execute_transaction_with_result_closure_start_offset
+                        + execute_transaction_with_result_closure_elapsed
+                ),
+                "timed build_payload operation"
+            );
             if let Err(err) = execution_result {
                 if let BlockExecutionError::Validation(BlockValidationError::InvalidTx {
                     error,
@@ -704,6 +829,7 @@ where
         let validation_work_at_tx_cutoff =
             elapsed_at_tx_cutoff.saturating_sub(normal_transaction_fill_idle_elapsed);
         drop(_block_fill_span);
+        let block_build_stop_reason_name = block_build_stop_reason_label(&block_build_stop_reason);
         self.metrics
             .inc_block_build_stop_reason(block_build_stop_reason);
         let normal_transaction_fill_elapsed = execution_start.elapsed();
@@ -713,12 +839,34 @@ where
         self.metrics
             .normal_transaction_fill_idle_duration_seconds
             .record(normal_transaction_fill_idle_elapsed);
+        let execution_start_offset = execution_start.duration_since(start);
+        debug!(
+            target: "payload_builder::build_payload_timing",
+            id = %payload_id,
+            phase = "normal_transaction_fill",
+            start_offset_us = duration_to_micros(execution_start_offset),
+            duration_us = duration_to_micros(normal_transaction_fill_elapsed),
+            end_offset_us = duration_to_micros(execution_start_offset + normal_transaction_fill_elapsed),
+            idle_duration_us = duration_to_micros(normal_transaction_fill_idle_elapsed),
+            stop_reason = block_build_stop_reason_name,
+            "timed build_payload operation"
+        );
         self.metrics
             .payment_transactions
             .record(payment_transactions as f64);
         self.metrics
             .payment_transactions_last
             .set(payment_transactions as f64);
+        debug!(
+            target: "payload_builder::build_payload_timing",
+            best_transactions_next_calls,
+            ?total_best_transactions_next_elapsed,
+            ?max_best_transactions_next_elapsed,
+            execute_transaction_with_result_closure_calls,
+            ?total_execute_transaction_with_result_closure_elapsed,
+            ?max_execute_transaction_with_result_closure_elapsed,
+            "completed normal transaction fill instrumentation"
+        );
 
         check_cancel!();
 
@@ -726,6 +874,17 @@ where
         if !is_better_payload(best_payload.as_ref(), total_fees)
             && !is_more_subblocks(best_payload.as_ref(), &subblocks)
         {
+            let elapsed = start.elapsed();
+            debug!(
+                target: "payload_builder::build_payload_timing",
+                id = %payload_id,
+                phase = "build_payload",
+                outcome = "aborted",
+                start_offset_us = 0_u64,
+                duration_us = duration_to_micros(elapsed),
+                end_offset_us = duration_to_micros(elapsed),
+                "timed build_payload operation"
+            );
             // Release db
             drop(builder);
             drop(db);
@@ -742,7 +901,7 @@ where
         let subblocks_count = subblocks.len() as f64;
         let mut subblock_transactions = 0f64;
         // Apply subblock transactions
-        for subblock in &subblocks {
+        for (subblock_index, subblock) in subblocks.iter().enumerate() {
             let subblock_start = Instant::now();
             let mut subblock_tx_count = 0f64;
 
@@ -768,12 +927,27 @@ where
                 subblock_tx_count += 1.0;
             }
 
+            let subblock_execution_elapsed = subblock_start.elapsed();
             self.metrics
                 .subblock_execution_duration_seconds
-                .record(subblock_start.elapsed());
+                .record(subblock_execution_elapsed);
             self.metrics
                 .subblock_transaction_count
                 .record(subblock_tx_count);
+            let subblock_start_offset = subblock_start.duration_since(start);
+            debug!(
+                target: "payload_builder::build_payload_timing",
+                id = %payload_id,
+                phase = "subblock_execution",
+                subblock_index,
+                transaction_count = subblock_tx_count,
+                start_offset_us = duration_to_micros(subblock_start_offset),
+                duration_us = duration_to_micros(subblock_execution_elapsed),
+                end_offset_us = duration_to_micros(
+                    subblock_start_offset + subblock_execution_elapsed
+                ),
+                "timed build_payload operation"
+            );
             subblock_transactions += subblock_tx_count;
         }
         drop(_subblock_txs_span);
@@ -781,6 +955,20 @@ where
         self.metrics
             .total_subblock_transaction_execution_duration_seconds
             .record(total_subblock_transaction_execution_elapsed);
+        let subblocks_start_offset = subblocks_start.duration_since(start);
+        debug!(
+            target: "payload_builder::build_payload_timing",
+            id = %payload_id,
+            phase = "total_subblock_transaction_execution",
+            subblocks_count,
+            transaction_count = subblock_transactions,
+            start_offset_us = duration_to_micros(subblocks_start_offset),
+            duration_us = duration_to_micros(total_subblock_transaction_execution_elapsed),
+            end_offset_us = duration_to_micros(
+                subblocks_start_offset + total_subblock_transaction_execution_elapsed
+            ),
+            "timed build_payload operation"
+        );
         self.metrics.subblocks.record(subblocks_count);
         self.metrics.subblocks_last.set(subblocks_count);
         self.metrics
@@ -804,6 +992,12 @@ where
         self.metrics
             .system_transactions_execution_duration_seconds
             .record(system_txs_execution_elapsed);
+        debug_build_payload_timing(
+            &payload_id,
+            "system_transactions_execution",
+            system_txs_execution_start.duration_since(start),
+            system_txs_execution_elapsed,
+        );
 
         let total_transaction_execution_elapsed = normal_transaction_fill_elapsed
             + total_subblock_transaction_execution_elapsed
@@ -834,6 +1028,12 @@ where
                         self.metrics
                             .sparse_trie_state_root_wait_duration_seconds
                             .record(elapsed);
+                        debug_build_payload_timing(
+                            &payload_id,
+                            "sparse_trie_state_root_wait",
+                            state_root_wait_start.duration_since(start),
+                            elapsed,
+                        );
                         debug!(
                             target: "payload_builder",
                             id = %payload_id,
@@ -879,11 +1079,23 @@ where
         self.metrics
             .builder_finish_duration_seconds
             .record(builder_finish_elapsed);
+        debug_build_payload_timing(
+            &payload_id,
+            "builder_finish",
+            builder_finish_start.duration_since(start),
+            builder_finish_elapsed,
+        );
         drop(_finish_span);
         let payload_finalization_elapsed = payload_finalization_start.elapsed();
         self.metrics
             .payload_finalization_duration_seconds
             .record(payload_finalization_elapsed);
+        debug_build_payload_timing(
+            &payload_id,
+            "payload_finalization",
+            payload_finalization_start.duration_since(start),
+            payload_finalization_elapsed,
+        );
 
         let total_transactions = block.transaction_count();
         self.metrics
@@ -974,6 +1186,16 @@ where
         self.metrics
             .rlp_block_size_bytes_last
             .set(rlp_length as f64);
+        debug!(
+            target: "payload_builder::build_payload_timing",
+            id = %payload_id,
+            phase = "build_payload",
+            outcome = "built",
+            start_offset_us = 0_u64,
+            duration_us = duration_to_micros(elapsed),
+            end_offset_us = duration_to_micros(elapsed),
+            "timed build_payload operation"
+        );
 
         info!(
             parent_hash = ?block.parent_hash(),
@@ -994,6 +1216,15 @@ where
             total_transactions,
             ?elapsed,
             ?validation_work_duration,
+            block_build_stop_reason = block_build_stop_reason_name,
+            ?best_transactions_create_elapsed,
+            ?pool_fetch_elapsed,
+            best_transactions_next_calls,
+            ?total_best_transactions_next_elapsed,
+            ?max_best_transactions_next_elapsed,
+            execute_transaction_with_result_closure_calls,
+            ?total_execute_transaction_with_result_closure_elapsed,
+            ?max_execute_transaction_with_result_closure_elapsed,
             ?normal_transaction_fill_elapsed,
             ?normal_transaction_fill_idle_elapsed,
             ?total_subblock_transaction_execution_elapsed,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -558,6 +558,7 @@ where
                 self.executor.clone(),
                 self.provider.clone(),
                 execution_cache,
+                payload_id,
                 parent_header.hash(),
                 builder.evm().evm_env(),
                 best_txs,

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -1,13 +1,17 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-    mpsc::{self, Receiver, Sender},
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, Receiver, Sender},
+    },
+    time::{Duration, Instant},
 };
 
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
 use alloy_sol_types::SolInterface;
 use reth_engine_tree::tree::{CachedStateProvider, SavedCache};
 use reth_evm::{Database, Evm, EvmEnvFor};
+use reth_payload_builder::PayloadId;
 use reth_revm::database::StateProviderDatabase;
 use reth_storage_api::{StateProviderBox, StateProviderFactory};
 use reth_tasks::{TaskExecutor, WorkerPool};
@@ -24,18 +28,24 @@ use tempo_precompiles::{
 };
 use tempo_primitives::TempoAddressExt;
 use tempo_transaction_pool::best::BestTransaction;
-use tracing::trace;
+use tracing::{debug, trace};
 
 type PrewarmEvmState = Option<TempoEvm<StateProviderDatabase<StateProviderBox>>>;
+
+fn timing_micros(duration: Duration) -> u128 {
+    duration.as_micros()
+}
 
 /// Prewarming orchestrator that consumes source [`BestTransactions`] with bounded
 /// lookahead, prewarms buffered transactions in parallel, and produces a new
 /// [`BestTransactions`] iterator with the source order and invalidations triggered
 /// by [`Self::mark_invalid`] preserved.
 pub(crate) struct BestTransactionsPrewarming {
+    payload_id: PayloadId,
     transactions_rx: Receiver<Option<BestTransaction>>,
     commands_tx: Sender<BestTransactionsCommand>,
     stop: Arc<AtomicBool>,
+    next_calls: u64,
 }
 
 impl BestTransactionsPrewarming {
@@ -44,6 +54,7 @@ impl BestTransactionsPrewarming {
         executor: TaskExecutor,
         provider: Provider,
         cache: Option<SavedCache>,
+        payload_id: PayloadId,
         parent_hash: B256,
         evm_env: EvmEnvFor<TempoEvmConfig>,
         best_txs: Txs,
@@ -64,9 +75,11 @@ impl BestTransactionsPrewarming {
         };
 
         let this = Self {
+            payload_id,
             transactions_rx,
             commands_tx: commands_tx.clone(),
             stop,
+            next_calls: 0,
         };
 
         let prewarm_executor = executor.clone();
@@ -240,13 +253,89 @@ impl Iterator for BestTransactionsPrewarming {
     type Item = BestTransaction;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Ok(Some(tx)) = self.transactions_rx.try_recv() {
-            return Some(tx);
-        }
-        self.commands_tx
+        self.next_calls += 1;
+        let call = self.next_calls;
+        let total_start = Instant::now();
+
+        let try_recv_result = match self.transactions_rx.try_recv() {
+            Ok(Some(tx)) => {
+                let total_elapsed = total_start.elapsed();
+                debug!(
+                    target: "payload_builder::build_payload_timing::prewarming",
+                    id = %self.payload_id,
+                    phase = "best_txs.prewarming.next",
+                    call,
+                    try_recv_result = "ready_transaction",
+                    ready_transaction = true,
+                    advance_sent = false,
+                    yielded_transaction = true,
+                    tx = %tx.hash(),
+                    send_advance_duration_us = 0u128,
+                    recv_wait_duration_us = 0u128,
+                    total_duration_us = timing_micros(total_elapsed),
+                    ?total_elapsed,
+                    "timed prewarming best_txs.next operation"
+                );
+                return Some(tx);
+            }
+            Ok(None) => "ready_none",
+            Err(mpsc::TryRecvError::Empty) => "empty",
+            Err(mpsc::TryRecvError::Disconnected) => "disconnected",
+        };
+
+        let send_advance_start = Instant::now();
+        let advance_sent = self
+            .commands_tx
             .send(BestTransactionsCommand::Advance)
-            .ok()?;
-        self.transactions_rx.recv().ok().flatten()
+            .is_ok();
+        let send_advance_elapsed = send_advance_start.elapsed();
+
+        if !advance_sent {
+            let total_elapsed = total_start.elapsed();
+            debug!(
+                target: "payload_builder::build_payload_timing::prewarming",
+                id = %self.payload_id,
+                phase = "best_txs.prewarming.next",
+                call,
+                try_recv_result,
+                ready_transaction = false,
+                advance_sent,
+                yielded_transaction = false,
+                send_advance_duration_us = timing_micros(send_advance_elapsed),
+                recv_wait_duration_us = 0u128,
+                total_duration_us = timing_micros(total_elapsed),
+                ?send_advance_elapsed,
+                ?total_elapsed,
+                "timed prewarming best_txs.next operation"
+            );
+            return None;
+        }
+
+        let recv_wait_start = Instant::now();
+        let tx = self.transactions_rx.recv().ok().flatten();
+        let recv_wait_elapsed = recv_wait_start.elapsed();
+        let total_elapsed = total_start.elapsed();
+
+        debug!(
+            target: "payload_builder::build_payload_timing::prewarming",
+            id = %self.payload_id,
+            phase = "best_txs.prewarming.next",
+            call,
+            try_recv_result,
+            ready_transaction = false,
+            advance_sent,
+            yielded_transaction = tx.is_some(),
+            tx = ?tx.as_ref().map(|tx| tx.hash()),
+            send_advance_duration_us = timing_micros(send_advance_elapsed),
+            recv_wait_duration_us = timing_micros(recv_wait_elapsed),
+            total_duration_us = timing_micros(total_elapsed),
+            ?send_advance_elapsed,
+            ?recv_wait_elapsed,
+            ?total_elapsed,
+            "timed prewarming best_txs.next operation"
+        );
+
+        tx
     }
 }
 
@@ -804,6 +893,7 @@ mod tests {
             executor.clone(),
             provider,
             None,
+            PayloadId::new([0; 8]),
             parent_header.hash(),
             evm_env,
             TestBestTransactions::new(txs, log),

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -20,7 +20,7 @@ use reth_storage_api::StateProviderFactory;
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use std::{
     collections::{BTreeMap, btree_map::Entry},
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tempo_chainspec::TempoChainSpec;
 use tempo_contracts::precompiles::{IAccountKeychain, IFeeManager, ITIP20, ITIP403Registry};
@@ -33,6 +33,10 @@ use tracing::{debug, error};
 /// Evict transactions this many seconds before they expire to reduce propagation
 /// of near-expiry transactions that are likely to fail validation on peers.
 const EVICTION_BUFFER_SECS: u64 = 3;
+
+fn timing_micros(duration: Duration) -> u128 {
+    duration.as_micros()
+}
 
 /// Aggregated block-level invalidation events for the transaction pool.
 ///
@@ -587,6 +591,7 @@ where
     }
 
     let amm_cache = pool.amm_liquidity_cache();
+    let mut maintain_iteration = 0u64;
 
     loop {
         tokio::select! {
@@ -601,7 +606,7 @@ where
 
             // Process all maintenance operations on new block commit or reorg
             Some(event) = chain_events.next() => {
-                let new = match event {
+                let (event_kind, new) = match event {
                     CanonStateNotification::Reorg { old: _, new } => {
                         // Repopulate AMM liquidity cache from the new canonical chain
                         // to invalidate stale entries from orphaned blocks.
@@ -609,23 +614,53 @@ where
                             error!(target: "txpool", ?err, "AMM liquidity cache repopulate after reorg failed");
                         }
 
-                        new
+                        ("reorg", new)
                     }
-                    CanonStateNotification::Commit { new } => new,
+                    CanonStateNotification::Commit { new } => ("commit", new),
                 };
 
+                maintain_iteration = maintain_iteration.wrapping_add(1);
                 let block_update_start = Instant::now();
 
                 let tip = &new;
                 let bundle_state = tip.execution_outcome().state().state();
+                let tip_number = tip.tip().header().number();
+                let tip_hash = tip.tip().hash();
                 let tip_timestamp = tip.tip().header().timestamp();
+
+                debug!(
+                    target: "payload_builder::build_payload_timing::txpool_update",
+                    phase = "maintain_tempo_pool.chain_event_start",
+                    maintain_iteration,
+                    event_kind,
+                    block_number = tip_number,
+                    %tip_hash,
+                    tip_timestamp,
+                    chain_len = tip.len(),
+                    bundle_state_accounts = bundle_state.len(),
+                    "timed txpool maintain phase"
+                );
 
                 // 1. Update 2D nonce pool before scan-based maintenance.
                 // This removes mined 2D nonce transactions and promotes newly
                 // unblocked transactions before later pool scans.
                 let nonce_pool_start = Instant::now();
-                let _mined_aa_txs = pool.notify_aa_pool_on_state_updates(bundle_state);
-                metrics.nonce_pool_update_duration_seconds.record(nonce_pool_start.elapsed());
+                let mined_aa_txs = pool.notify_aa_pool_on_state_updates(bundle_state);
+                let nonce_pool_elapsed = nonce_pool_start.elapsed();
+                metrics
+                    .nonce_pool_update_duration_seconds
+                    .record(nonce_pool_elapsed);
+                debug!(
+                    target: "payload_builder::build_payload_timing::txpool_update",
+                    phase = "maintain_tempo_pool.notify_aa_pool_on_state_updates",
+                    maintain_iteration,
+                    block_number = tip_number,
+                    %tip_hash,
+                    mined_aa_count = mined_aa_txs.len(),
+                    duration_us = timing_micros(nonce_pool_elapsed),
+                    ?nonce_pool_elapsed,
+                    "timed txpool maintain phase"
+                );
 
                 // 2. Update AMM liquidity cache before revalidation/invalidation scans.
                 let amm_start = Instant::now();
@@ -635,12 +670,51 @@ where
                 {
                     error!(target: "txpool", ?err, "AMM liquidity cache update failed");
                 }
-                metrics.amm_cache_update_duration_seconds.record(amm_start.elapsed());
+                let amm_elapsed = amm_start.elapsed();
+                metrics.amm_cache_update_duration_seconds.record(amm_elapsed);
+                debug!(
+                    target: "payload_builder::build_payload_timing::txpool_update",
+                    phase = "maintain_tempo_pool.amm_cache_update",
+                    maintain_iteration,
+                    block_number = tip_number,
+                    %tip_hash,
+                    duration_us = timing_micros(amm_elapsed),
+                    ?amm_elapsed,
+                    "timed txpool maintain phase"
+                );
 
                 // 3. Collect all block-level invalidation events
+                let updates_from_chain_start = Instant::now();
                 let mut updates = TempoPoolUpdates::from_chain(tip);
+                let updates_from_chain_elapsed = updates_from_chain_start.elapsed();
+                debug!(
+                    target: "payload_builder::build_payload_timing::txpool_update",
+                    phase = "maintain_tempo_pool.updates_from_chain",
+                    maintain_iteration,
+                    block_number = tip_number,
+                    %tip_hash,
+                    revoked_keys = updates.revoked_keys.len(),
+                    key_authorization_target_changes =
+                        updates.key_authorization_target_changes.len(),
+                    spending_limit_changes = updates.spending_limit_changes.len(),
+                    spending_limit_spends = updates.spending_limit_spends.len(),
+                    validator_token_changes = updates.validator_token_changes.len(),
+                    user_token_changes = updates.user_token_changes.len(),
+                    blacklist_additions = updates.blacklist_additions.len(),
+                    whitelist_removals = updates.whitelist_removals.len(),
+                    pause_events = updates.pause_events.len(),
+                    transfer_policy_updates = updates.transfer_policy_updates.len(),
+                    quote_token_updates = updates.quote_token_updates.len(),
+                    fee_balance_changes = updates.fee_balance_changes.len(),
+                    key_authorization_witness_burns =
+                        updates.key_authorization_witness_burns.len(),
+                    duration_us = timing_micros(updates_from_chain_elapsed),
+                    ?updates_from_chain_elapsed,
+                    "timed txpool maintain phase"
+                );
 
                 // Remove expiry tracking for mined transactions.
+                let expiry_tracking_start = Instant::now();
                 state.untrack_many(tip.transaction_hashes());
 
                 // Evict transactions slightly before they expire to prevent
@@ -656,10 +730,23 @@ where
                         .filter(|hash| !mined_hashes.contains(hash) && pool.contains(hash))
                         .collect();
                 }
+                let expiry_tracking_elapsed = expiry_tracking_start.elapsed();
+                debug!(
+                    target: "payload_builder::build_payload_timing::txpool_update",
+                    phase = "maintain_tempo_pool.expiry_tracking",
+                    maintain_iteration,
+                    block_number = tip_number,
+                    %tip_hash,
+                    expired_count = updates.expired_txs.len(),
+                    duration_us = timing_micros(expiry_tracking_elapsed),
+                    ?expiry_tracking_elapsed,
+                    "timed txpool maintain phase"
+                );
 
                 // 4. Evict expired AA transactions
                 let expired_start = Instant::now();
                 let expired_count = updates.expired_txs.len();
+                let mut expired_removed_count = 0;
                 if expired_count > 0 {
                     debug!(
                         target: "txpool",
@@ -667,10 +754,26 @@ where
                         tip_timestamp,
                         "Evicting expired AA transactions (valid_before)"
                     );
-                    pool.remove_transactions(updates.expired_txs.clone());
+                    let removed_txs = pool.remove_transactions(updates.expired_txs.clone());
+                    expired_removed_count = removed_txs.len();
                     metrics.expired_transactions_evicted.increment(expired_count as u64);
                 }
-                metrics.expired_eviction_duration_seconds.record(expired_start.elapsed());
+                let expired_elapsed = expired_start.elapsed();
+                metrics
+                    .expired_eviction_duration_seconds
+                    .record(expired_elapsed);
+                debug!(
+                    target: "payload_builder::build_payload_timing::txpool_update",
+                    phase = "maintain_tempo_pool.expired_eviction",
+                    maintain_iteration,
+                    block_number = tip_number,
+                    %tip_hash,
+                    expired_count,
+                    removed_count = expired_removed_count,
+                    duration_us = timing_micros(expired_elapsed),
+                    ?expired_elapsed,
+                    "timed txpool maintain phase"
+                );
 
                 // 5. Handle fee token pause/unpause events
                 let pause_start = Instant::now();
@@ -687,7 +790,24 @@ where
                 // Process pause events: fetch pool transactions once for all pause tokens.
                 // This avoids the O(pause_events * pool_size) cost of fetching per event.
                 if !pause_tokens.is_empty() {
+                    let pause_all_transactions_start = Instant::now();
                     let all_txs = pool.all_transactions();
+                    let pause_all_transactions_elapsed = pause_all_transactions_start.elapsed();
+                    let pending_count = all_txs.pending.len();
+                    let queued_count = all_txs.queued.len();
+                    debug!(
+                        target: "payload_builder::build_payload_timing::txpool_update",
+                        phase = "maintain_tempo_pool.pause_all_transactions",
+                        maintain_iteration,
+                        block_number = tip_number,
+                        %tip_hash,
+                        pause_token_count = pause_tokens.len(),
+                        pending_count,
+                        queued_count,
+                        duration_us = timing_micros(pause_all_transactions_elapsed),
+                        ?pause_all_transactions_elapsed,
+                        "timed txpool maintain phase"
+                    );
 
                     // Group transactions by effective fee token for efficient batch processing.
                     // This single pass over all transactions handles all pause events.
@@ -709,8 +829,24 @@ where
                             continue;
                         };
 
+                        let hash_count = hashes_to_pause.len();
+                        let pause_remove_start = Instant::now();
                         let removed_txs = pool.remove_transactions(hashes_to_pause);
+                        let pause_remove_elapsed = pause_remove_start.elapsed();
                         let count = removed_txs.len();
+                        debug!(
+                            target: "payload_builder::build_payload_timing::txpool_update",
+                            phase = "maintain_tempo_pool.pause_remove_transactions",
+                            maintain_iteration,
+                            block_number = tip_number,
+                            %tip_hash,
+                            %token,
+                            hash_count,
+                            removed_count = count,
+                            duration_us = timing_micros(pause_remove_elapsed),
+                            ?pause_remove_elapsed,
+                            "timed txpool maintain phase"
+                        );
 
                         if count > 0 {
                             // Clean up expiry tracking for paused txs
@@ -812,7 +948,19 @@ where
                         &updates.key_authorization_witness_burns,
                     );
                 }
-                metrics.pause_events_duration_seconds.record(pause_start.elapsed());
+                let pause_elapsed = pause_start.elapsed();
+                metrics.pause_events_duration_seconds.record(pause_elapsed);
+                debug!(
+                    target: "payload_builder::build_payload_timing::txpool_update",
+                    phase = "maintain_tempo_pool.pause_events_total",
+                    maintain_iteration,
+                    block_number = tip_number,
+                    %tip_hash,
+                    pause_events = updates.pause_events.len(),
+                    duration_us = timing_micros(pause_elapsed),
+                    ?pause_elapsed,
+                    "timed txpool maintain phase"
+                );
 
                 // 8. Handle potentially invalidating updates
                 // When a cached value changes of a token (transfer policy, or quote token) changes,
@@ -834,7 +982,26 @@ where
                         continue;
                     }
 
+                    let revalidation_all_transactions_start = Instant::now();
                     let all_txs = pool.all_transactions();
+                    let revalidation_all_transactions_elapsed =
+                        revalidation_all_transactions_start.elapsed();
+                    let pending_count = all_txs.pending.len();
+                    let queued_count = all_txs.queued.len();
+                    debug!(
+                        target: "payload_builder::build_payload_timing::txpool_update",
+                        phase = "maintain_tempo_pool.revalidation_all_transactions",
+                        maintain_iteration,
+                        block_number = tip_number,
+                        %tip_hash,
+                        reason,
+                        updated_count = updated.len(),
+                        pending_count,
+                        queued_count,
+                        duration_us = timing_micros(revalidation_all_transactions_elapsed),
+                        ?revalidation_all_transactions_elapsed,
+                        "timed txpool maintain phase"
+                    );
                     let hashes: Vec<TxHash> = all_txs
                         .pending
                         .iter()
@@ -847,8 +1014,24 @@ where
                         .map(|tx| *tx.hash())
                         .collect();
                     if !hashes.is_empty() {
+                        let hash_count = hashes.len();
+                        let revalidation_remove_start = Instant::now();
                         let removed_txs = pool.remove_transactions(hashes);
+                        let revalidation_remove_elapsed = revalidation_remove_start.elapsed();
                         let count = removed_txs.len();
+                        debug!(
+                            target: "payload_builder::build_payload_timing::txpool_update",
+                            phase = "maintain_tempo_pool.revalidation_remove_transactions",
+                            maintain_iteration,
+                            block_number = tip_number,
+                            %tip_hash,
+                            reason,
+                            hash_count,
+                            removed_count = count,
+                            duration_us = timing_micros(revalidation_remove_elapsed),
+                            ?revalidation_remove_elapsed,
+                            "timed txpool maintain phase"
+                        );
 
                         for tx in &removed_txs {
                             state.untrack(tx.hash());
@@ -896,23 +1079,48 @@ where
                         "Processing transaction invalidation events"
                     );
                     let evicted = pool.evict_invalidated_transactions(&updates);
+                    let invalidation_elapsed = invalidation_start.elapsed();
                     for hash in &evicted {
                         state.untrack(hash);
                     }
                     metrics.transactions_invalidated.increment(evicted.len() as u64);
                     metrics
                         .invalidation_eviction_duration_seconds
-                        .record(invalidation_start.elapsed());
+                        .record(invalidation_elapsed);
+                    debug!(
+                        target: "payload_builder::build_payload_timing::txpool_update",
+                        phase = "maintain_tempo_pool.evict_invalidated_transactions",
+                        maintain_iteration,
+                        block_number = tip_number,
+                        %tip_hash,
+                        evicted_count = evicted.len(),
+                        duration_us = timing_micros(invalidation_elapsed),
+                        ?invalidation_elapsed,
+                        "timed txpool maintain phase"
+                    );
                 }
 
                 // 10. Evict stale pending transactions (must happen after AA pool promotions in step 1)
                 // Only runs once per interval (~30 min) to avoid overhead on every block.
                 // Transactions pending across two consecutive snapshots are considered stale.
                 if state.pending_staleness.should_check(tip_timestamp) {
+                    let stale_pending_snapshot_start = Instant::now();
                     let current_pending: B256Set =
                         pool.pending_transactions().iter().map(|tx| *tx.hash()).collect();
+                    let stale_pending_snapshot_elapsed = stale_pending_snapshot_start.elapsed();
                     let stale_to_evict =
                         state.pending_staleness.check_and_update(current_pending, tip_timestamp);
+                    debug!(
+                        target: "payload_builder::build_payload_timing::txpool_update",
+                        phase = "maintain_tempo_pool.stale_pending_snapshot",
+                        maintain_iteration,
+                        block_number = tip_number,
+                        %tip_hash,
+                        stale_to_evict_count = stale_to_evict.len(),
+                        duration_us = timing_micros(stale_pending_snapshot_elapsed),
+                        ?stale_pending_snapshot_elapsed,
+                        "timed txpool maintain phase"
+                    );
 
                     if !stale_to_evict.is_empty() {
                         debug!(
@@ -925,12 +1133,40 @@ where
                         for hash in &stale_to_evict {
                             state.untrack(hash);
                         }
+                        let hash_count = stale_to_evict.len();
+                        let stale_remove_start = Instant::now();
                         pool.remove_transactions(stale_to_evict);
+                        let stale_remove_elapsed = stale_remove_start.elapsed();
+                        debug!(
+                            target: "payload_builder::build_payload_timing::txpool_update",
+                            phase = "maintain_tempo_pool.stale_remove_transactions",
+                            maintain_iteration,
+                            block_number = tip_number,
+                            %tip_hash,
+                            hash_count,
+                            duration_us = timing_micros(stale_remove_elapsed),
+                            ?stale_remove_elapsed,
+                            "timed txpool maintain phase"
+                        );
                     }
                 }
 
                 // Record total block update duration
-                metrics.block_update_duration_seconds.record(block_update_start.elapsed());
+                let block_update_elapsed = block_update_start.elapsed();
+                metrics
+                    .block_update_duration_seconds
+                    .record(block_update_elapsed);
+                debug!(
+                    target: "payload_builder::build_payload_timing::txpool_update",
+                    phase = "maintain_tempo_pool.chain_event_total",
+                    maintain_iteration,
+                    event_kind,
+                    block_number = tip_number,
+                    %tip_hash,
+                    duration_us = timing_micros(block_update_elapsed),
+                    ?block_update_elapsed,
+                    "timed txpool maintain phase"
+                );
             }
         }
     }

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -102,11 +102,44 @@ where
         &self,
         state: &AddressMap<BundleAccount>,
     ) -> Vec<Arc<ValidPoolTransaction<TempoPooledTransaction>>> {
-        let (promoted, mined) = self.aa_2d_pool.write().on_state_updates(state);
+        let total_start = Instant::now();
+        let aa_write_lock_start = Instant::now();
+        let mut aa_pool = self.aa_2d_pool.write();
+        let aa_write_lock_wait_elapsed = aa_write_lock_start.elapsed();
+
+        let aa_on_state_updates_start = Instant::now();
+        let (promoted, mined) = aa_pool.on_state_updates(state);
+        let aa_write_lock_hold_elapsed = aa_on_state_updates_start.elapsed();
+        drop(aa_pool);
+
+        let promoted_count = promoted.len();
+        let mined_count = mined.len();
+
         // Note: mined transactions are notified via the vanilla pool updates
+        let protocol_notify_start = Instant::now();
         self.protocol_pool
             .inner()
             .notify_on_transaction_updates(promoted, Vec::new());
+        let protocol_notify_elapsed = protocol_notify_start.elapsed();
+        let total_elapsed = total_start.elapsed();
+
+        tracing::debug!(
+            target: "payload_builder::build_payload_timing::txpool_update",
+            phase = "tempo_pool.notify_aa_pool_on_state_updates",
+            state_accounts = state.len(),
+            promoted_count,
+            mined_count,
+            aa_write_lock_wait_duration_us = timing_micros(aa_write_lock_wait_elapsed),
+            aa_write_lock_hold_duration_us = timing_micros(aa_write_lock_hold_elapsed),
+            protocol_notify_duration_us = timing_micros(protocol_notify_elapsed),
+            total_duration_us = timing_micros(total_elapsed),
+            ?aa_write_lock_wait_elapsed,
+            ?aa_write_lock_hold_elapsed,
+            ?protocol_notify_elapsed,
+            ?total_elapsed,
+            "timed txpool update phase"
+        );
+
         mined
     }
 
@@ -135,11 +168,14 @@ where
             return Vec::new();
         }
 
+        let total_start = Instant::now();
+
         // Fetch state provider if any check needs on-chain reads:
         // - validator token changes (liquidity check)
         // - blacklist/whitelist (policy check)
         // - fee payer balance changes (balance check)
         // - spending limit spends (remaining limit check)
+        let state_provider_start = Instant::now();
         let mut state_provider = if !updates.validator_token_changes.is_empty()
             || !updates.blacklist_additions.is_empty()
             || !updates.whitelist_removals.is_empty()
@@ -150,6 +186,7 @@ where
         } else {
             None
         };
+        let state_provider_elapsed = state_provider_start.elapsed();
 
         // Resolve the active hardfork for storage context.
         let tip_timestamp = self
@@ -213,7 +250,13 @@ where
             !updates.key_authorization_target_changes.is_empty();
         let mut fee_balance_cache: HashMap<(Address, Address), U256> = HashMap::default();
 
+        let all_transactions_start = Instant::now();
         let all_txs = self.all_transactions();
+        let all_transactions_elapsed = all_transactions_start.elapsed();
+        let pending_count = all_txs.pending.len();
+        let queued_count = all_txs.queued.len();
+
+        let scan_start = Instant::now();
         for tx in all_txs.pending.iter().chain(all_txs.queued.iter()) {
             // Avoid recovering key ids unless a keychain invalidation can use them.
             if has_keychain_subject_updates || has_key_authorization_target_updates {
@@ -460,7 +503,9 @@ where
                 user_token_count += 1;
             }
         }
+        let scan_elapsed = scan_start.elapsed();
 
+        let mut remove_elapsed = Duration::ZERO;
         if !to_remove.is_empty() {
             tracing::debug!(
                 target: "txpool",
@@ -477,8 +522,41 @@ where
                 insolvent_fee_payer_count,
                 "Evicting invalidated transactions"
             );
+            let remove_start = Instant::now();
             self.remove_transactions(to_remove.clone());
+            remove_elapsed = remove_start.elapsed();
         }
+        let total_elapsed = total_start.elapsed();
+
+        tracing::debug!(
+            target: "payload_builder::build_payload_timing::txpool_update",
+            phase = "tempo_pool.evict_invalidated_transactions",
+            pending_count,
+            queued_count,
+            total_scanned = pending_count + queued_count,
+            removed_count = to_remove.len(),
+            revoked_count,
+            key_authorization_target_count,
+            spending_limit_count,
+            spending_limit_spend_count,
+            key_authorization_witness_count,
+            liquidity_count,
+            user_token_count,
+            blacklisted_count,
+            unwhitelisted_count,
+            insolvent_fee_payer_count,
+            state_provider_duration_us = timing_micros(state_provider_elapsed),
+            all_transactions_duration_us = timing_micros(all_transactions_elapsed),
+            scan_duration_us = timing_micros(scan_elapsed),
+            remove_transactions_duration_us = timing_micros(remove_elapsed),
+            total_duration_us = timing_micros(total_elapsed),
+            ?state_provider_elapsed,
+            ?all_transactions_elapsed,
+            ?scan_elapsed,
+            ?remove_elapsed,
+            ?total_elapsed,
+            "timed txpool update phase"
+        );
         to_remove
     }
 
@@ -528,11 +606,37 @@ where
                         .tip_timestamp();
                     let hardfork = self.client().chain_spec().tempo_hardfork_at(tip_timestamp);
 
-                    let added = self.aa_2d_pool.write().add_transaction(
-                        Arc::new(tx),
+                    let tx = Arc::new(tx);
+                    let tx_hash = *tx.hash();
+                    let total_start = Instant::now();
+                    let aa_write_lock_start = Instant::now();
+                    let mut aa_pool = self.aa_2d_pool.write();
+                    let aa_write_lock_wait_elapsed = aa_write_lock_start.elapsed();
+
+                    let aa_add_transaction_start = Instant::now();
+                    let added_result = aa_pool.add_transaction(tx, state_nonce, hardfork);
+                    let aa_write_lock_hold_elapsed = aa_add_transaction_start.elapsed();
+                    drop(aa_pool);
+                    let total_elapsed = total_start.elapsed();
+
+                    tracing::debug!(
+                        target: "payload_builder::build_payload_timing::txpool_update",
+                        phase = "tempo_pool.add_validated_transaction.aa_2d",
+                        %tx_hash,
                         state_nonce,
-                        hardfork,
-                    )?;
+                        success = added_result.is_ok(),
+                        aa_write_lock_wait_duration_us =
+                            timing_micros(aa_write_lock_wait_elapsed),
+                        aa_write_lock_hold_duration_us =
+                            timing_micros(aa_write_lock_hold_elapsed),
+                        total_duration_us = timing_micros(total_elapsed),
+                        ?aa_write_lock_wait_elapsed,
+                        ?aa_write_lock_hold_elapsed,
+                        ?total_elapsed,
+                        "timed txpool update phase"
+                    );
+
+                    let added = added_result?;
                     let hash = *added.hash();
                     if let Some(pending) = added.as_pending() {
                         if pending.discarded.iter().any(|tx| *tx.hash() == hash) {
@@ -948,8 +1052,43 @@ where
         &self,
         hashes: Vec<B256>,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        let mut txs = self.aa_2d_pool.write().remove_transactions(hashes.iter());
-        txs.extend(self.protocol_pool.remove_transactions(hashes));
+        let total_start = Instant::now();
+        let hash_count = hashes.len();
+
+        let aa_write_lock_start = Instant::now();
+        let mut aa_pool = self.aa_2d_pool.write();
+        let aa_write_lock_wait_elapsed = aa_write_lock_start.elapsed();
+
+        let aa_remove_start = Instant::now();
+        let mut txs = aa_pool.remove_transactions(hashes.iter());
+        let aa_write_lock_hold_elapsed = aa_remove_start.elapsed();
+        drop(aa_pool);
+        let aa_removed_count = txs.len();
+
+        let protocol_remove_start = Instant::now();
+        let protocol_removed = self.protocol_pool.remove_transactions(hashes);
+        let protocol_remove_elapsed = protocol_remove_start.elapsed();
+        let protocol_removed_count = protocol_removed.len();
+        txs.extend(protocol_removed);
+        let total_elapsed = total_start.elapsed();
+
+        tracing::debug!(
+            target: "payload_builder::build_payload_timing::txpool_update",
+            phase = "tempo_pool.remove_transactions",
+            hash_count,
+            aa_removed_count,
+            protocol_removed_count,
+            total_removed_count = txs.len(),
+            aa_write_lock_wait_duration_us = timing_micros(aa_write_lock_wait_elapsed),
+            aa_write_lock_hold_duration_us = timing_micros(aa_write_lock_hold_elapsed),
+            protocol_remove_duration_us = timing_micros(protocol_remove_elapsed),
+            total_duration_us = timing_micros(total_elapsed),
+            ?aa_write_lock_wait_elapsed,
+            ?aa_write_lock_hold_elapsed,
+            ?protocol_remove_elapsed,
+            ?total_elapsed,
+            "timed txpool update phase"
+        );
         txs
     }
 
@@ -957,13 +1096,44 @@ where
         &self,
         hashes: Vec<B256>,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        let mut txs = self
-            .aa_2d_pool
-            .write()
-            .remove_transactions_and_descendants(hashes.iter());
-        txs.extend(
-            self.protocol_pool
-                .remove_transactions_and_descendants(hashes),
+        let total_start = Instant::now();
+        let hash_count = hashes.len();
+
+        let aa_write_lock_start = Instant::now();
+        let mut aa_pool = self.aa_2d_pool.write();
+        let aa_write_lock_wait_elapsed = aa_write_lock_start.elapsed();
+
+        let aa_remove_start = Instant::now();
+        let mut txs = aa_pool.remove_transactions_and_descendants(hashes.iter());
+        let aa_write_lock_hold_elapsed = aa_remove_start.elapsed();
+        drop(aa_pool);
+        let aa_removed_count = txs.len();
+
+        let protocol_remove_start = Instant::now();
+        let protocol_removed = self
+            .protocol_pool
+            .remove_transactions_and_descendants(hashes);
+        let protocol_remove_elapsed = protocol_remove_start.elapsed();
+        let protocol_removed_count = protocol_removed.len();
+        txs.extend(protocol_removed);
+        let total_elapsed = total_start.elapsed();
+
+        tracing::debug!(
+            target: "payload_builder::build_payload_timing::txpool_update",
+            phase = "tempo_pool.remove_transactions_and_descendants",
+            hash_count,
+            aa_removed_count,
+            protocol_removed_count,
+            total_removed_count = txs.len(),
+            aa_write_lock_wait_duration_us = timing_micros(aa_write_lock_wait_elapsed),
+            aa_write_lock_hold_duration_us = timing_micros(aa_write_lock_hold_elapsed),
+            protocol_remove_duration_us = timing_micros(protocol_remove_elapsed),
+            total_duration_us = timing_micros(total_elapsed),
+            ?aa_write_lock_wait_elapsed,
+            ?aa_write_lock_hold_elapsed,
+            ?protocol_remove_elapsed,
+            ?total_elapsed,
+            "timed txpool update phase"
         );
         txs
     }
@@ -972,11 +1142,42 @@ where
         &self,
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        let mut txs = self
-            .aa_2d_pool
-            .write()
-            .remove_transactions_by_sender(sender);
-        txs.extend(self.protocol_pool.remove_transactions_by_sender(sender));
+        let total_start = Instant::now();
+
+        let aa_write_lock_start = Instant::now();
+        let mut aa_pool = self.aa_2d_pool.write();
+        let aa_write_lock_wait_elapsed = aa_write_lock_start.elapsed();
+
+        let aa_remove_start = Instant::now();
+        let mut txs = aa_pool.remove_transactions_by_sender(sender);
+        let aa_write_lock_hold_elapsed = aa_remove_start.elapsed();
+        drop(aa_pool);
+        let aa_removed_count = txs.len();
+
+        let protocol_remove_start = Instant::now();
+        let protocol_removed = self.protocol_pool.remove_transactions_by_sender(sender);
+        let protocol_remove_elapsed = protocol_remove_start.elapsed();
+        let protocol_removed_count = protocol_removed.len();
+        txs.extend(protocol_removed);
+        let total_elapsed = total_start.elapsed();
+
+        tracing::debug!(
+            target: "payload_builder::build_payload_timing::txpool_update",
+            phase = "tempo_pool.remove_transactions_by_sender",
+            %sender,
+            aa_removed_count,
+            protocol_removed_count,
+            total_removed_count = txs.len(),
+            aa_write_lock_wait_duration_us = timing_micros(aa_write_lock_wait_elapsed),
+            aa_write_lock_hold_duration_us = timing_micros(aa_write_lock_hold_elapsed),
+            protocol_remove_duration_us = timing_micros(protocol_remove_elapsed),
+            total_duration_us = timing_micros(total_elapsed),
+            ?aa_write_lock_wait_elapsed,
+            ?aa_write_lock_hold_elapsed,
+            ?protocol_remove_elapsed,
+            ?total_elapsed,
+            "timed txpool update phase"
+        );
         txs
     }
 
@@ -984,8 +1185,43 @@ where
         &self,
         hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        let mut txs = self.aa_2d_pool.write().remove_transactions(hashes.iter());
-        txs.extend(self.protocol_pool.prune_transactions(hashes));
+        let total_start = Instant::now();
+        let hash_count = hashes.len();
+
+        let aa_write_lock_start = Instant::now();
+        let mut aa_pool = self.aa_2d_pool.write();
+        let aa_write_lock_wait_elapsed = aa_write_lock_start.elapsed();
+
+        let aa_remove_start = Instant::now();
+        let mut txs = aa_pool.remove_transactions(hashes.iter());
+        let aa_write_lock_hold_elapsed = aa_remove_start.elapsed();
+        drop(aa_pool);
+        let aa_removed_count = txs.len();
+
+        let protocol_prune_start = Instant::now();
+        let protocol_removed = self.protocol_pool.prune_transactions(hashes);
+        let protocol_prune_elapsed = protocol_prune_start.elapsed();
+        let protocol_removed_count = protocol_removed.len();
+        txs.extend(protocol_removed);
+        let total_elapsed = total_start.elapsed();
+
+        tracing::debug!(
+            target: "payload_builder::build_payload_timing::txpool_update",
+            phase = "tempo_pool.prune_transactions",
+            hash_count,
+            aa_removed_count,
+            protocol_removed_count,
+            total_removed_count = txs.len(),
+            aa_write_lock_wait_duration_us = timing_micros(aa_write_lock_wait_elapsed),
+            aa_write_lock_hold_duration_us = timing_micros(aa_write_lock_hold_elapsed),
+            protocol_prune_duration_us = timing_micros(protocol_prune_elapsed),
+            total_duration_us = timing_micros(total_elapsed),
+            ?aa_write_lock_wait_elapsed,
+            ?aa_write_lock_hold_elapsed,
+            ?protocol_prune_elapsed,
+            ?total_elapsed,
+            "timed txpool update phase"
+        );
         txs
     }
 
@@ -1234,15 +1470,59 @@ where
     type Block = Block;
 
     fn set_block_info(&self, info: BlockInfo) {
-        self.protocol_pool.set_block_info(info)
+        let start = Instant::now();
+        self.protocol_pool.set_block_info(info);
+        let elapsed = start.elapsed();
+
+        tracing::debug!(
+            target: "payload_builder::build_payload_timing::txpool_update",
+            phase = "tempo_pool.set_block_info",
+            block_number = info.last_seen_block_number,
+            block_hash = %info.last_seen_block_hash,
+            duration_us = timing_micros(elapsed),
+            ?elapsed,
+            "timed txpool update phase"
+        );
     }
 
     fn on_canonical_state_change(&self, update: CanonicalStateUpdate<'_, Self::Block>) {
-        self.protocol_pool.on_canonical_state_change(update)
+        let block_number = update.number();
+        let block_hash = update.hash();
+        let changed_accounts_count = update.changed_accounts.len();
+        let mined_transactions_count = update.mined_transactions.len();
+        let update_kind = update.update_kind;
+        let start = Instant::now();
+        self.protocol_pool.on_canonical_state_change(update);
+        let elapsed = start.elapsed();
+
+        tracing::debug!(
+            target: "payload_builder::build_payload_timing::txpool_update",
+            phase = "tempo_pool.on_canonical_state_change",
+            block_number,
+            %block_hash,
+            changed_accounts_count,
+            mined_transactions_count,
+            ?update_kind,
+            duration_us = timing_micros(elapsed),
+            ?elapsed,
+            "timed txpool update phase"
+        );
     }
 
     fn update_accounts(&self, accounts: Vec<ChangedAccount>) {
-        self.protocol_pool.update_accounts(accounts)
+        let accounts_count = accounts.len();
+        let start = Instant::now();
+        self.protocol_pool.update_accounts(accounts);
+        let elapsed = start.elapsed();
+
+        tracing::debug!(
+            target: "payload_builder::build_payload_timing::txpool_update",
+            phase = "tempo_pool.update_accounts",
+            accounts_count,
+            duration_us = timing_micros(elapsed),
+            ?elapsed,
+            "timed txpool update phase"
+        );
     }
 
     fn delete_blob(&self, tx: B256) {

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -28,7 +28,10 @@ use reth_transaction_pool::{
     identifier::TransactionId,
 };
 use revm::database::BundleAccount;
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tempo_chainspec::{
     TempoChainSpec,
     hardfork::{TempoHardfork, TempoHardforks},
@@ -43,6 +46,10 @@ use tempo_precompiles::{
 };
 use tempo_primitives::Block;
 use tempo_revm::TempoStateAccess;
+
+fn timing_micros(duration: Duration) -> u128 {
+    duration.as_micros()
+}
 
 /// Tempo transaction pool that routes based on nonce_key
 pub struct TempoTransactionPool<Client> {
@@ -841,9 +848,42 @@ where
     fn best_transactions(
         &self,
     ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
+        let total_start = Instant::now();
+
+        let protocol_start = Instant::now();
         let left = self.protocol_pool.inner().best_transactions();
-        let right = self.aa_2d_pool.read().best_transactions();
-        Box::new(MergeBestTransactions::new(left, right))
+        let protocol_elapsed = protocol_start.elapsed();
+
+        let aa_lock_start = Instant::now();
+        let aa_pool = self.aa_2d_pool.read();
+        let aa_lock_wait_elapsed = aa_lock_start.elapsed();
+
+        let aa_snapshot_start = Instant::now();
+        let right = aa_pool.best_transactions();
+        let aa_snapshot_elapsed = aa_snapshot_start.elapsed();
+        drop(aa_pool);
+
+        let merge_start = Instant::now();
+        let merged = MergeBestTransactions::new(left, right);
+        let merge_elapsed = merge_start.elapsed();
+        let total_elapsed = total_start.elapsed();
+
+        tracing::debug!(
+            target: "payload_builder::build_payload_timing::txpool",
+            phase = "tempo_pool.best_transactions",
+            protocol_duration_us = timing_micros(protocol_elapsed),
+            aa_lock_wait_duration_us = timing_micros(aa_lock_wait_elapsed),
+            aa_snapshot_duration_us = timing_micros(aa_snapshot_elapsed),
+            merge_duration_us = timing_micros(merge_elapsed),
+            total_duration_us = timing_micros(total_elapsed),
+            ?protocol_elapsed,
+            ?aa_lock_wait_elapsed,
+            ?aa_snapshot_elapsed,
+            ?merge_elapsed,
+            ?total_elapsed,
+            "timed best_transactions pool phase"
+        );
+        Box::new(merged)
     }
 
     fn best_transactions_with_attributes(

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{
     map::{AddressMap, B256Map, HashMap, HashSet, U256Map},
 };
 use reth_primitives_traits::transaction::error::InvalidTransactionError;
-use reth_tracing::tracing::trace;
+use reth_tracing::tracing::{debug, trace};
 use reth_transaction_pool::{
     AllPoolTransactions, BestTransactions, CoinbaseTipOrdering, GetPooledTransactionLimit,
     PoolResult, PoolTransaction, PriceBumpConfig, Priority, SubPool, SubPoolLimit,
@@ -25,12 +25,18 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
+    time::{Duration, Instant},
 };
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_precompiles::NONCE_PRECOMPILE_ADDRESS;
 use tokio::sync::broadcast;
 
 type TxOrdering = CoinbaseTipOrdering<TempoPooledTransaction>;
+
+fn timing_micros(duration: Duration) -> u128 {
+    duration.as_micros()
+}
+
 /// A sub-pool that keeps track of 2D nonce transactions.
 ///
 /// It maintains both pending and queued transactions.
@@ -557,22 +563,66 @@ impl AA2dPool {
     /// Returns the best, executable transactions for this sub-pool
     #[allow(clippy::mutable_key_type)]
     pub(crate) fn best_transactions(&self) -> BestAA2dTransactions {
+        let total_start = Instant::now();
+        let independent_count = self.independent_transactions.len();
+        let expiring_count = self.expiring_nonce_txs.len();
+        let by_id_count = self.by_id.len();
+        let pending_count = self.pending_count;
+        let queued_count = self.queued_count;
+
         // Collect independent transactions from both 2D nonce pool and expiring nonce pool
+        let independent_start = Instant::now();
         let mut independent: BTreeSet<_> =
             self.independent_transactions.values().cloned().collect();
+        let independent_clone_elapsed = independent_start.elapsed();
+
         // Expiring nonce txs are always independent (no nonce dependencies)
+        let expiring_start = Instant::now();
         independent.extend(self.expiring_nonce_txs.values().cloned());
+        let expiring_clone_elapsed = expiring_start.elapsed();
+        let independent_snapshot_count = independent.len();
+
+        let by_id_start = Instant::now();
+        let by_id = self
+            .by_id
+            .iter()
+            .filter(|(_, tx)| tx.is_pending())
+            .map(|(id, tx)| (*id, tx.inner.clone()))
+            .collect();
+        let by_id_clone_elapsed = by_id_start.elapsed();
+
+        let subscribe_start = Instant::now();
+        let new_transaction_receiver = Some(self.new_transaction_notifier.subscribe());
+        let subscribe_elapsed = subscribe_start.elapsed();
+        let total_elapsed = total_start.elapsed();
+
+        debug!(
+            target: "payload_builder::build_payload_timing::txpool",
+            phase = "aa_2d.best_transactions",
+            independent_count,
+            expiring_count,
+            independent_snapshot_count,
+            by_id_count,
+            pending_count,
+            queued_count,
+            independent_clone_duration_us = timing_micros(independent_clone_elapsed),
+            expiring_clone_duration_us = timing_micros(expiring_clone_elapsed),
+            by_id_clone_duration_us = timing_micros(by_id_clone_elapsed),
+            subscribe_duration_us = timing_micros(subscribe_elapsed),
+            total_duration_us = timing_micros(total_elapsed),
+            ?independent_clone_elapsed,
+            ?expiring_clone_elapsed,
+            ?by_id_clone_elapsed,
+            ?subscribe_elapsed,
+            ?total_elapsed,
+            "timed aa_2d best_transactions snapshot"
+        );
 
         BestAA2dTransactions {
             independent,
-            by_id: self
-                .by_id
-                .iter()
-                .filter(|(_, tx)| tx.is_pending())
-                .map(|(id, tx)| (*id, tx.inner.clone()))
-                .collect(),
+            by_id,
             invalid: Default::default(),
-            new_transaction_receiver: Some(self.new_transaction_notifier.subscribe()),
+            new_transaction_receiver,
             last_priority: None,
         }
     }


### PR DESCRIPTION
Adds temporary debug timing logs inside `build_payload` under the `payload_builder::build_payload_timing` target so benchmark output can be turned into a timeline diagram.

The logs include relative start offsets, durations, and end offsets for pool iterator creation, `best_txs.next()`, transaction execution, fill phases, subblocks, system transactions, and finalization. This draft is intended for collecting benchmark logs, not as a merge-ready instrumentation change.