### PR TITLE
ci: show Amp errors in reth update workflow

### DIFF
--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -115,7 +115,7 @@ jobs:
           #!/usr/bin/env bash
           set -euo pipefail
           set +e
-          OUTPUT=$(amp "$@" --stream-json --take-me-back 2>&1)
+          OUTPUT=$(amp "$@" --stream-json 2>&1)
           AMP_EXIT=$?
           set -e
           FIRST_LINE=$(echo "$OUTPUT" | head -1 || true)

--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -114,17 +114,28 @@ jobs:
           cat > /usr/local/bin/amp-run <<'WRAPPER'
           #!/usr/bin/env bash
           set -euo pipefail
+          set +e
           OUTPUT=$(amp "$@" --stream-json --take-me-back 2>&1)
+          AMP_EXIT=$?
+          set -e
           FIRST_LINE=$(echo "$OUTPUT" | head -1 || true)
           THREAD_ID=$(echo "$FIRST_LINE" | jq -r '.session_id // empty' 2>/dev/null || true)
           if [ -n "$THREAD_ID" ]; then
             echo "🔗 Amp thread: https://ampcode.com/threads/${THREAD_ID}"
           fi
           # Print the final result text
-          echo "$OUTPUT" | jq -r 'select(.type=="result") | .result // empty' 2>/dev/null || true
+          RESULT_TEXT=$(echo "$OUTPUT" | jq -r 'select(.type=="result") | .result // empty' 2>/dev/null || true)
+          if [ -n "$RESULT_TEXT" ]; then
+            echo "$RESULT_TEXT"
+          else
+            echo "$OUTPUT"
+          fi
           # Propagate error if amp failed
-          IS_ERROR=$(echo "$OUTPUT" | jq -r 'select(.type=="result") | .is_error // false' 2>/dev/null || true)
-          if [ "$IS_ERROR" = "true" ]; then
+          IS_ERROR=$(echo "$OUTPUT" | jq -e 'select(.type=="result" and .is_error == true)' >/dev/null 2>&1; echo $?)
+          if [ "$AMP_EXIT" -ne 0 ]; then
+            exit "$AMP_EXIT"
+          fi
+          if [ "$IS_ERROR" -eq 0 ]; then
             exit 1
           fi
           WRAPPER


### PR DESCRIPTION
Fixes the `amp-run` wrapper in `update-reth.yml` so failed Amp invocations print their captured output before the workflow exits.

The wrapper now preserves the Amp process exit code, prints parsed result text when available, falls back to raw output when JSON parsing yields nothing, and still treats streamed `is_error: true` results as failures.

Validation:
- Extracted generated wrapper and ran `bash -n`
- Simulated a failing `amp` executable and confirmed stderr is printed while preserving the exit code

Prompted by: @klkvr