### PR TITLE
fix(bench): pass localnet signing secret in e2e

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -537,6 +537,11 @@ def build-e2e-consensus-args [node_dir: string, trusted_peers: string, port: int
     let signing_key = $"($node_dir)/signing.key"
     let signing_share = $"($node_dir)/signing.share"
     let enode_key = $"($node_dir)/enode.key"
+    let signing_secret_args = if ((open --raw $signing_key) | str starts-with "age-encryption.org/") {
+        ["--consensus.secret" "<(printf '%s\\n' 'tempo-localnet-signing-key-secret')"]
+    } else {
+        []
+    }
 
     let execution_p2p_port = $port + 1
     let metrics_port = $port + 2
@@ -545,6 +550,7 @@ def build-e2e-consensus-args [node_dir: string, trusted_peers: string, port: int
 
     [
         "--consensus.signing-key" $signing_key
+        ...$signing_secret_args
         "--consensus.signing-share" $signing_share
         "--consensus.listen-address" $"($ip):($port)"
         "--consensus.metrics-address" $"($ip):($metrics_port)"


### PR DESCRIPTION
## Summary
- detect age-encrypted localnet signing keys in bench-e2e
- pass the localnet signing-key secret only for encrypted keys
- keep old plaintext bloat snapshots working without `--consensus.secret`

## Validation
- `nu --commands 'source bench-e2e.nu'`
- exercised `build-e2e-consensus-args` with sample encrypted and plaintext `signing.key` files; encrypted includes `--consensus.secret`, plaintext omits it

Prompted by: @shekhirin