### PR TITLE
docs(tips): draft current committee state TIP

### DIFF
--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -84,7 +84,7 @@ The returned `publicKeys` MUST be ordered exactly as the `players` vector in the
 
 The interface does not expose `getCommitteeMembers(uint64 epoch)` and does not require historical committee storage. Contracts that need old committee data must use another mechanism, such as historical headers or logs.
 
-## Boundary System Transaction
+## System Transaction Execution
 
 When proposing the last block of epoch `E`, the proposer already writes the DKG outcome for epoch `E+1` to the block header. At the same boundary, the proposer MUST execute a system transaction that persists the effective committee for epoch `E+1` to execution-layer state.
 
@@ -97,6 +97,8 @@ committee(E+1) = selected_dkg_outcome(E).players
 If the DKG round for epoch `E` succeeds, `selected_dkg_outcome(E)` is the newly produced outcome. If the DKG round fails, `selected_dkg_outcome(E)` is the previous successful outcome selected by consensus fallback rules.
 
 The system transaction MUST NOT derive the committee by calling `getActiveValidators()` at the boundary. `getActiveValidators()` remains a registry query and may include validators that are not in the fallback DKG outcome, or exclude validators that remain in the fallback DKG outcome.
+
+The system transaction MUST reuse the existing committee storage space and overwrite the previous committee. Implementations MUST NOT append a new committee record per epoch or otherwise grow state as epochs advance.
 
 ## Relationship to `getActiveValidators()`
 

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -55,7 +55,13 @@ The pattern mirrors EIP-2935: consensus maintains protocol data in a dedicated s
 
 Committee state MUST live outside `ValidatorConfigV2`. This TIP does not require `ValidatorConfigV2` to store, update, or expose the effective committee.
 
-Implementations SHOULD expose the committee through a dedicated system contract or precompile, following the same broad model as EIP-2935's history contract: consensus writes protocol data into contract storage during block processing, and EVM callers read it through a narrow contract interface. The exact address is left to the implementation TIP or fork configuration, but the storage owner MUST be the committee-state component, not `ValidatorConfigV2`.
+This TIP defines a network parameter:
+
+```solidity
+address constant CURRENT_COMMITTEE_ADDRESS = TBD;
+```
+
+Implementations SHOULD expose the committee through the dedicated system contract or precompile at `CURRENT_COMMITTEE_ADDRESS`, following the same broad model as EIP-2935's history contract: consensus writes protocol data into contract storage during block processing, and EVM callers read it through a narrow contract interface. The storage owner MUST be the committee-state component, not `ValidatorConfigV2`.
 
 ## Interface
 

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -42,7 +42,7 @@ Callers that need the current effective committee must therefore inspect consens
 
 ## State Location
 
-Committee state MUST live outside `ValidatorConfigV2`. This TIP does not require `ValidatorConfigV2` to store, update, or expose the effective committee.
+Committee state MUST live in dedicated execution-layer state for the current effective committee.
 
 This TIP defines a network parameter:
 

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -1,18 +1,18 @@
 ---
 id: TIP-1066
-title: Validator Committee Query
-description: Add a canonical ValidatorConfigV2 query for the effective committee members selected by DKG.
+title: Validator Committee State
+description: Add canonical execution-layer state for the effective committee members selected by DKG.
 authors: Janis (@superfluffy)
 status: Draft
 related: TIP-1017
 protocolVersion: TBD
 ---
 
-# TIP-1066: Validator Committee Query
+# TIP-1066: Validator Committee State
 
 ## Abstract
 
-This TIP extends `ValidatorConfigV2` with a read-only query that returns the effective committee members for an epoch. The committee is derived from the DKG outcome that consensus already writes at the epoch boundary, rather than from the current validator configuration. This gives contracts, tools, and operators a canonical execution-layer view of the validators that are actually expected to sign consensus messages.
+This TIP adds dedicated execution-layer state for the effective committee members for each epoch. The committee is derived from the DKG outcome that consensus already writes at the epoch boundary, rather than from the current validator configuration. This gives contracts, tools, and operators a canonical execution-layer view of the validators that are actually expected to sign consensus messages without making `ValidatorConfigV2` responsible for storing committee state.
 
 ## Motivation
 
@@ -26,6 +26,8 @@ The mismatch is operationally important:
 - the DKG outcome answers "which validator public keys are effective committee members for this epoch?"
 
 Callers that need the second answer currently have to inspect consensus data or reconstruct it from block headers. This TIP makes the effective committee available through a smart contract call, avoiding ambiguity and giving downstream contracts a stable interface.
+
+The committee state is intentionally separate from `ValidatorConfigV2`. `ValidatorConfigV2` remains the validator/player selection mechanism: it defines the configured validator registry that consensus uses when selecting DKG players for a future epoch. The committee state defined here records the DKG result that consensus actually selected for an epoch.
 
 ## Assumptions
 
@@ -46,9 +48,15 @@ Callers that need the second answer currently have to inspect consensus data or 
 
 # Specification
 
+## State Location
+
+Committee state MUST live outside `ValidatorConfigV2`. This TIP does not require `ValidatorConfigV2` to store, update, or expose the effective committee.
+
+Implementations SHOULD expose the committee through a dedicated system contract or precompile. The exact address is left to the implementation TIP or fork configuration, but the storage owner MUST be the committee-state component, not `ValidatorConfigV2`.
+
 ## Interface
 
-`ValidatorConfigV2` is extended with a new read-only query:
+The committee-state component exposes a read-only query:
 
 ```solidity
 /// @notice Get the effective committee members for the current epoch.
@@ -88,7 +96,7 @@ Callers MUST use:
 - `getActiveValidators()` to inspect the configured active validator registry.
 - `getCommitteeMembers()` to inspect the ordered public keys that are effective consensus committee members for the current epoch.
 
-Callers that need validator registry metadata MAY call `validatorByPublicKey(publicKey)` for each returned public key. This metadata lookup is separate from committee membership and can reflect later registry changes such as deactivation.
+Callers that need validator registry metadata MAY call `ValidatorConfigV2.validatorByPublicKey(publicKey)` for each returned public key. This metadata lookup is separate from committee membership and can reflect later registry changes such as deactivation.
 
 The two results are allowed to differ.
 

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -33,9 +33,7 @@ Callers that need the second answer currently have to inspect consensus data or 
 - The boundary block's DKG outcome is the canonical source of truth for the next epoch's committee.
 - If a DKG round fails, the effective committee for the next epoch is the previous successful DKG outcome selected by consensus.
 - The execution layer can persist enough committee state at the boundary block to answer future reads without requiring callers to parse historical block headers.
-- `Validator.publicKey` remains the stable join key between `ValidatorConfigV2` registry entries and DKG outcome `players`.
-
-If any public key in the effective committee no longer maps to a current validator registry entry, the query MUST still return the public key. Implementations SHOULD return any registry metadata that remains available, but MUST NOT substitute a different validator.
+- DKG outcome `players` are ordered Ed25519 public keys.
 
 ## Threat Model
 
@@ -53,39 +51,19 @@ If any public key in the effective committee no longer maps to a current validat
 `ValidatorConfigV2` is extended with a new read-only query:
 
 ```solidity
-/// @notice Validator effective committee member.
-/// @param publicKey Ed25519 communication public key from the DKG outcome players.
-/// @param validatorAddress Validator address from ValidatorConfigV2, or address(0) if the public key has no current registry entry.
-/// @param ingress Inbound address in `<ip>:<port>` format, or empty string if unavailable.
-/// @param egress Outbound address in `<ip>` format, or empty string if unavailable.
-/// @param index ValidatorConfigV2 validators-array position, or type(uint64).max if unavailable.
-/// @param addedAtHeight Block height when the registry entry was added, or 0 if unavailable.
-/// @param deactivatedAtHeight Block height when the registry entry was deactivated, or 0 if unavailable.
-/// @param feeRecipient Fee recipient from ValidatorConfigV2, or address(0) if unavailable.
-struct CommitteeMember {
-    bytes32 publicKey;
-    address validatorAddress;
-    string ingress;
-    string egress;
-    uint64 index;
-    uint64 addedAtHeight;
-    uint64 deactivatedAtHeight;
-    address feeRecipient;
-}
-
 /// @notice Get the effective committee members for the current epoch.
 /// @dev This returns the DKG outcome players selected by consensus, not the registry's active validator set.
 /// @return epoch Epoch for which the returned committee is effective.
-/// @return members Effective committee members, in DKG outcome player order.
+/// @return publicKeys Effective committee member public keys, in DKG outcome player order.
 function getCommitteeMembers()
     external
     view
-    returns (uint64 epoch, CommitteeMember[] memory members);
+    returns (uint64 epoch, bytes32[] memory publicKeys);
 ```
 
 `getCommitteeMembers()` MUST return the committee used by consensus for the epoch containing the block at which the call is evaluated.
 
-The returned `members` MUST be ordered exactly as the `players` vector in the DKG outcome selected for that epoch. If consensus falls back to a previous DKG outcome, the returned `members` MUST match the fallback outcome.
+The returned `publicKeys` MUST be ordered exactly as the `players` vector in the DKG outcome selected for that epoch. If consensus falls back to a previous DKG outcome, the returned `publicKeys` MUST match the fallback outcome.
 
 ## Boundary System Transaction
 
@@ -101,22 +79,6 @@ If the DKG round for epoch `E` succeeds, `selected_dkg_outcome(E)` is the newly 
 
 The system transaction MUST NOT derive the committee by calling `getActiveValidators()` at the boundary. `getActiveValidators()` remains a registry query and may include validators that are not in the fallback DKG outcome, or exclude validators that remain in the fallback DKG outcome.
 
-## Registry Metadata Resolution
-
-For each persisted committee public key, `getCommitteeMembers()` SHOULD attach the current `ValidatorConfigV2.Validator` metadata for the same `publicKey`.
-
-If no registry entry exists for a committee public key, or if the implementation cannot attach metadata without ambiguity, the returned `CommitteeMember` MUST still include the public key and MUST use sentinel values for unavailable metadata:
-
-- `validatorAddress = address(0)`
-- `ingress = ""`
-- `egress = ""`
-- `index = type(uint64).max`
-- `addedAtHeight = 0`
-- `deactivatedAtHeight = 0`
-- `feeRecipient = address(0)`
-
-If the matching registry entry has since been deactivated, the query MUST still return that metadata with its nonzero `deactivatedAtHeight`. A deactivated registry entry can remain an effective committee member after DKG fallback.
-
 ## Relationship to `getActiveValidators()`
 
 `getActiveValidators()` is unchanged. It continues to return registry entries whose `deactivatedAtHeight == 0`.
@@ -124,7 +86,9 @@ If the matching registry entry has since been deactivated, the query MUST still 
 Callers MUST use:
 
 - `getActiveValidators()` to inspect the configured active validator registry.
-- `getCommitteeMembers()` to inspect the validators that are effective consensus committee members for the current epoch.
+- `getCommitteeMembers()` to inspect the ordered public keys that are effective consensus committee members for the current epoch.
+
+Callers that need validator registry metadata MAY call `validatorByPublicKey(publicKey)` for each returned public key. This metadata lookup is separate from committee membership and can reflect later registry changes such as deactivation.
 
 The two results are allowed to differ.
 

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -104,19 +104,16 @@ Implementations MUST emit an event when the boundary system transaction updates 
 /// @param epoch Epoch for which the committee is effective.
 /// @param membersHash keccak256 hash of the ABI-encoded committee public keys in order.
 /// @param memberCount Number of committee members.
-/// @param dkgFallback True if the committee was selected from a previous DKG outcome because the current DKG round failed.
 event CommitteeUpdated(
     uint64 indexed epoch,
     bytes32 indexed membersHash,
-    uint64 memberCount,
-    bool dkgFallback
+    uint64 memberCount
 );
 ```
 
 This event answers:
 
 - which epoch's committee was written,
-- whether the write came from a fallback outcome,
 - whether two nodes agree on the ordered committee without logging every member.
 
 # Invariants

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -35,6 +35,7 @@ The pattern mirrors EIP-2935: consensus maintains protocol data in a dedicated s
 
 - The consensus layer already determines the effective committee from the DKG outcome used for the epoch.
 - The boundary block's DKG outcome is the canonical source of truth for the next epoch's committee.
+- Validators verify the DKG outcome and must all arrive at the same outcome. This is ensured by Tempo's use of Commonware's implementation of the Feldman/Desmedt DKG construction.
 - If a DKG round fails, the effective committee for the next epoch is the previous successful DKG outcome selected by consensus.
 - The execution layer can persist enough committee state at the boundary block to answer current-committee reads without requiring callers to parse historical block headers.
 - DKG outcome `players` are ordered Ed25519 public keys.

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -35,7 +35,7 @@ The pattern mirrors EIP-2935: consensus maintains protocol data in a dedicated s
 
 - The consensus layer already determines the effective committee from the DKG outcome used for the epoch.
 - The boundary block's DKG outcome is the canonical source of truth for the next epoch's committee.
-- Validators verify the DKG outcome and must all arrive at the same outcome. This is ensured by Tempo's use of Commonware's Feldman/Desmedt-style DKG implementation.
+- Validators verify the DKG outcome and a quorum of validators must arrive at the same outcome. This is ensured by Tempo's use of Commonware's Feldman/Desmedt-style DKG implementation.
 - If a DKG round fails, the effective committee for the next epoch is the previous successful DKG outcome selected by consensus.
 - The execution layer can persist enough committee state at the boundary block to answer current-committee reads without requiring callers to parse historical block headers.
 - DKG outcome `players` are ordered Ed25519 public keys.

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -35,7 +35,7 @@ The pattern mirrors EIP-2935: consensus maintains protocol data in a dedicated s
 
 - The consensus layer already determines the effective committee from the DKG outcome used for the epoch.
 - The boundary block's DKG outcome is the canonical source of truth for the next epoch's committee.
-- Validators verify the DKG outcome and must all arrive at the same outcome. This is ensured by Tempo's use of Commonware's implementation of the Feldman/Desmedt DKG construction.
+- Validators verify the DKG outcome and must all arrive at the same outcome. This is ensured by Tempo's use of Commonware's Feldman/Desmedt-style DKG implementation.
 - If a DKG round fails, the effective committee for the next epoch is the previous successful DKG outcome selected by consensus.
 - The execution layer can persist enough committee state at the boundary block to answer current-committee reads without requiring callers to parse historical block headers.
 - DKG outcome `players` are ordered Ed25519 public keys.

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -124,11 +124,6 @@ This event answers:
 
 # Invariants
 
-- `getCommitteeMembers()` MUST return the DKG outcome `players` selected by consensus for the current epoch.
-- The returned member order MUST match the selected DKG outcome player order.
-- A failed DKG round MUST NOT cause `getCommitteeMembers()` to return `getActiveValidators()` unless the fallback DKG outcome players are exactly equal to that active-validator set.
-- The boundary system transaction MUST write the committee for epoch `E+1` while processing the last block of epoch `E`.
-- `getActiveValidators()` behavior MUST remain unchanged.
-- A validator added during epoch `E` MUST NOT appear in `getCommitteeMembers()` for epoch `E+1` unless it is present in the selected DKG outcome players.
-- A validator deactivated during epoch `E` MUST remain in `getCommitteeMembers()` for epoch `E+1` if it is present in the selected DKG outcome players because of DKG fallback.
-- `CommitteeUpdated.membersHash` MUST equal `keccak256(abi.encode(publicKeys))`, where `publicKeys` is the ordered `bytes32[]` returned by `getCommitteeMembers()` for that epoch.
+- The boundary system transaction MUST write exactly the `players` recorded in the DKG outcome written to the boundary block header as the committee members for the next epoch.
+- `getCommitteeMembers()` MUST return those same `players` as the effective committee members for the epoch in which the call is evaluated.
+- Validators MUST verify that a proposed boundary block contains the required DKG outcome in the block header and that the boundary system transaction writes exactly the committee implied by that DKG outcome.

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -89,19 +89,6 @@ The system transaction MUST NOT derive the committee by calling `getActiveValida
 
 The system transaction MUST reuse the existing committee storage space and overwrite the previous committee. Implementations MUST NOT append a new committee record per epoch or otherwise grow state as epochs advance.
 
-## Relationship to `getActiveValidators()`
-
-`getActiveValidators()` is unchanged. It continues to return registry entries whose `deactivatedAtHeight == 0`.
-
-Callers MUST use:
-
-- `getActiveValidators()` to inspect the configured active validator registry.
-- `getCommitteeMembers()` to inspect the ordered public keys that are effective consensus committee members for the current epoch.
-
-Callers that need validator registry metadata MAY call `ValidatorConfigV2.validatorByPublicKey(publicKey)` for each returned public key. This metadata lookup is separate from committee membership and can reflect later registry changes such as deactivation.
-
-The two results are allowed to differ.
-
 ## Activation
 
 At activation, implementations MUST initialize the committee state from the latest DKG outcome that consensus treats as effective at the activation boundary. After activation, every epoch boundary MUST update the persisted current committee state for the next epoch.

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -29,7 +29,7 @@ Callers that need the second answer currently have to inspect consensus data or 
 
 The committee state is intentionally separate from `ValidatorConfigV2`. `ValidatorConfigV2` remains the validator/player selection mechanism: it defines the configured validator registry that consensus uses when selecting DKG players for a future epoch. The committee state defined here records the DKG result that consensus actually selected for the current epoch.
 
-The pattern mirrors EIP-2935: consensus maintains protocol data in a dedicated system contract so that EVM callers can read it from state. Unlike EIP-2935's ring buffer of historical block hashes, this TIP only requires storing the current effective committee. Historical committee lookup is explicitly out of scope.
+The pattern mirrors EIP-2935: consensus maintains protocol data in a dedicated system contract so that EVM callers can read it from state. Unlike EIP-2935's ring buffer of historical block hashes, this TIP only requires storing the current effective committee. Historic committee lookup remains available by reading the DKG outcome written to historic boundary block headers.
 
 ## Assumptions
 

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -61,7 +61,7 @@ This TIP defines a network parameter:
 address constant CURRENT_COMMITTEE_ADDRESS = TBD;
 ```
 
-Implementations SHOULD expose the committee through the dedicated system contract or precompile at `CURRENT_COMMITTEE_ADDRESS`, following the same broad model as EIP-2935's history contract: consensus writes protocol data into contract storage during block processing, and EVM callers read it through a narrow contract interface. The storage owner MUST be the committee-state component, not `ValidatorConfigV2`.
+Implementations SHOULD expose the committee through the dedicated system contract or precompile at `CURRENT_COMMITTEE_ADDRESS`, following the same broad model as EIP-2935's history contract: consensus writes protocol data into contract storage during block processing, and EVM callers read it through a narrow contract interface.
 
 ## Interface
 

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -16,9 +16,12 @@ This TIP proposes a system transaction that writes the current committee members
 
 ## Motivation
 
-`ValidatorConfigV2.getActiveValidators()` is a recurring source of confusion because it returns the configured validator registry, not necessarily the committee currently active in consensus. Registry changes such as `addValidator`, `rotateValidator`, and `deactivateValidator` only affect the committee if the relevant DKG round succeeds; if DKG fails, consensus falls back to the previous successful DKG outcome, and the effective committee remains that outcome's `players`.
+`ValidatorConfigV2.getActiveValidators()` is a recurring source of confusion because it returns the configured validator registry, not necessarily the committee currently active in consensus.
+Registry changes such as `addValidator`, `rotateValidator`, and `deactivateValidator` immediately affect the return value of `getActiveValidators` returns even if the changes have not yet been propagated to the committee.
+Likewise, the committee is only updated if the relevant DKG round succeeds; if DKG fails, the committee remains that of the previous epoch, thus potentially containing validators that are marked deactivated and which would therefore be excluded from `getActiveValidators`.
 
-Callers that need the current effective committee must therefore inspect consensus data or reconstruct it from boundary block headers. This TIP gives contracts a stable execution-layer query for that value while keeping it separate from `ValidatorConfigV2`: the registry remains the input to future DKG player selection, and the new committee state records the DKG result consensus actually selected for the current epoch.
+Callers that need the current effective committee must therefore inspect consensus data or reconstruct it from boundary block headers.
+This TIP gives contracts a stable execution-layer query for that value while keeping it separate from `ValidatorConfigV2`: the registry remains the input to future DKG player selection, and the new committee state records the DKG result consensus actually selected for the current epoch.
 
 ## Assumptions
 
@@ -71,21 +74,15 @@ function getCommitteeMembers()
 
 The returned `publicKeys` MUST be ordered exactly as the `players` vector in the DKG outcome selected for that epoch. If consensus falls back to a previous DKG outcome, the returned `publicKeys` MUST match the fallback outcome.
 
-The interface does not expose `getCommitteeMembers(uint64 epoch)` and does not require historical committee storage. Contracts that need old committee data must use another mechanism, such as historical headers or logs.
-
 ## System Transaction Execution
 
 When proposing the last block of epoch `E`, the proposer already writes the DKG outcome for epoch `E+1` to the block header. At the same boundary, the proposer MUST execute a system transaction that persists the effective committee for epoch `E+1` to execution-layer state.
 
-The persisted committee MUST be derived from the effective DKG outcome selected by consensus:
+The persisted committee MUST be the effective DKG outcome selected by consensus:
 
 ```text
 committee(E+1) = selected_dkg_outcome(E).players
 ```
-
-If the DKG round for epoch `E` succeeds, `selected_dkg_outcome(E)` is the newly produced outcome. If the DKG round fails, `selected_dkg_outcome(E)` is the previous successful outcome selected by consensus fallback rules.
-
-The system transaction MUST NOT derive the committee by calling `getActiveValidators()` at the boundary. `getActiveValidators()` remains a registry query and may include validators that are not in the fallback DKG outcome, or exclude validators that remain in the fallback DKG outcome.
 
 The system transaction MUST reuse the existing committee storage space and overwrite the previous committee. Implementations MUST NOT append a new committee record per epoch or otherwise grow state as epochs advance.
 

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP adds dedicated execution-layer state for the current effective committee members. The committee is derived from the DKG outcome that consensus already writes at the epoch boundary, rather than from the current validator configuration. This gives contracts, tools, and operators a canonical execution-layer view of the validators that are actually expected to sign consensus messages without making `ValidatorConfigV2` responsible for storing committee state.
+This TIP proposes a system transaction that writes the current committee members, according to the DKG outcome, to execution-layer state.
 
 ## Motivation
 

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -1,18 +1,18 @@
 ---
 id: TIP-1066
-title: Validator Committee State
-description: Add canonical execution-layer state for the effective committee members selected by DKG.
+title: Current Committee State
+description: Add canonical execution-layer state for the current effective committee selected by DKG.
 authors: Janis (@superfluffy)
 status: Draft
 related: TIP-1017
 protocolVersion: TBD
 ---
 
-# TIP-1066: Validator Committee State
+# TIP-1066: Current Committee State
 
 ## Abstract
 
-This TIP adds dedicated execution-layer state for the effective committee members for each epoch. The committee is derived from the DKG outcome that consensus already writes at the epoch boundary, rather than from the current validator configuration. This gives contracts, tools, and operators a canonical execution-layer view of the validators that are actually expected to sign consensus messages without making `ValidatorConfigV2` responsible for storing committee state.
+This TIP adds dedicated execution-layer state for the current effective committee members. The committee is derived from the DKG outcome that consensus already writes at the epoch boundary, rather than from the current validator configuration. This gives contracts, tools, and operators a canonical execution-layer view of the validators that are actually expected to sign consensus messages without making `ValidatorConfigV2` responsible for storing committee state.
 
 ## Motivation
 
@@ -25,16 +25,18 @@ The mismatch is operationally important:
 - `getActiveValidators()` answers "which registry entries are currently configured as active?"
 - the DKG outcome answers "which validator public keys are effective committee members for this epoch?"
 
-Callers that need the second answer currently have to inspect consensus data or reconstruct it from block headers. This TIP makes the effective committee available through a smart contract call, avoiding ambiguity and giving downstream contracts a stable interface.
+Callers that need the second answer currently have to inspect consensus data or reconstruct it from block headers. This TIP makes the current effective committee available through a smart contract call, avoiding ambiguity and giving downstream contracts a stable interface.
 
-The committee state is intentionally separate from `ValidatorConfigV2`. `ValidatorConfigV2` remains the validator/player selection mechanism: it defines the configured validator registry that consensus uses when selecting DKG players for a future epoch. The committee state defined here records the DKG result that consensus actually selected for an epoch.
+The committee state is intentionally separate from `ValidatorConfigV2`. `ValidatorConfigV2` remains the validator/player selection mechanism: it defines the configured validator registry that consensus uses when selecting DKG players for a future epoch. The committee state defined here records the DKG result that consensus actually selected for the current epoch.
+
+The pattern mirrors EIP-2935: consensus maintains protocol data in a dedicated system contract so that EVM callers can read it from state. Unlike EIP-2935's ring buffer of historical block hashes, this TIP only requires storing the current effective committee. Historical committee lookup is explicitly out of scope.
 
 ## Assumptions
 
 - The consensus layer already determines the effective committee from the DKG outcome used for the epoch.
 - The boundary block's DKG outcome is the canonical source of truth for the next epoch's committee.
 - If a DKG round fails, the effective committee for the next epoch is the previous successful DKG outcome selected by consensus.
-- The execution layer can persist enough committee state at the boundary block to answer future reads without requiring callers to parse historical block headers.
+- The execution layer can persist enough committee state at the boundary block to answer current-committee reads without requiring callers to parse historical block headers.
 - DKG outcome `players` are ordered Ed25519 public keys.
 
 ## Threat Model
@@ -52,11 +54,11 @@ The committee state is intentionally separate from `ValidatorConfigV2`. `Validat
 
 Committee state MUST live outside `ValidatorConfigV2`. This TIP does not require `ValidatorConfigV2` to store, update, or expose the effective committee.
 
-Implementations SHOULD expose the committee through a dedicated system contract or precompile. The exact address is left to the implementation TIP or fork configuration, but the storage owner MUST be the committee-state component, not `ValidatorConfigV2`.
+Implementations SHOULD expose the committee through a dedicated system contract or precompile, following the same broad model as EIP-2935's history contract: consensus writes protocol data into contract storage during block processing, and EVM callers read it through a narrow contract interface. The exact address is left to the implementation TIP or fork configuration, but the storage owner MUST be the committee-state component, not `ValidatorConfigV2`.
 
 ## Interface
 
-The committee-state component exposes a read-only query:
+The committee-state component exposes a current-only read query:
 
 ```solidity
 /// @notice Get the effective committee members for the current epoch.
@@ -72,6 +74,8 @@ function getCommitteeMembers()
 `getCommitteeMembers()` MUST return the committee used by consensus for the epoch containing the block at which the call is evaluated.
 
 The returned `publicKeys` MUST be ordered exactly as the `players` vector in the DKG outcome selected for that epoch. If consensus falls back to a previous DKG outcome, the returned `publicKeys` MUST match the fallback outcome.
+
+The interface does not expose `getCommitteeMembers(uint64 epoch)` and does not require historical committee storage. Contracts that need old committee data must use another mechanism, such as historical headers or logs.
 
 ## Boundary System Transaction
 
@@ -102,7 +106,7 @@ The two results are allowed to differ.
 
 ## Activation
 
-At activation, implementations MUST initialize the committee state from the latest DKG outcome that consensus treats as effective at the activation boundary. After activation, every epoch boundary MUST update the persisted committee state for the next epoch.
+At activation, implementations MUST initialize the committee state from the latest DKG outcome that consensus treats as effective at the activation boundary. After activation, every epoch boundary MUST update the persisted current committee state for the next epoch.
 
 Before the first boundary after activation, `getCommitteeMembers()` MUST return the activation-initialized committee. It MUST NOT return `getActiveValidators()` as a fallback unless that set is known to be the selected effective DKG outcome.
 

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -1,0 +1,170 @@
+---
+id: TIP-1066
+title: Validator Committee Query
+description: Add a canonical ValidatorConfigV2 query for the effective committee members selected by DKG.
+authors: Janis (@superfluffy)
+status: Draft
+related: TIP-1017
+protocolVersion: TBD
+---
+
+# TIP-1066: Validator Committee Query
+
+## Abstract
+
+This TIP extends `ValidatorConfigV2` with a read-only query that returns the effective committee members for an epoch. The committee is derived from the DKG outcome that consensus already writes at the epoch boundary, rather than from the current validator configuration. This gives contracts, tools, and operators a canonical execution-layer view of the validators that are actually expected to sign consensus messages.
+
+## Motivation
+
+`ValidatorConfigV2.getActiveValidators()` is a recurring source of confusion. Callers naturally expect it to return the validators that are currently active in consensus, but TIP-1017 defines it as a registry query: it returns validators whose `deactivatedAtHeight == 0`.
+
+That registry state can differ from the effective committee. At the last block of epoch `E`, the proposer writes the DKG outcome for epoch `E+1` into the boundary block header. The `players` in that outcome are the committee members for epoch `E+1`. If the DKG round fails, consensus falls back to the previous successful DKG outcome. In that case, the committee remains the previous DKG `players`, even if `addValidator`, `rotateValidator`, or `deactivateValidator` changed the registry during the epoch.
+
+The mismatch is operationally important:
+
+- `getActiveValidators()` answers "which registry entries are currently configured as active?"
+- the DKG outcome answers "which validator public keys are effective committee members for this epoch?"
+
+Callers that need the second answer currently have to inspect consensus data or reconstruct it from block headers. This TIP makes the effective committee available through a smart contract call, avoiding ambiguity and giving downstream contracts a stable interface.
+
+## Assumptions
+
+- The consensus layer already determines the effective committee from the DKG outcome used for the epoch.
+- The boundary block's DKG outcome is the canonical source of truth for the next epoch's committee.
+- If a DKG round fails, the effective committee for the next epoch is the previous successful DKG outcome selected by consensus.
+- The execution layer can persist enough committee state at the boundary block to answer future reads without requiring callers to parse historical block headers.
+- `Validator.publicKey` remains the stable join key between `ValidatorConfigV2` registry entries and DKG outcome `players`.
+
+If any public key in the effective committee no longer maps to a current validator registry entry, the query MUST still return the public key. Implementations SHOULD return any registry metadata that remains available, but MUST NOT substitute a different validator.
+
+## Threat Model
+
+- **Consensus proposer**: trusted only to execute the system transaction required by the protocol at the boundary block. Invalid committee writes are consensus-invalid.
+- **ValidatorConfigV2 owner**: can change configured validator state, but cannot directly change the effective committee except through the normal DKG process.
+- **Contract callers and offchain tools**: untrusted readers. They rely on this query as a canonical view of effective committee membership and must not need to infer committee state from `getActiveValidators()`.
+- **Failed or incomplete DKG rounds**: in scope. The interface must expose the fallback committee selected by consensus, not the intended player set from registry state.
+
+---
+
+# Specification
+
+## Interface
+
+`ValidatorConfigV2` is extended with a new read-only query:
+
+```solidity
+/// @notice Validator effective committee member.
+/// @param publicKey Ed25519 communication public key from the DKG outcome players.
+/// @param validatorAddress Validator address from ValidatorConfigV2, or address(0) if the public key has no current registry entry.
+/// @param ingress Inbound address in `<ip>:<port>` format, or empty string if unavailable.
+/// @param egress Outbound address in `<ip>` format, or empty string if unavailable.
+/// @param index ValidatorConfigV2 validators-array position, or type(uint64).max if unavailable.
+/// @param addedAtHeight Block height when the registry entry was added, or 0 if unavailable.
+/// @param deactivatedAtHeight Block height when the registry entry was deactivated, or 0 if unavailable.
+/// @param feeRecipient Fee recipient from ValidatorConfigV2, or address(0) if unavailable.
+struct CommitteeMember {
+    bytes32 publicKey;
+    address validatorAddress;
+    string ingress;
+    string egress;
+    uint64 index;
+    uint64 addedAtHeight;
+    uint64 deactivatedAtHeight;
+    address feeRecipient;
+}
+
+/// @notice Get the effective committee members for the current epoch.
+/// @dev This returns the DKG outcome players selected by consensus, not the registry's active validator set.
+/// @return epoch Epoch for which the returned committee is effective.
+/// @return members Effective committee members, in DKG outcome player order.
+function getCommitteeMembers()
+    external
+    view
+    returns (uint64 epoch, CommitteeMember[] memory members);
+```
+
+`getCommitteeMembers()` MUST return the committee used by consensus for the epoch containing the block at which the call is evaluated.
+
+The returned `members` MUST be ordered exactly as the `players` vector in the DKG outcome selected for that epoch. If consensus falls back to a previous DKG outcome, the returned `members` MUST match the fallback outcome.
+
+## Boundary System Transaction
+
+When proposing the last block of epoch `E`, the proposer already writes the DKG outcome for epoch `E+1` to the block header. At the same boundary, the proposer MUST execute a system transaction that persists the effective committee for epoch `E+1` to execution-layer state.
+
+The persisted committee MUST be derived from the effective DKG outcome selected by consensus:
+
+```text
+committee(E+1) = selected_dkg_outcome(E).players
+```
+
+If the DKG round for epoch `E` succeeds, `selected_dkg_outcome(E)` is the newly produced outcome. If the DKG round fails, `selected_dkg_outcome(E)` is the previous successful outcome selected by consensus fallback rules.
+
+The system transaction MUST NOT derive the committee by calling `getActiveValidators()` at the boundary. `getActiveValidators()` remains a registry query and may include validators that are not in the fallback DKG outcome, or exclude validators that remain in the fallback DKG outcome.
+
+## Registry Metadata Resolution
+
+For each persisted committee public key, `getCommitteeMembers()` SHOULD attach the current `ValidatorConfigV2.Validator` metadata for the same `publicKey`.
+
+If no registry entry exists for a committee public key, or if the implementation cannot attach metadata without ambiguity, the returned `CommitteeMember` MUST still include the public key and MUST use sentinel values for unavailable metadata:
+
+- `validatorAddress = address(0)`
+- `ingress = ""`
+- `egress = ""`
+- `index = type(uint64).max`
+- `addedAtHeight = 0`
+- `deactivatedAtHeight = 0`
+- `feeRecipient = address(0)`
+
+If the matching registry entry has since been deactivated, the query MUST still return that metadata with its nonzero `deactivatedAtHeight`. A deactivated registry entry can remain an effective committee member after DKG fallback.
+
+## Relationship to `getActiveValidators()`
+
+`getActiveValidators()` is unchanged. It continues to return registry entries whose `deactivatedAtHeight == 0`.
+
+Callers MUST use:
+
+- `getActiveValidators()` to inspect the configured active validator registry.
+- `getCommitteeMembers()` to inspect the validators that are effective consensus committee members for the current epoch.
+
+The two results are allowed to differ.
+
+## Activation
+
+At activation, implementations MUST initialize the committee state from the latest DKG outcome that consensus treats as effective at the activation boundary. After activation, every epoch boundary MUST update the persisted committee state for the next epoch.
+
+Before the first boundary after activation, `getCommitteeMembers()` MUST return the activation-initialized committee. It MUST NOT return `getActiveValidators()` as a fallback unless that set is known to be the selected effective DKG outcome.
+
+# Observability
+
+Implementations MUST emit an event when the boundary system transaction updates the effective committee:
+
+```solidity
+/// @notice Emitted when the effective committee for an epoch is persisted.
+/// @param epoch Epoch for which the committee is effective.
+/// @param membersHash keccak256 hash of the ABI-encoded committee public keys in order.
+/// @param memberCount Number of committee members.
+/// @param dkgFallback True if the committee was selected from a previous DKG outcome because the current DKG round failed.
+event CommitteeUpdated(
+    uint64 indexed epoch,
+    bytes32 indexed membersHash,
+    uint64 memberCount,
+    bool dkgFallback
+);
+```
+
+This event answers:
+
+- which epoch's committee was written,
+- whether the write came from a fallback outcome,
+- whether two nodes agree on the ordered committee without logging every member.
+
+# Invariants
+
+- `getCommitteeMembers()` MUST return the DKG outcome `players` selected by consensus for the current epoch.
+- The returned member order MUST match the selected DKG outcome player order.
+- A failed DKG round MUST NOT cause `getCommitteeMembers()` to return `getActiveValidators()` unless the fallback DKG outcome players are exactly equal to that active-validator set.
+- The boundary system transaction MUST write the committee for epoch `E+1` while processing the last block of epoch `E`.
+- `getActiveValidators()` behavior MUST remain unchanged.
+- A validator added during epoch `E` MUST NOT appear in `getCommitteeMembers()` for epoch `E+1` unless it is present in the selected DKG outcome players.
+- A validator deactivated during epoch `E` MUST remain in `getCommitteeMembers()` for epoch `E+1` if it is present in the selected DKG outcome players because of DKG fallback.
+- `CommitteeUpdated.membersHash` MUST equal `keccak256(abi.encode(publicKeys))`, where `publicKeys` is the ordered `bytes32[]` returned by `getCommitteeMembers()` for that epoch.

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -16,20 +16,9 @@ This TIP proposes a system transaction that writes the current committee members
 
 ## Motivation
 
-`ValidatorConfigV2.getActiveValidators()` is a recurring source of confusion. Callers naturally expect it to return the validators that are currently active in consensus, but TIP-1017 defines it as a registry query: it returns validators whose `deactivatedAtHeight == 0`. These are the validators that should become committee members if the relevant DKG round succeeds; they are not necessarily the validators that are effective committee members right now.
+`ValidatorConfigV2.getActiveValidators()` is a recurring source of confusion because it returns the configured validator registry, not necessarily the committee currently active in consensus. Registry changes such as `addValidator`, `rotateValidator`, and `deactivateValidator` only affect the committee if the relevant DKG round succeeds; if DKG fails, consensus falls back to the previous successful DKG outcome, and the effective committee remains that outcome's `players`.
 
-That registry state can differ from the effective committee. At the last block of epoch `E`, the proposer writes the DKG outcome for epoch `E+1` into the boundary block header. The `players` in that outcome are the committee members for epoch `E+1`. If the DKG round fails, consensus falls back to the previous successful DKG outcome. In that case, the committee remains the previous DKG `players`, even if `addValidator`, `rotateValidator`, or `deactivateValidator` changed the registry during the epoch.
-
-The mismatch is operationally important:
-
-- `getActiveValidators()` answers "which registry entries are currently configured as active, and therefore should become committee members after a successful DKG round?"
-- the DKG outcome answers "which validator public keys are effective committee members for this epoch?"
-
-Callers that need the second answer currently have to inspect consensus data or reconstruct it from block headers. This TIP makes the current effective committee available through a smart contract call, avoiding ambiguity and giving downstream contracts a stable interface.
-
-The committee state is intentionally separate from `ValidatorConfigV2`. `ValidatorConfigV2` remains the validator/player selection mechanism: it defines the configured validator registry that consensus uses when selecting DKG players for a future epoch. The committee state defined here records the DKG result that consensus actually selected for the current epoch.
-
-The pattern mirrors EIP-2935: consensus maintains protocol data in a dedicated system contract so that EVM callers can read it from state. Unlike EIP-2935's ring buffer of historical block hashes, this TIP only requires storing the current effective committee. Historic committee lookup remains available by reading the DKG outcome written to historic boundary block headers.
+Callers that need the current effective committee must therefore inspect consensus data or reconstruct it from boundary block headers. This TIP gives contracts a stable execution-layer query for that value while keeping it separate from `ValidatorConfigV2`: the registry remains the input to future DKG player selection, and the new committee state records the DKG result consensus actually selected for the current epoch.
 
 ## Assumptions
 

--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -16,13 +16,13 @@ This TIP proposes a system transaction that writes the current committee members
 
 ## Motivation
 
-`ValidatorConfigV2.getActiveValidators()` is a recurring source of confusion. Callers naturally expect it to return the validators that are currently active in consensus, but TIP-1017 defines it as a registry query: it returns validators whose `deactivatedAtHeight == 0`.
+`ValidatorConfigV2.getActiveValidators()` is a recurring source of confusion. Callers naturally expect it to return the validators that are currently active in consensus, but TIP-1017 defines it as a registry query: it returns validators whose `deactivatedAtHeight == 0`. These are the validators that should become committee members if the relevant DKG round succeeds; they are not necessarily the validators that are effective committee members right now.
 
 That registry state can differ from the effective committee. At the last block of epoch `E`, the proposer writes the DKG outcome for epoch `E+1` into the boundary block header. The `players` in that outcome are the committee members for epoch `E+1`. If the DKG round fails, consensus falls back to the previous successful DKG outcome. In that case, the committee remains the previous DKG `players`, even if `addValidator`, `rotateValidator`, or `deactivateValidator` changed the registry during the epoch.
 
 The mismatch is operationally important:
 
-- `getActiveValidators()` answers "which registry entries are currently configured as active?"
+- `getActiveValidators()` answers "which registry entries are currently configured as active, and therefore should become committee members after a successful DKG round?"
 - the DKG outcome answers "which validator public keys are effective committee members for this epoch?"
 
 Callers that need the second answer currently have to inspect consensus data or reconstruct it from block headers. This TIP makes the current effective committee available through a smart contract call, avoiding ambiguity and giving downstream contracts a stable interface.

--- a/tips/tip-1070.md
+++ b/tips/tip-1070.md
@@ -1,14 +1,14 @@
 ---
-id: TIP-1066
+id: TIP-1070
 title: Current Committee State
 description: Add canonical execution-layer state for the current effective committee selected by DKG.
-authors: Janis (@superfluffy)
+authors: Richard Janis Goldschmidt (@superfluffy)
 status: Draft
 related: TIP-1017
 protocolVersion: TBD
 ---
 
-# TIP-1066: Current Committee State
+# TIP-1070: Current Committee State
 
 ## Abstract
 


### PR DESCRIPTION
Drafts TIP-1066 for current committee state: a dedicated system contract/precompile, modeled after the EIP-2935 pattern, that exposes the DKG-selected committee from execution-layer state without coupling committee storage to ValidatorConfigV2.

Prompted by: @SuperFluffy