### PR TITLE
Add bench e2e 2D nonce preset

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -58,6 +58,7 @@ on:
         default: tip20
         options:
           - tip20
+          - tip20_2d_nonces
           - tip20_random_recipients
           - tip20_existing_recipients
           - mpp

--- a/contrib/bench/txgen/presets/tip20_2d_nonces.yml
+++ b/contrib/bench/txgen/presets/tip20_2d_nonces.yml
@@ -1,0 +1,41 @@
+chain_id: 1337
+
+gas:
+  max_fee_per_gas: 100000000000
+  max_priority_fee_per_gas: 100000000000
+
+accounts:
+  users:
+    mnemonic: "test test test test test test test test test test test junk"
+    range:
+      - 0
+      - ${TXGEN_ACCOUNTS}
+
+artifacts:
+  ERC20: ../erc20.abi.json
+
+templates:
+  tip20_transfer:
+    type: tempo
+    from:
+      pool: users
+      select: random
+    gas_limit: 300000
+    max_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 100000000000
+    fee_token: "0x20c0000000000000000000000000000000000000"
+    nonce_key:
+      uniform: [1, 115792089237316195423570985008687907853269984665640564039457584007913129639935]
+    call:
+      to: "0x20c0000000000000000000000000000000000000"
+      abi: ERC20
+      function: transfer
+      args:
+        - pool:
+            pool: users
+            select: random
+        - 1
+
+mix:
+  - template: tip20_transfer
+    weight: 100


### PR DESCRIPTION
## Summary
- add `tip20_2d_nonces` txgen preset for regular 2D nonce TIP20 transfers
- expose the preset in the `bench-e2e.yml` workflow dispatch choices

## Testing
- `nu -c 'source contrib/bench/txgen/helpers.nu; txgen-preset-path tip20_2d_nonces'`\n\nPrompted by: @shekhirin