### PR TITLE
docs(tip-1069): renumber from TIP-1053

### DIFF
--- a/crates/contracts/src/precompiles/account_keychain.rs
+++ b/crates/contracts/src/precompiles/account_keychain.rs
@@ -96,10 +96,10 @@ crate::sol! {
             uint256 remainingLimit
         );
 
-        /// Emitted when a key authorization carries a TIP-1053 witness.
+        /// Emitted when a key authorization carries a TIP-1069 witness.
         event KeyAuthorizationWitness(address indexed account, bytes32 indexed witness);
 
-        /// Emitted when a TIP-1053 key-authorization witness is manually burned.
+        /// Emitted when a TIP-1069 key-authorization witness is manually burned.
         event KeyAuthorizationWitnessBurned(address indexed account, bytes32 indexed witness);
 
         /// Legacy authorize-key entrypoint used before T3.
@@ -121,7 +121,7 @@ crate::sol! {
             KeyRestrictions calldata config
         ) external;
 
-        /// Authorize a new key with a TIP-1053 witness.
+        /// Authorize a new key with a TIP-1069 witness.
         /// @dev The witness must not be burned for the caller's account. bytes32(0) is valid.
         function authorizeKey(
             address keyId,
@@ -138,7 +138,7 @@ crate::sol! {
             bytes32 witness
         ) external;
 
-        /// Burn a TIP-1053 key-authorization witness without authorizing a key.
+        /// Burn a TIP-1069 key-authorization witness without authorizing a key.
         /// @dev Callable only by the account admin key.
         function burnKeyAuthorizationWitness(bytes32 witness) external;
 
@@ -207,7 +207,7 @@ crate::sol! {
             address keyId
         ) external view returns (bool isScoped, CallScope[] memory scopes);
 
-        /// Returns whether a TIP-1053 key-authorization witness has been manually burned.
+        /// Returns whether a TIP-1069 key-authorization witness has been manually burned.
         function isKeyAuthorizationWitnessBurned(address account, bytes32 witness) external view returns (bool);
 
         /// Returns true if `keyId` is the root key or an active admin key for `account`.

--- a/crates/node/tests/it/tempo_transaction/types.rs
+++ b/crates/node/tests/it/tempo_transaction/types.rs
@@ -764,7 +764,7 @@ pub(crate) enum AuthKind {
         num_limits: usize,
         allowed_calls: AllowedCallsMode,
     },
-    /// Inline key authorization carrying a TIP-1053 witness.
+    /// Inline key authorization carrying a TIP-1069 witness.
     KeyAuthWitness {
         key_type: SignatureType,
         num_limits: usize,

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -401,7 +401,7 @@ impl AccountKeychain {
         ))
     }
 
-    /// Burns a TIP-1053 witness without authorizing a key.
+    /// Burns a TIP-1069 witness without authorizing a key.
     pub fn burn_key_authorization_witness(
         &mut self,
         msg_sender: Address,
@@ -692,7 +692,7 @@ impl AccountKeychain {
         })
     }
 
-    /// Returns whether a TIP-1053 key-authorization witness has been manually burned.
+    /// Returns whether a TIP-1069 key-authorization witness has been manually burned.
     pub fn is_key_authorization_witness_burned(
         &self,
         call: isKeyAuthorizationWitnessBurnedCall,

--- a/crates/primitives/src/transaction/key_authorization.rs
+++ b/crates/primitives/src/transaction/key_authorization.rs
@@ -180,7 +180,7 @@ impl From<SelectorRule> for AbiSelectorRule {
 /// - `limits`: `None` (omitted or 0x80) = unlimited spending, `Some([])` = no spending, `Some([...])` = specific limits
 /// - `allowed_calls`: `None` (canonically omitted, explicit 0x80 accepted) = unrestricted,
 ///   `Some([])` = scoped with no allowed calls, `Some([...])` = scoped calls
-/// - `witness`: `None` (canonically omitted) = no TIP-1053 witness,
+/// - `witness`: `None` (canonically omitted) = no TIP-1069 witness,
 ///   `Some(bytes32)` = arbitrary signed witness checked against the account's burned set.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -219,7 +219,7 @@ pub struct KeyAuthorization {
     /// - `Some([CallScope{...}])` = explicit target/selector scope list
     pub allowed_calls: Option<Vec<CallScope>>,
 
-    /// Optional TIP-1053 witness for offchain context binding and manual revocation.
+    /// Optional TIP-1069 witness for offchain context binding and manual revocation.
     ///
     /// `None` means no witness. `Some(witness)` means the witness field is present, including when
     /// `witness == B256::ZERO`.
@@ -283,13 +283,13 @@ impl KeyAuthorization {
         self
     }
 
-    /// Attach a TIP-1053 witness to this authorization.
+    /// Attach a TIP-1069 witness to this authorization.
     pub fn with_witness(mut self, witness: B256) -> Self {
         self.witness = Some(witness);
         self
     }
 
-    /// Returns this authorization's TIP-1053 witness, if present.
+    /// Returns this authorization's TIP-1069 witness, if present.
     pub fn witness(&self) -> Option<B256> {
         self.witness
     }
@@ -331,7 +331,7 @@ impl KeyAuthorization {
         self.allowed_calls.is_some()
     }
 
-    /// Returns whether this authorization carries a TIP-1053 witness field.
+    /// Returns whether this authorization carries a TIP-1069 witness field.
     pub fn has_witness(&self) -> bool {
         self.witness.is_some()
     }

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -93,7 +93,7 @@ pub struct TempoPoolUpdates {
     /// with the runtime's actual spending-limit decrements instead of inferring them from
     /// the mined transaction body.
     pub spending_limit_spends: SpendingLimitUpdates,
-    /// TIP-1053 key-authorization witness burns.
+    /// TIP-1069 key-authorization witness burns.
     ///
     /// Pending AA transactions carrying the same `(account, witness)` key authorization are no
     /// longer executable once the account explicitly burns that witness.

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -281,7 +281,7 @@ where
                 }
             }
 
-            // Check 2c: TIP-1053 key-authorization witness burns
+            // Check 2c: TIP-1069 key-authorization witness burns
             if !updates.key_authorization_witness_burns.is_empty()
                 && let Some(subject) = tx.transaction.key_authorization_witness_subject()
                 && updates

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -229,7 +229,7 @@ impl TempoPooledTransaction {
         })
     }
 
-    /// Extracts the TIP-1053 key-authorization witness carried by this transaction, if any.
+    /// Extracts the TIP-1069 key-authorization witness carried by this transaction, if any.
     pub fn key_authorization_witness_subject(&self) -> Option<KeyAuthorizationWitnessSubject> {
         let aa_tx = self.inner().as_aa()?;
         let witness = aa_tx
@@ -1409,7 +1409,7 @@ impl KeychainSubject {
 pub struct KeyAuthorizationWitnessSubject {
     /// The account whose key-authorization witness is carried or burned.
     pub account: Address,
-    /// The TIP-1053 witness.
+    /// The TIP-1069 witness.
     pub witness: B256,
 }
 

--- a/tips/tip-1049.md
+++ b/tips/tip-1049.md
@@ -59,7 +59,7 @@ A new function on the `AccountKeychain` precompile authorizes an admin key for t
 /// @notice Authorizes an admin key for the caller's account.
 /// @param keyId The key identifier (address derived from public key)
 /// @param signatureType 0: secp256k1, 1: P256, 2: WebAuthn
-/// @param witness TIP-1053 key-authorization witness for this authorization
+/// @param witness TIP-1069 key-authorization witness for this authorization
 function authorizeAdminKey(
     address keyId,
     SignatureType signatureType,
@@ -71,7 +71,7 @@ function authorizeAdminKey(
 - MUST reject if `witness` is already burned for `account`. `bytes32(0)` is a valid witness value.
 - MUST reject `keyId == account` with `AccountKeychainError::InvalidKeyId`, including attempts to authorize the root EOA key as an admin access key.
 - MUST reject if `keys[account][keyId]` is already registered with `AccountKeychainError::KeyAlreadyExists`; previously revoked key IDs MUST reject with `AccountKeychainError::KeyAlreadyRevoked`. Only newly authorized keys can be marked as admin.
-- On success, sets `keys[account][keyId].is_admin = true` and emits `AdminKeyAuthorized`. It also emits the TIP-1053 witness event for `witness`.
+- On success, sets `keys[account][keyId].is_admin = true` and emits `AdminKeyAuthorized`. It also emits the TIP-1069 witness event for `witness`.
 
 ### `AdminKeyAuthorized` Event
 
@@ -159,7 +159,7 @@ Revocation of an admin key does NOT automatically revoke keys that it authorized
 
 ## Transaction Encoding
 
-`KeyAuthorization` remains an RLP list. TIP-1053 adds `witness?`; TIP-1049 adds the `is_admin?` and `account?` trailing optional fields after it:
+`KeyAuthorization` remains an RLP list. TIP-1069 adds `witness?`; TIP-1049 adds the `is_admin?` and `account?` trailing optional fields after it:
 
 ```
 rlp([chain_id, key_type, key_id, expiry?, limits?, allowed_calls?, witness?, is_admin?, account?])

--- a/tips/tip-1057.md
+++ b/tips/tip-1057.md
@@ -4,7 +4,7 @@ title: T5 Hardfork Meta TIP
 description: Meta TIP collecting bug fixes, security hardening, and infrastructure changes gated behind the T5 hardfork.
 authors: Marc Martinez (@0xrusowsky)
 status: Draft
-related: TIP-1026, TIP-1030, TIP-1033, TIP-1034, TIP-1035, TIP-1045, TIP-1053, TIP-1056
+related: TIP-1026, TIP-1030, TIP-1033, TIP-1034, TIP-1035, TIP-1045, TIP-1069, TIP-1056
 protocolVersion: T5
 ---
 
@@ -12,7 +12,7 @@ protocolVersion: T5
 
 ## Abstract
 
-This meta TIP collects bug fixes, security hardening, and infrastructure changes that activate at T5. Each item is small in isolation, but together they define the complete in-scope T5 bug-fix and infrastructure bundle. Feature changes already specified by standalone TIPs (TIP-1026, TIP-1030, TIP-1033, TIP-1034, TIP-1035, TIP-1045, TIP-1053, TIP-1056) are intentionally excluded from this meta TIP.
+This meta TIP collects bug fixes, security hardening, and infrastructure changes that activate at T5. Each item is small in isolation, but together they define the complete in-scope T5 bug-fix and infrastructure bundle. Feature changes already specified by standalone TIPs (TIP-1026, TIP-1030, TIP-1033, TIP-1034, TIP-1035, TIP-1045, TIP-1069, TIP-1056) are intentionally excluded from this meta TIP.
 
 ## Motivation
 

--- a/tips/tip-1069.md
+++ b/tips/tip-1069.md
@@ -1,5 +1,5 @@
 ---
-id: TIP-1053
+id: TIP-1069
 title: Witnesses in Key Authorizations
 description: Add an optional 32-byte witness to key authorizations so a single signature can both authorize an access key and bind to an arbitrary application context, with manual witness burning for revocation.
 authors: Jake Moxey (@jxom)
@@ -8,7 +8,7 @@ related: TIP-1011, TIP-1020
 protocolVersion: T5
 ---
 
-# TIP-1053: Witnesses in Key Authorizations
+# TIP-1069: Witnesses in Key Authorizations
 
 ## Abstract
 
@@ -33,7 +33,7 @@ The protocol stays minimal: it does not learn about sign-in semantics, applicati
 
 - The offchain verifier (e.g. app server) is responsible for replay protection of its own session flow. The protocol exposes the witness but does not make it single-use when a key authorization succeeds.
 - The `witness` format is application-defined when used as a challenge digest. The protocol does not validate its structure.
-- This TIP is purely additive to `key_authorization`. Existing authorizations (without the field) continue to validate identically. When the field is absent, the resulting hash is byte-equivalent to pre-TIP-1053 encoding for that authorization and no witness check or event is performed.
+- This TIP is purely additive to `key_authorization`. Existing authorizations (without the field) continue to validate identically. When the field is absent, the resulting hash is byte-equivalent to pre-TIP-1069 encoding for that authorization and no witness check or event is performed.
 - A manually burned `(account, witness)` prevents future witness-bearing authorizations that use the same pair. Successful witness-bearing authorizations do not burn the witness.
 
 ---
@@ -81,7 +81,7 @@ The protocol:
 - MUST NOT enforce ordering, monotonicity, or any other structural constraint on `witness`. Witnesses may be arbitrary 32-byte values chosen by the application.
 - MUST NOT interpret the `witness` value beyond checking whether it has been burned.
 
-A witness-less authorization (field absent) is processed exactly as in pre-TIP-1053 behavior: no witness check is performed, no witness event is emitted, and the existing `keys[account][key_id]` permanence is the sole replay guard.
+A witness-less authorization (field absent) is processed exactly as in pre-TIP-1069 behavior: no witness check is performed, no witness event is emitted, and the existing `keys[account][key_id]` permanence is the sole replay guard.
 
 The field is invisible to existing precompile read paths that surface `KeyInfo`. A new read path MAY be added to query burn status of a given `(account, witness)` pair.
 
@@ -123,7 +123,7 @@ The `witness` format is application-defined when used as a challenge digest. The
 
 ## Backward Compatibility
 
-- Existing key authorizations without the field continue to validate and produce byte-equivalent encodings to pre-TIP-1053 payloads.
+- Existing key authorizations without the field continue to validate and produce byte-equivalent encodings to pre-TIP-1069 payloads.
 - Legacy verifiers that don't understand the field will compute the same hash for legacy-shaped authorizations and will reject (signature mismatch) for authorizations with a present witness, which is the correct fail-safe.
 - Witness burn checks are only engaged when the witness field is present; legacy witness-less authorizations incur no additional state reads or writes.
 


### PR DESCRIPTION
Renumber the witnesses-in-key-authorizations TIP from 1053 to 1069 (next available number).

Updates all in-tree doc comments and cross-TIP references. Merged commit history still references TIP-1053.