### PR TITLE
perf(payload): reuse recovered built payload blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13327,6 +13327,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "derive_more",
+ "either",
  "reth-ethereum-engine-primitives",
  "reth-node-api",
  "reth-payload-primitives",

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -1009,7 +1009,7 @@ async fn verify_block<TContext: Pacer>(
     );
     let (block, block_access_list) = block.clone().into_parts();
     let execution_data = TempoExecutionData {
-        block: Arc::new(block),
+        block: block.into(),
         block_access_list,
         validator_set,
     };

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -577,7 +577,7 @@ where
             .add_ons_handle
             .beacon_engine_handle
             .new_payload(TempoExecutionData {
-                block: Arc::new(block),
+                block: block.into(),
                 block_access_list,
                 // can be omitted for finalized blocks
                 validator_set: None,

--- a/crates/evm/src/engine.rs
+++ b/crates/evm/src/engine.rs
@@ -5,10 +5,9 @@ use reth_evm::{
     ConfigureEngineEvm, ConfigureEvm, EvmEnvFor, ExecutableTxIterator, ExecutionCtxFor,
     FromRecoveredTx, RecoveredTx, ToTxEnv, block::ExecutableTxParts,
 };
-use reth_primitives_traits::{SealedBlock, SignedTransaction};
-use std::sync::Arc;
-use tempo_payload_types::TempoExecutionData;
-use tempo_primitives::{Block, TempoTxEnvelope};
+use reth_primitives_traits::SignedTransaction;
+use tempo_payload_types::{TempoExecutionBlock, TempoExecutionData};
+use tempo_primitives::TempoTxEnvelope;
 use tempo_revm::TempoTxEnv;
 
 impl ConfigureEngineEvm<TempoExecutionData> for TempoEvmConfig {
@@ -16,7 +15,7 @@ impl ConfigureEngineEvm<TempoExecutionData> for TempoEvmConfig {
         &self,
         payload: &TempoExecutionData,
     ) -> Result<EvmEnvFor<Self>, Self::Error> {
-        self.evm_env(&payload.block)
+        self.evm_env(payload.block.header())
     }
 
     fn context_for_payload<'a>(
@@ -28,7 +27,7 @@ impl ConfigureEngineEvm<TempoExecutionData> for TempoEvmConfig {
             block_access_list: _,
             validator_set,
         } = payload;
-        let mut context = self.context_for_block(block)?;
+        let mut context = self.context_for_block(block.sealed_block())?;
 
         context.validator_set = validator_set.clone();
 
@@ -61,7 +60,7 @@ impl ConfigureEngineEvm<TempoExecutionData> for TempoEvmConfig {
 /// clone block or transaction.
 #[derive(Clone)]
 struct RecoveredInBlock {
-    block: Arc<SealedBlock<Block>>,
+    block: TempoExecutionBlock,
     index: usize,
     sender: Address,
     expiring_nonce_idx: Option<usize>,
@@ -69,9 +68,12 @@ struct RecoveredInBlock {
 
 impl RecoveredInBlock {
     fn new(
-        (block, index, expiring_nonce_idx): (Arc<SealedBlock<Block>>, usize, Option<usize>),
+        (block, index, expiring_nonce_idx): (TempoExecutionBlock, usize, Option<usize>),
     ) -> Result<Self, RecoveryError> {
-        let sender = block.body().transactions[index].try_recover()?;
+        let sender = block.recovered_block().map_or_else(
+            || block.body().transactions[index].try_recover(),
+            |block| Ok(block.senders()[index]),
+        )?;
         Ok(Self {
             block,
             index,
@@ -119,9 +121,12 @@ mod tests {
     use rayon::iter::{IntoParallelIterator, ParallelIterator};
     use reth_chainspec::EthChainSpec;
     use reth_evm::{ConfigureEngineEvm, ConvertTx, ExecutableTxTuple};
+    use reth_primitives_traits::{RecoveredBlock, SealedBlock};
+    use std::sync::Arc;
     use tempo_chainspec::{TempoChainSpec, spec::MODERATO};
     use tempo_primitives::{
-        BlockBody, SubBlockMetadata, TempoHeader, transaction::envelope::TEMPO_SYSTEM_TX_SIGNATURE,
+        Block, BlockBody, SubBlockMetadata, TempoHeader,
+        transaction::envelope::TEMPO_SYSTEM_TX_SIGNATURE,
     };
 
     fn create_legacy_tx() -> TempoTxEnvelope {
@@ -194,7 +199,7 @@ mod tests {
         let block = create_test_block(vec![tx1, tx2, system_tx]);
 
         let payload = TempoExecutionData {
-            block,
+            block: block.into(),
             block_access_list: None,
             validator_set: None,
         };
@@ -217,6 +222,32 @@ mod tests {
     }
 
     #[test]
+    fn test_tx_iterator_for_recovered_payload_uses_cached_sender() {
+        let chainspec = Arc::new(TempoChainSpec::from_genesis(MODERATO.genesis().clone()));
+        let evm_config = TempoEvmConfig::new(chainspec);
+
+        let block = create_test_block(vec![create_legacy_tx()]);
+        let cached_sender = Address::repeat_byte(0x42);
+        let recovered_block = Arc::new(RecoveredBlock::new_sealed(
+            Arc::unwrap_or_clone(block),
+            vec![cached_sender],
+        ));
+
+        let payload = TempoExecutionData {
+            block: TempoExecutionBlock::recovered(recovered_block),
+            block_access_list: None,
+            validator_set: None,
+        };
+
+        let tuple = evm_config.tx_iterator_for_payload(&payload).unwrap();
+        let (iter, recover_fn) = tuple.into_parts();
+        let item = iter.into_iter().next().unwrap();
+        let recovered = recover_fn.convert(item).unwrap();
+
+        assert_eq!(*recovered.signer(), cached_sender);
+    }
+
+    #[test]
     fn test_context_for_payload() {
         let chainspec = Arc::new(TempoChainSpec::from_genesis(MODERATO.genesis().clone()));
         let evm_config = TempoEvmConfig::new(chainspec.clone());
@@ -226,7 +257,7 @@ mod tests {
         let validator_set = Some(vec![B256::repeat_byte(0x01), B256::repeat_byte(0x02)]);
 
         let payload = TempoExecutionData {
-            block,
+            block: block.into(),
             block_access_list: None,
             validator_set: validator_set.clone(),
         };
@@ -252,7 +283,7 @@ mod tests {
         let block = create_test_block(vec![system_tx]);
 
         let payload = TempoExecutionData {
-            block: block.clone(),
+            block: block.clone().into(),
             block_access_list: None,
             validator_set: None,
         };

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -1,7 +1,6 @@
 use crate::{TempoExecutionData, TempoPayloadTypes};
 use reth_node_api::{InvalidPayloadAttributesError, NewPayloadError, PayloadValidator};
-use reth_primitives_traits::{AlloyBlockHeader as _, SealedBlock};
-use std::sync::Arc;
+use reth_primitives_traits::{AlloyBlockHeader as _, RecoveredBlock, SealedBlock};
 use tempo_payload_types::TempoPayloadAttributes;
 use tempo_primitives::{Block, TempoHeader};
 
@@ -29,7 +28,19 @@ impl PayloadValidator<TempoPayloadTypes> for TempoEngineValidator {
             block_access_list: _,
             validator_set: _,
         } = payload;
-        Ok(Arc::unwrap_or_clone(block))
+        Ok(block.into_sealed_block())
+    }
+
+    fn ensure_well_formed_payload(
+        &self,
+        payload: TempoExecutionData,
+    ) -> Result<RecoveredBlock<Self::Block>, NewPayloadError> {
+        let TempoExecutionData {
+            block,
+            block_access_list: _,
+            validator_set: _,
+        } = payload;
+        block.into_recovered_block().map_err(NewPayloadError::other)
     }
 
     fn validate_payload_attributes_against_header(

--- a/crates/payload/types/Cargo.toml
+++ b/crates/payload/types/Cargo.toml
@@ -24,6 +24,7 @@ alloy-rpc-types-eth.workspace = true
 alloy-rpc-types-engine.workspace = true
 
 derive_more.workspace = true
+either.workspace = true
 serde.workspace = true
 tracing.workspace = true
 

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -9,16 +9,19 @@ mod budget;
 use alloy_primitives::{B256, Bytes};
 pub use attrs::TempoPayloadAttributes;
 pub use budget::{MarshalPersistEstimator, marshal_persist_estimate, observe_marshal_persist};
-use std::{sync::Arc, time::Duration};
+use std::{ops::Deref, sync::Arc, time::Duration};
 
 use alloy_eips::eip7685::Requests;
 use alloy_primitives::U256;
 use alloy_rpc_types_eth::Withdrawal;
+use either::Either;
 use reth_ethereum_engine_primitives::EthBuiltPayload;
 use reth_node_api::{BlockBody, ExecutionPayload, PayloadTypes};
 use reth_payload_primitives::{BuiltPayload, BuiltPayloadExecutedBlock};
-use reth_primitives_traits::{AlloyBlockHeader as _, SealedBlock};
-use serde::{Deserialize, Serialize};
+use reth_primitives_traits::{
+    AlloyBlockHeader as _, RecoveredBlock, SealedBlock, transaction::signed::RecoveryError,
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tempo_primitives::{Block, TempoPrimitives};
 
 /// Payload types for Tempo node.
@@ -68,10 +71,20 @@ impl TempoBuiltPayload {
 
     /// Converts the built payload into owned execution payload parts.
     pub fn into_execution_payload(self) -> (SealedBlock<Block>, Option<Bytes>) {
-        (
-            Arc::unwrap_or_clone(self.inner.block_arc().clone()).into_sealed_block(),
-            self.block_access_list,
-        )
+        let Self {
+            inner,
+            block_access_list,
+            executed_block,
+            ..
+        } = self;
+        let block = inner.block_arc().clone();
+        drop(inner);
+        drop(executed_block);
+        let block = match Arc::try_unwrap(block) {
+            Ok(block) => block.into_sealed_block(),
+            Err(block) => block.clone_sealed_block(),
+        };
+        (block, block_access_list)
     }
 
     /// Returns the time validators are expected to spend reproducing this payload's build work.
@@ -89,9 +102,17 @@ impl TempoBuiltPayload {
 
     /// Converts the built payload into [`TempoExecutionData`].
     pub fn into_execution_data(self) -> TempoExecutionData {
-        let (block, block_access_list) = self.into_execution_payload();
+        let Self {
+            inner,
+            block_access_list,
+            executed_block,
+            ..
+        } = self;
+        let block = inner.block_arc().clone();
+        drop(inner);
+        drop(executed_block);
         TempoExecutionData {
-            block: Arc::new(block),
+            block: TempoExecutionBlock::recovered(block),
             block_access_list,
             validator_set: None,
         }
@@ -122,11 +143,11 @@ impl BuiltPayload for TempoBuiltPayload {
     }
 }
 
-/// Execution data for Tempo node. Simply wraps a sealed block.
+/// Execution data for Tempo node.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TempoExecutionData {
-    /// The built block.
-    pub block: Arc<SealedBlock<Block>>,
+    /// The built block, optionally with recovered transaction senders.
+    pub block: TempoExecutionBlock,
     /// RLP-encoded EIP-7928 block access list, when supplied with the payload.
     pub block_access_list: Option<Bytes>,
     /// Validator set active at the time this block was built.
@@ -196,9 +217,105 @@ impl PayloadTypes for TempoPayloadTypes {
 
     fn block_to_payload(block: SealedBlock<Block>, bal: Option<Bytes>) -> Self::ExecutionData {
         TempoExecutionData {
-            block: Arc::new(block),
+            block: block.into(),
             block_access_list: bal,
             validator_set: None,
         }
+    }
+}
+
+/// A Tempo execution block, optionally retaining recovered transaction senders.
+#[derive(Debug, Clone)]
+pub struct TempoExecutionBlock(Either<Arc<SealedBlock<Block>>, Arc<RecoveredBlock<Block>>>);
+
+impl TempoExecutionBlock {
+    /// Creates an execution block from a sealed block.
+    pub fn sealed(block: SealedBlock<Block>) -> Self {
+        Self(Either::Left(Arc::new(block)))
+    }
+
+    /// Creates an execution block from a shared sealed block.
+    pub fn sealed_arc(block: Arc<SealedBlock<Block>>) -> Self {
+        Self(Either::Left(block))
+    }
+
+    /// Creates an execution block from a shared recovered block.
+    pub fn recovered(block: Arc<RecoveredBlock<Block>>) -> Self {
+        Self(Either::Right(block))
+    }
+
+    /// Returns the sealed block view.
+    pub fn sealed_block(&self) -> &SealedBlock<Block> {
+        match &self.0 {
+            Either::Left(block) => block,
+            Either::Right(block) => block.sealed_block(),
+        }
+    }
+
+    /// Returns the recovered block when this payload retained recovered senders.
+    pub fn recovered_block(&self) -> Option<&RecoveredBlock<Block>> {
+        match &self.0 {
+            Either::Left(_) => None,
+            Either::Right(block) => Some(block),
+        }
+    }
+
+    /// Consumes this block and returns the sealed block.
+    pub fn into_sealed_block(self) -> SealedBlock<Block> {
+        match self.0 {
+            Either::Left(block) => Arc::unwrap_or_clone(block),
+            Either::Right(block) => match Arc::try_unwrap(block) {
+                Ok(block) => block.into_sealed_block(),
+                Err(block) => block.clone_sealed_block(),
+            },
+        }
+    }
+
+    /// Consumes this block and returns the recovered block, recovering sealed-only blocks as needed.
+    pub fn into_recovered_block(self) -> Result<RecoveredBlock<Block>, RecoveryError> {
+        match self.0 {
+            Either::Left(block) => Arc::unwrap_or_clone(block)
+                .try_recover()
+                .map_err(Into::into),
+            Either::Right(block) => Ok(Arc::unwrap_or_clone(block)),
+        }
+    }
+}
+
+impl From<SealedBlock<Block>> for TempoExecutionBlock {
+    fn from(block: SealedBlock<Block>) -> Self {
+        Self::sealed(block)
+    }
+}
+
+impl From<Arc<SealedBlock<Block>>> for TempoExecutionBlock {
+    fn from(block: Arc<SealedBlock<Block>>) -> Self {
+        Self::sealed_arc(block)
+    }
+}
+
+impl From<Arc<RecoveredBlock<Block>>> for TempoExecutionBlock {
+    fn from(block: Arc<RecoveredBlock<Block>>) -> Self {
+        Self::recovered(block)
+    }
+}
+
+impl Deref for TempoExecutionBlock {
+    type Target = SealedBlock<Block>;
+
+    fn deref(&self) -> &Self::Target {
+        self.sealed_block()
+    }
+}
+
+impl Serialize for TempoExecutionBlock {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.sealed_block().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for TempoExecutionBlock {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        SealedBlock::<Block>::deserialize(deserializer).map(Self::sealed)
     }
 }


### PR DESCRIPTION
Keeps locally built payloads backed by `RecoveredBlock` so engine execution can reuse cached transaction senders instead of recovering them again. The sealed-only path remains available for external payloads and serialization continues to use the sealed block form.

This also avoids the forced sealed-block clone when converting a built payload into proposal execution parts by dropping the other local `Arc` owners before extracting the block.