### PR TITLE
feat(consensus): add speculative BAL payload builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.35.1"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58673bde58f17022886547b618346aeae9b147ed398f9c847105fa91c49f97eb"
+checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,9 +8624,10 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928 0.4.1",
  "alloy-eips",
  "alloy-primitives",
  "alloy-signer",
@@ -8646,6 +8647,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-trie",
+ "revm-bytecode",
  "revm-database",
  "revm-state",
  "serde",
@@ -8657,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8775,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8785,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8838,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8881,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8906,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8935,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8961,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8991,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9006,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9079,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9114,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9199,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9222,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9247,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9352,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9368,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9390,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9429,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9451,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9492,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9515,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9590,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9604,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9639,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9659,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9690,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9709,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9747,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9761,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9799,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9819,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9836,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9867,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9964,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10016,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10057,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10180,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10223,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10247,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10300,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10312,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10325,6 +10327,7 @@ dependencies = [
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
+ "reth-storage-api",
  "reth-trie-parallel",
  "tokio",
  "tokio-stream",
@@ -10334,7 +10337,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10349,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10372,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10464,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10492,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10508,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10599,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10629,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10672,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10692,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10821,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10835,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10866,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10917,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10945,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10959,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10979,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11020,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11059,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11075,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11085,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11123,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11168,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11194,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11221,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11241,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11270,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=03d9691e7e8b26897bd4f32a053bab46ee84fd11#03d9691e7e8b26897bd4f32a053bab46ee84fd11"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12964,6 +12967,7 @@ version = "1.8.0"
 dependencies = [
  "age",
  "alloy-consensus",
+ "alloy-eip7928 0.4.1",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -12993,14 +12997,17 @@ dependencies = [
  "prometheus-client",
  "rand 0.8.6",
  "rand_core 0.6.4",
+ "reth-chain-state",
  "reth-consensus-common",
  "reth-ethereum",
  "reth-evm",
  "reth-node-builder",
  "reth-node-core",
+ "reth-payload-builder",
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
+ "reth-storage-api",
  "serde_json",
  "tempfile",
  "tempo-alloy",
@@ -13141,6 +13148,7 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8659,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8679,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8692,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8775,7 +8775,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8785,7 +8785,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8838,7 +8838,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8868,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8881,7 +8881,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8906,7 +8906,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8935,7 +8935,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8961,7 +8961,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8991,7 +8991,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9006,7 +9006,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9055,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9079,7 +9079,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9114,7 +9114,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9171,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9199,7 +9199,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9222,7 +9222,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9247,7 +9247,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9352,7 +9352,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9368,7 +9368,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9390,7 +9390,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9401,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9429,7 +9429,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9451,7 +9451,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9492,7 +9492,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "clap",
  "eyre",
@@ -9515,7 +9515,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9560,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9590,7 +9590,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9604,7 +9604,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9614,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9639,7 +9639,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9659,7 +9659,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9690,7 +9690,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9709,7 +9709,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9747,7 +9747,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9761,7 +9761,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "serde",
  "serde_json",
@@ -9771,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9799,7 +9799,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "bytes",
  "futures",
@@ -9819,7 +9819,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9836,7 +9836,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "bindgen",
  "cc",
@@ -9845,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "futures",
  "metrics",
@@ -9858,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9867,7 +9867,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9881,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9939,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9964,7 +9964,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9987,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10016,7 +10016,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10033,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10057,7 +10057,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10180,7 +10180,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10223,7 +10223,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10247,7 +10247,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10271,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "bytes",
  "eyre",
@@ -10300,7 +10300,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10312,7 +10312,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10337,7 +10337,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10349,7 +10349,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10372,7 +10372,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10415,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10464,7 +10464,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10492,7 +10492,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10508,7 +10508,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10523,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10599,7 +10599,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10629,7 +10629,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10672,7 +10672,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10692,7 +10692,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10723,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10770,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10821,7 +10821,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10835,7 +10835,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10866,7 +10866,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10917,7 +10917,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10945,7 +10945,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10959,7 +10959,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10979,7 +10979,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10994,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11020,7 +11020,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11059,7 +11059,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11075,7 +11075,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11085,7 +11085,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "clap",
  "eyre",
@@ -11104,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11123,7 +11123,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11168,7 +11168,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11194,7 +11194,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11221,7 +11221,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11241,7 +11241,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11270,7 +11270,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#1e622040c2a6ad3908ac6059c28e3a22e5a0010b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3828,7 +3828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8659,7 +8659,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8679,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8692,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8775,7 +8775,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8785,7 +8785,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8838,7 +8838,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8868,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8881,7 +8881,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8906,7 +8906,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8935,7 +8935,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8961,7 +8961,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8991,7 +8991,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9006,7 +9006,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9055,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9079,7 +9079,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9114,7 +9114,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9171,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9199,7 +9199,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9222,7 +9222,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9247,7 +9247,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9352,7 +9352,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9368,7 +9368,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9390,7 +9390,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9401,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9429,7 +9429,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9451,7 +9451,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9492,7 +9492,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "clap",
  "eyre",
@@ -9515,7 +9515,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9560,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9590,7 +9590,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9604,7 +9604,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9614,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9639,7 +9639,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9659,7 +9659,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9690,7 +9690,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9709,7 +9709,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9747,7 +9747,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9761,7 +9761,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "serde",
  "serde_json",
@@ -9771,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9799,7 +9799,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "bytes",
  "futures",
@@ -9819,7 +9819,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9836,7 +9836,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "bindgen",
  "cc",
@@ -9845,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "futures",
  "metrics",
@@ -9858,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9867,7 +9867,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9881,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9939,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9964,7 +9964,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9987,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10016,7 +10016,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10033,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10057,7 +10057,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10180,7 +10180,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10223,7 +10223,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10247,7 +10247,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10271,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "bytes",
  "eyre",
@@ -10300,7 +10300,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10312,7 +10312,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10337,7 +10337,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10349,7 +10349,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10372,7 +10372,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10415,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10464,7 +10464,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10492,7 +10492,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10508,7 +10508,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10523,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10599,7 +10599,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10629,7 +10629,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10672,7 +10672,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10692,7 +10692,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10723,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10770,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10821,7 +10821,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10835,7 +10835,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10866,7 +10866,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10917,7 +10917,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10945,7 +10945,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10959,7 +10959,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10979,7 +10979,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10994,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11020,7 +11020,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11059,7 +11059,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11075,7 +11075,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11085,7 +11085,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "clap",
  "eyre",
@@ -11104,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11123,7 +11123,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11168,7 +11168,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11194,7 +11194,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11221,7 +11221,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11241,7 +11241,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11270,7 +11270,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#3afda53b82b3e0ce441e70e52ff486ff6bc2d417"
+source = "git+https://github.com/paradigmxyz/reth?branch=dan%2Fbal-overlay-concurrent-build#9870a58e5f86b238b0de8893b97c18b3eebecb9d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12999,6 +12999,8 @@ dependencies = [
  "rand_core 0.6.4",
  "reth-chain-state",
  "reth-consensus-common",
+ "reth-engine-primitives",
+ "reth-engine-tree",
  "reth-ethereum",
  "reth-evm",
  "reth-node-builder",
@@ -13008,6 +13010,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-storage-api",
+ "reth-trie-db",
  "serde_json",
  "tempfile",
  "tempo-alloy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,7 @@ reth-discv5 = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-o
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
 reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
 reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
 reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
 reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
 reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,67 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "03d9691e7e8b26897bd4f32a053bab46ee84fd11", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "dan/bal-overlay-concurrent-build", features = [
   "std",
   "optional-checks",
 ] }
@@ -208,9 +209,9 @@ revm = { version = "40.0.3", features = ["optional_fee_charge"], default-feature
 alloy = { version = "2.0.5", default-features = false }
 alloy-consensus = { version = "2.0.5", default-features = false }
 alloy-contract = { version = "2.0.5", default-features = false }
-alloy-eip7928 = { version = "0.4.0", default-features = false }
+alloy-eip7928 = { version = "0.4.0", default-features = false, features = ["rlp"] }
 alloy-eips = { version = "2.0.5", default-features = false }
-alloy-evm = { version = "0.35.1", default-features = false }
+alloy-evm = { version = "0.36.0", default-features = false }
 revm-inspectors = "0.40.0"
 alloy-genesis = { version = "2.0.5", default-features = false }
 alloy-hardforks = "0.4.7"

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -785,6 +785,7 @@ mod tests {
             node_cmd.ext.consensus.network_budget.into_duration(),
             Duration::from_millis(50)
         );
+        assert!(!node_cmd.ext.consensus.speculative_bal_build);
         assert_eq!(node_cmd.ext.node_args.builder_build_time_multiplier, 1.35);
 
         let cli = TempoCli::try_parse_from([
@@ -809,5 +810,17 @@ mod tests {
             node_cmd.ext.consensus.network_budget.into_duration(),
             Duration::from_millis(50)
         );
+
+        let cli = TempoCli::try_parse_from([
+            "tempo",
+            "node",
+            "--dev",
+            "--consensus.speculative-bal-build",
+        ])
+        .unwrap();
+        let Commands::Node(node_cmd) = cli.command else {
+            panic!("expected node command");
+        };
+        assert!(node_cmd.ext.consensus.speculative_bal_build);
     }
 }

--- a/crates/commonware-node/Cargo.toml
+++ b/crates/commonware-node/Cargo.toml
@@ -58,6 +58,8 @@ rand_08.workspace = true
 reth-consensus-common.workspace = true
 rand_core.workspace = true
 reth-chain-state.workspace = true
+reth-engine-primitives.workspace = true
+reth-engine-tree.workspace = true
 reth-ethereum.workspace = true
 reth-evm.workspace = true
 reth-node-builder.workspace = true
@@ -67,6 +69,7 @@ reth-revm.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-storage-api.workspace = true
+reth-trie-db.workspace = true
 
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/commonware-node/Cargo.toml
+++ b/crates/commonware-node/Cargo.toml
@@ -22,6 +22,7 @@ tempo-precompiles.workspace = true
 tempo-telemetry-util.workspace = true
 
 alloy-consensus.workspace = true
+alloy-eip7928.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-rlp.workspace = true
@@ -56,13 +57,16 @@ rand_08.workspace = true
 
 reth-consensus-common.workspace = true
 rand_core.workspace = true
+reth-chain-state.workspace = true
 reth-ethereum.workspace = true
 reth-evm.workspace = true
 reth-node-builder.workspace = true
 reth-node-core.workspace = true
+reth-payload-builder.workspace = true
 reth-revm.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
+reth-storage-api.workspace = true
 
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/commonware-node/src/args.rs
+++ b/crates/commonware-node/src/args.rs
@@ -289,6 +289,11 @@ pub struct Args {
     #[arg(long = "consensus.fcu-heartbeat-interval", default_value = "5m")]
     pub fcu_heartbeat_interval: PositiveDuration,
 
+    /// Build the next proposal speculatively over the parent BAL while parent
+    /// validation is still running.
+    #[arg(long = "consensus.speculative-bal-build", default_value_t = false)]
+    pub speculative_bal_build: bool,
+
     /// Cache for the signing key loaded from CLI-provided file.
     #[clap(skip)]
     loaded_signing_key: Arc<tokio::sync::OnceCell<Option<SigningKey>>>,

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -726,108 +726,6 @@ impl Inner<Init> {
                     validity_token.clone(),
                 )?);
 
-                let payload_id_result = {
-                    let rx = payload_id_rx.as_mut().expect("just set");
-                    tokio::select! {
-                        result = rx => Some(
-                            result
-                                .wrap_err("executor dropped response")
-                                .and_then(|res| res.wrap_err("failed starting speculative payload build"))
-                        ),
-                        _ = context.sleep(SPECULATIVE_PAYLOAD_ID_TIMEOUT) => None,
-                    }
-                };
-
-                let payload_id = match payload_id_result {
-                    Some(Ok(payload_id)) => payload_id,
-                    Some(Err(error)) => {
-                        self.metrics.speculative_build_fallbacks.inc();
-                        warn!(
-                            %error,
-                            parent.height = %parent.height(),
-                            parent.digest = %parent.digest(),
-                            "falling back to serial proposal build because speculative build could not start",
-                        );
-                        *payload_id_rx = None;
-                        // Fall through to the existing serial validate-then-build path.
-                        if should_verify_parent
-                            && !verify_block(
-                                context.clone(),
-                                parent_epoch_info.epoch(),
-                                &self.epoch_strategy,
-                                self.execution_node
-                                    .add_ons_handle
-                                    .beacon_engine_handle
-                                    .clone(),
-                                &parent,
-                                parent.parent_digest(),
-                                &self.scheme_provider,
-                            )
-                            .await
-                            .wrap_err("failed verifying block against execution layer")?
-                        {
-                            bail!("the proposal parent block is not valid");
-                        }
-
-                        return self
-                            .build_payload_after_parent_validation(
-                                context,
-                                propose_start,
-                                parent,
-                                attrs,
-                                marshal_persist,
-                                payload_id_rx,
-                            )
-                            .await;
-                    }
-                    None => {
-                        validity_token.mark_invalid();
-                        self.metrics.speculative_build_cancelled.inc();
-                        self.metrics.speculative_build_fallbacks.inc();
-                        warn!(
-                            timeout = ?SPECULATIVE_PAYLOAD_ID_TIMEOUT,
-                            parent.height = %parent.height(),
-                            parent.digest = %parent.digest(),
-                            "falling back to serial proposal build because speculative build did not register in time",
-                        );
-                        self.cancel_payload_build(&context, payload_id_rx).await;
-                        if should_verify_parent
-                            && !verify_block(
-                                context.clone(),
-                                parent_epoch_info.epoch(),
-                                &self.epoch_strategy,
-                                self.execution_node
-                                    .add_ons_handle
-                                    .beacon_engine_handle
-                                    .clone(),
-                                &parent,
-                                parent.parent_digest(),
-                                &self.scheme_provider,
-                            )
-                            .await
-                            .wrap_err("failed verifying block against execution layer")?
-                        {
-                            bail!("the proposal parent block is not valid");
-                        }
-
-                        return self
-                            .build_payload_after_parent_validation(
-                                context,
-                                propose_start,
-                                parent,
-                                attrs,
-                                marshal_persist,
-                                payload_id_rx,
-                            )
-                            .await;
-                    }
-                };
-
-                self.metrics.speculative_build_started.inc();
-                let (tx, rx) = oneshot::channel();
-                let _ = tx.send(Ok(payload_id));
-                *payload_id_rx = Some(rx);
-
                 let validation_start = Instant::now();
                 let is_good = verify_block(
                     context.clone(),
@@ -854,6 +752,53 @@ impl Inner<Init> {
                 }
 
                 validity_token.mark_valid();
+
+                let payload_id_timeout = self
+                    .proposal_return_budget
+                    .saturating_sub(propose_start.elapsed())
+                    .max(Duration::from_millis(1));
+                let payload_id_result = {
+                    let rx = payload_id_rx.as_mut().expect("just set");
+                    tokio::select! {
+                        result = rx => result
+                            .wrap_err("executor dropped response")
+                            .and_then(|res| res.wrap_err("failed starting speculative payload build")),
+                        _ = context.sleep(payload_id_timeout) => Err(eyre!(
+                            "timed out waiting {payload_id_timeout:?} for speculative payload build to register"
+                        )),
+                    }
+                };
+
+                let payload_id = match payload_id_result {
+                    Ok(payload_id) => payload_id,
+                    Err(error) => {
+                        validity_token.mark_invalid();
+                        self.metrics.speculative_build_cancelled.inc();
+                        self.metrics.speculative_build_fallbacks.inc();
+                        warn!(
+                            %error,
+                            parent.height = %parent.height(),
+                            parent.digest = %parent.digest(),
+                            "falling back to serial proposal build because speculative build could not start",
+                        );
+                        self.cancel_payload_build(&context, payload_id_rx).await;
+                        return self
+                            .build_payload_after_parent_validation(
+                                context,
+                                propose_start,
+                                parent,
+                                attrs,
+                                marshal_persist,
+                                payload_id_rx,
+                            )
+                            .await;
+                    }
+                };
+
+                self.metrics.speculative_build_started.inc();
+                let (tx, rx) = oneshot::channel();
+                let _ = tx.send(Ok(payload_id));
+                *payload_id_rx = Some(rx);
 
                 if let Err(error) = self
                     .state

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -15,7 +15,7 @@ use std::{
     time::{Duration, Instant, SystemTime},
 };
 
-use alloy_consensus::BlockHeader;
+use alloy_consensus::{BlockHeader, transaction::TxHashRef};
 use alloy_primitives::{B256, Bytes};
 use alloy_rpc_types_engine::PayloadId;
 use commonware_codec::{Encode as _, ReadExt as _};
@@ -40,14 +40,15 @@ use futures::{
     future::try_join,
 };
 use rand_08::{CryptoRng, Rng};
-use reth_node_builder::{Block as _, ConsensusEngineHandle, PayloadKind};
+use reth_node_builder::{Block as _, BuiltPayload as _, ConsensusEngineHandle, PayloadKind};
+use reth_payload_builder::PayloadValidityToken;
 use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
 use tempo_node::{TempoExecutionData, TempoFullNode, TempoPayloadTypes};
 use tempo_telemetry_util::display_duration;
 
 use reth_provider::{BlockHashReader as _, BlockReader as _, BlockSource};
 use tempo_payload_types::{
-    TempoPayloadAttributes, marshal_persist_estimate, observe_marshal_persist,
+    TempoBuiltPayload, TempoPayloadAttributes, marshal_persist_estimate, observe_marshal_persist,
 };
 use tempo_primitives::TempoConsensusContext;
 use tracing::{Level, debug, info, info_span, instrument, warn};
@@ -83,6 +84,8 @@ struct ProposalReturn {
     time: SystemTime,
     block_size_bytes: usize,
 }
+
+const SPECULATIVE_PAYLOAD_ID_TIMEOUT: Duration = Duration::from_millis(50);
 
 impl<TContext, TState> Actor<TContext, TState> {
     pub(super) fn mailbox(&self) -> &Mailbox {
@@ -125,6 +128,7 @@ where
                 subblocks: config.subblocks,
 
                 scheme_provider: config.scheme_provider,
+                speculative_bal_build: config.speculative_bal_build,
 
                 metrics,
 
@@ -225,6 +229,7 @@ struct Inner<TState> {
     executor: crate::executor::Mailbox,
     subblocks: Option<subblocks::Mailbox>,
     scheme_provider: SchemeProvider,
+    speculative_bal_build: bool,
 
     metrics: Metrics,
 
@@ -370,7 +375,7 @@ impl Inner<Init> {
 
                     Some(block) = &mut already_verified => {
                         drop(proposal);
-                        self.cancel_payload_build(&mut payload_id_rx).await;
+                        self.cancel_payload_build(&context, &mut payload_id_rx).await;
                         debug!("skipping proposal: verified block already exists for round on restart");
                         (block, None)
                     },
@@ -413,7 +418,7 @@ impl Inner<Init> {
             tokio::select! {
                 () = response.closed() => {
                     drop(proposal);
-                    self.cancel_payload_build(&mut payload_id_rx).await;
+                    self.cancel_payload_build(&context, &mut payload_id_rx).await;
 
                     return Err(eyre!(
                         "proposal return channel was closed by consensus \
@@ -496,15 +501,25 @@ impl Inner<Init> {
         Ok(())
     }
 
-    async fn cancel_payload_build(
+    async fn cancel_payload_build<TContext: Pacer>(
         &self,
+        context: &TContext,
         payload_id_rx: &mut Option<oneshot::Receiver<eyre::Result<PayloadId>>>,
     ) {
-        let Some(rx) = payload_id_rx.take() else {
+        let Some(mut rx) = payload_id_rx.take() else {
             return;
         };
 
-        let payload_id = match rx.await {
+        let payload_id = match tokio::select! {
+            result = &mut rx => result,
+            _ = context.sleep(SPECULATIVE_PAYLOAD_ID_TIMEOUT) => {
+                warn!(
+                    timeout = ?SPECULATIVE_PAYLOAD_ID_TIMEOUT,
+                    "timed out waiting for payload id before cancellation"
+                );
+                return;
+            }
+        } {
             Ok(Ok(payload_id)) => payload_id,
             Ok(Err(error)) => {
                 warn!(%error, "payload build was not started before cancellation");
@@ -593,33 +608,7 @@ impl Inner<Init> {
         let is_genesis_parent = parent.height().is_zero()
             || parent_epoch_info.last() == parent.height()
                 && parent_epoch_info.epoch().next() == round.epoch();
-
-        // Send the proposal parent to execution layer to cover edge cases when
-        // we were not asked to to verify it (and hence are missing it in the
-        // EL).
-        //
-        // If proposing the first block of an epoch, its parent
-        // (genesis/boundary block) must exist and be finalized, so we can skip
-        // it.
-        if !is_genesis_parent
-            && !verify_block(
-                context.clone(),
-                parent_epoch_info.epoch(),
-                &self.epoch_strategy,
-                self.execution_node
-                    .add_ons_handle
-                    .beacon_engine_handle
-                    .clone(),
-                &parent,
-                // It is safe to not verify the parent of the parent because this block is already notarized.
-                parent.parent_digest(),
-                &self.scheme_provider,
-            )
-            .await
-            .wrap_err("failed verifying block against execution layer")?
-        {
-            bail!("the proposal parent block is not valid");
-        }
+        let should_verify_parent = !is_genesis_parent;
 
         // Query DKG manager for ceremony data before building payload
         // This data will be passed to the payload builder via attributes
@@ -692,6 +681,7 @@ impl Inner<Init> {
 
         let parent_hash = parent.block_hash();
         let proposer_public_key = crate::utils::public_key_to_b256(&self.public_key);
+        let subblocks = self.subblocks.clone();
         let marshal_persist = marshal_persist_estimate();
         // Give the builder only the proposal window that remains when payload
         // construction is requested. This accounts for a late `handle_propose`
@@ -706,7 +696,7 @@ impl Inner<Init> {
             extra_data,
             consensus_context,
             move || {
-                self.subblocks
+                subblocks
                     .as_ref()
                     .and_then(|s| s.get_subblocks(parent_hash).ok())
                     .unwrap_or_default()
@@ -714,6 +704,348 @@ impl Inner<Init> {
         )
         .with_payload_build_budget(build_budget);
 
+        if self.speculative_bal_build && should_verify_parent {
+            self.metrics.speculative_build_attempts.inc();
+
+            if parent.block_access_list().is_none() {
+                self.metrics.speculative_build_fallbacks.inc();
+                debug!(
+                    parent.height = %parent.height(),
+                    parent.digest = %parent.digest(),
+                    "falling back to serial proposal build because parent has no BAL sidecar",
+                );
+            } else {
+                let validity_token = PayloadValidityToken::pending(parent.block_hash());
+                let speculative_attrs = attrs
+                    .clone()
+                    .with_excluded_transaction_hashes(block_transaction_hashes(&parent));
+                let payload_build_start = Instant::now();
+                *payload_id_rx = Some(self.state.executor.speculatively_build(
+                    parent.clone(),
+                    speculative_attrs.clone(),
+                    validity_token.clone(),
+                )?);
+
+                let payload_id_result = {
+                    let rx = payload_id_rx.as_mut().expect("just set");
+                    tokio::select! {
+                        result = rx => Some(
+                            result
+                                .wrap_err("executor dropped response")
+                                .and_then(|res| res.wrap_err("failed starting speculative payload build"))
+                        ),
+                        _ = context.sleep(SPECULATIVE_PAYLOAD_ID_TIMEOUT) => None,
+                    }
+                };
+
+                let payload_id = match payload_id_result {
+                    Some(Ok(payload_id)) => payload_id,
+                    Some(Err(error)) => {
+                        self.metrics.speculative_build_fallbacks.inc();
+                        warn!(
+                            %error,
+                            parent.height = %parent.height(),
+                            parent.digest = %parent.digest(),
+                            "falling back to serial proposal build because speculative build could not start",
+                        );
+                        *payload_id_rx = None;
+                        // Fall through to the existing serial validate-then-build path.
+                        if should_verify_parent
+                            && !verify_block(
+                                context.clone(),
+                                parent_epoch_info.epoch(),
+                                &self.epoch_strategy,
+                                self.execution_node
+                                    .add_ons_handle
+                                    .beacon_engine_handle
+                                    .clone(),
+                                &parent,
+                                parent.parent_digest(),
+                                &self.scheme_provider,
+                            )
+                            .await
+                            .wrap_err("failed verifying block against execution layer")?
+                        {
+                            bail!("the proposal parent block is not valid");
+                        }
+
+                        return self
+                            .build_payload_after_parent_validation(
+                                context,
+                                propose_start,
+                                parent,
+                                attrs,
+                                marshal_persist,
+                                payload_id_rx,
+                            )
+                            .await;
+                    }
+                    None => {
+                        validity_token.mark_invalid();
+                        self.metrics.speculative_build_cancelled.inc();
+                        self.metrics.speculative_build_fallbacks.inc();
+                        warn!(
+                            timeout = ?SPECULATIVE_PAYLOAD_ID_TIMEOUT,
+                            parent.height = %parent.height(),
+                            parent.digest = %parent.digest(),
+                            "falling back to serial proposal build because speculative build did not register in time",
+                        );
+                        self.cancel_payload_build(&context, payload_id_rx).await;
+                        if should_verify_parent
+                            && !verify_block(
+                                context.clone(),
+                                parent_epoch_info.epoch(),
+                                &self.epoch_strategy,
+                                self.execution_node
+                                    .add_ons_handle
+                                    .beacon_engine_handle
+                                    .clone(),
+                                &parent,
+                                parent.parent_digest(),
+                                &self.scheme_provider,
+                            )
+                            .await
+                            .wrap_err("failed verifying block against execution layer")?
+                        {
+                            bail!("the proposal parent block is not valid");
+                        }
+
+                        return self
+                            .build_payload_after_parent_validation(
+                                context,
+                                propose_start,
+                                parent,
+                                attrs,
+                                marshal_persist,
+                                payload_id_rx,
+                            )
+                            .await;
+                    }
+                };
+
+                self.metrics.speculative_build_started.inc();
+                let (tx, rx) = oneshot::channel();
+                let _ = tx.send(Ok(payload_id));
+                *payload_id_rx = Some(rx);
+
+                let validation_start = Instant::now();
+                let is_good = verify_block(
+                    context.clone(),
+                    parent_epoch_info.epoch(),
+                    &self.epoch_strategy,
+                    self.execution_node
+                        .add_ons_handle
+                        .beacon_engine_handle
+                        .clone(),
+                    &parent,
+                    // It is safe to not verify the parent of the parent because this block is already notarized.
+                    parent.parent_digest(),
+                    &self.scheme_provider,
+                )
+                .await
+                .wrap_err("failed verifying block against execution layer")?;
+                let parent_validation_elapsed = validation_start.elapsed();
+
+                if !is_good {
+                    validity_token.mark_invalid();
+                    self.metrics.speculative_build_cancelled.inc();
+                    self.cancel_payload_build(&context, payload_id_rx).await;
+                    bail!("the proposal parent block is not valid");
+                }
+
+                validity_token.mark_valid();
+
+                if let Err(error) = self
+                    .state
+                    .executor
+                    .canonicalize_head(parent.height(), parent.digest())
+                    .await
+                {
+                    validity_token.mark_invalid();
+                    self.metrics.speculative_build_cancelled.inc();
+                    self.metrics.speculative_build_fallbacks.inc();
+                    warn!(
+                        %error,
+                        parent.height = %parent.height(),
+                        parent.digest = %parent.digest(),
+                        "falling back to serial proposal build because canonicalizing validated parent failed",
+                    );
+                    self.cancel_payload_build(&context, payload_id_rx).await;
+                    return self
+                        .build_payload_after_parent_validation(
+                            context,
+                            propose_start,
+                            parent,
+                            attrs,
+                            marshal_persist,
+                            payload_id_rx,
+                        )
+                        .await;
+                }
+
+                let resolve_timeout = self
+                    .proposal_return_budget
+                    .saturating_sub(propose_start.elapsed())
+                    .max(Duration::from_millis(1));
+                let payload_result = {
+                    let payload_result = self
+                        .execution_node
+                        .payload_builder_handle
+                        .resolve_kind(payload_id, PayloadKind::WaitForPending)
+                        .pace(&context, Duration::from_millis(20));
+                    tokio::pin!(payload_result);
+                    tokio::select! {
+                        result = &mut payload_result => result
+                            .ok_or_eyre("no payload found under provided id")
+                            .and_then(|rsp| rsp.map_err(Into::<eyre::Report>::into))
+                            .wrap_err_with(|| {
+                                format!("failed getting speculative payload for payload ID `{payload_id}`")
+                            }),
+                        _ = context.sleep(resolve_timeout) => Err(eyre!(
+                            "timed out waiting {resolve_timeout:?} for speculative payload `{payload_id}`"
+                        )),
+                    }
+                };
+                let payload = match payload_result {
+                    Ok(payload) => payload,
+                    Err(error) => {
+                        validity_token.mark_invalid();
+                        self.metrics.speculative_build_cancelled.inc();
+                        self.metrics.speculative_build_fallbacks.inc();
+                        warn!(
+                            %error,
+                            %payload_id,
+                            parent.height = %parent.height(),
+                            parent.digest = %parent.digest(),
+                            "falling back to serial proposal build because speculative payload could not be resolved",
+                        );
+                        self.cancel_payload_build(&context, payload_id_rx).await;
+                        return self
+                            .build_payload_after_parent_validation(
+                                context,
+                                propose_start,
+                                parent,
+                                attrs,
+                                marshal_persist,
+                                payload_id_rx,
+                            )
+                            .await;
+                    }
+                };
+
+                if let Err(error) = ensure_speculative_payload_matches_context(
+                    &payload,
+                    &parent,
+                    &speculative_attrs,
+                ) {
+                    validity_token.mark_invalid();
+                    self.metrics.speculative_build_cancelled.inc();
+                    self.metrics.speculative_build_fallbacks.inc();
+                    warn!(
+                        %error,
+                        %payload_id,
+                        parent.height = %parent.height(),
+                        parent.digest = %parent.digest(),
+                        "falling back to serial proposal build because speculative payload no longer matches proposal context",
+                    );
+                    self.cancel_payload_build(&context, payload_id_rx).await;
+                    return self
+                        .build_payload_after_parent_validation(
+                            context,
+                            propose_start,
+                            parent,
+                            attrs,
+                            marshal_persist,
+                            payload_id_rx,
+                        )
+                        .await;
+                }
+
+                self.metrics.speculative_build_used.inc();
+
+                let payload_build_elapsed = payload_build_start.elapsed();
+                let payload_validation_elapsed = payload.validation_work_duration();
+                let block_size_bytes = payload.rlp_block_size_bytes();
+                let validator_marshal_persist = marshal_persist.estimate(block_size_bytes);
+                let proposal_elapsed = propose_start.elapsed();
+                let return_delay = self
+                    .proposal_return_budget
+                    .saturating_sub(proposal_elapsed)
+                    .saturating_sub(payload_validation_elapsed)
+                    .saturating_sub(validator_marshal_persist);
+                debug!(
+                    proposal_elapsed = %display_duration(proposal_elapsed),
+                    speculative_build_time = %display_duration(payload_build_elapsed),
+                    parent_validation_time = %display_duration(parent_validation_elapsed),
+                    validation_time = %display_duration(payload_validation_elapsed),
+                    validator_marshal_persist = %display_duration(validator_marshal_persist),
+                    return_time = %display_duration(return_delay),
+                    block_size_bytes,
+                    "using speculative BAL-overlay payload after parent validation"
+                );
+                let proposal_return_time = context.current() + return_delay;
+
+                let (block, block_access_list) = payload.into_execution_payload();
+                let proposal = Block::from_execution_block(block, block_access_list)
+                    .wrap_err("payload builder produced an invalid block access list")?;
+
+                return Ok((
+                    proposal,
+                    Some(ProposalReturn {
+                        time: proposal_return_time,
+                        block_size_bytes,
+                    }),
+                ));
+            }
+        }
+
+        // Send the proposal parent to execution layer to cover edge cases when
+        // we were not asked to to verify it (and hence are missing it in the
+        // EL).
+        //
+        // If proposing the first block of an epoch, its parent
+        // (genesis/boundary block) must exist and be finalized, so we can skip
+        // it.
+        if should_verify_parent
+            && !verify_block(
+                context.clone(),
+                parent_epoch_info.epoch(),
+                &self.epoch_strategy,
+                self.execution_node
+                    .add_ons_handle
+                    .beacon_engine_handle
+                    .clone(),
+                &parent,
+                // It is safe to not verify the parent of the parent because this block is already notarized.
+                parent.parent_digest(),
+                &self.scheme_provider,
+            )
+            .await
+            .wrap_err("failed verifying block against execution layer")?
+        {
+            bail!("the proposal parent block is not valid");
+        }
+
+        self.build_payload_after_parent_validation(
+            context,
+            propose_start,
+            parent,
+            attrs,
+            marshal_persist,
+            payload_id_rx,
+        )
+        .await
+    }
+
+    async fn build_payload_after_parent_validation<TContext: Pacer>(
+        self,
+        context: TContext,
+        propose_start: Instant,
+        parent: Block,
+        attrs: TempoPayloadAttributes,
+        marshal_persist: tempo_payload_types::MarshalPersistEstimator,
+        payload_id_rx: &mut Option<oneshot::Receiver<eyre::Result<PayloadId>>>,
+    ) -> eyre::Result<(Block, Option<ProposalReturn>)> {
         // Share the dispatch receiver with the cancel branch so that, if cancellation
         // hits between dispatch send and receiving `payload_id`, the cancel branch can
         // still drain the rx, learn `payload_id`, and cancel the now-registered job.
@@ -926,6 +1258,7 @@ impl Inner<Uninit> {
             },
             subblocks: self.subblocks,
             scheme_provider: self.scheme_provider,
+            speculative_bal_build: self.speculative_bal_build,
             metrics: self.metrics,
         };
 
@@ -1037,6 +1370,46 @@ async fn verify_block<TContext: Pacer>(
             )
         }
     }
+}
+
+fn ensure_speculative_payload_matches_context(
+    payload: &TempoBuiltPayload,
+    parent: &Block,
+    attrs: &TempoPayloadAttributes,
+) -> eyre::Result<()> {
+    let block = payload.block();
+    ensure!(
+        block.parent_hash() == parent.block_hash(),
+        "speculative payload parent hash mismatch: expected {}, got {}",
+        parent.block_hash(),
+        block.parent_hash(),
+    );
+    ensure!(
+        block.timestamp() == attrs.timestamp,
+        "speculative payload timestamp mismatch: expected {}, got {}",
+        attrs.timestamp,
+        block.timestamp(),
+    );
+    ensure!(
+        block.header().timestamp_millis_part == attrs.timestamp_millis_part(),
+        "speculative payload timestamp millis mismatch: expected {}, got {}",
+        attrs.timestamp_millis_part(),
+        block.header().timestamp_millis_part,
+    );
+    ensure!(
+        block.header().consensus_context == attrs.consensus_context(),
+        "speculative payload consensus context mismatch",
+    );
+    Ok(())
+}
+
+fn block_transaction_hashes(block: &Block) -> impl Iterator<Item = B256> + '_ {
+    block
+        .block()
+        .body()
+        .transactions
+        .iter()
+        .map(|tx| *tx.tx_hash())
 }
 
 #[instrument(skip_all, err(Display))]
@@ -1153,6 +1526,11 @@ async fn get_parent(
 #[derive(Clone)]
 struct Metrics {
     parent_ahead_of_local_time: Counter,
+    speculative_build_attempts: Counter,
+    speculative_build_started: Counter,
+    speculative_build_used: Counter,
+    speculative_build_cancelled: Counter,
+    speculative_build_fallbacks: Counter,
 }
 
 impl Metrics {
@@ -1166,9 +1544,160 @@ impl Metrics {
             "number of times the parent block timestamp was ahead of local time",
             parent_ahead_of_local_time.clone(),
         );
+        let speculative_build_attempts = Counter::default();
+        context.register(
+            "speculative_bal_build_attempts",
+            "number of attempted BAL-overlay speculative payload builds",
+            speculative_build_attempts.clone(),
+        );
+        let speculative_build_started = Counter::default();
+        context.register(
+            "speculative_bal_build_started",
+            "number of BAL-overlay speculative payload builds started",
+            speculative_build_started.clone(),
+        );
+        let speculative_build_used = Counter::default();
+        context.register(
+            "speculative_bal_build_used",
+            "number of BAL-overlay speculative payloads used after parent validation",
+            speculative_build_used.clone(),
+        );
+        let speculative_build_cancelled = Counter::default();
+        context.register(
+            "speculative_bal_build_cancelled",
+            "number of BAL-overlay speculative payload builds cancelled or discarded",
+            speculative_build_cancelled.clone(),
+        );
+        let speculative_build_fallbacks = Counter::default();
+        context.register(
+            "speculative_bal_build_fallbacks",
+            "number of BAL-overlay speculative build fallbacks to serial proposal building",
+            speculative_build_fallbacks.clone(),
+        );
 
         Self {
             parent_ahead_of_local_time,
+            speculative_build_attempts,
+            speculative_build_started,
+            speculative_build_used,
+            speculative_build_cancelled,
+            speculative_build_fallbacks,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{BlockBody, Header};
+    use alloy_primitives::U256;
+    use reth_node_core::primitives::SealedBlock;
+    use reth_payload_builder::EthBuiltPayload;
+    use tempo_primitives::{
+        Block as TempoBlock, TempoHeader, TempoPrimitives, ed25519::PublicKey as TempoPublicKey,
+    };
+
+    fn consensus_context() -> TempoConsensusContext {
+        TempoConsensusContext {
+            epoch: 1,
+            view: 2,
+            parent_view: 3,
+            proposer: TempoPublicKey::from_seed([7; 32]),
+        }
+    }
+
+    fn parent_block() -> Block {
+        let execution_block = SealedBlock::seal_slow(TempoBlock {
+            header: TempoHeader {
+                inner: Header {
+                    number: 1,
+                    timestamp: 10,
+                    gas_limit: 30_000_000,
+                    base_fee_per_gas: Some(0),
+                    withdrawals_root: Some(B256::ZERO),
+                    blob_gas_used: Some(0),
+                    excess_blob_gas: Some(0),
+                    parent_beacon_block_root: Some(B256::ZERO),
+                    requests_hash: Some(B256::ZERO),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            body: Default::default(),
+        });
+        Block::from_execution_block(execution_block, None).expect("parent block")
+    }
+
+    fn built_payload(
+        parent_hash: B256,
+        timestamp: u64,
+        timestamp_millis_part: u64,
+        consensus_context: Option<TempoConsensusContext>,
+    ) -> TempoBuiltPayload {
+        let block = TempoBlock {
+            header: TempoHeader {
+                timestamp_millis_part,
+                consensus_context,
+                inner: Header {
+                    parent_hash,
+                    number: 2,
+                    timestamp,
+                    gas_limit: 30_000_000,
+                    base_fee_per_gas: Some(0),
+                    withdrawals_root: Some(B256::ZERO),
+                    blob_gas_used: Some(0),
+                    excess_blob_gas: Some(0),
+                    parent_beacon_block_root: Some(B256::ZERO),
+                    requests_hash: Some(B256::ZERO),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            body: BlockBody::default(),
+        }
+        .try_into_recovered()
+        .expect("recoverable test block");
+        let eth = EthBuiltPayload::<TempoPrimitives>::new(Arc::new(block), U256::ZERO, None, None);
+        TempoBuiltPayload::new(eth, None, None, Duration::ZERO, 0)
+    }
+
+    #[test]
+    fn speculative_payload_context_accepts_matching_payload() {
+        let parent = parent_block();
+        let ctx = consensus_context();
+        let attrs = TempoPayloadAttributes::new(None, 11, 123, Bytes::new(), Some(ctx), Vec::new);
+        let payload = built_payload(
+            parent.block_hash(),
+            attrs.timestamp,
+            attrs.timestamp_millis_part(),
+            attrs.consensus_context(),
+        );
+
+        ensure_speculative_payload_matches_context(&payload, &parent, &attrs)
+            .expect("matching payload context");
+    }
+
+    #[test]
+    fn speculative_payload_context_rejects_stale_parent() {
+        let parent = parent_block();
+        let attrs = TempoPayloadAttributes::new(
+            None,
+            11,
+            123,
+            Bytes::new(),
+            Some(consensus_context()),
+            Vec::new,
+        );
+        let payload = built_payload(
+            B256::repeat_byte(0x55),
+            attrs.timestamp,
+            attrs.timestamp_millis_part(),
+            attrs.consensus_context(),
+        );
+
+        let err = ensure_speculative_payload_matches_context(&payload, &parent, &attrs)
+            .expect_err("stale parent must be rejected");
+
+        assert!(err.to_string().contains("parent hash mismatch"));
     }
 }

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -1513,14 +1513,39 @@ async fn get_parent(
         })?
     {
         // EL database reads do not include commonware sidecars.
-        Ok(Block::from_execution_block_unchecked(parent.seal(), None))
+        let parent = Block::from_execution_block_unchecked(parent.seal(), None);
+        if parent.block().header().block_access_list_hash().is_some() {
+            let parent =
+                get_parent_from_marshal(round, parent_digest, parent_view, marshal).await?;
+            ensure!(
+                parent.block_access_list().is_some(),
+                "parent block `{parent_digest}` has a BAL hash but marshal returned no BAL sidecar",
+            );
+            debug!(
+                parent.height = %parent.height(),
+                parent.digest = %parent.digest(),
+                "restored parent BAL sidecar from marshal",
+            );
+            return Ok(parent);
+        }
+
+        Ok(parent)
     } else {
-        marshal
-            .subscribe_by_digest(Some(Round::new(round.epoch(), parent_view)), parent_digest)
-            .await
-            .await
-            .map_err(|_| eyre!("syncer dropped channel before the parent block was sent"))
+        get_parent_from_marshal(round, parent_digest, parent_view, marshal).await
     }
+}
+
+async fn get_parent_from_marshal(
+    round: Round,
+    parent_digest: Digest,
+    parent_view: View,
+    marshal: &crate::alias::marshal::Mailbox,
+) -> eyre::Result<Block> {
+    marshal
+        .subscribe_by_digest(Some(Round::new(round.epoch(), parent_view)), parent_digest)
+        .await
+        .await
+        .map_err(|_| eyre!("syncer dropped channel before the parent block was sent"))
 }
 
 #[derive(Clone)]

--- a/crates/commonware-node/src/consensus/application/mod.rs
+++ b/crates/commonware-node/src/consensus/application/mod.rs
@@ -64,6 +64,10 @@ pub(super) struct Config<TContext> {
     /// budget to the payload builder.
     pub(super) proposal_return_budget: Duration,
 
+    /// Whether proposals may build a child payload speculatively over the
+    /// candidate parent's BAL while parent validation is still in flight.
+    pub(super) speculative_bal_build: bool,
+
     /// The epoch strategy used by tempo, to map block heights to epochs.
     pub(super) epoch_strategy: FixedEpocher,
 

--- a/crates/commonware-node/src/consensus/block.rs
+++ b/crates/commonware-node/src/consensus/block.rs
@@ -7,9 +7,7 @@ use alloy_consensus::BlockHeader as _;
 use alloy_primitives::{B256, Bytes, keccak256};
 use alloy_rlp::Encodable as _;
 use bytes::{Buf, BufMut};
-#[cfg(feature = "bal")]
-use commonware_codec::RangeCfg;
-use commonware_codec::{EncodeSize, Read, Write};
+use commonware_codec::{EncodeSize, RangeCfg, Read, Write};
 use commonware_consensus::{
     Heightable,
     simplex::types::Context,
@@ -63,8 +61,7 @@ impl BlockAccessListError {
 pub(crate) struct Block {
     /// The execution-layer block.
     execution_block: SealedBlock<tempo_primitives::Block>,
-    /// Optional block access list. Only provided if the network supports BALs.
-    #[cfg(feature = "bal")]
+    /// Optional block access list sidecar. Present when the header commits to a BAL hash.
     block_access_list: Option<Bytes>,
 }
 
@@ -94,12 +91,8 @@ impl Block {
         execution_block: SealedBlock<tempo_primitives::Block>,
         block_access_list: Option<Bytes>,
     ) -> Self {
-        #[cfg(not(feature = "bal"))]
-        let _ = block_access_list;
-
         Self {
             execution_block,
-            #[cfg(feature = "bal")]
             block_access_list,
         }
     }
@@ -111,17 +104,7 @@ impl Block {
 
     /// Consumes the block and returns the execution-layer block plus optional BAL.
     pub(crate) fn into_parts(self) -> (SealedBlock<tempo_primitives::Block>, Option<Bytes>) {
-        (
-            self.execution_block,
-            #[cfg(feature = "bal")]
-            {
-                self.block_access_list
-            },
-            #[cfg(not(feature = "bal"))]
-            {
-                None
-            },
-        )
+        (self.execution_block, self.block_access_list)
     }
 
     /// Returns the (eth) hash of the wrapped block.
@@ -151,14 +134,7 @@ impl Block {
 
     /// Returns the block access list of the wrapped block.
     pub(crate) fn block_access_list(&self) -> Option<&Bytes> {
-        #[cfg(feature = "bal")]
-        {
-            self.block_access_list.as_ref()
-        }
-        #[cfg(not(feature = "bal"))]
-        {
-            None
-        }
+        self.block_access_list.as_ref()
     }
 }
 
@@ -173,7 +149,6 @@ impl std::ops::Deref for Block {
 impl Write for Block {
     fn write(&self, buf: &mut impl BufMut) {
         self.execution_block.encode(buf);
-        #[cfg(feature = "bal")]
         if self.execution_block.block_access_list_hash().is_some() {
             // FIXME: Blocks reconstructed from persisted EL data can carry a BAL hash
             // without the commonware BAL sidecar. Encoding one will panic here, which
@@ -217,7 +192,6 @@ impl Read for Block {
                 commonware_codec::Error::Wrapped("reading RLP encoded block", rlp_err.into())
             })?;
 
-        #[cfg(feature = "bal")]
         let block_access_list = {
             if inner.block_access_list_hash().is_some() {
                 let block_access_list: Bytes = bytes::Bytes::read_cfg(buf, &RangeCfg::from(..))
@@ -230,8 +204,6 @@ impl Read for Block {
                 None
             }
         };
-        #[cfg(not(feature = "bal"))]
-        let block_access_list = None;
 
         Self::from_execution_block(inner, block_access_list).map_err(|err| err.codec_error())
     }
@@ -239,23 +211,16 @@ impl Read for Block {
 
 impl EncodeSize for Block {
     fn encode_size(&self) -> usize {
-        #[cfg(feature = "bal")]
-        {
-            let mut size = self.execution_block.length();
-            size += if self.execution_block.block_access_list_hash().is_some() {
-                self.block_access_list
-                    .as_ref()
-                    .expect("BAL bytes must be present when header contains a BAL hash")
-                    .encode_size()
-            } else {
-                0
-            };
-            size
-        }
-        #[cfg(not(feature = "bal"))]
-        {
-            self.execution_block.length()
-        }
+        let mut size = self.execution_block.length();
+        size += if self.execution_block.block_access_list_hash().is_some() {
+            self.block_access_list
+                .as_ref()
+                .expect("BAL bytes must be present when header contains a BAL hash")
+                .encode_size()
+        } else {
+            0
+        };
+        size
     }
 }
 
@@ -505,18 +470,13 @@ impl commonware_consensus::CertifiableBlock for Block {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "bal")]
     use alloy_consensus::BlockHeader as _;
     use alloy_primitives::{B256, bytes, keccak256};
-    #[cfg(not(feature = "bal"))]
-    use commonware_codec::Write as _;
     use commonware_codec::{Encode, Read as _};
     use reth_node_core::primitives::SealedBlock;
     use tempo_primitives::{Block as TempoBlock, TempoHeader};
 
-    use super::Block;
-    #[cfg(feature = "bal")]
-    use super::BlockAccessListError;
+    use super::{Block, BlockAccessListError};
 
     fn execution_block_with_block_access_list_hash(
         block_access_list_hash: B256,
@@ -590,25 +550,6 @@ mod tests {
         assert_eq!(encoded.as_ref(), block_bytes.as_slice());
     }
 
-    #[cfg(not(feature = "bal"))]
-    #[test]
-    fn read_rejects_block_access_list_hash_when_bal_feature_disabled() {
-        let block_access_list = bytes!("0xc0");
-        let execution_block =
-            execution_block_with_block_access_list_hash(keccak256(block_access_list.as_ref()));
-        let mut encoded = Vec::new();
-        alloy_rlp::Encodable::encode(&execution_block, &mut encoded);
-        block_access_list.write(&mut encoded);
-
-        let err = Block::read_cfg(&mut encoded.as_ref(), &()).unwrap_err();
-
-        assert!(matches!(
-            err,
-            commonware_codec::Error::Invalid("block access list", "missing for header hash")
-        ));
-    }
-
-    #[cfg(feature = "bal")]
     #[test]
     fn rejects_block_access_list_without_header_hash() {
         let execution_block = SealedBlock::seal_slow(TempoBlock {
@@ -624,7 +565,6 @@ mod tests {
         assert_eq!(err, BlockAccessListError::Unexpected);
     }
 
-    #[cfg(feature = "bal")]
     #[test]
     fn rejects_missing_block_access_list_with_header_hash() {
         let execution_block = execution_block_with_block_access_list_hash(B256::ZERO);
@@ -638,7 +578,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "bal")]
     #[test]
     fn reads_wraps_missing_block_access_list_error() {
         let execution_block = execution_block_with_block_access_list_hash(B256::ZERO);
@@ -653,7 +592,6 @@ mod tests {
         ));
     }
 
-    #[cfg(feature = "bal")]
     #[test]
     fn roundtrips_block_access_list_with_matching_header_hash() {
         let block_access_list = bytes!("0xc0");
@@ -672,7 +610,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "bal")]
     #[test]
     fn rejects_block_access_list_with_mismatched_header_hash() {
         let block_access_list = bytes!("0xc0");
@@ -689,7 +626,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "bal")]
     #[test]
     fn reads_reject_block_access_list_with_mismatched_header_hash() {
         let block_access_list = bytes!("0xc0");

--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -79,6 +79,7 @@ pub struct Builder<TBlocker, TPeerManager> {
     pub time_to_build_subblock: Duration,
     pub subblock_broadcast_interval: Duration,
     pub fcu_heartbeat_interval: Duration,
+    pub speculative_bal_build: bool,
     pub with_subblocks: bool,
 
     pub feed_state: crate::feed::FeedStateHandle,
@@ -250,6 +251,7 @@ where
             execution_node: execution_node.clone(),
             executor: executor_mailbox.clone(),
             proposal_return_budget: self.proposal_return_budget,
+            speculative_bal_build: self.speculative_bal_build,
             subblocks: subblocks.as_ref().map(|s| s.mailbox()),
             scheme_provider: scheme_provider.clone(),
             epoch_strategy: epoch_strategy.clone(),

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -24,14 +24,18 @@ use futures::{
     stream::FuturesOrdered,
 };
 use prometheus_client::metrics::counter::Counter;
-use reth_chain_state::BalStateOverlay;
-use reth_ethereum::{chainspec::EthChainSpec, rpc::eth::primitives::BlockNumHash};
-use reth_payload_builder::{
-    BuildNewPayload, PayloadBuilderError, PayloadStateAnchor, PayloadValidityToken,
-    SpeculativePayloadState, SpeculativeStateProvider,
+use reth_chain_state::{BalStateOverlay, ComputedTrieData};
+use reth_engine_primitives::NoopInvalidBlockHook;
+use reth_engine_tree::tree::{
+    BasicEngineValidator, SpeculativeBalPayloadBuildRequest, SpeculativePayloadBuildResources,
 };
-use reth_storage_api::{StateProviderBox, StateProviderFactory};
-use tempo_node::{TempoExecutionData, TempoFullNode};
+use reth_ethereum::{chainspec::EthChainSpec, rpc::eth::primitives::BlockNumHash};
+use reth_payload_builder::{BuildNewPayload, PayloadBuilderError, PayloadValidityToken};
+use reth_storage_api::{StateProviderFactory, StateRootProvider};
+use reth_trie_db::ChangesetCache;
+use tempo_node::{
+    TempoExecutionData, TempoFullNode, consensus::TempoConsensus, engine::TempoEngineValidator,
+};
 use tempo_payload_types::TempoPayloadAttributes;
 use tokio::select;
 use tracing::{
@@ -484,11 +488,12 @@ where
         tokio::sync::oneshot::Receiver<std::result::Result<PayloadId, PayloadBuilderError>>,
     > {
         let parent_hash = parent.block_hash();
-        let state_anchor = speculative_state_anchor_for_parent(
+        let resources = speculative_build_resources_for_parent(
             &parent,
-            self.execution_node.provider.clone(),
-            validity_token,
+            &self.execution_node,
+            validity_token.clone(),
         )?;
+        let (state_anchor, cache, trie_handle) = resources.into_payload_builder_parts();
 
         Ok(self
             .execution_node
@@ -497,8 +502,8 @@ where
                 BuildNewPayload {
                     attributes,
                     parent_hash,
-                    cache: None,
-                    trie_handle: None,
+                    cache,
+                    trie_handle,
                 },
                 state_anchor,
             ))
@@ -676,14 +681,32 @@ where
     }
 }
 
+#[cfg(test)]
 fn speculative_state_anchor_for_parent<Provider>(
     parent: &Block,
     provider: Provider,
     validity_token: PayloadValidityToken,
-) -> eyre::Result<PayloadStateAnchor>
+) -> eyre::Result<reth_payload_builder::PayloadStateAnchor>
 where
     Provider: StateProviderFactory + Clone + Send + Sync + 'static,
 {
+    let overlay = parent_bal_overlay(parent)?;
+    let base_parent_hash = parent.parent_hash();
+    let state_provider = reth_payload_builder::SpeculativeStateProvider::new(
+        "tempo-parent-bal-overlay",
+        move || {
+            let fallback = provider.state_by_block_hash(base_parent_hash)?;
+            Ok(Box::new(overlay.clone().provider(fallback)) as reth_storage_api::StateProviderBox)
+        },
+    );
+
+    Ok(reth_payload_builder::PayloadStateAnchor::Speculative(
+        reth_payload_builder::SpeculativePayloadState::new(validity_token)
+            .with_state_provider(state_provider),
+    ))
+}
+
+fn parent_bal_overlay(parent: &Block) -> eyre::Result<BalStateOverlay> {
     let block_access_list = parent
         .block_access_list()
         .cloned()
@@ -697,17 +720,67 @@ where
             .wrap_err("parent BAL sidecar hash does not match header")?;
     }
 
-    let overlay = BalStateOverlay::from_bal(decoded.as_bal())
-        .wrap_err("failed constructing parent BAL final-write overlay")?;
-    let base_parent_hash = parent.parent_hash();
-    let state_provider = SpeculativeStateProvider::new("tempo-parent-bal-overlay", move || {
-        let fallback = provider.state_by_block_hash(base_parent_hash)?;
-        Ok(Box::new(overlay.clone().provider(fallback)) as StateProviderBox)
-    });
+    BalStateOverlay::from_bal(decoded.as_bal())
+        .wrap_err("failed constructing parent BAL final-write overlay")
+}
 
-    Ok(PayloadStateAnchor::Speculative(
-        SpeculativePayloadState::new(validity_token).with_state_provider(state_provider),
-    ))
+fn speculative_build_resources_for_parent(
+    parent: &Block,
+    execution_node: &TempoFullNode,
+    validity_token: PayloadValidityToken,
+) -> eyre::Result<SpeculativePayloadBuildResources> {
+    let parent_hash = parent.block_hash();
+    let parent_state_anchor = parent.parent_hash();
+    let parent_state_root = parent.block().header().state_root();
+    let bal_overlay = parent_bal_overlay(parent)?;
+
+    let fallback = execution_node
+        .provider
+        .state_by_block_hash(parent_state_anchor)
+        .wrap_err("failed opening parent state anchor for BAL overlay")?;
+    let hashed_overlay = bal_overlay
+        .clone()
+        .provider(fallback)
+        .hashed_overlay_state()
+        .wrap_err("failed hashing parent BAL overlay")?;
+
+    let fallback = execution_node
+        .provider
+        .state_by_block_hash(parent_state_anchor)
+        .wrap_err("failed reopening parent state anchor for BAL trie updates")?;
+    let (validated_parent_state_root, parent_trie_updates) = fallback
+        .state_root_with_updates(hashed_overlay.clone())
+        .wrap_err("failed computing parent BAL overlay trie updates")?;
+
+    let parent_trie_data = ComputedTrieData::new(
+        Arc::new(hashed_overlay.into_sorted()),
+        Arc::new(parent_trie_updates.into_sorted()),
+    );
+
+    let validator = BasicEngineValidator::new(
+        execution_node.provider.clone(),
+        Arc::new(TempoConsensus::new(execution_node.chain_spec())),
+        execution_node.evm_config.clone(),
+        TempoEngineValidator::new(),
+        execution_node.config.engine.tree_config(),
+        Box::<NoopInvalidBlockHook>::default(),
+        ChangesetCache::default(),
+        execution_node.task_executor.clone(),
+    );
+
+    let resources = validator
+        .speculative_bal_payload_build_resources(SpeculativeBalPayloadBuildRequest {
+            parent_hash,
+            parent_state_root,
+            validated_parent_state_root,
+            parent_state_anchor,
+            bal_overlay,
+            parent_trie_data,
+            validity_dependency: Some(validity_token),
+        })
+        .wrap_err("failed creating speculative BAL payload build resources")?;
+
+    Ok(resources)
 }
 
 /// Controls canonicalization: if attributes are sent, the FCU also builds a payload.

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -494,11 +494,12 @@ where
             validity_token.clone(),
         )?;
         let (state_anchor, cache, trie_handle) = resources.into_payload_builder_parts();
+        let parent_header = Arc::new(parent.block().sealed_header().clone());
 
         Ok(self
             .execution_node
             .payload_builder_handle
-            .send_new_payload_with_state_anchor(
+            .send_new_payload_with_state_anchor_and_parent_header(
                 BuildNewPayload {
                     attributes,
                     parent_hash,
@@ -506,6 +507,7 @@ where
                     trie_handle,
                 },
                 state_anchor,
+                parent_header,
             ))
     }
 

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -757,7 +757,7 @@ impl std::fmt::Display for HeadOrFinalized {
     }
 }
 
-#[cfg(all(test, feature = "bal"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use alloy_consensus::Header;

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -6,6 +6,8 @@
 
 use std::{ops::RangeInclusive, pin::Pin, sync::Arc, time::Duration};
 
+use alloy_consensus::BlockHeader as _;
+use alloy_eip7928::bal::DecodedBal;
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadId};
 use commonware_consensus::{Heightable as _, marshal::Update, types::Height};
 use commonware_cryptography::ed25519::PublicKey;
@@ -22,7 +24,13 @@ use futures::{
     stream::FuturesOrdered,
 };
 use prometheus_client::metrics::counter::Counter;
+use reth_chain_state::BalStateOverlay;
 use reth_ethereum::{chainspec::EthChainSpec, rpc::eth::primitives::BlockNumHash};
+use reth_payload_builder::{
+    BuildNewPayload, PayloadBuilderError, PayloadStateAnchor, PayloadValidityToken,
+    SpeculativePayloadState, SpeculativeStateProvider,
+};
+use reth_storage_api::{StateProviderBox, StateProviderFactory};
 use tempo_node::{TempoExecutionData, TempoFullNode};
 use tempo_payload_types::TempoPayloadAttributes;
 use tokio::select;
@@ -32,7 +40,7 @@ use tracing::{
 
 use super::{
     Config,
-    ingress::{CanonicalizeHead, Command, Message},
+    ingress::{CanonicalizeHead, Command, Message, SpeculativeBuild},
 };
 use crate::{
     consensus::{Digest, block::Block},
@@ -387,7 +395,11 @@ where
         let is_backfilling =
             self.pending_backfill.is_some() || !self.finalized_heights_to_backfill.is_empty();
         match message.command {
-            Command::CanonicalizeHead(..) | Command::CanonicalizeAndBuild(..) if is_backfilling => {
+            Command::CanonicalizeHead(..)
+            | Command::CanonicalizeAndBuild(..)
+            | Command::SpeculativeBuild(..)
+                if is_backfilling =>
+            {
                 info_span!("handle_message")
                     .in_scope(|| info!("request to canonicalize dropped while backfilling"));
             }
@@ -423,6 +435,25 @@ where
                 )
                 .await;
             }
+            Command::SpeculativeBuild(SpeculativeBuild {
+                parent,
+                attributes,
+                validity_token,
+                response,
+            }) => {
+                let rx = match self.start_speculative_build(*parent, *attributes, validity_token) {
+                    Ok(rx) => rx,
+                    Err(error) => {
+                        let _ = response.send(Err(error));
+                        return Ok(());
+                    }
+                };
+                let payload_id = rx
+                    .await
+                    .map_err(|_| eyre!("payload builder dropped speculative build response"))
+                    .and_then(|res| res.map_err(Report::new));
+                let _ = response.send(payload_id);
+            }
             Command::Finalize(finalized) => match *finalized {
                 Update::Tip(_, height, digest) => {
                     self.latest_observed_finalized_tip.replace((height, digest));
@@ -434,6 +465,43 @@ where
             },
         }
         Ok(())
+    }
+
+    /// Starts a child payload build over the speculative state `parent.parent + parent.BAL`.
+    #[instrument(
+        skip_all,
+        fields(
+            parent.height = %parent.height(),
+            parent.digest = %parent.digest(),
+        ),
+    )]
+    fn start_speculative_build(
+        &self,
+        parent: Block,
+        attributes: TempoPayloadAttributes,
+        validity_token: PayloadValidityToken,
+    ) -> eyre::Result<
+        tokio::sync::oneshot::Receiver<std::result::Result<PayloadId, PayloadBuilderError>>,
+    > {
+        let parent_hash = parent.block_hash();
+        let state_anchor = speculative_state_anchor_for_parent(
+            &parent,
+            self.execution_node.provider.clone(),
+            validity_token,
+        )?;
+
+        Ok(self
+            .execution_node
+            .payload_builder_handle
+            .send_new_payload_with_state_anchor(
+                BuildNewPayload {
+                    attributes,
+                    parent_hash,
+                    cache: None,
+                    trie_handle: None,
+                },
+                state_anchor,
+            ))
     }
 
     /// Canonicalizes `digest` by sending a forkchoice update to the execution layer.
@@ -608,6 +676,40 @@ where
     }
 }
 
+fn speculative_state_anchor_for_parent<Provider>(
+    parent: &Block,
+    provider: Provider,
+    validity_token: PayloadValidityToken,
+) -> eyre::Result<PayloadStateAnchor>
+where
+    Provider: StateProviderFactory + Clone + Send + Sync + 'static,
+{
+    let block_access_list = parent
+        .block_access_list()
+        .cloned()
+        .ok_or_else(|| eyre!("parent block has no BAL sidecar"))?;
+    let decoded = DecodedBal::from_rlp_bytes(block_access_list)
+        .wrap_err("failed decoding parent BAL sidecar")?;
+
+    if let Some(expected) = parent.block().block_access_list_hash() {
+        decoded
+            .ensure_hash(expected)
+            .wrap_err("parent BAL sidecar hash does not match header")?;
+    }
+
+    let overlay = BalStateOverlay::from_bal(decoded.as_bal())
+        .wrap_err("failed constructing parent BAL final-write overlay")?;
+    let base_parent_hash = parent.parent_hash();
+    let state_provider = SpeculativeStateProvider::new("tempo-parent-bal-overlay", move || {
+        let fallback = provider.state_by_block_hash(base_parent_hash)?;
+        Ok(Box::new(overlay.clone().provider(fallback)) as StateProviderBox)
+    });
+
+    Ok(PayloadStateAnchor::Speculative(
+        SpeculativePayloadState::new(validity_token).with_state_provider(state_provider),
+    ))
+}
+
 /// Controls canonicalization: if attributes are sent, the FCU also builds a payload.
 enum JustCanonicalizeOrAlsoBuild {
     JustCanonicalize {
@@ -652,5 +754,160 @@ impl std::fmt::Display for HeadOrFinalized {
             Self::Finalized => "finalized",
         };
         f.write_str(msg)
+    }
+}
+
+#[cfg(all(test, feature = "bal"))]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use alloy_eip7928::{
+        AccountChanges, BalanceChange, BlockAccessIndex, SlotChanges, StorageChange, bal::Bal,
+    };
+    use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
+    use reth_node_core::primitives::SealedBlock;
+    use reth_storage_api::{AccountReader as _, StateProvider as _, noop::NoopProvider};
+    use std::sync::Arc;
+    use tempo_chainspec::{TempoChainSpec, spec::DEV};
+    use tempo_primitives::{Block as TempoBlock, TempoHeader, TempoPrimitives};
+
+    fn test_provider() -> NoopProvider<TempoChainSpec, TempoPrimitives> {
+        NoopProvider::new(Arc::new(TempoChainSpec::from_genesis(
+            DEV.genesis().clone(),
+        )))
+    }
+
+    fn execution_block_with_bal_hash(block_access_list_hash: B256) -> SealedBlock<TempoBlock> {
+        SealedBlock::seal_slow(TempoBlock {
+            header: TempoHeader {
+                inner: Header {
+                    base_fee_per_gas: Some(0),
+                    withdrawals_root: Some(B256::ZERO),
+                    blob_gas_used: Some(0),
+                    excess_blob_gas: Some(0),
+                    parent_beacon_block_root: Some(B256::ZERO),
+                    requests_hash: Some(B256::ZERO),
+                    block_access_list_hash: Some(block_access_list_hash),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            body: Default::default(),
+        })
+    }
+
+    fn execution_block_without_bal_hash() -> SealedBlock<TempoBlock> {
+        SealedBlock::seal_slow(TempoBlock {
+            header: TempoHeader {
+                inner: Header {
+                    base_fee_per_gas: Some(0),
+                    withdrawals_root: Some(B256::ZERO),
+                    blob_gas_used: Some(0),
+                    excess_blob_gas: Some(0),
+                    parent_beacon_block_root: Some(B256::ZERO),
+                    requests_hash: Some(B256::ZERO),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            body: Default::default(),
+        })
+    }
+
+    fn encode_bal(bal: &Bal) -> Bytes {
+        Bytes::from(alloy_rlp::encode(bal))
+    }
+
+    fn bal_with_final_writes(address: Address, slot: U256) -> Bal {
+        Bal::new(vec![
+            AccountChanges::new(address)
+                .with_balance_change(BalanceChange::new(BlockAccessIndex::new(1), U256::from(7)))
+                .with_storage_change(SlotChanges::new(
+                    slot,
+                    vec![StorageChange::new(BlockAccessIndex::new(1), U256::from(3))],
+                )),
+        ])
+    }
+
+    #[test]
+    fn speculative_state_anchor_rejects_parent_without_bal_sidecar() {
+        let parent = Block::from_execution_block(execution_block_without_bal_hash(), None)
+            .expect("block without BAL sidecar");
+        let token = PayloadValidityToken::pending(parent.block_hash());
+
+        let err = speculative_state_anchor_for_parent(&parent, test_provider(), token).unwrap_err();
+
+        assert!(err.to_string().contains("no BAL sidecar"));
+    }
+
+    #[test]
+    fn speculative_state_anchor_rejects_malformed_bal_sidecar() {
+        let block_access_list = Bytes::from_static(b"not-rlp");
+        let parent = Block::from_execution_block(
+            execution_block_with_bal_hash(keccak256(block_access_list.as_ref())),
+            Some(block_access_list),
+        )
+        .expect("header commits to malformed BAL bytes");
+        let token = PayloadValidityToken::pending(parent.block_hash());
+
+        let err = speculative_state_anchor_for_parent(&parent, test_provider(), token).unwrap_err();
+
+        assert!(err.to_string().contains("decoding parent BAL"));
+    }
+
+    #[test]
+    fn speculative_state_anchor_rejects_mismatched_bal_hash() {
+        let block_access_list = encode_bal(&Bal::default());
+        let parent = Block::from_execution_block_unchecked(
+            execution_block_with_bal_hash(B256::ZERO),
+            Some(block_access_list),
+        );
+        let token = PayloadValidityToken::pending(parent.block_hash());
+
+        let err = speculative_state_anchor_for_parent(&parent, test_provider(), token).unwrap_err();
+
+        assert!(err.to_string().contains("hash does not match"));
+    }
+
+    #[test]
+    fn speculative_state_anchor_exposes_parent_bal_overlay() {
+        let address = Address::from([0x11; 20]);
+        let slot = U256::from(2);
+        let block_access_list = encode_bal(&bal_with_final_writes(address, slot));
+        let parent = Block::from_execution_block(
+            execution_block_with_bal_hash(keccak256(block_access_list.as_ref())),
+            Some(block_access_list),
+        )
+        .expect("valid BAL sidecar");
+        let token = PayloadValidityToken::pending(parent.block_hash());
+
+        let anchor = speculative_state_anchor_for_parent(&parent, test_provider(), token.clone())
+            .expect("speculative state anchor");
+
+        assert!(anchor.is_speculative());
+        let dependency = anchor
+            .validity_dependency()
+            .expect("anchor carries parent validity dependency");
+        assert_eq!(dependency.parent_hash(), parent.block_hash());
+        assert!(!dependency.should_discard());
+        token.mark_invalid();
+        assert!(dependency.should_discard());
+
+        let provider = anchor
+            .state_provider()
+            .expect("anchor carries state provider")
+            .open()
+            .expect("overlay provider opens");
+        let account = provider
+            .basic_account(&address)
+            .expect("account lookup")
+            .expect("BAL overlay account");
+        assert_eq!(account.balance, U256::from(7));
+        assert_eq!(
+            provider
+                .storage(address, slot.into())
+                .expect("storage lookup"),
+            Some(U256::from(3))
+        );
     }
 }

--- a/crates/commonware-node/src/executor/ingress.rs
+++ b/crates/commonware-node/src/executor/ingress.rs
@@ -5,6 +5,7 @@ use futures::{
     SinkExt as _,
     channel::{mpsc, oneshot},
 };
+use reth_payload_builder::PayloadValidityToken;
 use tempo_payload_types::TempoPayloadAttributes;
 use tracing::Span;
 
@@ -55,6 +56,25 @@ impl Mailbox {
             )?;
         Ok(rx)
     }
+
+    /// Starts a speculative build for the child of `parent` without canonicalizing `parent`.
+    pub(crate) fn speculatively_build(
+        &self,
+        parent: Block,
+        attributes: TempoPayloadAttributes,
+        validity_token: PayloadValidityToken,
+    ) -> eyre::Result<oneshot::Receiver<eyre::Result<PayloadId>>> {
+        let (response, rx) = oneshot::channel();
+        self.inner
+            .unbounded_send(Message::in_current_span(SpeculativeBuild {
+                parent: Box::new(parent),
+                attributes: Box::new(attributes),
+                validity_token,
+                response,
+            }))
+            .wrap_err("failed sending speculative build request to agent, this means it exited")?;
+        Ok(rx)
+    }
 }
 
 #[derive(Debug)]
@@ -78,6 +98,8 @@ pub(super) enum Command {
     CanonicalizeHead(CanonicalizeHead),
     /// Requests the agent to canonicalize the head and build a new payload.
     CanonicalizeAndBuild(CanonicalizeAndBuild),
+    /// Requests the agent to build a child payload against a speculative parent state.
+    SpeculativeBuild(SpeculativeBuild),
     /// Requests the agent to forward a finalization event to the execution layer.
     Finalize(Box<Update<Block>>),
 }
@@ -97,6 +119,14 @@ pub(super) struct CanonicalizeAndBuild {
     pub(super) response: oneshot::Sender<eyre::Result<PayloadId>>,
 }
 
+#[derive(Debug)]
+pub(super) struct SpeculativeBuild {
+    pub(super) parent: Box<Block>,
+    pub(super) attributes: Box<TempoPayloadAttributes>,
+    pub(super) validity_token: PayloadValidityToken,
+    pub(super) response: oneshot::Sender<eyre::Result<PayloadId>>,
+}
+
 impl From<CanonicalizeHead> for Command {
     fn from(value: CanonicalizeHead) -> Self {
         Self::CanonicalizeHead(value)
@@ -106,6 +136,12 @@ impl From<CanonicalizeHead> for Command {
 impl From<CanonicalizeAndBuild> for Command {
     fn from(value: CanonicalizeAndBuild) -> Self {
         Self::CanonicalizeAndBuild(value)
+    }
+}
+
+impl From<SpeculativeBuild> for Command {
+    fn from(value: SpeculativeBuild) -> Self {
+        Self::SpeculativeBuild(value)
     }
 }
 

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -127,6 +127,7 @@ pub async fn run_consensus_stack(
         time_to_build_subblock: config.time_to_build_subblock.into_duration(),
         subblock_broadcast_interval: config.subblock_broadcast_interval.into_duration(),
         fcu_heartbeat_interval: config.fcu_heartbeat_interval.into_duration(),
+        speculative_bal_build: config.speculative_bal_build,
         with_subblocks: false,
 
         feed_state,

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -46,7 +46,7 @@ pub struct TempoConsensus {
 impl TempoConsensus {
     /// Creates a new [`TempoConsensus`] with the given chain spec.
     pub fn new(chain_spec: Arc<TempoChainSpec>) -> Self {
-        Self::new_with_bal_hashes(chain_spec, false)
+        Self::new_with_bal_hashes(chain_spec, true)
     }
 
     /// Creates a new [`TempoConsensus`] with optional pre-Amsterdam BAL hash support.

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -77,5 +77,8 @@ alloy-network.workspace = true
 
 rand_08.workspace = true
 
+[features]
+bal = ["tempo-commonware-node/bal", "tempo-node/bal"]
+
 [lints]
 workspace = true

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -140,6 +140,9 @@ pub struct Setup {
     /// Whether to activate subblocks building.
     pub with_subblocks: bool,
 
+    /// Whether to enable the opt-in speculative BAL payload build path.
+    pub speculative_bal_build: bool,
+
     /// The fee recipient written into the V2 contract for each validator.
     pub fee_recipient: Address,
 
@@ -163,6 +166,7 @@ impl Setup {
             epoch_length: 20,
             proposal_return_budget: Duration::from_millis(300),
             with_subblocks: false,
+            speculative_bal_build: false,
             fee_recipient: Address::ZERO,
             no_legacy_archive: false,
         }
@@ -211,6 +215,13 @@ impl Setup {
         }
     }
 
+    pub fn speculative_bal_build(self, speculative_bal_build: bool) -> Self {
+        Self {
+            speculative_bal_build,
+            ..self
+        }
+    }
+
     pub fn fee_recipient(self, fee_recipient: Address) -> Self {
         Self {
             fee_recipient,
@@ -247,6 +258,7 @@ pub async fn setup_validators(
         linkage,
         proposal_return_budget,
         with_subblocks,
+        speculative_bal_build,
         fee_recipient,
         no_legacy_archive,
         ..
@@ -320,6 +332,7 @@ pub async fn setup_validators(
             fcu_heartbeat_interval: Duration::from_secs(3),
             feed_state,
             with_subblocks,
+            speculative_bal_build,
             // Plenty of headroom for any test; the marshal will fall back to
             // reth past this depth via the hybrid finalized blocks store.
             finalized_blocks_retention: 1024,

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -297,6 +297,10 @@ pub async fn setup_validators(
     for ((public_key, consensus_node_config), mut execution_config) in
         validators.into_iter().zip_eq(execution_configs)
     {
+        if speculative_bal_build {
+            execution_config.share_sparse_trie_with_payload_builder = true;
+        }
+
         let ConsensusNodeConfig {
             address,
             ingress,

--- a/crates/e2e/src/tests/payload_builder.rs
+++ b/crates/e2e/src/tests/payload_builder.rs
@@ -29,6 +29,8 @@ const POOL_TRANSACTIONS_INCLUSION_RATIO_COUNT_METRIC: &str =
     "reth_tempo_payload_builder_pool_transactions_inclusion_ratio_count";
 const POOL_TRANSACTIONS_INCLUSION_RATIO_LAST_METRIC: &str =
     "reth_tempo_payload_builder_pool_transactions_inclusion_ratio_last";
+const NORMAL_TX_FILL_IDLE_SUM_METRIC: &str =
+    "reth_tempo_payload_builder_normal_transaction_fill_idle_duration_seconds_sum";
 const NULLIFICATIONS_PER_LEADER_METRIC_SUFFIX: &str = "_nullifications_per_leader";
 
 // These tests compute deltas from the process-global Prometheus recorder, so
@@ -71,6 +73,25 @@ fn mixed_validators_build_blocks_with_and_without_shared_sparse_trie_payload_bui
     );
 }
 
+#[test_traced]
+fn shared_sparse_trie_empty_pool_does_not_idle_until_budget() {
+    let _guard = payload_builder_test_lock();
+    let deltas = run_payload_builder_test_with_setup(&[true], 5, |setup| {
+        setup.proposal_return_budget(Duration::from_millis(300))
+    });
+
+    assert!(
+        deltas.normal_transaction_fill_idle_duration_seconds_sum < 0.5,
+        "expected shared sparse-trie empty-pool builds to stop idling before the full \
+         proposal budget; idle sum was {:.3}s",
+        deltas.normal_transaction_fill_idle_duration_seconds_sum
+    );
+    assert_eq!(
+        deltas.nullification_count, 0,
+        "expected empty-pool shared sparse-trie startup to build without consensus nullifications"
+    );
+}
+
 fn payload_builder_test_lock() -> MutexGuard<'static, ()> {
     PAYLOAD_BUILDER_TEST_LOCK
         .lock()
@@ -80,6 +101,18 @@ fn payload_builder_test_lock() -> MutexGuard<'static, ()> {
 fn run_payload_builder_test(
     share_sparse_trie_with_payload_builder: &[bool],
     target_height: u64,
+) -> MetricDelta {
+    run_payload_builder_test_with_setup(
+        share_sparse_trie_with_payload_builder,
+        target_height,
+        core::convert::identity,
+    )
+}
+
+fn run_payload_builder_test_with_setup(
+    share_sparse_trie_with_payload_builder: &[bool],
+    target_height: u64,
+    configure_setup: impl FnOnce(Setup) -> Setup,
 ) -> MetricDelta {
     let _ = tempo_eyre::install();
     let metrics_recorder = install_prometheus_recorder();
@@ -99,12 +132,16 @@ fn run_payload_builder_test(
         metrics_recorder,
         POOL_TRANSACTIONS_INCLUSION_RATIO_COUNT_METRIC,
     );
+    let initial_normal_transaction_fill_idle_duration_seconds_sum =
+        prometheus_metric_value(metrics_recorder, NORMAL_TX_FILL_IDLE_SUM_METRIC).unwrap_or(0.0);
+    let setup = configure_setup(
+        Setup::new()
+            .how_many_signers(share_sparse_trie_with_payload_builder.len() as u32)
+            .epoch_length(100),
+    );
 
     let nullification_count =
         Runner::from(Config::default().with_seed(0)).start(|mut context| async move {
-            let setup = Setup::new()
-                .how_many_signers(share_sparse_trie_with_payload_builder.len() as u32)
-                .epoch_length(100);
             let (mut nodes, _execution_runtime) = setup_validators(&mut context, setup).await;
 
             for (node, share_sparse_trie) in nodes
@@ -149,6 +186,8 @@ fn run_payload_builder_test(
         metrics_recorder,
         POOL_TRANSACTIONS_INCLUSION_RATIO_LAST_METRIC,
     );
+    let final_normal_transaction_fill_idle_duration_seconds_sum =
+        prometheus_metric_value(metrics_recorder, NORMAL_TX_FILL_IDLE_SUM_METRIC).unwrap_or(0.0);
 
     MetricDelta {
         finalization_count: final_finalization_count - initial_finalization_count,
@@ -163,6 +202,9 @@ fn run_payload_builder_test(
         pool_transactions_inclusion_ratio_count: final_pool_transactions_inclusion_ratio_count
             - initial_pool_transactions_inclusion_ratio_count,
         pool_transactions_inclusion_ratio_last,
+        normal_transaction_fill_idle_duration_seconds_sum:
+            final_normal_transaction_fill_idle_duration_seconds_sum
+                - initial_normal_transaction_fill_idle_duration_seconds_sum,
         nullification_count,
     }
 }
@@ -176,6 +218,7 @@ struct MetricDelta {
     pool_transactions_included_count: u64,
     pool_transactions_inclusion_ratio_count: u64,
     pool_transactions_inclusion_ratio_last: Option<f64>,
+    normal_transaction_fill_idle_duration_seconds_sum: f64,
     nullification_count: u64,
 }
 
@@ -203,7 +246,9 @@ fn assert_pool_inclusion_metrics(deltas: &MetricDelta) {
 }
 
 async fn wait_for_height(context: &Context, expected_validators: u32, target_height: u64) {
-    loop {
+    const MAX_HEIGHT_WAIT_SECONDS: u64 = 60;
+
+    for elapsed_seconds in 0..=MAX_HEIGHT_WAIT_SECONDS {
         let validators_at_height = context
             .encode()
             .lines()
@@ -220,7 +265,14 @@ async fn wait_for_height(context: &Context, expected_validators: u32, target_hei
             .count() as u32;
 
         if validators_at_height == expected_validators {
-            break;
+            return;
+        }
+
+        if elapsed_seconds == MAX_HEIGHT_WAIT_SECONDS {
+            panic!(
+                "timed out waiting for {expected_validators} validators to reach height \
+                 {target_height}; {validators_at_height} validators reached it"
+            );
         }
 
         context.sleep(Duration::from_secs(1)).await;

--- a/crates/e2e/src/tests/simple.rs
+++ b/crates/e2e/src/tests/simple.rs
@@ -1,5 +1,11 @@
 //! Simple tests: just start and build a few blocks.
-use std::time::Duration;
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use crate::{Setup, run};
 use commonware_macros::test_traced;
@@ -18,6 +24,66 @@ fn single_node() {
             false
         }
     });
+}
+
+#[cfg(not(feature = "bal"))]
+#[test_traced]
+fn speculative_bal_build_falls_back_without_bal_sidecars() {
+    let _ = tempo_eyre::install();
+
+    let saw_fallback = Arc::new(AtomicBool::new(false));
+    let stop_saw_fallback = saw_fallback.clone();
+    let setup = Setup::new()
+        .how_many_signers(1)
+        .epoch_length(100)
+        .seed(0)
+        .speculative_bal_build(true);
+    let _state = run(setup, |metric, value| {
+        if metric.contains("_speculative_bal_build_fallbacks") {
+            let value = value.parse::<u64>().unwrap();
+            let reached = value >= 1;
+            if reached {
+                stop_saw_fallback.store(true, Ordering::Relaxed);
+            }
+            reached
+        } else if metric.ends_with("_marshal_processed_height") {
+            let value = value.parse::<u64>().unwrap();
+            value >= 20
+        } else {
+            false
+        }
+    });
+    assert!(saw_fallback.load(Ordering::Relaxed));
+}
+
+#[cfg(feature = "bal")]
+#[test_traced]
+fn speculative_bal_build_uses_parent_bal_sidecar() {
+    let _ = tempo_eyre::install();
+
+    let saw_use = Arc::new(AtomicBool::new(false));
+    let stop_saw_use = saw_use.clone();
+    let setup = Setup::new()
+        .how_many_signers(1)
+        .epoch_length(100)
+        .seed(0)
+        .speculative_bal_build(true);
+    let _state = run(setup, |metric, value| {
+        if metric.contains("_speculative_bal_build_used") {
+            let value = value.parse::<u64>().unwrap();
+            let reached = value >= 1;
+            if reached {
+                stop_saw_use.store(true, Ordering::Relaxed);
+            }
+            reached
+        } else if metric.ends_with("_marshal_processed_height") {
+            let value = value.parse::<u64>().unwrap();
+            value >= 20
+        } else {
+            false
+        }
+    });
+    assert!(saw_use.load(Ordering::Relaxed));
 }
 
 #[test_traced]

--- a/crates/e2e/src/tests/simple.rs
+++ b/crates/e2e/src/tests/simple.rs
@@ -26,43 +26,14 @@ fn single_node() {
     });
 }
 
-#[cfg(not(feature = "bal"))]
-#[test_traced]
-fn speculative_bal_build_falls_back_without_bal_sidecars() {
-    let _ = tempo_eyre::install();
-
-    let saw_fallback = Arc::new(AtomicBool::new(false));
-    let stop_saw_fallback = saw_fallback.clone();
-    let setup = Setup::new()
-        .how_many_signers(1)
-        .epoch_length(100)
-        .seed(0)
-        .speculative_bal_build(true);
-    let _state = run(setup, |metric, value| {
-        if metric.contains("_speculative_bal_build_fallbacks") {
-            let value = value.parse::<u64>().unwrap();
-            let reached = value >= 1;
-            if reached {
-                stop_saw_fallback.store(true, Ordering::Relaxed);
-            }
-            reached
-        } else if metric.ends_with("_marshal_processed_height") {
-            let value = value.parse::<u64>().unwrap();
-            value >= 20
-        } else {
-            false
-        }
-    });
-    assert!(saw_fallback.load(Ordering::Relaxed));
-}
-
-#[cfg(feature = "bal")]
 #[test_traced]
 fn speculative_bal_build_uses_parent_bal_sidecar() {
     let _ = tempo_eyre::install();
 
     let saw_use = Arc::new(AtomicBool::new(false));
     let stop_saw_use = saw_use.clone();
+    let saw_fallback = Arc::new(AtomicBool::new(false));
+    let stop_saw_fallback = saw_fallback.clone();
     let setup = Setup::new()
         .how_many_signers(1)
         .epoch_length(100)
@@ -75,15 +46,22 @@ fn speculative_bal_build_uses_parent_bal_sidecar() {
             if reached {
                 stop_saw_use.store(true, Ordering::Relaxed);
             }
-            reached
+            false
+        } else if metric.contains("_speculative_bal_build_fallbacks") {
+            let value = value.parse::<u64>().unwrap();
+            if value > 0 {
+                stop_saw_fallback.store(true, Ordering::Relaxed);
+            }
+            false
         } else if metric.ends_with("_marshal_processed_height") {
             let value = value.parse::<u64>().unwrap();
-            value >= 20
+            value >= 20 && stop_saw_use.load(Ordering::Relaxed)
         } else {
             false
         }
     });
     assert!(saw_use.load(Ordering::Relaxed));
+    assert!(!saw_fallback.load(Ordering::Relaxed));
 }
 
 #[test_traced]

--- a/crates/e2e/src/tests/simple.rs
+++ b/crates/e2e/src/tests/simple.rs
@@ -2,7 +2,7 @@
 use std::{
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::Duration,
 };
@@ -10,6 +10,10 @@ use std::{
 use crate::{Setup, run};
 use commonware_macros::test_traced;
 use commonware_p2p::simulated::Link;
+use reth_node_metrics::recorder::{PrometheusRecorder, install_prometheus_recorder};
+
+const SPARSE_TRIE_STATE_ROOT_WAIT_COUNT_METRIC: &str =
+    "reth_tempo_payload_builder_sparse_trie_state_root_wait_duration_seconds_count";
 
 #[test_traced]
 fn single_node() {
@@ -29,11 +33,14 @@ fn single_node() {
 #[test_traced]
 fn speculative_bal_build_uses_parent_bal_sidecar() {
     let _ = tempo_eyre::install();
+    let metrics_recorder = install_prometheus_recorder();
+    let initial_sparse_trie_state_root_wait_count =
+        prometheus_histogram_count(metrics_recorder, SPARSE_TRIE_STATE_ROOT_WAIT_COUNT_METRIC);
 
     let saw_use = Arc::new(AtomicBool::new(false));
     let stop_saw_use = saw_use.clone();
-    let saw_fallback = Arc::new(AtomicBool::new(false));
-    let stop_saw_fallback = saw_fallback.clone();
+    let fallback_count = Arc::new(AtomicU64::new(0));
+    let stop_fallback_count = fallback_count.clone();
     let setup = Setup::new()
         .how_many_signers(1)
         .epoch_length(100)
@@ -49,9 +56,7 @@ fn speculative_bal_build_uses_parent_bal_sidecar() {
             false
         } else if metric.contains("_speculative_bal_build_fallbacks") {
             let value = value.parse::<u64>().unwrap();
-            if value > 0 {
-                stop_saw_fallback.store(true, Ordering::Relaxed);
-            }
+            stop_fallback_count.store(value, Ordering::Relaxed);
             false
         } else if metric.ends_with("_marshal_processed_height") {
             let value = value.parse::<u64>().unwrap();
@@ -60,8 +65,31 @@ fn speculative_bal_build_uses_parent_bal_sidecar() {
             false
         }
     });
+    let final_sparse_trie_state_root_wait_count =
+        prometheus_histogram_count(metrics_recorder, SPARSE_TRIE_STATE_ROOT_WAIT_COUNT_METRIC);
+
     assert!(saw_use.load(Ordering::Relaxed));
-    assert!(!saw_fallback.load(Ordering::Relaxed));
+    assert!(
+        final_sparse_trie_state_root_wait_count > initial_sparse_trie_state_root_wait_count,
+        "expected sparse trie state-root wait metric to increase"
+    );
+    assert!(
+        fallback_count.load(Ordering::Relaxed) <= 1,
+        "expected at most one bootstrap fallback before BAL sidecars are available"
+    );
+}
+
+fn prometheus_histogram_count(recorder: &PrometheusRecorder, metric: &str) -> u64 {
+    recorder.handle().run_upkeep();
+    recorder
+        .handle()
+        .render()
+        .lines()
+        .find_map(|line| {
+            let mut parts = line.split_whitespace();
+            (parts.next()? == metric).then(|| parts.next()?.parse().ok())?
+        })
+        .unwrap_or(0)
 }
 
 #[test_traced]

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -34,6 +34,7 @@ alloy-rlp.workspace = true
 alloy-evm.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
+alloy-rpc-types-eth = { workspace = true, optional = true }
 
 derive_more.workspace = true
 thiserror.workspace = true
@@ -55,7 +56,7 @@ tempo-primitives = { workspace = true, features = ["arbitrary"] }
 
 [features]
 default = ["rpc", "engine"]
-rpc = ["dep:reth-rpc-eth-api", "tempo-revm/rpc", "tempo-primitives/serde", "tempo-primitives/reth-codec"]
+rpc = ["dep:alloy-rpc-types-eth", "dep:reth-rpc-eth-api", "tempo-revm/rpc", "tempo-primitives/serde", "tempo-primitives/reth-codec"]
 engine = ["dep:tempo-payload-types", "dep:rayon"]
 
 [[bench]]

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -4,8 +4,7 @@ use alloy_evm::{
     Database, Evm, RecoveredTx,
     block::{
         BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockValidationError,
-        ExecutableTx, GasOutput, OnStateHook, StateChangePreBlockSource, StateChangeSource,
-        TxResult,
+        ExecutableTx, GasOutput, TxResult,
     },
     eth::{
         EthBlockExecutor, EthTxResult,
@@ -205,10 +204,6 @@ where
             account.info.code = Some(code);
             account.mark_touch();
             let state = EvmState::from_iter([(address, account)]);
-            self.inner.system_caller.on_state(
-                StateChangeSource::PreBlock(StateChangePreBlockSource::BlockHashesContract),
-                &state,
-            );
             self.inner.evm.db_mut().commit(state);
         }
         Ok(())
@@ -647,10 +642,6 @@ where
         }
 
         Ok((evm, result))
-    }
-
-    fn set_state_hook(&mut self, hook: Option<Box<dyn OnStateHook>>) {
-        self.inner.set_state_hook(hook)
     }
 
     fn evm_mut(&mut self) -> &mut Self::Evm {
@@ -1716,17 +1707,14 @@ mod tests {
             .with_parent_beacon_block_root(B256::ZERO)
             .build(&mut db, &chainspec);
 
-        let hook_calls: Arc<Mutex<Vec<(StateChangeSource, EvmState)>>> =
-            Arc::new(Mutex::new(Vec::new()));
+        let hook_calls: Arc<Mutex<Vec<EvmState>>> = Arc::new(Mutex::new(Vec::new()));
         let hook_calls_clone = hook_calls.clone();
-        executor.set_state_hook(Some(Box::new(
-            move |source: StateChangeSource, state: &EvmState| {
-                hook_calls_clone
-                    .lock()
-                    .unwrap()
-                    .push((source, state.clone()));
-            },
-        )));
+        executor
+            .evm_mut()
+            .db_mut()
+            .set_state_hook(Some(Box::new(move |state: &EvmState| {
+                hook_calls_clone.lock().unwrap().push(state.clone());
+            })));
 
         let addr = Address::with_last_byte(0xff);
         executor.deploy_precompile_at_boundary(addr).unwrap();
@@ -1740,11 +1728,11 @@ mod tests {
         let calls = hook_calls.lock().unwrap();
         assert_eq!(calls.len(), 1, "state hook should be called exactly once");
         assert!(
-            calls[0].1.contains_key(&addr),
+            calls[0].contains_key(&addr),
             "state hook should contain the deployed address"
         );
         assert_eq!(
-            calls[0].1[&addr].original_info(),
+            calls[0][&addr].original_info(),
             Default::default(),
             "state hook account should preserve original_info"
         );
@@ -1768,24 +1756,21 @@ mod tests {
             .with_parent_beacon_block_root(B256::ZERO)
             .build(&mut db, &chainspec);
 
-        let hook_calls: Arc<Mutex<Vec<(StateChangeSource, EvmState)>>> =
-            Arc::new(Mutex::new(Vec::new()));
+        let hook_calls: Arc<Mutex<Vec<EvmState>>> = Arc::new(Mutex::new(Vec::new()));
         let hook_calls_clone = hook_calls.clone();
-        executor.set_state_hook(Some(Box::new(
-            move |source: StateChangeSource, state: &EvmState| {
-                hook_calls_clone
-                    .lock()
-                    .unwrap()
-                    .push((source, state.clone()));
-            },
-        )));
+        executor
+            .evm_mut()
+            .db_mut()
+            .set_state_hook(Some(Box::new(move |state: &EvmState| {
+                hook_calls_clone.lock().unwrap().push(state.clone());
+            })));
 
         executor.deploy_precompile_at_boundary(addr).unwrap();
 
         let calls = hook_calls.lock().unwrap();
         assert_eq!(calls.len(), 1, "state hook should be called exactly once");
         assert_eq!(
-            calls[0].1[&addr].original_info(),
+            calls[0][&addr].original_info(),
             original_info,
             "state hook account should preserve existing original_info"
         );

--- a/crates/evm/src/context.rs
+++ b/crates/evm/src/context.rs
@@ -52,9 +52,12 @@ pub struct TempoNextBlockEnvAttributes {
 impl reth_rpc_eth_api::helpers::pending_block::BuildPendingEnv<tempo_primitives::TempoHeader>
     for TempoNextBlockEnvAttributes
 {
-    fn build_pending_env(parent: &crate::SealedHeader<tempo_primitives::TempoHeader>) -> Self {
+    fn build_pending_env(
+        parent: &crate::SealedHeader<tempo_primitives::TempoHeader>,
+        block_overrides: Option<&alloy_rpc_types_eth::BlockOverrides>,
+    ) -> Self {
         Self {
-            inner: NextBlockEnvAttributes::build_pending_env(parent),
+            inner: NextBlockEnvAttributes::build_pending_env(parent, block_overrides),
             general_gas_limit: parent.general_gas_limit,
             shared_gas_limit: parent.shared_gas_limit,
             timestamp_millis_part: parent.timestamp_millis_part,
@@ -91,7 +94,7 @@ mod tests {
             ..Default::default()
         };
         let parent = SealedHeader::seal_slow(parent_header);
-        let pending_env = TempoNextBlockEnvAttributes::build_pending_env(&parent);
+        let pending_env = TempoNextBlockEnvAttributes::build_pending_env(&parent, None);
 
         // Verify values are copied directly from parent
         assert_eq!(pending_env.general_gas_limit, general_gas_limit);

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -386,7 +386,7 @@ pub struct TempoConsensusBuilder {
 impl Default for TempoConsensusBuilder {
     fn default() -> Self {
         Self {
-            allow_bal_hashes: cfg!(feature = "bal"),
+            allow_bal_hashes: true,
         }
     }
 }

--- a/crates/node/tests/it/eth_call.rs
+++ b/crates/node/tests/it/eth_call.rs
@@ -510,13 +510,20 @@ async fn test_eth_estimate_gas_validator_fee_token_mismatch() -> eyre::Result<()
 
     *dynamic_validator.lock().unwrap() = wallet_address;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-
-    let block = provider
-        .get_block(BlockId::latest())
-        .await?
-        .expect("Could not get latest block");
-    assert_eq!(block.header.beneficiary, wallet_address);
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let block = provider
+            .get_block(BlockId::latest())
+            .await?
+            .expect("Could not get latest block");
+        if block.header.beneficiary == wallet_address {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            assert_eq!(block.header.beneficiary, wallet_address);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
 
     let recipient = Address::random();
     let calldata = user_fee_token

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -41,7 +41,7 @@ use reth_evm::{
     execute::BlockAssemblerInput,
 };
 use reth_execution_types::BlockExecutionOutput;
-use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError};
+use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError, PayloadStateAnchor};
 use reth_payload_primitives::{BuiltPayload, BuiltPayloadExecutedBlock};
 use reth_primitives_traits::{
     Recovered, RecoveredBlock, transaction::error::InvalidTransactionError,
@@ -73,7 +73,7 @@ use tempo_primitives::{
     transaction::envelope::{TEMPO_SYSTEM_TX_SENDER, TEMPO_SYSTEM_TX_SIGNATURE},
 };
 use tempo_transaction_pool::{
-    StateAwareBestTransactions, TempoTransactionPool,
+    ExcludingBestTransactions, StateAwareBestTransactions, TempoTransactionPool,
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
 use tokio::sync::oneshot;
@@ -88,6 +88,24 @@ fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> boo
                 .is_some_and(|valid| valid.get() <= timestamp)
         })
     })
+}
+
+fn should_prewarm_best_transactions(enable_prewarming: bool, is_speculative: bool) -> bool {
+    enable_prewarming && !is_speculative
+}
+
+fn state_aware_best_transactions_for_build<Txs>(
+    best_txs: Txs,
+    is_speculative: bool,
+) -> StateAwareBestTransactions<Txs>
+where
+    Txs: BestTransactions<Item = Arc<ValidPoolTransaction<TempoPooledTransaction>>> + Send,
+{
+    let mut best_txs = StateAwareBestTransactions::new(best_txs);
+    if is_speculative {
+        best_txs.no_updates();
+    }
+    best_txs
 }
 
 #[derive(Debug, Clone)]
@@ -253,10 +271,19 @@ where
         &self,
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
     ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
+        self.try_build_with_state_anchor(args, PayloadStateAnchor::Canonical)
+    }
+
+    fn try_build_with_state_anchor(
+        &self,
+        args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
+        state_anchor: PayloadStateAnchor,
+    ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
         self.build_payload(
             args,
             |attributes| self.pool.best_transactions_with_attributes(attributes),
             false,
+            state_anchor,
         )
     }
 
@@ -271,6 +298,14 @@ where
         &self,
         config: PayloadConfig<Self::Attributes, TempoHeader>,
     ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
+        self.build_empty_payload_with_state_anchor(config, PayloadStateAnchor::Canonical)
+    }
+
+    fn build_empty_payload_with_state_anchor(
+        &self,
+        config: PayloadConfig<Self::Attributes, TempoHeader>,
+        state_anchor: PayloadStateAnchor,
+    ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
         self.build_payload(
             BuildArguments::new(
                 Default::default(),
@@ -282,6 +317,7 @@ where
             ),
             |_| core::iter::empty(),
             true,
+            state_anchor,
         )?
         .into_payload()
         .ok_or_else(|| PayloadBuilderError::MissingPayload)
@@ -307,6 +343,7 @@ where
         args: BuildArguments<TempoPayloadAttributes, TempoBuiltPayload>,
         best_txs: impl FnOnce(BestTransactionsAttributes) -> Txs,
         empty: bool,
+        state_anchor: PayloadStateAnchor,
     ) -> Result<BuildOutcome<TempoBuiltPayload>, PayloadBuilderError>
     where
         Txs: BestTransactions<Item = Arc<ValidPoolTransaction<TempoPooledTransaction>>>
@@ -327,6 +364,7 @@ where
             attributes,
             payload_id,
         } = config;
+        let is_speculative = state_anchor.is_speculative();
         let build_once_with_shared_trie =
             // When trie handle is provided, we build the payload once so the shared trie can be reused.
             trie_handle.is_some()
@@ -335,7 +373,11 @@ where
 
         macro_rules! check_cancel {
             () => {
-                if cancel.is_cancelled() {
+                if cancel.is_cancelled()
+                    || state_anchor
+                        .validity_dependency()
+                        .is_some_and(|token| token.should_discard())
+                {
                     return Ok(BuildOutcome::Cancelled);
                 }
             };
@@ -352,7 +394,17 @@ where
 
         let state_setup_start = Instant::now();
         let _state_setup_span = debug_span!(target: "payload_builder", "state_setup").entered();
-        let mut state_provider = self.provider.state_by_block_hash(parent_header.hash())?;
+        let mut state_provider = if let Some(provider) = state_anchor.state_provider() {
+            trace!(
+                target: "payload_builder",
+                id = %payload_id,
+                label = %provider.label(),
+                "opening speculative payload state provider"
+            );
+            provider.open()?
+        } else {
+            self.provider.state_by_block_hash(parent_header.hash())?
+        };
         if let Some(execution_cache) = &execution_cache {
             state_provider = Box::new(CachedStateProvider::new(
                 state_provider,
@@ -487,7 +539,10 @@ where
         maybe_override_fee_recipient(&mut executor, &attributes);
 
         if let Some(ref handle) = trie_handle {
-            executor.set_state_hook(Some(Box::new(handle.state_hook())));
+            executor
+                .evm_mut()
+                .db_mut()
+                .set_state_hook(Some(Box::new(handle.state_hook())));
         }
 
         executor.apply_pre_execution_changes().map_err(|err| {
@@ -523,20 +578,27 @@ where
                 .blob_gasprice()
                 .map(|gasprice| gasprice as u64),
         ));
+        let best_txs = ExcludingBestTransactions::new(
+            best_txs,
+            attributes.excluded_transaction_hashes().iter().copied(),
+        );
         // Wrap best transactions into state-aware wrapper to skip transactions that
         // get invalidated by already-executed ones.
-        let mut best_txs = StateAwareBestTransactions::new(if self.enable_prewarming {
-            Box::new(BestTransactionsPrewarming::new(
-                self.executor.clone(),
-                self.provider.clone(),
-                execution_cache,
-                parent_header.hash(),
-                executor.evm().evm_env(),
-                best_txs,
-            )) as Box<dyn BestTransactions<Item = _>>
-        } else {
-            Box::new(best_txs)
-        });
+        let mut best_txs = state_aware_best_transactions_for_build(
+            if should_prewarm_best_transactions(self.enable_prewarming, is_speculative) {
+                Box::new(BestTransactionsPrewarming::new(
+                    self.executor.clone(),
+                    self.provider.clone(),
+                    execution_cache,
+                    parent_header.hash(),
+                    executor.evm().evm_env(),
+                    best_txs,
+                )) as Box<dyn BestTransactions<Item = _>>
+            } else {
+                Box::new(best_txs)
+            },
+            is_speculative,
+        );
         self.metrics
             .pool_fetch_duration_seconds
             .record(pool_fetch_start.elapsed());
@@ -1262,6 +1324,7 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes};
     use core::num::NonZeroU64;
     use reth_primitives_traits::Block as _;
+    use std::sync::atomic::AtomicBool;
     use tempo_primitives::{
         AASigned, Block, SignedSubBlock, SubBlock, SubBlockVersion, TempoSignature,
         TempoTransaction,
@@ -1269,6 +1332,61 @@ mod tests {
 
     fn nz(value: u64) -> NonZeroU64 {
         NonZeroU64::new(value).expect("test valid_before must be non-zero")
+    }
+
+    struct RecordingBestTransactions {
+        no_updates_called: Arc<AtomicBool>,
+    }
+
+    impl Iterator for RecordingBestTransactions {
+        type Item = Arc<ValidPoolTransaction<TempoPooledTransaction>>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    impl BestTransactions for RecordingBestTransactions {
+        fn mark_invalid(&mut self, _: &Self::Item, _: InvalidPoolTransactionError) {}
+
+        fn no_updates(&mut self) {
+            self.no_updates_called.store(true, Ordering::Relaxed);
+        }
+
+        fn set_skip_blobs(&mut self, _: bool) {}
+    }
+
+    #[test]
+    fn prewarming_is_disabled_for_speculative_builds() {
+        assert!(should_prewarm_best_transactions(true, false));
+        assert!(!should_prewarm_best_transactions(true, true));
+        assert!(!should_prewarm_best_transactions(false, false));
+    }
+
+    #[test]
+    fn speculative_best_transactions_suppress_live_pool_updates() {
+        let no_updates_called = Arc::new(AtomicBool::new(false));
+        let _best_txs = state_aware_best_transactions_for_build(
+            RecordingBestTransactions {
+                no_updates_called: no_updates_called.clone(),
+            },
+            true,
+        );
+
+        assert!(no_updates_called.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn canonical_best_transactions_keep_live_pool_updates() {
+        let no_updates_called = Arc::new(AtomicBool::new(false));
+        let _best_txs = state_aware_best_transactions_for_build(
+            RecordingBestTransactions {
+                no_updates_called: no_updates_called.clone(),
+            },
+            false,
+        );
+
+        assert!(!no_updates_called.load(Ordering::Relaxed));
     }
 
     trait TestExt {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -927,6 +927,10 @@ where
         self.metrics
             .system_transactions_execution_duration_seconds
             .record(system_txs_execution_elapsed);
+        if trie_handle.is_some() {
+            // Dropping the hook sends FinishedStateUpdates to the shared trie before we wait on it.
+            executor.evm_mut().db_mut().set_state_hook(None);
+        }
 
         let total_transaction_execution_elapsed = normal_transaction_fill_elapsed
             + total_subblock_transaction_execution_elapsed

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -108,6 +108,27 @@ where
     best_txs
 }
 
+const EMPTY_POOL_INITIAL_IDLE_LIMIT: Duration = Duration::from_millis(25);
+
+fn should_wait_for_more_pool_transactions(
+    build_once_with_shared_trie: bool,
+    has_payload_build_budget: bool,
+    cumulative_gas_used: u64,
+    non_shared_gas_limit: u64,
+    pool_transactions_yielded: u64,
+    normal_transaction_fill_idle_elapsed: Duration,
+) -> bool {
+    if !build_once_with_shared_trie
+        || !has_payload_build_budget
+        || cumulative_gas_used >= non_shared_gas_limit
+    {
+        return false;
+    }
+
+    pool_transactions_yielded > 0
+        || normal_transaction_fill_idle_elapsed < EMPTY_POOL_INITIAL_IDLE_LIMIT
+}
+
 #[derive(Debug, Clone)]
 pub struct TempoPayloadBuilder<Provider> {
     pool: TempoTransactionPool<Provider>,
@@ -644,10 +665,14 @@ where
             }
 
             let Some(pool_tx) = best_txs.next() else {
-                if build_once_with_shared_trie
-                    && payload_build_budget.is_some()
-                    && cumulative_gas_used < non_shared_gas_limit
-                {
+                if should_wait_for_more_pool_transactions(
+                    build_once_with_shared_trie,
+                    payload_build_budget.is_some(),
+                    cumulative_gas_used,
+                    non_shared_gas_limit,
+                    pool_transactions_yielded,
+                    normal_transaction_fill_idle_elapsed,
+                ) {
                     std::thread::sleep(Duration::from_millis(1));
                     normal_transaction_fill_idle_elapsed += Duration::from_millis(1);
                     continue;
@@ -1387,6 +1412,34 @@ mod tests {
         );
 
         assert!(!no_updates_called.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn shared_trie_builds_do_not_spend_full_budget_on_initial_empty_pool() {
+        assert!(should_wait_for_more_pool_transactions(
+            true,
+            true,
+            0,
+            1_000_000,
+            0,
+            Duration::ZERO,
+        ));
+        assert!(!should_wait_for_more_pool_transactions(
+            true,
+            true,
+            0,
+            1_000_000,
+            0,
+            EMPTY_POOL_INITIAL_IDLE_LIMIT,
+        ));
+        assert!(should_wait_for_more_pool_transactions(
+            true,
+            true,
+            0,
+            1_000_000,
+            1,
+            EMPTY_POOL_INITIAL_IDLE_LIMIT,
+        ));
     }
 
     trait TestExt {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -153,8 +153,6 @@ pub struct TempoPayloadBuilder<Provider> {
     state_provider_metrics: bool,
     /// Whether to enable prewarming of best transactions.
     enable_prewarming: bool,
-    /// Whether to include block access lists in built execution payloads.
-    enable_bal: bool,
     /// Learned estimate of total replayable build work divided by work at tx cutoff.
     ///
     /// This lets the builder reserve time for non-interruptible
@@ -209,7 +207,6 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             is_dev: config.is_dev,
             state_provider_metrics: config.state_provider_metrics,
             enable_prewarming: config.enable_prewarming,
-            enable_bal: cfg!(feature = "bal"),
             build_time_multiplier: Arc::new(AtomicU64::new(scaled_build_time_multiplier(
                 config.build_time_multiplier,
             ))),
@@ -441,7 +438,7 @@ where
         let mut db = State::builder()
             .with_database(Box::new(state) as Box<dyn Database<Error = ProviderError>>)
             .with_bundle_update()
-            .with_bal_builder_if(self.enable_bal)
+            .with_bal_builder()
             .build();
         drop(_state_setup_span);
         self.metrics
@@ -1146,6 +1143,9 @@ where
             timestamp = block.timestamp_millis(),
             gas_limit = block.gas_limit(),
             gas_used,
+            block_access_list_hash = ?block.block_access_list_hash(),
+            block_access_list_accounts = block_access_list.as_ref().map_or(0, Vec::len),
+            block_access_list_rlp_bytes = block_access_list.as_ref().map_or(0, Encodable::length),
             cumulative_state_gas_used,
             extra_data = %block.extra_data(),
             subblocks_count,

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -97,13 +97,10 @@ impl BestTransactionsPrewarming {
         Provider: StateProviderFactory + Clone + 'static,
     {
         let pool = executor.prewarming_pool();
+        let prewarm = ctx.prewarm.clone();
+        pool.init::<PrewarmEvmState>(|_| prewarm.evm_for_ctx());
 
         pool.in_place_scope(|scope| {
-            let prewarm = ctx.prewarm.clone();
-            scope.spawn(move |_| {
-                pool.init::<PrewarmEvmState>(|_| prewarm.evm_for_ctx());
-            });
-
             let advance = |ctx: &mut BestTransactionsPrewarmingContext<Txs, Provider>| {
                 let Some(tx) = ctx.best_txs.next() else {
                     let _ = ctx.transactions_tx.send(None);
@@ -997,7 +994,7 @@ mod tests {
     }
 
     #[test]
-    fn prewarming_does_not_use_shared_worker_state_slot() {
+    fn prewarming_replaces_stale_worker_state_before_tasks() {
         let executor = TaskExecutor::test();
         let pool = executor.prewarming_pool();
         pool.init::<usize>(|existing| existing.map(|value| *value).unwrap_or(1));
@@ -1008,8 +1005,13 @@ mod tests {
         let mut prewarming = prewarming_with_executor(executor.clone(), txs, log);
 
         assert!(prewarming.next().is_some());
+        drop(prewarming);
 
         pool.broadcast(pool.current_num_threads(), |worker| {
+            worker.init::<usize>(|existing| {
+                assert!(existing.is_none());
+                1
+            });
             assert_eq!(*worker.get::<usize>(), 1);
         });
     }

--- a/crates/payload/types/src/attrs.rs
+++ b/crates/payload/types/src/attrs.rs
@@ -27,6 +27,10 @@ pub struct TempoPayloadAttributes {
     /// builder should not stop early for block pacing.
     #[serde(skip)]
     payload_build_budget: Option<Duration>,
+    /// Transactions that should be treated as already consumed for this local
+    /// payload build without mutating the live pool.
+    #[serde(skip, default = "default_excluded_transaction_hashes")]
+    excluded_transaction_hashes: Arc<[B256]>,
     /// Milliseconds portion of the timestamp.
     timestamp_millis_part: u64,
     /// DKG ceremony data to include in the block's extra_data header field.
@@ -76,6 +80,7 @@ impl TempoPayloadAttributes {
                 slot_number: None,
             },
             payload_build_budget: None,
+            excluded_transaction_hashes: Arc::from([]),
             timestamp_millis_part,
             extra_data,
             proposer_public_key,
@@ -113,6 +118,21 @@ impl TempoPayloadAttributes {
         self.payload_build_budget
     }
 
+    /// Sets transaction hashes that should be skipped by this payload build's
+    /// local best-transaction iterator.
+    pub fn with_excluded_transaction_hashes(
+        mut self,
+        hashes: impl IntoIterator<Item = B256>,
+    ) -> Self {
+        self.excluded_transaction_hashes = hashes.into_iter().collect::<Vec<_>>().into();
+        self
+    }
+
+    /// Returns the transaction hashes excluded from this local payload build.
+    pub fn excluded_transaction_hashes(&self) -> &[B256] {
+        &self.excluded_transaction_hashes
+    }
+
     /// Returns the milliseconds portion of the timestamp.
     pub fn timestamp_millis_part(&self) -> u64 {
         self.timestamp_millis_part
@@ -145,6 +165,7 @@ impl From<EthPayloadAttributes> for TempoPayloadAttributes {
         Self {
             inner,
             payload_build_budget: None,
+            excluded_transaction_hashes: Arc::from([]),
             timestamp_millis_part: 0,
             extra_data: Bytes::default(),
             proposer_public_key: None,
@@ -225,6 +246,10 @@ fn payload_id_from_parent_and_context(
 
 fn default_subblocks() -> Arc<dyn Fn() -> Vec<RecoveredSubBlock> + Send + Sync + 'static> {
     Arc::new(Vec::new)
+}
+
+fn default_excluded_transaction_hashes() -> Arc<[B256]> {
+    Arc::from([])
 }
 
 #[cfg(test)]
@@ -427,6 +452,20 @@ mod tests {
         let mut attrs = attrs;
         attrs.timestamp = 123;
         assert_eq!(attrs.inner.timestamp, 123);
+    }
+
+    #[test]
+    fn excluded_transaction_hashes_are_local_build_state() {
+        let excluded = B256::random();
+        let attrs = TempoPayloadAttributes::random().with_excluded_transaction_hashes([excluded]);
+
+        assert_eq!(attrs.excluded_transaction_hashes(), &[excluded]);
+
+        let json = serde_json::to_string(&attrs).unwrap();
+        assert!(!json.contains("excludedTransactionHashes"));
+
+        let deserialized: TempoPayloadAttributes = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.excluded_transaction_hashes().is_empty());
     }
 
     #[test]

--- a/crates/transaction-pool/src/best.rs
+++ b/crates/transaction-pool/src/best.rs
@@ -4,7 +4,10 @@ use crate::{
     ordering::TempoTipOrdering, transaction::TempoPooledTransaction,
     tt_2d_pool::BestAA2dTransactions,
 };
-use alloy_primitives::{Address, U256, map::HashMap};
+use alloy_primitives::{
+    Address, B256, U256,
+    map::{B256Set, HashMap},
+};
 use reth_evm::block::TxResult;
 use reth_primitives_traits::transaction::error::InvalidTransactionError;
 use reth_transaction_pool::{
@@ -108,6 +111,60 @@ impl BestTransactions for MergeBestTransactions {
     fn set_skip_blobs(&mut self, skip_blobs: bool) {
         self.protocol_pool.set_skip_blobs(skip_blobs);
         self.aa_2d_pool.set_skip_blobs(skip_blobs);
+    }
+}
+
+/// A best-transaction iterator that consumes, but does not return, excluded transactions.
+///
+/// This is useful for branch-local block building: the skipped transaction is
+/// treated like a mined transaction for this iterator view, so nonce descendants
+/// can still be unlocked without mutating the live pool.
+pub struct ExcludingBestTransactions<I> {
+    inner: I,
+    excluded: B256Set,
+}
+
+impl<I> ExcludingBestTransactions<I> {
+    /// Creates a wrapper that skips any transaction whose hash is in `excluded`.
+    pub fn new(inner: I, excluded: impl IntoIterator<Item = B256>) -> Self {
+        Self {
+            inner,
+            excluded: excluded.into_iter().collect(),
+        }
+    }
+}
+
+impl<I> Iterator for ExcludingBestTransactions<I>
+where
+    I: BestTransactions<Item = Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
+{
+    type Item = Arc<ValidPoolTransaction<TempoPooledTransaction>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let tx = self.inner.next()?;
+            if self.excluded.contains(tx.hash()) {
+                continue;
+            }
+            return Some(tx);
+        }
+    }
+}
+
+impl<I> BestTransactions for ExcludingBestTransactions<I>
+where
+    I: BestTransactions<Item = Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
+{
+    fn mark_invalid(&mut self, transaction: &Self::Item, kind: InvalidPoolTransactionError) {
+        self.inner.mark_invalid(transaction, kind);
+    }
+
+    fn no_updates(&mut self) {
+        self.inner.no_updates();
+    }
+
+    fn set_skip_blobs(&mut self, skip_blobs: bool) {
+        self.inner.set_skip_blobs(skip_blobs);
     }
 }
 
@@ -308,6 +365,34 @@ mod tests {
             protocol_best_transactions(protocol_txs),
             aa_2d_best_transactions(aa_2d_txs),
         )
+    }
+
+    #[test]
+    fn excluded_best_transactions_skip_protocol_tx_and_unlock_descendant() {
+        let sender = Address::random();
+        let tx0 = protocol_tx_for_sender(sender, 0, 10);
+        let tx1 = protocol_tx_for_sender(sender, 1, 9);
+        let mut best = ExcludingBestTransactions::new(
+            protocol_best_transactions(vec![tx0.clone(), tx1.clone()]),
+            [*tx0.hash()],
+        );
+
+        assert_eq!(best.next().map(|tx| *tx.hash()), Some(*tx1.hash()));
+        assert!(best.next().is_none());
+    }
+
+    #[test]
+    fn excluded_best_transactions_skip_aa_2d_tx_and_unlock_descendant() {
+        let sender = Address::random();
+        let tx0 = aa_2d_tx_for_sequence(sender, 0, 10);
+        let tx1 = aa_2d_tx_for_sequence(sender, 1, 9);
+        let mut best = ExcludingBestTransactions::new(
+            aa_2d_best_transactions(vec![tx0.clone(), tx1.clone()]),
+            [*tx0.hash()],
+        );
+
+        assert_eq!(best.next().map(|tx| *tx.hash()), Some(*tx1.hash()));
+        assert!(best.next().is_none());
     }
 
     #[test]

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -22,7 +22,7 @@ pub mod ordering;
 pub mod paused;
 pub mod tt_2d_pool;
 
-pub use best::StateAwareBestTransactions;
+pub use best::{ExcludingBestTransactions, StateAwareBestTransactions};
 pub use maintain::TempoPoolUpdates;
 
 pub use metrics::{AA2dPoolMetrics, TempoPoolMaintenanceMetrics};

--- a/docs/speculative-bal-build.md
+++ b/docs/speculative-bal-build.md
@@ -1,0 +1,54 @@
+# Speculative BAL Payload Builds
+
+Tempo can opt in to building the next proposal while the parent block is still
+being validated with `--consensus.speculative-bal-build`. The flag is disabled
+by default.
+
+The optimistic path only starts when the parent block carries a block access
+list sidecar. Tempo decodes the sidecar, verifies it against the parent header's
+BAL hash, and asks Reth to build the child payload over a `PayloadStateAnchor`
+whose state provider is `parent.parent + parent.BAL`. Tempo also passes a
+`PayloadValidityToken` so Reth can discard the child if parent validation later
+fails.
+
+Tempo owns scheduling policy, fallback, and cancellation:
+
+- start the speculative child build before calling `newPayload` for the parent;
+- mark the validity token invalid and cancel the payload job if parent
+  validation fails;
+- mark the token invalid and fall back if the executor does not register a
+  speculative payload id promptly, or if the completed payload cannot be
+  resolved within the remaining proposal budget;
+- mark the token valid, canonicalize the parent, and resolve the already-running
+  child payload when validation succeeds;
+- use the speculative child only if the resolved block still matches the active
+  parent hash, timestamp, millisecond timestamp part, and consensus context;
+- fall back to the existing serial validate-then-build path when no BAL exists,
+  speculative setup fails, canonicalization fails, or the speculative payload
+  cannot be resolved.
+
+Reth owns the execution semantics and speculative state plumbing:
+
+- `PayloadStateAnchor`, `SpeculativePayloadState`, and `SpeculativeStateProvider`
+  carry the explicit state anchor into payload jobs;
+- `BalStateOverlay` materializes final writes from the parent BAL over the base
+  parent state provider;
+- the payload builder checks the validity token during build cancellation and
+  uses the supplied state provider instead of reopening canonical parent state.
+
+Speculative builds still use the normal best-transaction iterator. Invalid
+transaction feedback and state-aware filtering are local to that iterator, and
+Tempo disables live pool updates for speculative iterators so a failed parent
+cannot affect which later transactions a discarded child observes. Payload
+prewarming is also disabled for speculative builds so it does not read or prime
+canonical-parent state while the child is anchored to the BAL overlay.
+
+Reth owns generic execution-cache generation, sparse trie sharing, and BAL
+overlay internals. Tempo only supplies the parent BAL, validity dependency, and
+scheduling policy for when a speculative child is allowed to be used.
+
+The path emits `speculative_bal_build_attempts`,
+`speculative_bal_build_started`, `speculative_bal_build_used`,
+`speculative_bal_build_cancelled`, and `speculative_bal_build_fallbacks` metrics.
+Logs include parent validation and payload build timing when a speculative
+payload is used.


### PR DESCRIPTION
Build child payloads over the parent BAL while parent validation is still in flight, with cancellation/fallback handling and local transaction exclusion for parent-mined transactions.

