### PR TITLE
ci: run Docker nightly build once daily

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,6 @@ on:
   workflow_call:
   schedule:
     - cron: "5 9 * * *"
-    - cron: "30 20 * * *"
 
 env:
   REGISTRY: ghcr.io/tempoxyz

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ on:
         type: boolean
         default: false
   workflow_call:
+  # We're building nightly only once a day to let the rollout cook for 24h without interruptions
   schedule:
     - cron: "5 9 * * *"
 


### PR DESCRIPTION
## Summary
- remove the second scheduled cron trigger from the Docker build workflow
- keep the nightly Docker build running once daily at 05:09 UTC

## Testing
- verified `.github/workflows/docker.yml` contains one `cron:` entry

Prompted by: @shekhirin