### PR TITLE
perf(payload): use crossbeam channels for prewarming

### DIFF
--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -1,11 +1,11 @@
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
-    mpsc::{self, Receiver, Sender},
 };
 
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
 use alloy_sol_types::SolInterface;
+use crossbeam_channel::{self, Receiver, Sender};
 use reth_engine_tree::tree::{CachedStateProvider, SavedCache};
 use reth_evm::{Database, Evm, EvmEnvFor};
 use reth_revm::database::StateProviderDatabase;
@@ -52,8 +52,8 @@ impl BestTransactionsPrewarming {
         Txs: BestTransactions<Item = BestTransaction> + Send + 'static,
         Provider: StateProviderFactory + Clone + 'static,
     {
-        let (transactions_tx, transactions_rx) = mpsc::channel();
-        let (commands_tx, commands_rx) = mpsc::channel();
+        let (transactions_tx, transactions_rx) = crossbeam_channel::unbounded();
+        let (commands_tx, commands_rx) = crossbeam_channel::unbounded();
         let stop = Arc::new(AtomicBool::new(false));
         let prewarm = PrewarmingExecutionContext {
             provider,
@@ -252,7 +252,7 @@ impl Iterator for BestTransactionsPrewarming {
 
 impl BestTransactions for BestTransactionsPrewarming {
     fn mark_invalid(&mut self, transaction: &Self::Item, kind: InvalidPoolTransactionError) {
-        let (new_tx, new_rx) = mpsc::channel();
+        let (new_tx, new_rx) = crossbeam_channel::unbounded();
         let old_rx = core::mem::replace(&mut self.transactions_rx, new_rx);
         let _ = self.commands_tx.send(BestTransactionsCommand::Invalid {
             invalid: InvalidTransaction {


### PR DESCRIPTION
Swaps the prewarming coordinator channels from `std::sync::mpsc` to `crossbeam_channel::unbounded` to avoid std receiver lock overhead on the best-transactions handoff.