### PR TITLE
fix(precompiles): reject state changes in static call context (#4104)

### DIFF
--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -107,6 +107,14 @@ pub enum TempoPrecompileError {
     #[error("Gas limit exceeded")]
     OutOfGas,
 
+    /// A state-changing operation was attempted while the precompile was
+    /// invoked in a static call context (EIP-214 / EIP-1153).
+    ///
+    /// Returned by state-mutating storage provider methods when the provider
+    /// was constructed with `is_static = true`.
+    #[error("State change attempted in static call context (EIP-214)")]
+    StateChangeInStaticCall,
+
     /// The calldata's 4-byte selector does not match any known precompile function.
     #[error("Unknown function selector: {0:?}")]
     UnknownFunctionSelector([u8; 4]),
@@ -168,7 +176,7 @@ impl TempoPrecompileError {
             Self::StorageCreditsError(e) => e.selector(),
             Self::UnknownFunctionSelector(selector) => *selector,
             Self::Panic(_) | Self::StorageDeltaUnderflow(_) => Panic::SELECTOR,
-            Self::OutOfGas | Self::Fatal(_) => [0, 0, 0, 0],
+            Self::OutOfGas | Self::StateChangeInStaticCall | Self::Fatal(_) => [0, 0, 0, 0],
         }
         .into()
     }
@@ -177,7 +185,11 @@ impl TempoPrecompileError {
     /// rather than swallowed, because state may be inconsistent.
     pub fn is_system_error(&self) -> bool {
         match self {
-            Self::OutOfGas | Self::Fatal(_) | Self::Panic(_) | Self::StorageDeltaUnderflow(_) => {
+            Self::OutOfGas
+            | Self::Fatal(_)
+            | Self::Panic(_)
+            | Self::StorageDeltaUnderflow(_)
+            | Self::StateChangeInStaticCall => {
                 true
             }
             Self::StablecoinDEX(_)
@@ -224,6 +236,7 @@ impl TempoPrecompileError {
     ///
     /// # Errors
     /// - `PrecompileOutput::halt(PrecompileHalt::OutOfGas, ..)` — if the variant is [`OutOfGas`](Self::OutOfGas)
+    /// - `PrecompileError::Fatal` — if the variant is [`StateChangeInStaticCall`](Self::StateChangeInStaticCall)
     /// - `PrecompileError::Fatal` — if the variant is [`Fatal`](Self::Fatal)
     pub fn into_precompile_result(self, gas: u64, reservoir: u64) -> PrecompileResult {
         let bytes = match self {
@@ -265,6 +278,11 @@ impl TempoPrecompileError {
             }
             .abi_encode()
             .into(),
+            Self::StateChangeInStaticCall => {
+                return Err(PrecompileError::Fatal(
+                    "state change attempted in static call context (EIP-214)".to_string(),
+                ));
+            }
             Self::Fatal(msg) => {
                 return Err(PrecompileError::Fatal(msg));
             }

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -189,9 +189,7 @@ impl TempoPrecompileError {
             | Self::Fatal(_)
             | Self::Panic(_)
             | Self::StorageDeltaUnderflow(_)
-            | Self::StateChangeInStaticCall => {
-                true
-            }
+            | Self::StateChangeInStaticCall => true,
             Self::StablecoinDEX(_)
             | Self::TIP20(_)
             | Self::TIP20ChannelReserveError(_)

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -99,6 +99,14 @@ pub enum TempoPrecompileError {
     #[error("Gas limit exceeded")]
     OutOfGas,
 
+    /// A state-changing operation was attempted while the precompile was
+    /// invoked in a static call context (EIP-214 / EIP-1153).
+    ///
+    /// Returned by state-mutating storage provider methods when the provider
+    /// was constructed with `is_static = true`.
+    #[error("State change attempted in static call context (EIP-214)")]
+    StateChangeInStaticCall,
+
     /// The calldata's 4-byte selector does not match any known precompile function.
     #[error("Unknown function selector: {0:?}")]
     UnknownFunctionSelector([u8; 4]),
@@ -159,7 +167,7 @@ impl TempoPrecompileError {
             Self::ReceivePolicyGuardError(e) => e.selector(),
             Self::UnknownFunctionSelector(selector) => *selector,
             Self::Panic(_) => Panic::SELECTOR,
-            Self::OutOfGas | Self::Fatal(_) => [0, 0, 0, 0],
+            Self::OutOfGas | Self::StateChangeInStaticCall | Self::Fatal(_) => [0, 0, 0, 0],
         }
         .into()
     }
@@ -168,7 +176,9 @@ impl TempoPrecompileError {
     /// rather than swallowed, because state may be inconsistent.
     pub fn is_system_error(&self) -> bool {
         match self {
-            Self::OutOfGas | Self::Fatal(_) | Self::Panic(_) => true,
+            Self::OutOfGas | Self::Fatal(_) | Self::Panic(_) | Self::StateChangeInStaticCall => {
+                true
+            }
             Self::StablecoinDEX(_)
             | Self::TIP20(_)
             | Self::TIP20ChannelReserveError(_)
@@ -207,6 +217,7 @@ impl TempoPrecompileError {
     ///
     /// # Errors
     /// - `PrecompileOutput::halt(PrecompileHalt::OutOfGas, ..)` — if the variant is [`OutOfGas`](Self::OutOfGas)
+    /// - `PrecompileError::Fatal` — if the variant is [`StateChangeInStaticCall`](Self::StateChangeInStaticCall)
     /// - `PrecompileError::Fatal` — if the variant is [`Fatal`](Self::Fatal)
     pub fn into_precompile_result(self, gas: u64, reservoir: u64) -> PrecompileResult {
         let bytes = match self {
@@ -240,6 +251,11 @@ impl TempoPrecompileError {
             }
             .abi_encode()
             .into(),
+            Self::StateChangeInStaticCall => {
+                return Err(PrecompileError::Fatal(
+                    "state change attempted in static call context (EIP-214)".to_string(),
+                ));
+            }
             Self::Fatal(msg) => {
                 return Err(PrecompileError::Fatal(msg));
             }

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -107,6 +107,10 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
 
     #[inline]
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), TempoPrecompileError> {
+        if self.is_static {
+            return Err(TempoPrecompileError::StateChangeInStaticCall);
+        }
+
         let code_len = code.len();
         self.deduct_gas(self.gas_params.code_deposit_cost(code_len))?;
 
@@ -175,6 +179,10 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
         key: U256,
         value: U256,
     ) -> Result<(), TempoPrecompileError> {
+        if self.is_static {
+            return Err(TempoPrecompileError::StateChangeInStaticCall);
+        }
+
         // T4+: pre-charge static gas before loading storage to avoid cheap useless work.
         let insufficient_gas_for_cold_load = if self.spec.is_t4() {
             self.deduct_gas(self.gas_params.sstore_static_gas())?;
@@ -215,6 +223,10 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
         key: U256,
         value: U256,
     ) -> Result<(), TempoPrecompileError> {
+        if self.is_static {
+            return Err(TempoPrecompileError::StateChangeInStaticCall);
+        }
+
         self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
         self.internals.tstore(address, key, value);
         Ok(())
@@ -222,6 +234,10 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
 
     #[inline]
     fn emit_event(&mut self, address: Address, event: LogData) -> Result<(), TempoPrecompileError> {
+        if self.is_static {
+            return Err(TempoPrecompileError::StateChangeInStaticCall);
+        }
+
         self.deduct_gas(
             gas::LOG
                 + self
@@ -463,6 +479,25 @@ mod tests {
 
         fn provider_with_reservoir(&mut self, reservoir: u64) -> EvmPrecompileStorageProvider<'_> {
             self.provider_with_gas_limit(u64::MAX, reservoir)
+        }
+
+        fn provider_static(&mut self) -> EvmPrecompileStorageProvider<'_> {
+            let ctx = self.0.ctx_mut();
+            let spec = ctx.cfg.spec;
+            let amsterdam_eip8037_enabled = ctx.cfg.enable_amsterdam_eip8037;
+            let gas_params = ctx.cfg.gas_params.clone();
+            let evm_internals =
+                EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
+
+            EvmPrecompileStorageProvider::new(
+                evm_internals,
+                u64::MAX,
+                0,
+                spec,
+                amsterdam_eip8037_enabled,
+                true,
+                gas_params,
+            )
         }
 
         fn provider_max_gas(&mut self) -> EvmPrecompileStorageProvider<'_> {
@@ -1180,6 +1215,92 @@ mod tests {
             "TIP-1016 says 0->X->0 should net to GAS_WARM_ACCESS (100)"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_sstore_rejected_in_static_context() {
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_static();
+        let address = Address::random();
+
+        let err = provider
+            .sstore(address, U256::ZERO, U256::from(1))
+            .expect_err("sstore must reject in static context");
+
+        assert!(matches!(err, TempoPrecompileError::StateChangeInStaticCall));
+        assert_eq!(
+            provider.gas_used(),
+            0,
+            "no gas should be deducted before the static guard fires"
+        );
+    }
+
+    #[test]
+    fn test_tstore_rejected_in_static_context() {
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_static();
+        let address = Address::random();
+
+        let err = provider
+            .tstore(address, U256::ZERO, U256::from(1))
+            .expect_err("tstore must reject in static context");
+
+        assert!(matches!(err, TempoPrecompileError::StateChangeInStaticCall));
+        assert_eq!(
+            provider.gas_used(),
+            0,
+            "no gas should be deducted before the static guard fires"
+        );
+    }
+
+    #[test]
+    fn test_emit_event_rejected_in_static_context() {
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_static();
+        let address = Address::random();
+
+        let err = provider
+            .emit_event(
+                address,
+                LogData::new_unchecked(Vec::new(), Default::default()),
+            )
+            .expect_err("emit_event must reject in static context");
+
+        assert!(matches!(err, TempoPrecompileError::StateChangeInStaticCall));
+        assert_eq!(
+            provider.gas_used(),
+            0,
+            "no gas should be deducted before the static guard fires"
+        );
+    }
+
+    #[test]
+    fn test_set_code_rejected_in_static_context() {
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_static();
+        let address = Address::random();
+
+        let err = provider
+            .set_code(address, Bytecode::new_raw(vec![0xef].into()))
+            .expect_err("set_code must reject in static context");
+
+        assert!(matches!(err, TempoPrecompileError::StateChangeInStaticCall));
+        assert_eq!(
+            provider.gas_used(),
+            0,
+            "no gas should be deducted before the static guard fires"
+        );
+    }
+
+    #[test]
+    fn test_sload_allowed_in_static_context() -> eyre::Result<()> {
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_static();
+        let address = Address::random();
+
+        let value = provider.sload(address, U256::ZERO)?;
+        assert_eq!(value, U256::ZERO);
         Ok(())
     }
 }

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -186,6 +186,10 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
         value: U256,
         action: StorageAction,
     ) -> Result<(), TempoPrecompileError> {
+        if self.is_static {
+            return Err(TempoPrecompileError::StateChangeInStaticCall);
+        }
+
         // T4+: pre-charge static gas before loading storage to avoid cheap useless work.
         let skip_cold_load = if self.spec.is_t4() {
             self.deduct_gas(self.gas_params.sstore_static_gas())?;
@@ -257,6 +261,10 @@ impl crate::storage_credits::StorageCreditsBackend for EvmPrecompileStorageProvi
         value: U256,
         skip_cold_load: bool,
     ) -> Result<StateLoad<SStoreResult>, Self::Error> {
+        if self.is_static {
+            return Err(TempoPrecompileError::StateChangeInStaticCall);
+        }
+
         let val = self.sstore_journal(address, key, value, skip_cold_load)?;
         self.actions
             .record(StorageAction::Sstore(address, key, value));
@@ -298,6 +306,10 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
 
     #[inline]
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), TempoPrecompileError> {
+        if self.is_static {
+            return Err(TempoPrecompileError::StateChangeInStaticCall);
+        }
+
         let code_len = code.len();
         self.deduct_gas(self.gas_params.code_deposit_cost(code_len))?;
 
@@ -427,6 +439,10 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
         key: U256,
         value: U256,
     ) -> Result<(), TempoPrecompileError> {
+        if self.is_static {
+            return Err(TempoPrecompileError::StateChangeInStaticCall);
+        }
+
         self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
         self.internals.tstore(address, key, value);
         Ok(())
@@ -434,6 +450,10 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
 
     #[inline]
     fn emit_event(&mut self, address: Address, event: LogData) -> Result<(), TempoPrecompileError> {
+        if self.is_static {
+            return Err(TempoPrecompileError::StateChangeInStaticCall);
+        }
+
         self.deduct_gas(
             gas::LOG
                 + self
@@ -656,6 +676,25 @@ mod tests {
 
         fn provider_with_reservoir(&mut self, reservoir: u64) -> EvmPrecompileStorageProvider<'_> {
             self.provider_with_gas_limit(u64::MAX, reservoir)
+        }
+
+        fn provider_static(&mut self) -> EvmPrecompileStorageProvider<'_> {
+            let ctx = self.0.ctx_mut();
+            let spec = ctx.cfg.spec;
+            let amsterdam_eip8037_enabled = ctx.cfg.enable_amsterdam_eip8037;
+            let gas_params = ctx.cfg.gas_params.clone();
+            let evm_internals =
+                EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
+
+            EvmPrecompileStorageProvider::new(
+                evm_internals,
+                u64::MAX,
+                0,
+                spec,
+                amsterdam_eip8037_enabled,
+                true,
+                gas_params,
+            )
         }
 
         fn provider_max_gas(&mut self) -> EvmPrecompileStorageProvider<'_> {
@@ -1423,6 +1462,92 @@ mod tests {
             "TIP-1016 says 0->X->0 should net to GAS_WARM_ACCESS (100)"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_sstore_rejected_in_static_context() {
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_static();
+        let address = Address::random();
+
+        let err = provider
+            .sstore(address, U256::ZERO, U256::from(1))
+            .expect_err("sstore must reject in static context");
+
+        assert!(matches!(err, TempoPrecompileError::StateChangeInStaticCall));
+        assert_eq!(
+            provider.gas_used(),
+            0,
+            "no gas should be deducted before the static guard fires"
+        );
+    }
+
+    #[test]
+    fn test_tstore_rejected_in_static_context() {
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_static();
+        let address = Address::random();
+
+        let err = provider
+            .tstore(address, U256::ZERO, U256::from(1))
+            .expect_err("tstore must reject in static context");
+
+        assert!(matches!(err, TempoPrecompileError::StateChangeInStaticCall));
+        assert_eq!(
+            provider.gas_used(),
+            0,
+            "no gas should be deducted before the static guard fires"
+        );
+    }
+
+    #[test]
+    fn test_emit_event_rejected_in_static_context() {
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_static();
+        let address = Address::random();
+
+        let err = provider
+            .emit_event(
+                address,
+                LogData::new_unchecked(Vec::new(), Default::default()),
+            )
+            .expect_err("emit_event must reject in static context");
+
+        assert!(matches!(err, TempoPrecompileError::StateChangeInStaticCall));
+        assert_eq!(
+            provider.gas_used(),
+            0,
+            "no gas should be deducted before the static guard fires"
+        );
+    }
+
+    #[test]
+    fn test_set_code_rejected_in_static_context() {
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_static();
+        let address = Address::random();
+
+        let err = provider
+            .set_code(address, Bytecode::new_raw(vec![0xef].into()))
+            .expect_err("set_code must reject in static context");
+
+        assert!(matches!(err, TempoPrecompileError::StateChangeInStaticCall));
+        assert_eq!(
+            provider.gas_used(),
+            0,
+            "no gas should be deducted before the static guard fires"
+        );
+    }
+
+    #[test]
+    fn test_sload_allowed_in_static_context() -> eyre::Result<()> {
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_static();
+        let address = Address::random();
+
+        let value = provider.sload(address, U256::ZERO)?;
+        assert_eq!(value, U256::ZERO);
         Ok(())
     }
 }


### PR DESCRIPTION
Closes #4104.

## Summary

`EvmPrecompileStorageProvider` stored `is_static` from the call context but never checked it in the state-mutating methods. A precompile invoked via `STATICCALL` could mutate persistent storage, transient storage, account code, and logs, which violates the invariant provided by `STATICCALL` and the static-context restriction for `TSTORE`.

## Changes

- Add `TempoPrecompileError::StateChangeInStaticCall` as a non-domain runtime error with no ABI selector.
- Route the new variant through the existing fatal precompile error path so it propagates as an exceptional halt rather than a Solidity-style revert.
- Guard `sstore`, `tstore`, `emit_event`, and `set_code` as the first statement in each method, before gas accounting or state access.
- Add `TestEvm::provider_static()` plus tests covering each rejected mutation and a positive control confirming `sload` still works in static context.

## Why the guard is first

The static-context check belongs before gas deduction and before loading state. That matches EVM execution semantics: mutation opcodes are rejected because the frame is static, not because execution partially proceeds and then rolls back.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p tempo-precompiles` — 926 passed, 1 ignored; doctests ok
- `cargo test -p tempo-precompiles static_context` — 5 passed
- `cargo clippy -p tempo-precompiles --all-targets -- -D warnings`

## Reviewer note

The new error currently maps to `PrecompileError::Fatal` for halt semantics. If maintainers prefer a dedicated `PrecompileHalt` variant mirroring revm's static-call halt reason, I can switch the representation in a follow-up commit.