### PR TITLE
deps: update reth from main (2026-06-01)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.36.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
+checksum = "58673bde58f17022886547b618346aeae9b147ed398f9c847105fa91c49f97eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10863,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11165,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12813,7 +12813,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -12894,7 +12894,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
-version = "1.8.0"
+version = "1.7.3"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -12960,7 +12960,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13021,7 +13021,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node-config"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13038,7 +13038,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -13057,7 +13057,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.8.0"
+version = "1.7.3"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -13069,7 +13069,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13083,7 +13083,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13134,14 +13134,13 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -13173,7 +13172,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13192,7 +13191,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "eyre",
  "indenter",
@@ -13200,7 +13199,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13213,7 +13212,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13282,15 +13281,12 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
- "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
- "crossbeam-channel",
  "metrics",
  "reth-basic-payload-builder",
  "reth-chainspec",
@@ -13314,13 +13310,12 @@ dependencies = [
  "tempo-precompiles",
  "tempo-primitives",
  "tempo-transaction-pool",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13339,7 +13334,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13371,7 +13366,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13381,7 +13376,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.8.0"
+version = "1.7.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13419,7 +13414,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13453,7 +13448,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "clap",
@@ -13478,7 +13473,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "eyre",
  "jiff",
@@ -13487,7 +13482,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13526,7 +13521,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13538,7 +13533,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-json-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10863,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11165,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.35.1"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58673bde58f17022886547b618346aeae9b147ed398f9c847105fa91c49f97eb"
+checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10863,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11165,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12894,7 +12894,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13057,7 +13057,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -13141,6 +13141,7 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -13284,9 +13285,12 @@ name = "tempo-payload-builder"
 version = "1.8.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
+ "crossbeam-channel",
  "metrics",
  "reth-basic-payload-builder",
  "reth-chainspec",
@@ -13310,6 +13314,7 @@ dependencies = [
  "tempo-precompiles",
  "tempo-primitives",
  "tempo-transaction-pool",
+ "tokio",
  "tracing",
 ]
 
@@ -13376,7 +13381,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,8 +208,9 @@ revm = { version = "40.0.3", features = ["optional_fee_charge"], default-feature
 alloy = { version = "2.0.5", default-features = false }
 alloy-consensus = { version = "2.0.5", default-features = false }
 alloy-contract = { version = "2.0.5", default-features = false }
+alloy-eip7928 = { version = "0.4.1", default-features = false }
 alloy-eips = { version = "2.0.5", default-features = false }
-alloy-evm = { version = "0.35.1", default-features = false }
+alloy-evm = { version = "0.36.0", default-features = false }
 revm-inspectors = "0.40.0"
 alloy-genesis = { version = "2.0.5", default-features = false }
 alloy-hardforks = "0.4.7"
@@ -305,6 +306,7 @@ tracy-client = "0.18.4"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
 paste = "1"
+crossbeam-channel = "0.5"
 secp256k1 = { version = "0.30.0", default-features = false }
 pyroscope = "0.5.8"
 pyroscope_pprofrs = "0.2.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.8.1"
+version = "1.8.0"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", features = [
   "std",
   "optional-checks",
 ] }
@@ -208,9 +208,8 @@ revm = { version = "40.0.3", features = ["optional_fee_charge"], default-feature
 alloy = { version = "2.0.5", default-features = false }
 alloy-consensus = { version = "2.0.5", default-features = false }
 alloy-contract = { version = "2.0.5", default-features = false }
-alloy-eip7928 = { version = "0.4.0", default-features = false }
 alloy-eips = { version = "2.0.5", default-features = false }
-alloy-evm = { version = "0.36.0", default-features = false }
+alloy-evm = { version = "0.35.1", default-features = false }
 revm-inspectors = "0.40.0"
 alloy-genesis = { version = "2.0.5", default-features = false }
 alloy-hardforks = "0.4.7"
@@ -262,7 +261,6 @@ criterion = { package = "codspeed-criterion-compat", version = "4.6.0" }
 dashmap = "6"
 dirs-next = "2.0.0"
 derive_more = { version = "2.1.1", default-features = false }
-crossbeam-channel = "0.5.13"
 
 ed25519-consensus = { version = "2.1.0", default-features = false }
 ed25519-dalek = { version = "2", features = ["rand_core"] }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -872,11 +872,6 @@ where
         let (evm, execution_result) = executor.finish()?;
         let evm_env = evm.into_env();
 
-        // Drop the state hook so the underlying `StateHookSender` is dropped, which
-        // signals `FinishedStateUpdates` to the background sparse trie task. Without
-        // this, `handle.state_root()` below would deadlock waiting for the sentinel.
-        db.set_state_hook(None);
-
         // merge all transitions into bundle state before deriving the hashed post-state
         db.merge_transitions(BundleRetention::Reverts);
 

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -872,6 +872,11 @@ where
         let (evm, execution_result) = executor.finish()?;
         let evm_env = evm.into_env();
 
+        // Drop the state hook so the underlying `StateHookSender` is dropped, which
+        // signals `FinishedStateUpdates` to the background sparse trie task. Without
+        // this, `handle.state_root()` below would deadlock waiting for the sentinel.
+        db.set_state_hook(None);
+
         // merge all transitions into bundle state before deriving the hashed post-state
         db.merge_transitions(BundleRetention::Reverts);
 


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`03d9691...259b8dc`](https://github.com/paradigmxyz/reth/compare/03d9691e7e8b26897bd4f32a053bab46ee84fd11...259b8dc)

🔗 Amp thread: https://ampcode.com/threads/T-019e830c-e3ea-7232-905f-8328824eda7b
- **RPC**
  - Default `eth_simulateV1` per-call gas to the remaining block gas ([#24387](https://github.com/paradigmxyz/reth/pull/24387)) and allow overriding the beacon block root for `eth_simulate` ([#24652](https://github.com/paradigmxyz/reth/pull/24652)).
- **Refactor**
  - Integrate state hook from `State<DB>` ([#24654](https://github.com/paradigmxyz/reth/pull/24654)).
- **DB**
  - Address static file cursor clippy lint ([#24672](https://github.com/paradigmxyz/reth/pull/24672)).

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019e830c-f94b-772c-9063-045e9b45ea4e
- Bumped reth git dependency from `03d9691e7e8b26897bd4f32a053bab46ee84fd11` to `259b8dc` across all `reth-*` crates in `Cargo.toml` to track upstream.
- Bumped `alloy-eip7928` `0.4.0` → `0.4.1` and `alloy-evm` `0.35.1` → `0.36.0` to match the new reth revision.
- Moved `crossbeam-channel` entry in `[workspace.dependencies]` and relaxed its pin from `0.5.13` to `0.5`.
- Added optional `alloy-rpc-types-eth` dependency to `crates/evm` and included it under the `rpc` feature, needed for the new `BuildPendingEnv` signature.
- Removed imports/usages of `OnStateHook`, `StateChangeSource`, and `StateChangePreBlockSource` in `crates/evm/src/block.rs` since upstream dropped the explicit state-change source enum.
- Dropped the `BlockExecutor::set_state_hook` override in `TempoBlockExecutor`; the state hook is now installed directly on the underlying `State<DB>` and invoked automatically on `commit`.
- In `deploy_precompile_at_boundary`, removed the manual `system_caller.on_state(...)` dispatch (now handled by the DB-level hook on commit) and updated tests to register the hook via `db.set_state_hook(...)` with the new `Fn(&EvmState)` signature.
- Updated `BuildPendingEnv::build_pending_env` impl (and its test) in `crates/evm/src/context.rs` to accept the new `Option<&alloy_rpc_types_eth::BlockOverrides>` parameter and forward it to the inner `NextBlockEnvAttributes`.
- In `crates/payload/builder/src/lib.rs`, switched from `executor.set_state_hook(...)` to `executor.evm_mut().db_mut().set_state_hook(...)` to match the new hook installation point.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/26752770146)
