### PR TITLE
ci(bench): include PR number in txgen bench metadata

### DIFF
--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -290,6 +290,7 @@ def txgen-run-preset-pipeline [
     let report_args = ["--report" $"json:($report_path)"]
         | append (if $victoriametrics_url != "" { ["--report" $"victoriametrics:($victoriametrics_url)"] } else { [] })
         | append (if $clickhouse_url != "" { ["--report" $"clickhouse:($clickhouse_url)"] } else { [] })
+    let pr_number = ($env | get --optional BENCH_PR | default "")
     let metadata_args = [
         "-m" "job=github-tempo-bench-e2e"
         "-m" $"chain_id=($chain_id)"
@@ -312,6 +313,7 @@ def txgen-run-preset-pipeline [
         | append (if $run_type != "" { ["-m" $"run_type=($run_type)"] } else { [] })
         | append (if $platform != "" { ["-m" $"platform=($platform)"] } else { [] })
         | append (if $scenario != "" { ["-m" $"scenario=($scenario)"] } else { [] })
+        | append (if $pr_number != "" { ["-m" $"pr_number=($pr_number)"] } else { [] })
     let bench_cmd = $bench_base_cmd | append $report_args | append $metadata_args
 
     let bench_env_export = if $bench_env != "" { $"export ($bench_env) && " } else { "" }


### PR DESCRIPTION
## Summary
- add BENCH_PR as pr_number metadata for txgen benchmark runs
- lets ClickHouse-backed perf surfaces read the originating pull request from txgen_runs.metadata

## Verification
- nu --commands 'source contrib/bench/txgen/helpers.nu'\n\nPrompted by: @shekhirin