### PR TITLE
fix(follower): don't hard fail when consensus block is missing

### DIFF
--- a/crates/commonware-node/src/follow/driver.rs
+++ b/crates/commonware-node/src/follow/driver.rs
@@ -265,8 +265,8 @@ where
                 warn!(
                     "cannot heal finalization gap; consensus layer epoch {consensus_epoch} is ahead \
                     of execution layer epoch {execution_epoch}, but the consensus layer does not have \
-                    the boundary block at height `{last_consensus_boundary}`. the node likely previously skipped \
-                    epoch boundaries via the network identity"
+                    the boundary block at height `{last_consensus_boundary}`. The node likely previously skipped \
+                    epoch boundaries via the network identity and will continue to try use it to verify finalizations"
                 );
 
                 return Ok(());

--- a/crates/commonware-node/src/follow/driver.rs
+++ b/crates/commonware-node/src/follow/driver.rs
@@ -256,19 +256,17 @@ where
                 .epoch_strategy
                 .last(previous)
                 .expect("strategy is valid for all heights and epochs");
-            let boundary_block = self
-                .config
-                .marshal
-                .get_block(last_consensus_boundary)
-                .await
-                .ok_or_else(|| {
-                    eyre::eyre!(
-                        "cannot heal finalization gap; consensus layer is \
-                        ahead of execution layer, but consensus layer does not \
-                        have boundary block at height \
-                        `{last_consensus_boundary}`"
-                    )
-                })?;
+
+            let Some(boundary_block) = self.config.marshal.get_block(last_consensus_boundary).await
+            else {
+                warn!(
+                    "cannot heal finalization gap; consensus layer is ahead of execution layer, \
+                   but consensus layer does not have the boundary block at height `{last_consensus_boundary}`. \
+                   the node likely skipped epoch boundaries via the network identity"
+                );
+
+                return Ok(());
+            };
 
             let onchain_outcome = tempo_dkg_onchain_artifacts::OnchainDkgOutcome::read(
                 &mut boundary_block.header().extra_data().as_ref(),

--- a/crates/commonware-node/src/follow/driver.rs
+++ b/crates/commonware-node/src/follow/driver.rs
@@ -242,6 +242,7 @@ where
             .epoch_strategy
             .containing(self.config.last_finalized_height)
             .expect("strategy is valid for all heights and epochs");
+
         let current_execution_epoch = self
             .config
             .epoch_strategy
@@ -259,10 +260,13 @@ where
 
             let Some(boundary_block) = self.config.marshal.get_block(last_consensus_boundary).await
             else {
+                let consensus_epoch = current_consensus_epoch.epoch();
+                let execution_epoch = current_execution_epoch.epoch();
                 warn!(
-                    "cannot heal finalization gap; consensus layer is ahead of execution layer, \
-                   but consensus layer does not have the boundary block at height `{last_consensus_boundary}`. \
-                   the node likely skipped epoch boundaries via the network identity"
+                    "cannot heal finalization gap; consensus layer epoch {consensus_epoch} is ahead \
+                    of execution layer epoch {execution_epoch}, but the consensus layer does not have \
+                    the boundary block at height `{last_consensus_boundary}`. the node likely previously skipped \
+                    epoch boundaries via the network identity"
                 );
 
                 return Ok(());


### PR DESCRIPTION
We can skip past epoch boundaries when we see a future finalization verified by the network identity. Thus on restart the last consensus boundary may not be available.

We should rely on the network identity fallback to continue chain progress rather than halting