### PR TITLE
bench-e2e: append side features to global features

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -30,6 +30,16 @@ const E2E_LOCAL_RETH_ARGS = [
     "--builder.enable-prewarming"
 ]
 
+def merge-e2e-features [...features: string] {
+    $features
+    | each { |f| $f | split row "," }
+    | flatten
+    | each { |f| $f | str trim }
+    | where { |f| $f != "" }
+    | uniq
+    | str join ","
+}
+
 def tempo-node-help [tempo_bin: string] {
     let result = (run-external $tempo_bin "node" "--help" | complete)
     if $result.exit_code != 0 {
@@ -1139,9 +1149,9 @@ def "main e2e" [
     --force-bloat                                      # Regenerate and promote both local e2e snapshots
     --init-only                                         # Refresh snapshots and exit without running benchmark phases
     --profile: string = $DEFAULT_PROFILE                # Cargo build profile
-    --features: string = $DEFAULT_FEATURES              # Cargo features
-    --baseline-features: string = ""                    # Cargo features for baseline build (defaults to --features)
-    --feature-features: string = ""                     # Cargo features for feature build (defaults to --features)
+    --features: string = ""                             # Additional Cargo features appended to the e2e defaults
+    --baseline-features: string = ""                    # Additional Cargo features for baseline build (defaults to --features)
+    --feature-features: string = ""                     # Additional Cargo features for feature build (defaults to --features)
     --no-default-features                               # Disable Cargo default features
     --samply                                            # Profile validators with samply
     --samply-args: string = ""                          # Additional samply arguments
@@ -1278,7 +1288,8 @@ def "main e2e" [
         if ($E2E_BLOAT_TMP_DIR | path exists) { rm -rf $E2E_BLOAT_TMP_DIR }
         mkdir $E2E_BLOAT_TMP_DIR
 
-        build-tempo --no-default-features=$no_default_features ["tempo"] $profile $features
+        let snapshot_features = (merge-e2e-features $DEFAULT_FEATURES $features)
+        build-tempo --no-default-features=$no_default_features ["tempo"] $profile $snapshot_features
         let tempo_bin = if $profile == "dev" { "./target/debug/tempo" } else { $"./target/($profile)/tempo" }
         let genesis_accounts = ([$accounts 3] | math max) + 1
         print $"Generating local e2e localnet config for validators: ($E2E_VALIDATORS)"
@@ -1367,11 +1378,13 @@ def "main e2e" [
         git worktree add $regenesis_wt origin/main
     }
 
-    let baseline_build_features = if $baseline_features != "" { $baseline_features } else { $features }
-    let feature_build_features = if $feature_features != "" { $feature_features } else { $features }
+    let global_build_features = (merge-e2e-features $DEFAULT_FEATURES $features)
+    let baseline_build_features = if $baseline_features != "" { merge-e2e-features $global_build_features $baseline_features } else { $global_build_features }
+    let feature_build_features = if $feature_features != "" { merge-e2e-features $global_build_features $feature_features } else { $global_build_features }
     let baseline_tbc = (tracy-build-config $baseline_build_features $tracy)
     let feature_tbc = (tracy-build-config $feature_build_features $tracy)
-    let regenesis_tbc = (tracy-build-config $features $tracy)
+    let regenesis_build_features = $global_build_features
+    let regenesis_tbc = (tracy-build-config $regenesis_build_features $tracy)
     let effective_no_cache = $no_cache or ($tracy != "off")
     # Build benchmark binaries in parallel. Regenesis uses latest origin/main so
     # snapshot rewriting is independent of either side being benchmarked.
@@ -1382,7 +1395,7 @@ def "main e2e" [
     ]
     let regenesis_sha = if $regenesis_needed { git rev-parse origin/main | str trim } else { "" }
     if $regenesis_needed {
-        $builds = ($builds | append { wt: $regenesis_wt, ref_name: "origin/main", sha: $regenesis_sha, label: "regenesis-main", features: $regenesis_tbc.features, extra_rustflags: $regenesis_tbc.extra_rustflags, bench_features: $features })
+        $builds = ($builds | append { wt: $regenesis_wt, ref_name: "origin/main", sha: $regenesis_sha, label: "regenesis-main", features: $regenesis_tbc.features, extra_rustflags: $regenesis_tbc.extra_rustflags, bench_features: $regenesis_build_features })
     }
     $builds | par-each { |b|
         if $effective_no_cache {

--- a/tempo.nu
+++ b/tempo.nu
@@ -355,7 +355,7 @@ def resolve-git-ref-label [sha: string, fallback: string] {
 }
 
 def bench-cache-key [commit_sha: string, features: string, no_default_features: bool] {
-    if not $no_default_features {
+    if (not $no_default_features) and $features == $DEFAULT_FEATURES {
         return $commit_sha
     }
 
@@ -368,7 +368,8 @@ def bench-cache-key [commit_sha: string, features: string, no_default_features: 
         | str replace -a " " "_"
     }
 
-    $"($commit_sha)-no-default-($feature_key)"
+    let mode_key = if $no_default_features { "no-default" } else { "features" }
+    $"($commit_sha)-($mode_key)-($feature_key)"
 }
 
 # Try to download cached binaries from MinIO for a given commit SHA.


### PR DESCRIPTION
## Summary
- bench-e2e now computes the global feature set as `merge(DEFAULT_FEATURES, --features)`.
- Side-specific flags append to that effective global set: `baseline = merge(global, --baseline-features)` and `feature = merge(global, --feature-features)`.
- Feature merging trims comma-separated entries, drops empty values, preserves order, and de-dupes repeats.
- Non-default feature sets are included in benchmark cache keys so custom-feature builds do not reuse the wrong binary.

For example, `--features jemalloc,asm-keccak,keccak-cache-global,otlp --feature-features bal` builds the feature binary with `jemalloc,asm-keccak,keccak-cache-global,otlp,bal`.

Prompted by: @joshieDo

## Tests
- `nu --commands 'source bench-e2e.nu; print (merge-e2e-features $DEFAULT_FEATURES "jemalloc,asm-keccak,keccak-cache-global,otlp" "bal"); print (merge-e2e-features $DEFAULT_FEATURES "otlp" "jemalloc,bal, otlp")'`
- `nu --commands 'source tempo.nu; print (bench-cache-key abc jemalloc,asm-keccak false); print (bench-cache-key abc jemalloc,asm-keccak,keccak-cache-global,otlp,bal false); print (bench-cache-key abc "" true)'`
- `nu --commands 'source bench-e2e.nu'`
- `git diff --check`
