### PR TITLE
chore: bump reth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.36.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
+checksum = "58673bde58f17022886547b618346aeae9b147ed398f9c847105fa91c49f97eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1177,7 +1177,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1188,7 +1188,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3828,7 +3828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4293,7 +4293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4796,8 +4796,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -5489,7 +5489,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5885,7 +5885,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7055,7 +7055,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,9 +10767,8 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
- "alloy-chains",
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
  "alloy-eips",
@@ -10818,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10831,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10862,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10913,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10941,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10955,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10990,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11016,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11034,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11081,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11100,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11119,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11164,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11217,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11237,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11266,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e4ac8ba241c58e8f059eda9636a1ebfe41286cb#2e4ac8ba241c58e8f059eda9636a1ebfe41286cb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11800,7 +11799,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11880,7 +11879,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12532,7 +12531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12808,7 +12807,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13141,7 +13140,6 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -14867,7 +14865,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "2e4ac8ba241c58e8f059eda9636a1ebfe41286cb", features = [
   "std",
   "optional-checks",
 ] }
@@ -210,7 +210,7 @@ alloy-consensus = { version = "2.0.5", default-features = false }
 alloy-contract = { version = "2.0.5", default-features = false }
 alloy-eip7928 = { version = "0.4.0", default-features = false }
 alloy-eips = { version = "2.0.5", default-features = false }
-alloy-evm = { version = "0.36.0", default-features = false }
+alloy-evm = { version = "0.35.1", default-features = false }
 revm-inspectors = "0.40.0"
 alloy-genesis = { version = "2.0.5", default-features = false }
 alloy-hardforks = "0.4.7"

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -50,11 +50,10 @@ impl TempoConsensus {
     }
 
     /// Creates a new [`TempoConsensus`] with optional pre-Amsterdam BAL hash support.
-    pub fn new_with_bal_hashes(chain_spec: Arc<TempoChainSpec>, allow_bal_hashes: bool) -> Self {
+    pub fn new_with_bal_hashes(chain_spec: Arc<TempoChainSpec>, _allow_bal_hashes: bool) -> Self {
         Self {
             inner: EthBeaconConsensus::new(chain_spec)
-                .with_max_extra_data_size(TEMPO_MAXIMUM_EXTRA_DATA_SIZE)
-                .with_allow_bal_hashes(allow_bal_hashes),
+                .with_max_extra_data_size(TEMPO_MAXIMUM_EXTRA_DATA_SIZE),
         }
     }
 

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -34,7 +34,6 @@ alloy-rlp.workspace = true
 alloy-evm.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
-alloy-rpc-types-eth = { workspace = true, optional = true }
 
 derive_more.workspace = true
 thiserror.workspace = true
@@ -56,7 +55,7 @@ tempo-primitives = { workspace = true, features = ["arbitrary"] }
 
 [features]
 default = ["rpc", "engine"]
-rpc = ["dep:alloy-rpc-types-eth", "dep:reth-rpc-eth-api", "tempo-revm/rpc", "tempo-primitives/serde", "tempo-primitives/reth-codec"]
+rpc = ["dep:reth-rpc-eth-api", "tempo-revm/rpc", "tempo-primitives/serde", "tempo-primitives/reth-codec"]
 engine = ["dep:tempo-payload-types", "dep:rayon"]
 
 [[bench]]

--- a/crates/evm/src/assemble.rs
+++ b/crates/evm/src/assemble.rs
@@ -2,7 +2,6 @@ use crate::{
     TempoEvmConfig, TempoEvmFactory, block::TempoReceiptBuilder, context::TempoBlockExecutionCtx,
 };
 use alloy_evm::{block::BlockExecutionError, eth::EthBlockExecutorFactory};
-use alloy_primitives::{B256, Bloom};
 use reth_evm::execute::{BlockAssembler, BlockAssemblerInput};
 use reth_evm_ethereum::EthBlockAssembler;
 use reth_primitives_traits::SealedHeader;
@@ -26,9 +25,9 @@ impl TempoBlockAssembler {
     pub fn assemble_block(
         &self,
         input: BlockAssemblerInput<'_, '_, TempoEvmConfig, TempoHeader>,
-        transactions_root: Option<B256>,
-        receipts_root: Option<B256>,
-        receipts_bloom: Option<Bloom>,
+        _transactions_root: Option<alloy_primitives::B256>,
+        _receipts_root: Option<alloy_primitives::B256>,
+        _receipts_bloom: Option<alloy_primitives::Bloom>,
     ) -> Result<tempo_primitives::Block, BlockExecutionError> {
         let BlockAssemblerInput {
             evm_env,
@@ -70,9 +69,6 @@ impl TempoBlockAssembler {
                 state_root,
                 block_access_list_hash,
             ),
-            transactions_root,
-            receipts_root,
-            receipts_bloom,
         )?;
 
         Ok(block.map_header(|inner| TempoHeader {

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -18,7 +18,7 @@ use commonware_cryptography::{
     Verifier,
     ed25519::{PublicKey, Signature},
 };
-use reth_evm::block::StateDB;
+use reth_evm::{block::StateDB, OnStateHook};
 use reth_revm::{
     Inspector,
     context::result::ResultAndState,
@@ -465,6 +465,10 @@ where
     type Receipt = TempoReceipt;
     type Evm = TempoEvm<DB, I>;
     type Result = TempoTxResult;
+
+    fn set_state_hook(&mut self, state_hook: Option<Box<dyn OnStateHook>>) {
+        self.inner.set_state_hook(state_hook);
+    }
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), alloy_evm::block::BlockExecutionError> {
         if self

--- a/crates/evm/src/context.rs
+++ b/crates/evm/src/context.rs
@@ -52,12 +52,9 @@ pub struct TempoNextBlockEnvAttributes {
 impl reth_rpc_eth_api::helpers::pending_block::BuildPendingEnv<tempo_primitives::TempoHeader>
     for TempoNextBlockEnvAttributes
 {
-    fn build_pending_env(
-        parent: &crate::SealedHeader<tempo_primitives::TempoHeader>,
-        block_overrides: Option<&alloy_rpc_types_eth::BlockOverrides>,
-    ) -> Self {
+    fn build_pending_env(parent: &crate::SealedHeader<tempo_primitives::TempoHeader>) -> Self {
         Self {
-            inner: NextBlockEnvAttributes::build_pending_env(parent, block_overrides),
+            inner: NextBlockEnvAttributes::build_pending_env(parent),
             general_gas_limit: parent.general_gas_limit,
             shared_gas_limit: parent.shared_gas_limit,
             timestamp_millis_part: parent.timestamp_millis_part,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -487,10 +487,7 @@ where
         maybe_override_fee_recipient(&mut executor, &attributes);
 
         if let Some(ref handle) = trie_handle {
-            executor
-                .evm_mut()
-                .db_mut()
-                .set_state_hook(Some(Box::new(handle.state_hook())));
+            executor.set_state_hook(Some(Box::new(handle.state_hook())));
         }
 
         executor.apply_pre_execution_changes().map_err(|err| {


### PR DESCRIPTION
## Summary
- Bump reth git dependencies to paradigmxyz/reth@2e4ac8ba241c58e8f059eda9636a1ebfe41286cb.
- Align alloy-evm with the reth revision and adapt Tempo consensus/EVM/payload builder code to the updated reth APIs.

## Validation
- cargo check --features bal
- Attempted: nu bench-e2e.nu e2e --baseline HEAD~1 --feature HEAD --baseline-features bal --feature-features bal
  - Blocked: bench-e2e requires --preset; available presets: mix, mpp, tip20, tip20_existing_recipients, tip20_random_recipients.

Prompted by: @shekhirin