### PR TITLE
perf(pool): store transaction priority as u64

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -17,7 +17,7 @@ use reth_node_builder::{
     BuilderContext, DebugNode, Node, NodeAdapter,
     components::{
         BasicPayloadServiceBuilder, ComponentsBuilder, ConsensusBuilder, ExecutorBuilder,
-        PayloadBuilderBuilder, PoolBuilder, TxPoolBuilder, spawn_maintenance_tasks,
+        PayloadBuilderBuilder, PoolBuilder, spawn_maintenance_tasks,
     },
     rpc::{
         BasicEngineValidatorBuilder, EngineValidatorAddOn, NoopEngineApiBuilder,
@@ -34,7 +34,9 @@ use reth_rpc_eth_api::{
 };
 use reth_storage_api::EmptyBodyStorage;
 use reth_tracing::tracing::{debug, info};
-use reth_transaction_pool::{TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore};
+use reth_transaction_pool::{
+    Pool, TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore,
+};
 use tempo_chainspec::spec::TempoChainSpec;
 use tempo_consensus::TempoConsensus;
 use tempo_evm::TempoEvmConfig;
@@ -46,6 +48,7 @@ use tempo_primitives::{TempoHeader, TempoPrimitives, TempoTxEnvelope, TempoTxTyp
 use tempo_transaction_pool::{
     AA2dPool, AA2dPoolConfig, TempoTransactionPool,
     amm::AmmLiquidityCache,
+    ordering::TempoTipOrdering,
     validator::{
         DEFAULT_AA_VALID_AFTER_MAX_SECS, DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
         TempoTransactionValidator,
@@ -501,9 +504,12 @@ where
                 amm_liquidity_cache.clone(),
             )
         });
-        let protocol_pool = TxPoolBuilder::new(ctx)
-            .with_validator(validator)
-            .build(blob_store, pool_config.clone());
+        let protocol_pool = Pool::new(
+            validator,
+            TempoTipOrdering::default(),
+            blob_store,
+            pool_config.clone(),
+        );
 
         // Wrap the protocol pool in our hybrid TempoTransactionPool
         let transaction_pool = TempoTransactionPool::new(protocol_pool, aa_2d_pool);

--- a/crates/transaction-pool/src/best.rs
+++ b/crates/transaction-pool/src/best.rs
@@ -1,20 +1,23 @@
 //! An iterator over the best transactions in the tempo pool.
 
-use crate::{transaction::TempoPooledTransaction, tt_2d_pool::BestAA2dTransactions};
+use crate::{
+    ordering::TempoTipOrdering, transaction::TempoPooledTransaction,
+    tt_2d_pool::BestAA2dTransactions,
+};
 use alloy_primitives::{Address, U256, map::HashMap};
 use reth_evm::block::TxResult;
 use reth_primitives_traits::transaction::error::InvalidTransactionError;
 use reth_transaction_pool::{
-    BestTransactions, CoinbaseTipOrdering, Priority, ValidPoolTransaction,
-    error::InvalidPoolTransactionError, pool::BestTransactions as BestProtocolTransactions,
+    BestTransactions, Priority, ValidPoolTransaction, error::InvalidPoolTransactionError,
+    pool::BestTransactions as BestProtocolTransactions,
 };
 use std::sync::Arc;
 use tempo_evm::TempoTxResult;
 use tempo_precompiles::tip20::{decode_tip20_balance, is_tip20_prefix};
 
-type TxOrdering = CoinbaseTipOrdering<TempoPooledTransaction>;
+type TxOrdering = TempoTipOrdering<TempoPooledTransaction>;
 pub type BestTransaction = Arc<ValidPoolTransaction<TempoPooledTransaction>>;
-type BestTransactionWithPriority = (BestTransaction, Priority<u128>);
+type BestTransactionWithPriority = (BestTransaction, Priority<u64>);
 
 /// A best-transaction iterator that merges the protocol pool and the 2D nonces pool,
 /// always yielding the next best item from either iterator.
@@ -255,7 +258,7 @@ mod tests {
     fn protocol_best_transactions(txs: Vec<TestTx>) -> BestProtocolTransactions<TxOrdering> {
         let pool = Pool::new(
             OkValidator::<TempoPooledTransaction>::default(),
-            CoinbaseTipOrdering::default(),
+            TempoTipOrdering::default(),
             InMemoryBlobStore::default(),
             PoolConfig::default(),
         );

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -18,6 +18,7 @@ pub mod amm;
 pub mod best;
 pub mod maintain;
 pub mod metrics;
+pub mod ordering;
 pub mod paused;
 pub mod tt_2d_pool;
 

--- a/crates/transaction-pool/src/ordering.rs
+++ b/crates/transaction-pool/src/ordering.rs
@@ -1,0 +1,58 @@
+//! Transaction ordering for Tempo's pool.
+
+use reth_transaction_pool::{PoolTransaction, Priority, TransactionOrdering};
+use std::marker::PhantomData;
+
+/// Orders transactions by effective coinbase tip using a compact priority value.
+#[derive(Debug)]
+pub struct TempoTipOrdering<T>(PhantomData<T>);
+
+impl<T> TransactionOrdering for TempoTipOrdering<T>
+where
+    T: PoolTransaction + 'static,
+{
+    type PriorityValue = u64;
+    type Transaction = T;
+
+    fn priority(
+        &self,
+        transaction: &Self::Transaction,
+        base_fee: u64,
+    ) -> Priority<Self::PriorityValue> {
+        transaction
+            .effective_tip_per_gas(base_fee)
+            .map(|priority| priority.try_into().unwrap_or(u64::MAX))
+            .into()
+    }
+}
+
+impl<T> Default for TempoTipOrdering<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<T> Clone for TempoTipOrdering<T> {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TempoTipOrdering, TransactionOrdering};
+    use crate::test_utils::TxBuilder;
+
+    #[test]
+    fn priority_saturates_to_u64_max() {
+        let tx = TxBuilder::default()
+            .max_fee(u128::MAX)
+            .max_priority_fee(u128::MAX)
+            .build();
+
+        assert_eq!(
+            TempoTipOrdering::default().priority(&tx, 0),
+            reth_transaction_pool::Priority::Value(u64::MAX)
+        );
+    }
+}

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -3,8 +3,9 @@
 // Routes user nonces (nonce_key>0) to minimal 2D nonce pool
 
 use crate::{
-    amm::AmmLiquidityCache, best::MergeBestTransactions, transaction::TempoPooledTransaction,
-    tt_2d_pool::AA2dPool, validator::TempoTransactionValidator,
+    amm::AmmLiquidityCache, best::MergeBestTransactions, ordering::TempoTipOrdering,
+    transaction::TempoPooledTransaction, tt_2d_pool::AA2dPool,
+    validator::TempoTransactionValidator,
 };
 use alloy_consensus::Transaction;
 use alloy_primitives::{
@@ -18,11 +19,10 @@ use reth_provider::{ChangedAccount, StateProviderFactory};
 use reth_storage_api::StateProvider;
 use reth_transaction_pool::{
     AddedTransactionOutcome, AllPoolTransactions, BestTransactions, BestTransactionsAttributes,
-    BlockInfo, CanonicalStateUpdate, CoinbaseTipOrdering, GetPooledTransactionLimit,
-    NewBlobSidecar, Pool, PoolResult, PoolSize, PoolTransaction, PropagatedTransactions,
-    TransactionEvents, TransactionOrigin, TransactionPool, TransactionPoolExt,
-    TransactionValidationOutcome, TransactionValidationTaskExecutor, TransactionValidator,
-    ValidPoolTransaction,
+    BlockInfo, CanonicalStateUpdate, GetPooledTransactionLimit, NewBlobSidecar, Pool, PoolResult,
+    PoolSize, PoolTransaction, PropagatedTransactions, TransactionEvents, TransactionOrigin,
+    TransactionPool, TransactionPoolExt, TransactionValidationOutcome,
+    TransactionValidationTaskExecutor, TransactionValidator, ValidPoolTransaction,
     blobstore::InMemoryBlobStore,
     error::{PoolError, PoolErrorKind},
     identifier::TransactionId,
@@ -49,7 +49,7 @@ pub struct TempoTransactionPool<Client> {
     /// Vanilla pool for all standard transactions and AA transactions with regular nonce.
     protocol_pool: Pool<
         TransactionValidationTaskExecutor<TempoTransactionValidator<Client>>,
-        CoinbaseTipOrdering<TempoPooledTransaction>,
+        TempoTipOrdering<TempoPooledTransaction>,
         InMemoryBlobStore,
     >,
     /// Minimal pool for 2D nonces (nonce_key > 0)
@@ -60,7 +60,7 @@ impl<Client> TempoTransactionPool<Client> {
     pub fn new(
         protocol_pool: Pool<
             TransactionValidationTaskExecutor<TempoTransactionValidator<Client>>,
-            CoinbaseTipOrdering<TempoPooledTransaction>,
+            TempoTipOrdering<TempoPooledTransaction>,
             InMemoryBlobStore,
         >,
         aa_2d_pool: AA2dPool,
@@ -1504,7 +1504,7 @@ mod tests {
         let (executor, _task) = TransactionValidationTaskExecutor::new(validator);
         let protocol_pool = Pool::new(
             executor,
-            CoinbaseTipOrdering::default(),
+            TempoTipOrdering::default(),
             InMemoryBlobStore::default(),
             PoolConfig::default(),
         );
@@ -1770,7 +1770,7 @@ mod tests {
         let (executor, _task) = TransactionValidationTaskExecutor::new(validator);
         let protocol_pool = Pool::new(
             executor,
-            CoinbaseTipOrdering::default(),
+            TempoTipOrdering::default(),
             InMemoryBlobStore::default(),
             PoolConfig::default(),
         );
@@ -1929,7 +1929,7 @@ mod tests {
         let (executor, _task) = TransactionValidationTaskExecutor::new(validator);
         let protocol_pool = Pool::new(
             executor,
-            CoinbaseTipOrdering::default(),
+            TempoTipOrdering::default(),
             InMemoryBlobStore::default(),
             PoolConfig::default(),
         );
@@ -2010,7 +2010,7 @@ mod tests {
         let (executor, _task) = TransactionValidationTaskExecutor::new(validator);
         let protocol_pool = Pool::new(
             executor,
-            CoinbaseTipOrdering::default(),
+            TempoTipOrdering::default(),
             InMemoryBlobStore::default(),
             PoolConfig::default(),
         );
@@ -2101,7 +2101,7 @@ mod tests {
         let (executor, _task) = TransactionValidationTaskExecutor::new(validator);
         let protocol_pool = Pool::new(
             executor,
-            CoinbaseTipOrdering::default(),
+            TempoTipOrdering::default(),
             InMemoryBlobStore::default(),
             PoolConfig::default(),
         );
@@ -2188,7 +2188,7 @@ mod tests {
         let (executor, _task) = TransactionValidationTaskExecutor::new(validator);
         let protocol_pool = Pool::new(
             executor,
-            CoinbaseTipOrdering::default(),
+            TempoTipOrdering::default(),
             InMemoryBlobStore::default(),
             PoolConfig::default(),
         );

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -1,5 +1,7 @@
 /// Basic 2D nonce pool for user nonces (nonce_key > 0) that are tracked on chain.
-use crate::{metrics::AA2dPoolMetrics, transaction::TempoPooledTransaction};
+use crate::{
+    metrics::AA2dPoolMetrics, ordering::TempoTipOrdering, transaction::TempoPooledTransaction,
+};
 use alloy_primitives::{
     Address, B256, TxHash, U256,
     map::{AddressMap, B256Map, HashMap, HashSet, U256Map},
@@ -7,9 +9,9 @@ use alloy_primitives::{
 use reth_primitives_traits::transaction::error::InvalidTransactionError;
 use reth_tracing::tracing::trace;
 use reth_transaction_pool::{
-    AllPoolTransactions, BestTransactions, CoinbaseTipOrdering, GetPooledTransactionLimit,
-    PoolResult, PoolTransaction, PriceBumpConfig, Priority, SubPool, SubPoolLimit,
-    TransactionOrdering, TransactionOrigin, ValidPoolTransaction,
+    AllPoolTransactions, BestTransactions, GetPooledTransactionLimit, PoolResult, PoolTransaction,
+    PriceBumpConfig, Priority, SubPool, SubPoolLimit, TransactionOrdering, TransactionOrigin,
+    ValidPoolTransaction,
     error::{InvalidPoolTransactionError, PoolError, PoolErrorKind},
     pool::{AddedPendingTransaction, AddedTransaction, QueuedReason, pending::PendingTransaction},
 };
@@ -31,7 +33,7 @@ use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_precompiles::NONCE_PRECOMPILE_ADDRESS;
 use tokio::sync::broadcast;
 
-type TxOrdering = CoinbaseTipOrdering<TempoPooledTransaction>;
+type TxOrdering = TempoTipOrdering<TempoPooledTransaction>;
 /// A sub-pool that keeps track of 2D nonce transactions.
 ///
 /// It maintains both pending and queued transactions.
@@ -208,7 +210,7 @@ impl AA2dPool {
         let tx = Arc::new(AA2dInternalTransaction {
             inner: PendingTransaction {
                 submission_id: self.next_id(),
-                priority: CoinbaseTipOrdering::default()
+                priority: TempoTipOrdering::default()
                     .priority(&transaction.transaction, hardfork.base_fee()),
                 transaction: transaction.clone(),
             },
@@ -393,7 +395,7 @@ impl AA2dPool {
         // Create pending transaction
         let pending_tx = PendingTransaction {
             submission_id: self.next_id(),
-            priority: CoinbaseTipOrdering::default()
+            priority: TempoTipOrdering::default()
                 .priority(&transaction.transaction, hardfork.base_fee()),
             transaction: transaction.clone(),
         };
@@ -1015,7 +1017,7 @@ impl AA2dPool {
 
     /// Removes lowest-priority transactions if the pool is above capacity.
     ///
-    /// This evicts transactions with the lowest priority (based on [`CoinbaseTipOrdering`])
+    /// This evicts transactions with the lowest priority (based on [`TempoTipOrdering`])
     /// to prevent DoS attacks where adversaries use vanity addresses with many leading zeroes
     /// to avoid eviction.
     ///
@@ -1541,7 +1543,7 @@ struct AA2dInternalTransaction {
     /// Keeps track of the transaction
     ///
     /// We can use [`PendingTransaction`] here because the priority remains unchanged.
-    inner: PendingTransaction<CoinbaseTipOrdering<TempoPooledTransaction>>,
+    inner: PendingTransaction<TxOrdering>,
     /// Whether this transaction is pending/executable.
     ///
     /// If it's not pending, it is queued.
@@ -1571,12 +1573,12 @@ impl AA2dInternalTransaction {
 /// cloned transaction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ExpiringNonceEvictionOrderKey {
-    priority: Priority<u128>,
+    priority: Priority<u64>,
     submission_id: u64,
 }
 
 impl ExpiringNonceEvictionOrderKey {
-    fn new(priority: Priority<u128>, submission_id: u64) -> Self {
+    fn new(priority: Priority<u64>, submission_id: u64) -> Self {
         Self {
             priority,
             submission_id,
@@ -1643,7 +1645,7 @@ impl ExpiringNonceEvictionKey {
         }
     }
 
-    fn priority(&self) -> &Priority<u128> {
+    fn priority(&self) -> &Priority<u64> {
         &self.order.priority
     }
 
@@ -1709,7 +1711,7 @@ impl EvictionKey {
     }
 
     /// Returns the transaction's priority.
-    fn priority(&self) -> &Priority<u128> {
+    fn priority(&self) -> &Priority<u64> {
         &self.tx.inner.priority
     }
 
@@ -1789,7 +1791,7 @@ pub(crate) struct BestAA2dTransactions {
     /// Live feed of new pending transactions arriving after this iterator was created.
     new_transaction_receiver: Option<broadcast::Receiver<PendingTransaction<TxOrdering>>>,
     /// Priority of the most recently yielded transaction, used to maintain ordering invariant.
-    last_priority: Option<Priority<u128>>,
+    last_priority: Option<Priority<u64>>,
 }
 
 impl BestAA2dTransactions {
@@ -1899,7 +1901,7 @@ impl BestAA2dTransactions {
         &mut self,
     ) -> Option<(
         Arc<ValidPoolTransaction<TempoPooledTransaction>>,
-        Priority<u128>,
+        Priority<u64>,
     )> {
         loop {
             self.add_new_transactions();


### PR DESCRIPTION
Switches the transaction pool to a Tempo-local coinbase-tip ordering whose priority value is `u64` instead of Reth's default `u128`.

The protocol pool and AA 2D pool now compare the same compact priority type, with values above `u64::MAX` saturating because they are outside practical gas-price ranges.