### PR TITLE
ci: use foundry `master` in specs workflow

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -77,8 +77,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          # tmp: rus/bump-tempo-v1.7
-          ref: 5ad62bb61e88facba18f800c73b9ff7b60ef3fb7
+          ref: master
           path: foundry
           persist-credentials: false
 
@@ -220,8 +219,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          # tmp: rus/bump-tempo-v1.7
-          ref: 5ad62bb61e88facba18f800c73b9ff7b60ef3fb7
+          ref: master
           path: foundry
           persist-credentials: false
 


### PR DESCRIPTION
## Summary
- update both Foundry checkouts in `.github/workflows/specs.yml` to use `ref: master`
- remove stale temporary branch comments

Prompted by: @0xrusowsky