### PR TITLE
ci(bench): increase bench-e2e default TPS to 50k

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -80,7 +80,7 @@ on:
         description: Target transactions per second.
         type: string
         required: true
-        default: "20000"
+        default: "50000"
       accounts:
         description: Number of benchmark accounts.
         type: string
@@ -188,7 +188,7 @@ on:
       tps:
         type: string
         required: false
-        default: "20000"
+        default: "50000"
       accounts:
         type: string
         required: false

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1140,7 +1140,7 @@ def "main e2e" [
     --baseline: string                                  # Baseline git SHA/ref
     --feature: string                                   # Feature git SHA/ref
     --preset: string = ""                               # Txgen preset name
-    --tps: int = 20000                                  # Target TPS
+    --tps: int = 50000                                  # Target TPS
     --duration: int = 90                                # Duration in seconds
     --accounts: int = 1000                              # Number of accounts
     --max-concurrent-requests: int = 100                # Max concurrent requests

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -28,6 +28,9 @@ const E2E_LOCAL_RETH_ARGS = [
     "--consensus.no-legacy-archive"
     "--engine.share-execution-cache-with-payload-builder"
     "--builder.enable-prewarming"
+    "--txpool.pending-max-count" "200000"
+    "--txpool.basefee-max-count" "200000"
+    "--txpool.queued-max-count" "200000"
 ]
 
 def merge-e2e-features [...features: string] {

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -31,6 +31,9 @@ const E2E_LOCAL_RETH_ARGS = [
     "--txpool.pending-max-count" "200000"
     "--txpool.basefee-max-count" "200000"
     "--txpool.queued-max-count" "200000"
+    "--txpool.max-pending-txns" "200000"
+    "--txpool.max-new-txns" "200000"
+    "--txpool.max-batch-size" "200000"
 ]
 
 def merge-e2e-features [...features: string] {

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -187,13 +187,13 @@ fn init_txpool_defaults() {
         .with_max_queued_lifetime(Duration::from_secs(120))
         .with_max_new_pending_txs_notifications(150000)
         .with_max_account_slots(150000)
-        .with_pending_tx_listener_buffer_size(200000)
-        .with_new_tx_listener_buffer_size(200000)
+        .with_pending_tx_listener_buffer_size(50000)
+        .with_new_tx_listener_buffer_size(50000)
         .with_disable_transactions_backup(true)
         .with_additional_validation_tasks(8)
         .with_minimal_protocol_basefee(TempoHardfork::default().base_fee())
         .with_minimum_priority_fee(Some(0))
-        .with_max_batch_size(200000)
+        .with_max_batch_size(50000)
         .try_init()
         .expect("failed to initialize txpool defaults");
 }

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -187,13 +187,13 @@ fn init_txpool_defaults() {
         .with_max_queued_lifetime(Duration::from_secs(120))
         .with_max_new_pending_txs_notifications(150000)
         .with_max_account_slots(150000)
-        .with_pending_tx_listener_buffer_size(50000)
-        .with_new_tx_listener_buffer_size(50000)
+        .with_pending_tx_listener_buffer_size(200000)
+        .with_new_tx_listener_buffer_size(200000)
         .with_disable_transactions_backup(true)
         .with_additional_validation_tasks(8)
         .with_minimal_protocol_basefee(TempoHardfork::default().base_fee())
         .with_minimum_priority_fee(Some(0))
-        .with_max_batch_size(50000)
+        .with_max_batch_size(200000)
         .try_init()
         .expect("failed to initialize txpool defaults");
 }


### PR DESCRIPTION
## Summary
- change bench-e2e manual dispatch TPS default from 20k to 50k
- change bench-e2e workflow-call/script TPS defaults from 20k to 50k

## Testing
- rg verified bench-e2e defaults are now 50000

Prompted by: @shekhirin