### PR TITLE
fix(bench): detect armored age signing keys

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -537,7 +537,9 @@ def build-e2e-consensus-args [node_dir: string, trusted_peers: string, port: int
     let signing_key = $"($node_dir)/signing.key"
     let signing_share = $"($node_dir)/signing.share"
     let enode_key = $"($node_dir)/enode.key"
-    let signing_secret_args = if ((open --raw $signing_key) | str starts-with "age-encryption.org/") {
+    let signing_key_contents = (open --raw $signing_key | into binary)
+    let signing_key_is_encrypted = ($signing_key_contents | bytes starts-with 0x[61 67 65 2d 65 6e 63 72 79 70 74 69 6f 6e 2e 6f 72 67 2f])
+    let signing_secret_args = if $signing_key_is_encrypted {
         ["--consensus.secret" "<(printf '%s\\n' 'tempo-localnet-signing-key-secret')"]
     } else {
         []


### PR DESCRIPTION
## Summary
- detect encrypted localnet signing keys in bench-e2e using the raw age byte prefix
- pass `--consensus.secret` for encrypted age keys
- keep plaintext bloat snapshots on the no-secret path

## Validation
- `cargo run -p tempo-xtask -- generate-localnet -o /tmp/tempo-localnet-check --accounts 4 --validators 127.0.0.2:8000,127.0.0.3:8100 --seed 1 --force`
- confirmed generated `signing.key` starts with `age-encryption.org/v1`
- exercised `build-e2e-consensus-args` with the real generated key: includes `--consensus.secret`
- exercised `build-e2e-consensus-args` with a plaintext sample key: omits `--consensus.secret`

Prompted by: @shekhirin