### PR TITLE
fix(consensus): avoid panic by mapping expired blocks to None

### DIFF
--- a/crates/commonware-node/src/storage/hybrid/mod.rs
+++ b/crates/commonware-node/src/storage/hybrid/mod.rs
@@ -85,7 +85,7 @@ use commonware_storage::{
 };
 use reth_node_core::primitives::SealedBlock;
 use reth_provider::{
-    BlockReader, BlockSource, ProviderResult,
+    BlockReader, BlockSource, ProviderError, ProviderResult,
     providers::{BlockchainProvider, ProviderNodeTypes},
 };
 use tracing::{debug, instrument, warn};
@@ -157,9 +157,16 @@ where
         if height > finalized {
             return Ok(None);
         }
-        Ok(self.block_by_number(height)?.map(|block| {
-            Block::from_execution_block_unchecked(SealedBlock::seal_slow(block), None)
-        }))
+        match self.block_by_number(height) {
+            Ok(maybe_block) => Ok(maybe_block.map(|block| {
+                Block::from_execution_block_unchecked(SealedBlock::seal_slow(block), None)
+            })),
+            Err(err @ ProviderError::BlockExpired { .. }) => {
+                warn!(error = %eyre::Report::new(err), "cannot find block");
+                Ok(None)
+            }
+            Err(bad_error) => Err(bad_error),
+        }
     }
 
     fn block_by_hash(&self, hash: B256) -> ProviderResult<Option<Block>> {

--- a/crates/commonware-node/src/storage/hybrid/mod.rs
+++ b/crates/commonware-node/src/storage/hybrid/mod.rs
@@ -88,7 +88,7 @@ use reth_provider::{
     BlockReader, BlockSource, ProviderError, ProviderResult,
     providers::{BlockchainProvider, ProviderNodeTypes},
 };
-use tracing::{debug, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 use crate::consensus::{Digest, block::Block};
 
@@ -142,6 +142,7 @@ where
             .map(|nh| nh.number)
     }
 
+    #[instrument(skip_all, fields(height), err)]
     fn block_by_height(&self, height: u64) -> ProviderResult<Option<Block>> {
         // Gate the lookup on reth's finalized watermark so the marshal can
         // never be served a block that reth has not yet marked as
@@ -162,13 +163,14 @@ where
                 Block::from_execution_block_unchecked(SealedBlock::seal_slow(block), None)
             })),
             Err(err @ ProviderError::BlockExpired { .. }) => {
-                warn!(error = %eyre::Report::new(err), "cannot find block");
+                info!(error = %eyre::Report::new(err), "cannot find block");
                 Ok(None)
             }
             Err(bad_error) => Err(bad_error),
         }
     }
 
+    #[instrument(skip_all, fields(hash), err)]
     fn block_by_hash(&self, hash: B256) -> ProviderResult<Option<Block>> {
         // `Canonical` (not `Any`) so the marshal can never be served a
         // block that lives only in reth's pending in-memory tree — see
@@ -178,7 +180,7 @@ where
                 Block::from_execution_block_unchecked(SealedBlock::seal_slow(block), None)
             })),
             Err(err @ ProviderError::BlockExpired { .. }) => {
-                warn!(error = %eyre::Report::new(err), "cannot find block");
+                info!(error = %eyre::Report::new(err), "cannot find block");
                 Ok(None)
             }
             Err(bad_error) => Err(bad_error),

--- a/crates/commonware-node/src/storage/hybrid/mod.rs
+++ b/crates/commonware-node/src/storage/hybrid/mod.rs
@@ -173,11 +173,16 @@ where
         // `Canonical` (not `Any`) so the marshal can never be served a
         // block that lives only in reth's pending in-memory tree — see
         // [`Blocks::get`] on [`Hybrid`].
-        Ok(self
-            .find_block_by_hash(hash, BlockSource::Canonical)?
-            .map(|block| {
+        match self.find_block_by_hash(hash, BlockSource::Canonical) {
+            Ok(maybe_block) => Ok(maybe_block.map(|block| {
                 Block::from_execution_block_unchecked(SealedBlock::seal_slow(block), None)
-            }))
+            })),
+            Err(err @ ProviderError::BlockExpired { .. }) => {
+                warn!(error = %eyre::Report::new(err), "cannot find block");
+                Ok(None)
+            }
+            Err(bad_error) => Err(bad_error),
+        }
     }
 }
 


### PR DESCRIPTION
Maps expired blocks to `None` when accessing finalized blocks in the execution layer.

Commonware's marshal actor panics if it encounters errors in its finalized block storage. Since introducing hybrid storage in https://github.com/tempoxyz/tempo/pull/3870, marshal is reading through to reth, which returns an error when trying to read blocks past its pruned watermark.