### PR TITLE
perf(pool): cache TIP-20 static prewarm info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13289,7 +13289,6 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-sol-types",
  "crossbeam-channel",
  "metrics",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13292,6 +13292,7 @@ dependencies = [
  "alloy-sol-types",
  "crossbeam-channel",
  "metrics",
+ "parking_lot",
  "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-consensus-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13291,7 +13291,6 @@ dependencies = [
  "alloy-rlp",
  "crossbeam-channel",
  "metrics",
- "parking_lot",
  "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-consensus-common",

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -43,6 +43,7 @@ alloy-rlp.workspace = true
 alloy-sol-types.workspace = true
 
 metrics.workspace = true
+parking_lot.workspace = true
 tracing.workspace = true
 crossbeam-channel.workspace = true
 tokio.workspace = true

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -40,7 +40,6 @@ alloy-eip7928.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
-alloy-sol-types.workspace = true
 
 metrics.workspace = true
 parking_lot.workspace = true

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -42,7 +42,6 @@ alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 
 metrics.workspace = true
-parking_lot.workspace = true
 tracing.workspace = true
 crossbeam-channel.workspace = true
 tokio.workspace = true

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -1,14 +1,10 @@
-use std::{
-    collections::HashSet,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-        mpsc::{self, Receiver, Sender},
-    },
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+    mpsc::{self, Receiver, Sender},
 };
 
-use alloy_primitives::{Address, B256};
-use parking_lot::Mutex;
+use alloy_primitives::B256;
 use reth_engine_tree::tree::{CachedStateProvider, SavedCache};
 use reth_evm::{Database, Evm, EvmEnvFor};
 use reth_revm::database::StateProviderDatabase;
@@ -18,10 +14,6 @@ use reth_transaction_pool::{
     BestTransactions, PoolTransaction, error::InvalidPoolTransactionError,
 };
 use tempo_evm::{TempoEvmConfig, evm::TempoEvm};
-use tempo_precompiles::{
-    NONCE_PRECOMPILE_ADDRESS, TIP_FEE_MANAGER_ADDRESS, nonce::slots as nonce_slots,
-    storage::StorageKey as _, tip_fee_manager::slots as fee_manager_slots,
-};
 use tempo_transaction_pool::{
     best::BestTransaction,
     tip20_info::{Tip20StaticInfo, Tip20StorageSlot},
@@ -63,7 +55,6 @@ impl BestTransactionsPrewarming {
             cache,
             evm_env,
             stop: stop.clone(),
-            dedup: Arc::new(PrewarmDedup::default()),
         };
 
         let this = Self {
@@ -185,13 +176,7 @@ impl BestTransactionsPrewarming {
             let tx_hash = *tx.hash();
 
             let touched = if let Some(static_info) = tx.transaction.tip20_static_info() {
-                match prewarm_static_tip20_transaction(
-                    evm,
-                    &prewarm,
-                    static_info,
-                    &tx,
-                    prewarm.evm_env.block_env.beneficiary,
-                ) {
+                match prewarm_static_tip20_transaction(evm, &prewarm, static_info) {
                     Ok(touched) => Some(touched),
                     Err(err) => {
                         trace!(
@@ -294,7 +279,6 @@ struct PrewarmingExecutionContext<Provider> {
     cache: Option<SavedCache>,
     evm_env: EvmEnvFor<TempoEvmConfig>,
     stop: Arc<AtomicBool>,
-    dedup: Arc<PrewarmDedup>,
 }
 
 impl<Provider> PrewarmingExecutionContext<Provider>
@@ -341,201 +325,46 @@ impl<Provider> PrewarmingExecutionContext<Provider> {
     }
 }
 
-#[derive(Debug, Default)]
-struct PrewarmDedup {
-    accounts: Mutex<HashSet<Address>>,
-    shared_storage_slots: Mutex<HashSet<Tip20StorageSlot>>,
-    tip20_token_info: Mutex<HashSet<Address>>,
-}
-
 fn prewarm_static_tip20_transaction<DB, Provider>(
     evm: &mut TempoEvm<DB>,
     prewarm: &PrewarmingExecutionContext<Provider>,
     info: &Tip20StaticInfo,
-    tx: &BestTransaction,
-    fee_recipient: Address,
 ) -> Result<usize, DB::Error>
 where
     DB: Database,
 {
     let mut touched = 0;
 
-    for token in info.token_info() {
-        if prewarm.is_stopped() {
-            return Ok(touched);
-        }
-        touched += warm_tip20_token_info_once(evm, prewarm, *token)?;
-    }
-
     for slot in info.balance_slots() {
         if prewarm.is_stopped() {
             return Ok(touched);
         }
-        touched += warm_storage_slot(evm, prewarm, *slot)?;
+        touched += warm_storage_slot(evm, *slot)?;
     }
 
     for slot in info.reward_slots() {
         if prewarm.is_stopped() {
             return Ok(touched);
         }
-        touched += warm_storage_slot(evm, prewarm, *slot)?;
+        touched += warm_storage_slot(evm, *slot)?;
     }
 
     for slot in info.allowance_slots() {
         if prewarm.is_stopped() {
             return Ok(touched);
         }
-        touched += warm_storage_slot(evm, prewarm, *slot)?;
+        touched += warm_storage_slot(evm, *slot)?;
     }
-
-    if prewarm.is_stopped() {
-        return Ok(touched);
-    }
-    touched += prewarm_fee_manager_touches_once(
-        evm,
-        prewarm,
-        fee_recipient,
-        tx.transaction.effective_fee_token(),
-    )?;
-
-    if prewarm.is_stopped() {
-        return Ok(touched);
-    }
-    touched += prewarm_expiring_nonce_touches_once(evm, prewarm, tx)?;
 
     Ok(touched)
 }
 
-fn warm_tip20_token_info_once<DB, Provider>(
-    evm: &mut TempoEvm<DB>,
-    prewarm: &PrewarmingExecutionContext<Provider>,
-    token: Address,
-) -> Result<usize, DB::Error>
+fn warm_storage_slot<DB>(evm: &mut TempoEvm<DB>, slot: Tip20StorageSlot) -> Result<usize, DB::Error>
 where
     DB: Database,
 {
-    let should_warm = prewarm.dedup.tip20_token_info.lock().insert(token);
-
-    if !should_warm {
-        return Ok(0);
-    }
-
-    let mut touched = warm_account_once(evm, prewarm, token)?;
-    for slot in Tip20StaticInfo::token_info_slots(token) {
-        touched += warm_shared_storage_slot_once(evm, prewarm, slot)?;
-    }
-    Ok(touched)
-}
-
-fn prewarm_fee_manager_touches_once<DB, Provider>(
-    evm: &mut TempoEvm<DB>,
-    prewarm: &PrewarmingExecutionContext<Provider>,
-    fee_recipient: Address,
-    fee_token: Address,
-) -> Result<usize, DB::Error>
-where
-    DB: Database,
-{
-    let mut touched = 0;
-    touched += warm_shared_storage_slot_once(
-        evm,
-        prewarm,
-        Tip20StorageSlot {
-            address: TIP_FEE_MANAGER_ADDRESS,
-            slot: fee_recipient.mapping_slot(fee_manager_slots::VALIDATOR_TOKENS),
-        },
-    )?;
-    touched += warm_shared_storage_slot_once(
-        evm,
-        prewarm,
-        Tip20StorageSlot {
-            address: TIP_FEE_MANAGER_ADDRESS,
-            slot: fee_token
-                .mapping_slot(fee_recipient.mapping_slot(fee_manager_slots::COLLECTED_FEES)),
-        },
-    )?;
-    Ok(touched)
-}
-
-fn prewarm_expiring_nonce_touches_once<DB, Provider>(
-    evm: &mut TempoEvm<DB>,
-    prewarm: &PrewarmingExecutionContext<Provider>,
-    tx: &BestTransaction,
-) -> Result<usize, DB::Error>
-where
-    DB: Database,
-{
-    let Some(expiring_nonce_slot) = tx.transaction.expiring_nonce_slot() else {
-        return Ok(0);
-    };
-
-    let mut touched = 0;
-    touched += warm_storage_slot(
-        evm,
-        prewarm,
-        Tip20StorageSlot {
-            address: NONCE_PRECOMPILE_ADDRESS,
-            slot: expiring_nonce_slot,
-        },
-    )?;
-    touched += warm_shared_storage_slot_once(
-        evm,
-        prewarm,
-        Tip20StorageSlot {
-            address: NONCE_PRECOMPILE_ADDRESS,
-            slot: nonce_slots::EXPIRING_NONCE_RING_PTR,
-        },
-    )?;
-    Ok(touched)
-}
-
-fn warm_account_once<DB, Provider>(
-    evm: &mut TempoEvm<DB>,
-    prewarm: &PrewarmingExecutionContext<Provider>,
-    address: Address,
-) -> Result<usize, DB::Error>
-where
-    DB: Database,
-{
-    let should_warm = prewarm.dedup.accounts.lock().insert(address);
-
-    if should_warm {
-        let _ = evm.db_mut().basic(address)?;
-        Ok(1)
-    } else {
-        Ok(0)
-    }
-}
-
-fn warm_shared_storage_slot_once<DB, Provider>(
-    evm: &mut TempoEvm<DB>,
-    prewarm: &PrewarmingExecutionContext<Provider>,
-    slot: Tip20StorageSlot,
-) -> Result<usize, DB::Error>
-where
-    DB: Database,
-{
-    let should_warm = prewarm.dedup.shared_storage_slots.lock().insert(slot);
-
-    if should_warm {
-        warm_storage_slot(evm, prewarm, slot)
-    } else {
-        Ok(0)
-    }
-}
-
-fn warm_storage_slot<DB, Provider>(
-    evm: &mut TempoEvm<DB>,
-    prewarm: &PrewarmingExecutionContext<Provider>,
-    slot: Tip20StorageSlot,
-) -> Result<usize, DB::Error>
-where
-    DB: Database,
-{
-    let mut touched = warm_account_once(evm, prewarm, slot.address)?;
     let _ = evm.db_mut().storage(slot.address, slot.slot)?;
-    touched += 1;
-    Ok(touched)
+    Ok(1)
 }
 
 /// Command sent by [`BestTransactionsPrewarming`] consumer.

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -1,11 +1,14 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-    mpsc::{self, Receiver, Sender},
+use std::{
+    collections::HashSet,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, Receiver, Sender},
+    },
 };
 
-use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
-use alloy_sol_types::SolInterface;
+use alloy_primitives::{Address, B256};
+use parking_lot::Mutex;
 use reth_engine_tree::tree::{CachedStateProvider, SavedCache};
 use reth_evm::{Database, Evm, EvmEnvFor};
 use reth_revm::database::StateProviderDatabase;
@@ -16,14 +19,13 @@ use reth_transaction_pool::{
 };
 use tempo_evm::{TempoEvmConfig, evm::TempoEvm};
 use tempo_precompiles::{
-    DEFAULT_FEE_TOKEN, NONCE_PRECOMPILE_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
-    nonce::slots as nonce_slots,
-    storage::StorageKey as _,
-    tip_fee_manager::slots as fee_manager_slots,
-    tip20::{ITIP20, tip20_slots},
+    NONCE_PRECOMPILE_ADDRESS, TIP_FEE_MANAGER_ADDRESS, nonce::slots as nonce_slots,
+    storage::StorageKey as _, tip_fee_manager::slots as fee_manager_slots,
 };
-use tempo_primitives::TempoAddressExt;
-use tempo_transaction_pool::best::BestTransaction;
+use tempo_transaction_pool::{
+    best::BestTransaction,
+    tip20_info::{Tip20StaticInfo, Tip20StorageSlot},
+};
 use tracing::trace;
 
 type PrewarmEvmState = Option<TempoEvm<StateProviderDatabase<StateProviderBox>>>;
@@ -61,6 +63,7 @@ impl BestTransactionsPrewarming {
             cache,
             evm_env,
             stop: stop.clone(),
+            dedup: Arc::new(PrewarmDedup::default()),
         };
 
         let this = Self {
@@ -181,15 +184,16 @@ impl BestTransactionsPrewarming {
 
             let tx_hash = *tx.hash();
 
-            let touched = if is_tip20_transfer_transaction(&tx) {
-                let touches =
-                    storage_touches_for_transaction(&tx, prewarm.evm_env.block_env.beneficiary);
-
-                for touch in &touches {
-                    if prewarm.is_stopped() {
-                        return;
-                    }
-                    if let Err(err) = touch.warm(evm) {
+            let touched = if let Some(static_info) = tx.transaction.tip20_static_info() {
+                match prewarm_static_tip20_transaction(
+                    evm,
+                    &prewarm,
+                    static_info,
+                    &tx,
+                    prewarm.evm_env.block_env.beneficiary,
+                ) {
+                    Ok(touched) => Some(touched),
+                    Err(err) => {
                         trace!(
                             target: "payload_builder",
                             %err,
@@ -199,8 +203,6 @@ impl BestTransactionsPrewarming {
                         return;
                     }
                 }
-
-                Some(touches.len())
             } else {
                 if prewarm.is_stopped() {
                     return;
@@ -292,6 +294,7 @@ struct PrewarmingExecutionContext<Provider> {
     cache: Option<SavedCache>,
     evm_env: EvmEnvFor<TempoEvmConfig>,
     stop: Arc<AtomicBool>,
+    dedup: Arc<PrewarmDedup>,
 }
 
 impl<Provider> PrewarmingExecutionContext<Provider>
@@ -326,7 +329,9 @@ where
 
         Some(TempoEvm::new(state_provider, evm_env))
     }
+}
 
+impl<Provider> PrewarmingExecutionContext<Provider> {
     fn is_stopped(&self) -> bool {
         self.stop.load(Ordering::Relaxed)
     }
@@ -336,240 +341,201 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum StorageTouch {
-    Account(Address),
-    Storage { address: Address, slot: U256 },
+#[derive(Debug, Default)]
+struct PrewarmDedup {
+    accounts: Mutex<HashSet<Address>>,
+    shared_storage_slots: Mutex<HashSet<Tip20StorageSlot>>,
+    tip20_token_info: Mutex<HashSet<Address>>,
 }
 
-impl StorageTouch {
-    fn warm<DB: Database>(&self, evm: &mut TempoEvm<DB>) -> Result<(), DB::Error> {
-        match *self {
-            Self::Account(address) => {
-                let _ = evm.db_mut().basic(address)?;
-            }
-            Self::Storage { address, slot } => {
-                let _ = evm.db_mut().storage(address, slot)?;
-            }
-        }
-
-        Ok(())
-    }
-}
-
-fn is_tip20_transfer_transaction(tx: &BestTransaction) -> bool {
-    tx.transaction.is_payment() && is_tip20_transfer_calls(tx.transaction.inner().calls())
-}
-
-fn is_tip20_transfer_calls<'a>(calls: impl IntoIterator<Item = (TxKind, &'a Bytes)>) -> bool {
-    let mut has_call = false;
-    for (kind, input) in calls {
-        has_call = true;
-        if !is_tip20_transfer_call(kind, input) {
-            return false;
-        }
-    }
-    has_call
-}
-
-fn is_tip20_transfer_call(kind: TxKind, input: &[u8]) -> bool {
-    let Some(token) = kind.to().copied() else {
-        return false;
-    };
-    if !token.is_tip20() {
-        return false;
-    }
-
-    matches!(
-        ITIP20::ITIP20Calls::abi_decode(input),
-        Ok(ITIP20::ITIP20Calls::transfer(_)
-            | ITIP20::ITIP20Calls::transferWithMemo(_)
-            | ITIP20::ITIP20Calls::transferFrom(_)
-            | ITIP20::ITIP20Calls::transferFromWithMemo(_))
-    )
-}
-
-fn storage_touches_for_transaction(
+fn prewarm_static_tip20_transaction<DB, Provider>(
+    evm: &mut TempoEvm<DB>,
+    prewarm: &PrewarmingExecutionContext<Provider>,
+    info: &Tip20StaticInfo,
     tx: &BestTransaction,
     fee_recipient: Address,
-) -> Vec<StorageTouch> {
-    let mut touches = Vec::new();
-    let sender = tx.transaction.sender();
-    let fee_payer = tx.transaction.inner().fee_payer(sender).unwrap_or(sender);
-    let fee_token = tx.transaction.resolved_fee_token().unwrap_or_else(|| {
-        tx.transaction
-            .inner()
-            .fee_token()
-            .unwrap_or(DEFAULT_FEE_TOKEN)
-    });
+) -> Result<usize, DB::Error>
+where
+    DB: Database,
+{
+    let mut touched = 0;
 
-    add_tip20_fee_touches(&mut touches, fee_token, fee_payer);
-    add_fee_manager_touches(&mut touches, fee_recipient, fee_token);
-
-    if tx.transaction.is_payment() {
-        for (kind, input) in tx.transaction.inner().calls() {
-            add_tip20_call_touches(&mut touches, sender, kind, input);
+    for token in info.token_info() {
+        if prewarm.is_stopped() {
+            return Ok(touched);
         }
+        touched += warm_tip20_token_info_once(evm, prewarm, *token)?;
     }
 
-    add_expiring_nonce_touches(&mut touches, tx);
-
-    touches
-}
-
-fn add_tip20_fee_touches(touches: &mut Vec<StorageTouch>, fee_token: Address, fee_payer: Address) {
-    if !fee_token.is_tip20() {
-        return;
+    for slot in info.balance_slots() {
+        if prewarm.is_stopped() {
+            return Ok(touched);
+        }
+        touched += warm_storage_slot(evm, prewarm, *slot)?;
     }
 
-    add_tip20_common_touches(touches, fee_token);
-    add_tip20_balance_touch(touches, fee_token, fee_payer);
-    add_tip20_balance_touch(touches, fee_token, TIP_FEE_MANAGER_ADDRESS);
-    add_tip20_reward_touches(touches, fee_token, fee_payer);
-}
-
-fn add_tip20_call_touches(
-    touches: &mut Vec<StorageTouch>,
-    sender: Address,
-    kind: TxKind,
-    input: &[u8],
-) {
-    let Some(token) = kind.to().copied() else {
-        return;
-    };
-    if !token.is_tip20() {
-        return;
+    for slot in info.reward_slots() {
+        if prewarm.is_stopped() {
+            return Ok(touched);
+        }
+        touched += warm_storage_slot(evm, prewarm, *slot)?;
     }
 
-    add_tip20_common_touches(touches, token);
-    let Ok(call) = ITIP20::ITIP20Calls::abi_decode(input) else {
-        return;
-    };
-
-    match call {
-        ITIP20::ITIP20Calls::transfer(call) => {
-            add_tip20_balance_touch(touches, token, sender);
-            add_tip20_balance_touch(touches, token, call.to);
-            add_tip20_reward_touches(touches, token, sender);
-            add_tip20_reward_touches(touches, token, call.to);
+    for slot in info.allowance_slots() {
+        if prewarm.is_stopped() {
+            return Ok(touched);
         }
-        ITIP20::ITIP20Calls::transferWithMemo(call) => {
-            add_tip20_balance_touch(touches, token, sender);
-            add_tip20_balance_touch(touches, token, call.to);
-            add_tip20_reward_touches(touches, token, sender);
-            add_tip20_reward_touches(touches, token, call.to);
-        }
-        ITIP20::ITIP20Calls::transferFrom(call) => {
-            add_tip20_balance_touch(touches, token, call.from);
-            add_tip20_balance_touch(touches, token, call.to);
-            add_tip20_allowance_touch(touches, token, call.from, sender);
-            add_tip20_reward_touches(touches, token, call.from);
-            add_tip20_reward_touches(touches, token, call.to);
-        }
-        ITIP20::ITIP20Calls::transferFromWithMemo(call) => {
-            add_tip20_balance_touch(touches, token, call.from);
-            add_tip20_balance_touch(touches, token, call.to);
-            add_tip20_allowance_touch(touches, token, call.from, sender);
-            add_tip20_reward_touches(touches, token, call.from);
-            add_tip20_reward_touches(touches, token, call.to);
-        }
-        ITIP20::ITIP20Calls::approve(call) => {
-            add_tip20_allowance_touch(touches, token, sender, call.spender);
-        }
-        ITIP20::ITIP20Calls::mint(call) => {
-            add_tip20_balance_touch(touches, token, call.to);
-            add_tip20_reward_touches(touches, token, call.to);
-        }
-        ITIP20::ITIP20Calls::mintWithMemo(call) => {
-            add_tip20_balance_touch(touches, token, call.to);
-            add_tip20_reward_touches(touches, token, call.to);
-        }
-        ITIP20::ITIP20Calls::burn(_) | ITIP20::ITIP20Calls::burnWithMemo(_) => {
-            add_tip20_balance_touch(touches, token, sender);
-            add_tip20_reward_touches(touches, token, sender);
-        }
-        _ => {}
+        touched += warm_storage_slot(evm, prewarm, *slot)?;
     }
+
+    if prewarm.is_stopped() {
+        return Ok(touched);
+    }
+    touched += prewarm_fee_manager_touches_once(
+        evm,
+        prewarm,
+        fee_recipient,
+        tx.transaction.effective_fee_token(),
+    )?;
+
+    if prewarm.is_stopped() {
+        return Ok(touched);
+    }
+    touched += prewarm_expiring_nonce_touches_once(evm, prewarm, tx)?;
+
+    Ok(touched)
 }
 
-fn add_tip20_common_touches(touches: &mut Vec<StorageTouch>, token: Address) {
-    add_account_touch(touches, token);
-    add_storage_touch(touches, token, tip20_slots::CURRENCY);
-    add_storage_touch(touches, token, tip20_slots::PAUSED);
-    add_storage_touch(touches, token, tip20_slots::TRANSFER_POLICY_ID);
-    add_storage_touch(touches, token, tip20_slots::GLOBAL_REWARD_PER_TOKEN);
-    add_storage_touch(touches, token, tip20_slots::OPTED_IN_SUPPLY);
-}
-
-fn add_tip20_balance_touch(touches: &mut Vec<StorageTouch>, token: Address, account: Address) {
-    add_storage_touch(touches, token, account.mapping_slot(tip20_slots::BALANCES));
-}
-
-fn add_tip20_allowance_touch(
-    touches: &mut Vec<StorageTouch>,
+fn warm_tip20_token_info_once<DB, Provider>(
+    evm: &mut TempoEvm<DB>,
+    prewarm: &PrewarmingExecutionContext<Provider>,
     token: Address,
-    owner: Address,
-    spender: Address,
-) {
-    add_storage_touch(
-        touches,
-        token,
-        spender.mapping_slot(owner.mapping_slot(tip20_slots::ALLOWANCES)),
-    );
+) -> Result<usize, DB::Error>
+where
+    DB: Database,
+{
+    let should_warm = prewarm.dedup.tip20_token_info.lock().insert(token);
+
+    if !should_warm {
+        return Ok(0);
+    }
+
+    let mut touched = warm_account_once(evm, prewarm, token)?;
+    for slot in Tip20StaticInfo::token_info_slots(token) {
+        touched += warm_shared_storage_slot_once(evm, prewarm, slot)?;
+    }
+    Ok(touched)
 }
 
-fn add_tip20_reward_touches(touches: &mut Vec<StorageTouch>, token: Address, account: Address) {
-    let base_slot = account.mapping_slot(tip20_slots::USER_REWARD_INFO);
-    add_storage_touch(touches, token, base_slot);
-    add_storage_touch(touches, token, base_slot + U256::from(1));
-    add_storage_touch(touches, token, base_slot + U256::from(2));
-}
-
-fn add_fee_manager_touches(
-    touches: &mut Vec<StorageTouch>,
+fn prewarm_fee_manager_touches_once<DB, Provider>(
+    evm: &mut TempoEvm<DB>,
+    prewarm: &PrewarmingExecutionContext<Provider>,
     fee_recipient: Address,
     fee_token: Address,
-) {
-    add_account_touch(touches, TIP_FEE_MANAGER_ADDRESS);
-    add_storage_touch(
-        touches,
-        TIP_FEE_MANAGER_ADDRESS,
-        fee_recipient.mapping_slot(fee_manager_slots::VALIDATOR_TOKENS),
-    );
-    add_storage_touch(
-        touches,
-        TIP_FEE_MANAGER_ADDRESS,
-        fee_token.mapping_slot(fee_recipient.mapping_slot(fee_manager_slots::COLLECTED_FEES)),
-    );
+) -> Result<usize, DB::Error>
+where
+    DB: Database,
+{
+    let mut touched = 0;
+    touched += warm_shared_storage_slot_once(
+        evm,
+        prewarm,
+        Tip20StorageSlot {
+            address: TIP_FEE_MANAGER_ADDRESS,
+            slot: fee_recipient.mapping_slot(fee_manager_slots::VALIDATOR_TOKENS),
+        },
+    )?;
+    touched += warm_shared_storage_slot_once(
+        evm,
+        prewarm,
+        Tip20StorageSlot {
+            address: TIP_FEE_MANAGER_ADDRESS,
+            slot: fee_token
+                .mapping_slot(fee_recipient.mapping_slot(fee_manager_slots::COLLECTED_FEES)),
+        },
+    )?;
+    Ok(touched)
 }
 
-fn add_expiring_nonce_touches(touches: &mut Vec<StorageTouch>, tx: &BestTransaction) {
+fn prewarm_expiring_nonce_touches_once<DB, Provider>(
+    evm: &mut TempoEvm<DB>,
+    prewarm: &PrewarmingExecutionContext<Provider>,
+    tx: &BestTransaction,
+) -> Result<usize, DB::Error>
+where
+    DB: Database,
+{
     let Some(expiring_nonce_slot) = tx.transaction.expiring_nonce_slot() else {
-        return;
+        return Ok(0);
     };
 
-    add_account_touch(touches, NONCE_PRECOMPILE_ADDRESS);
-    add_storage_touch(touches, NONCE_PRECOMPILE_ADDRESS, expiring_nonce_slot);
-    add_storage_touch(
-        touches,
-        NONCE_PRECOMPILE_ADDRESS,
-        nonce_slots::EXPIRING_NONCE_RING_PTR,
-    );
+    let mut touched = 0;
+    touched += warm_storage_slot(
+        evm,
+        prewarm,
+        Tip20StorageSlot {
+            address: NONCE_PRECOMPILE_ADDRESS,
+            slot: expiring_nonce_slot,
+        },
+    )?;
+    touched += warm_shared_storage_slot_once(
+        evm,
+        prewarm,
+        Tip20StorageSlot {
+            address: NONCE_PRECOMPILE_ADDRESS,
+            slot: nonce_slots::EXPIRING_NONCE_RING_PTR,
+        },
+    )?;
+    Ok(touched)
 }
 
-fn add_account_touch(touches: &mut Vec<StorageTouch>, address: Address) {
-    add_unique_touch(touches, StorageTouch::Account(address));
-}
+fn warm_account_once<DB, Provider>(
+    evm: &mut TempoEvm<DB>,
+    prewarm: &PrewarmingExecutionContext<Provider>,
+    address: Address,
+) -> Result<usize, DB::Error>
+where
+    DB: Database,
+{
+    let should_warm = prewarm.dedup.accounts.lock().insert(address);
 
-fn add_storage_touch(touches: &mut Vec<StorageTouch>, address: Address, slot: U256) {
-    add_account_touch(touches, address);
-    add_unique_touch(touches, StorageTouch::Storage { address, slot });
-}
-
-fn add_unique_touch(touches: &mut Vec<StorageTouch>, touch: StorageTouch) {
-    if !touches.contains(&touch) {
-        touches.push(touch);
+    if should_warm {
+        let _ = evm.db_mut().basic(address)?;
+        Ok(1)
+    } else {
+        Ok(0)
     }
+}
+
+fn warm_shared_storage_slot_once<DB, Provider>(
+    evm: &mut TempoEvm<DB>,
+    prewarm: &PrewarmingExecutionContext<Provider>,
+    slot: Tip20StorageSlot,
+) -> Result<usize, DB::Error>
+where
+    DB: Database,
+{
+    let should_warm = prewarm.dedup.shared_storage_slots.lock().insert(slot);
+
+    if should_warm {
+        warm_storage_slot(evm, prewarm, slot)
+    } else {
+        Ok(0)
+    }
+}
+
+fn warm_storage_slot<DB, Provider>(
+    evm: &mut TempoEvm<DB>,
+    prewarm: &PrewarmingExecutionContext<Provider>,
+    slot: Tip20StorageSlot,
+) -> Result<usize, DB::Error>
+where
+    DB: Database,
+{
+    let mut touched = warm_account_once(evm, prewarm, slot.address)?;
+    let _ = evm.db_mut().storage(slot.address, slot.slot)?;
+    touched += 1;
+    Ok(touched)
 }
 
 /// Command sent by [`BestTransactionsPrewarming`] consumer.
@@ -620,7 +586,6 @@ mod tests {
     use super::*;
     use alloy_consensus::{BlockHeader, Header, Signed, TxLegacy};
     use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
-    use alloy_sol_types::SolCall;
     use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
     use reth_primitives_traits::{
         Recovered, SealedHeader, transaction::error::InvalidTransactionError,
@@ -826,83 +791,6 @@ mod tests {
     }
 
     #[test]
-    fn tip20_touch_collection_dedups_overlapping_fee_and_call_slots() {
-        let sender = Address::random();
-        let recipient = Address::random();
-        let token = DEFAULT_FEE_TOKEN;
-        let mut touches = Vec::new();
-
-        add_tip20_fee_touches(&mut touches, token, sender);
-        add_tip20_call_touches(
-            &mut touches,
-            sender,
-            TxKind::Call(token),
-            &ITIP20::transferCall {
-                to: recipient,
-                amount: U256::from(1),
-            }
-            .abi_encode(),
-        );
-
-        for (index, touch) in touches.iter().enumerate() {
-            assert!(
-                !touches[index + 1..].contains(touch),
-                "duplicate storage prewarm touch: {touch:?}"
-            );
-        }
-
-        assert!(touches.contains(&StorageTouch::Account(token)));
-        assert!(touches.contains(&StorageTouch::Storage {
-            address: token,
-            slot: sender.mapping_slot(tip20_slots::BALANCES)
-        }));
-        assert!(touches.contains(&StorageTouch::Storage {
-            address: token,
-            slot: recipient.mapping_slot(tip20_slots::BALANCES)
-        }));
-    }
-
-    #[test]
-    fn tip20_fast_path_is_limited_to_transfers() {
-        let token = DEFAULT_FEE_TOKEN;
-        let transfer = Bytes::from(
-            ITIP20::transferCall {
-                to: Address::random(),
-                amount: U256::from(1),
-            }
-            .abi_encode(),
-        );
-        let transfer_from = Bytes::from(
-            ITIP20::transferFromCall {
-                from: Address::random(),
-                to: Address::random(),
-                amount: U256::from(1),
-            }
-            .abi_encode(),
-        );
-        let approve = Bytes::from(
-            ITIP20::approveCall {
-                spender: Address::random(),
-                amount: U256::from(1),
-            }
-            .abi_encode(),
-        );
-
-        assert!(is_tip20_transfer_call(TxKind::Call(token), &transfer));
-        assert!(is_tip20_transfer_calls(
-            [&transfer, &transfer_from]
-                .into_iter()
-                .map(|input| (TxKind::Call(token), input)),
-        ));
-        assert!(!is_tip20_transfer_call(TxKind::Call(token), &approve));
-        assert!(!is_tip20_transfer_calls(
-            [&transfer, &approve]
-                .into_iter()
-                .map(|input| (TxKind::Call(token), input)),
-        ));
-    }
-
-    #[test]
     fn source_ordering_is_unchanged_when_prewarming_is_enabled() {
         let sender = Address::random();
         let txs = vec![test_tx(sender, 0), test_tx(sender, 1), test_tx(sender, 2)];
@@ -993,24 +881,6 @@ mod tests {
         wait_until(|| {
             let log = log.lock().unwrap();
             log.no_updates == 1 && log.skip_blobs == vec![true]
-        });
-    }
-
-    #[test]
-    fn prewarming_does_not_use_shared_worker_state_slot() {
-        let executor = TaskExecutor::test();
-        let pool = executor.prewarming_pool();
-        pool.init::<usize>(|existing| existing.map(|value| *value).unwrap_or(1));
-
-        let sender = Address::random();
-        let txs = vec![test_tx(sender, 0)];
-        let log = Arc::new(Mutex::new(TestLog::default()));
-        let mut prewarming = prewarming_with_executor(executor.clone(), txs, log);
-
-        assert!(prewarming.next().is_some());
-
-        pool.broadcast(pool.current_num_threads(), |worker| {
-            assert_eq!(*worker.get::<usize>(), 1);
         });
     }
 }

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+pub mod tip20_info;
 pub mod transaction;
 pub mod validator;
 

--- a/crates/transaction-pool/src/tip20_info.rs
+++ b/crates/transaction-pool/src/tip20_info.rs
@@ -1,0 +1,243 @@
+use crate::transaction::TempoPooledTransaction;
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_sol_types::SolInterface;
+use reth_transaction_pool::PoolTransaction;
+use tempo_contracts::precompiles::ITIP20;
+use tempo_precompiles::{TIP_FEE_MANAGER_ADDRESS, storage::StorageKey, tip20::tip20_slots};
+use tempo_primitives::TempoAddressExt;
+
+/// Precomputed storage slot owned by a TIP-20 token account.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Tip20StorageSlot {
+    /// Token account whose storage is touched.
+    pub address: Address,
+    /// Storage slot to prewarm.
+    pub slot: U256,
+}
+
+/// Static TIP-20 storage metadata derived from a transfer-only payment transaction.
+///
+/// The vectors are separated by storage kind so the payload builder can keep
+/// cheaper per-kind seen sets. `token_info` is the token-global path:
+/// account load plus currency, pause, policy, and reward aggregate slots.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Tip20StaticInfo {
+    token_info: Vec<Address>,
+    balance_slots: Vec<Tip20StorageSlot>,
+    reward_slots: Vec<Tip20StorageSlot>,
+    allowance_slots: Vec<Tip20StorageSlot>,
+}
+
+impl Tip20StaticInfo {
+    /// Derives static TIP-20 prewarm metadata for transfer-only payment transactions.
+    pub(crate) fn for_transaction(tx: &TempoPooledTransaction) -> Option<Self> {
+        if !tx.is_payment() || !is_tip20_transfer_calls(tx.inner().calls()) {
+            return None;
+        }
+
+        let sender = tx.sender();
+        let fee_payer = tx.inner().fee_payer(sender).unwrap_or(sender);
+        let fee_token = tx.effective_fee_token();
+
+        let mut info = Self::default();
+        info.add_fee_touches(fee_token, fee_payer);
+
+        for (kind, input) in tx.inner().calls() {
+            let token = *kind.to()?;
+            let call = ITIP20::ITIP20Calls::abi_decode(input).ok()?;
+            info.add_transfer_call(sender, token, call);
+        }
+
+        (!info.is_empty()).then_some(info)
+    }
+
+    /// TIP-20 tokens whose global token metadata slots are touched.
+    pub fn token_info(&self) -> &[Address] {
+        &self.token_info
+    }
+
+    /// Global token storage slots touched when loading TIP-20 token metadata.
+    pub fn token_info_slots(token: Address) -> [Tip20StorageSlot; 5] {
+        [
+            Tip20StorageSlot {
+                address: token,
+                slot: tip20_slots::CURRENCY,
+            },
+            Tip20StorageSlot {
+                address: token,
+                slot: tip20_slots::PAUSED,
+            },
+            Tip20StorageSlot {
+                address: token,
+                slot: tip20_slots::TRANSFER_POLICY_ID,
+            },
+            Tip20StorageSlot {
+                address: token,
+                slot: tip20_slots::GLOBAL_REWARD_PER_TOKEN,
+            },
+            Tip20StorageSlot {
+                address: token,
+                slot: tip20_slots::OPTED_IN_SUPPLY,
+            },
+        ]
+    }
+
+    /// TIP-20 balance storage slots touched by the transaction.
+    pub fn balance_slots(&self) -> &[Tip20StorageSlot] {
+        &self.balance_slots
+    }
+
+    /// TIP-20 reward storage slots touched by the transaction.
+    pub fn reward_slots(&self) -> &[Tip20StorageSlot] {
+        &self.reward_slots
+    }
+
+    /// TIP-20 allowance storage slots touched by the transaction.
+    pub fn allowance_slots(&self) -> &[Tip20StorageSlot] {
+        &self.allowance_slots
+    }
+
+    /// Total number of static entries in this plan.
+    pub fn len(&self) -> usize {
+        self.token_info.len()
+            + self.balance_slots.len()
+            + self.reward_slots.len()
+            + self.allowance_slots.len()
+    }
+
+    /// Returns true if the plan has no static entries.
+    pub fn is_empty(&self) -> bool {
+        self.token_info.is_empty()
+            && self.balance_slots.is_empty()
+            && self.reward_slots.is_empty()
+            && self.allowance_slots.is_empty()
+    }
+
+    fn add_token_info(&mut self, token: Address) {
+        add_unique(&mut self.token_info, token);
+    }
+
+    fn add_balance_slot(&mut self, token: Address, account: Address) {
+        add_unique(
+            &mut self.balance_slots,
+            Tip20StorageSlot {
+                address: token,
+                slot: account.mapping_slot(tip20_slots::BALANCES),
+            },
+        );
+    }
+
+    fn add_reward_slots(&mut self, token: Address, account: Address) {
+        let base_slot = account.mapping_slot(tip20_slots::USER_REWARD_INFO);
+        add_unique(
+            &mut self.reward_slots,
+            Tip20StorageSlot {
+                address: token,
+                slot: base_slot,
+            },
+        );
+        add_unique(
+            &mut self.reward_slots,
+            Tip20StorageSlot {
+                address: token,
+                slot: base_slot + U256::from(1),
+            },
+        );
+        add_unique(
+            &mut self.reward_slots,
+            Tip20StorageSlot {
+                address: token,
+                slot: base_slot + U256::from(2),
+            },
+        );
+    }
+
+    fn add_allowance_slot(&mut self, token: Address, owner: Address, spender: Address) {
+        add_unique(
+            &mut self.allowance_slots,
+            Tip20StorageSlot {
+                address: token,
+                slot: spender.mapping_slot(owner.mapping_slot(tip20_slots::ALLOWANCES)),
+            },
+        );
+    }
+
+    fn add_fee_touches(&mut self, fee_token: Address, fee_payer: Address) {
+        if !fee_token.is_tip20() {
+            return;
+        }
+
+        self.add_token_info(fee_token);
+        self.add_balance_slot(fee_token, fee_payer);
+        self.add_balance_slot(fee_token, TIP_FEE_MANAGER_ADDRESS);
+        self.add_reward_slots(fee_token, fee_payer);
+    }
+
+    fn add_transfer_call(&mut self, sender: Address, token: Address, call: ITIP20::ITIP20Calls) {
+        self.add_token_info(token);
+
+        match call {
+            ITIP20::ITIP20Calls::transfer(call) => {
+                self.add_balance_slot(token, sender);
+                self.add_balance_slot(token, call.to);
+                self.add_reward_slots(token, sender);
+                self.add_reward_slots(token, call.to);
+            }
+            ITIP20::ITIP20Calls::transferWithMemo(call) => {
+                self.add_balance_slot(token, sender);
+                self.add_balance_slot(token, call.to);
+                self.add_reward_slots(token, sender);
+                self.add_reward_slots(token, call.to);
+            }
+            ITIP20::ITIP20Calls::transferFrom(call) => {
+                self.add_balance_slot(token, call.from);
+                self.add_balance_slot(token, call.to);
+                self.add_allowance_slot(token, call.from, sender);
+                self.add_reward_slots(token, call.from);
+                self.add_reward_slots(token, call.to);
+            }
+            ITIP20::ITIP20Calls::transferFromWithMemo(call) => {
+                self.add_balance_slot(token, call.from);
+                self.add_balance_slot(token, call.to);
+                self.add_allowance_slot(token, call.from, sender);
+                self.add_reward_slots(token, call.from);
+                self.add_reward_slots(token, call.to);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn is_tip20_transfer_calls<'a>(calls: impl IntoIterator<Item = (TxKind, &'a Bytes)>) -> bool {
+    let mut has_call = false;
+    for (kind, input) in calls {
+        has_call = true;
+        if !is_tip20_transfer_call(kind, input) {
+            return false;
+        }
+    }
+    has_call
+}
+
+fn is_tip20_transfer_call(kind: TxKind, input: &[u8]) -> bool {
+    let Some(token) = kind.to().copied() else {
+        return false;
+    };
+    if !token.is_tip20() {
+        return false;
+    }
+
+    matches!(
+        ITIP20::ITIP20Calls::abi_decode(input),
+        Ok(ITIP20::ITIP20Calls::transfer(_)
+            | ITIP20::ITIP20Calls::transferWithMemo(_)
+            | ITIP20::ITIP20Calls::transferFrom(_)
+            | ITIP20::ITIP20Calls::transferFromWithMemo(_))
+    )
+}
+
+fn add_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
+    if !items.contains(&item) {
+        items.push(item);
+    }
+}

--- a/crates/transaction-pool/src/tip20_info.rs
+++ b/crates/transaction-pool/src/tip20_info.rs
@@ -17,12 +17,11 @@ pub struct Tip20StorageSlot {
 
 /// Static TIP-20 storage metadata derived from a transfer-only payment transaction.
 ///
-/// The vectors are separated by storage kind so the payload builder can keep
-/// cheaper per-kind seen sets. `token_info` is the token-global path:
-/// account load plus currency, pause, policy, and reward aggregate slots.
+/// The vectors are separated by storage kind so the payload builder can warm the
+/// high-cardinality per-transaction storage directly. Token-global metadata is
+/// intentionally omitted and left to normal execution.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Tip20StaticInfo {
-    token_info: Vec<Address>,
     balance_slots: Vec<Tip20StorageSlot>,
     reward_slots: Vec<Tip20StorageSlot>,
     allowance_slots: Vec<Tip20StorageSlot>,
@@ -51,37 +50,6 @@ impl Tip20StaticInfo {
         (!info.is_empty()).then_some(info)
     }
 
-    /// TIP-20 tokens whose global token metadata slots are touched.
-    pub fn token_info(&self) -> &[Address] {
-        &self.token_info
-    }
-
-    /// Global token storage slots touched when loading TIP-20 token metadata.
-    pub fn token_info_slots(token: Address) -> [Tip20StorageSlot; 5] {
-        [
-            Tip20StorageSlot {
-                address: token,
-                slot: tip20_slots::CURRENCY,
-            },
-            Tip20StorageSlot {
-                address: token,
-                slot: tip20_slots::PAUSED,
-            },
-            Tip20StorageSlot {
-                address: token,
-                slot: tip20_slots::TRANSFER_POLICY_ID,
-            },
-            Tip20StorageSlot {
-                address: token,
-                slot: tip20_slots::GLOBAL_REWARD_PER_TOKEN,
-            },
-            Tip20StorageSlot {
-                address: token,
-                slot: tip20_slots::OPTED_IN_SUPPLY,
-            },
-        ]
-    }
-
     /// TIP-20 balance storage slots touched by the transaction.
     pub fn balance_slots(&self) -> &[Tip20StorageSlot] {
         &self.balance_slots
@@ -99,22 +67,14 @@ impl Tip20StaticInfo {
 
     /// Total number of static entries in this plan.
     pub fn len(&self) -> usize {
-        self.token_info.len()
-            + self.balance_slots.len()
-            + self.reward_slots.len()
-            + self.allowance_slots.len()
+        self.balance_slots.len() + self.reward_slots.len() + self.allowance_slots.len()
     }
 
     /// Returns true if the plan has no static entries.
     pub fn is_empty(&self) -> bool {
-        self.token_info.is_empty()
-            && self.balance_slots.is_empty()
+        self.balance_slots.is_empty()
             && self.reward_slots.is_empty()
             && self.allowance_slots.is_empty()
-    }
-
-    fn add_token_info(&mut self, token: Address) {
-        add_unique(&mut self.token_info, token);
     }
 
     fn add_balance_slot(&mut self, token: Address, account: Address) {
@@ -167,15 +127,12 @@ impl Tip20StaticInfo {
             return;
         }
 
-        self.add_token_info(fee_token);
         self.add_balance_slot(fee_token, fee_payer);
         self.add_balance_slot(fee_token, TIP_FEE_MANAGER_ADDRESS);
         self.add_reward_slots(fee_token, fee_payer);
     }
 
     fn add_transfer_call(&mut self, sender: Address, token: Address, call: ITIP20::ITIP20Calls) {
-        self.add_token_info(token);
-
         match call {
             ITIP20::ITIP20Calls::transfer(call) => {
                 self.add_balance_slot(token, sender);

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -1,4 +1,7 @@
-use crate::tt_2d_pool::{AA2dTransactionId, AASequenceId};
+use crate::{
+    tip20_info::Tip20StaticInfo,
+    tt_2d_pool::{AA2dTransactionId, AASequenceId},
+};
 use alloy_consensus::{
     BlobTransactionValidationError, Transaction, crypto::RecoveryError, transaction::TxHashRef,
 };
@@ -74,6 +77,8 @@ pub struct TempoPooledTransaction {
     /// Stores `(fee_token, balance_slot)` so the payload builder's state-aware iterator
     /// can check if the fee payer's balance was modified without recomputing the keccak.
     fee_balance_slot: OnceLock<Option<(Address, U256)>>,
+    /// Static TIP-20 storage prewarm plan for transfer-only payment transactions.
+    tip20_static_info: OnceLock<Option<Tip20StaticInfo>>,
 }
 
 impl TempoPooledTransaction {
@@ -109,6 +114,7 @@ impl TempoPooledTransaction {
             key_authorization_signer_subject: OnceLock::new(),
             key_authorization_target_subject: OnceLock::new(),
             fee_balance_slot: OnceLock::new(),
+            tip20_static_info: OnceLock::new(),
         }
     }
 
@@ -367,6 +373,26 @@ impl TempoPooledTransaction {
                 TIP20Token::from_address_unchecked(fee_token).balances[fee_payer].base_slot();
             Some((fee_token, slot))
         })
+    }
+
+    /// Returns the cached static TIP-20 storage prewarm plan for transfer-only
+    /// payment transactions, computing it on first access.
+    pub fn tip20_static_info(&self) -> Option<&Tip20StaticInfo> {
+        if self.tip20_static_info.get().is_none()
+            && self.inner().as_aa().is_some()
+            && self.inner().fee_token().is_none()
+            && self.resolved_fee_token().is_none()
+        {
+            return None;
+        }
+
+        self.tip20_static_info
+            .get_or_init(|| self.compute_tip20_static_info())
+            .as_ref()
+    }
+
+    fn compute_tip20_static_info(&self) -> Option<Tip20StaticInfo> {
+        Tip20StaticInfo::for_transaction(self)
     }
 
     /// Returns true when the transaction fee is paid by the transaction sender.
@@ -860,9 +886,9 @@ impl EthPoolTransaction for TempoPooledTransaction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::TxBuilder;
+    use crate::{test_utils::TxBuilder, tip20_info::Tip20StorageSlot};
     use alloy_consensus::TxEip1559;
-    use alloy_primitives::{Address, Signature, TxKind, address};
+    use alloy_primitives::{Address, Bytes, Signature, TxKind, address};
     use alloy_sol_types::SolCall;
     use tempo_contracts::precompiles::ITIP20;
     use tempo_precompiles::{PATH_USD_ADDRESS, nonce::NonceManager};
@@ -927,6 +953,145 @@ mod tests {
 
         let pooled_tx = TempoPooledTransaction::new(recovered);
         assert!(!pooled_tx.is_payment());
+    }
+
+    fn pooled_tip20_eip1559(
+        sender: Address,
+        token: Address,
+        input: Bytes,
+    ) -> TempoPooledTransaction {
+        let tx = TxEip1559 {
+            to: TxKind::Call(token),
+            gas_limit: 21_000,
+            input,
+            ..Default::default()
+        };
+
+        let envelope = TempoTxEnvelope::Eip1559(alloy_consensus::Signed::new_unchecked(
+            tx,
+            Signature::test_signature(),
+            B256::ZERO,
+        ));
+
+        TempoPooledTransaction::new(Recovered::new_unchecked(envelope, sender))
+    }
+
+    #[test]
+    fn tip20_static_info_dedups_overlapping_fee_and_call_slots() {
+        let sender = Address::random();
+        let recipient = Address::random();
+        let token = DEFAULT_FEE_TOKEN;
+        let pooled_tx = pooled_tip20_eip1559(
+            sender,
+            token,
+            Bytes::from(
+                ITIP20::transferCall {
+                    to: recipient,
+                    amount: U256::from(1),
+                }
+                .abi_encode(),
+            ),
+        );
+
+        let info = pooled_tx
+            .tip20_static_info()
+            .expect("transfer payment has static TIP20 info");
+
+        assert_eq!(info.token_info(), &[token]);
+
+        let sender_balance = Tip20StorageSlot {
+            address: token,
+            slot: sender.mapping_slot(tip20_slots::BALANCES),
+        };
+        let recipient_balance = Tip20StorageSlot {
+            address: token,
+            slot: recipient.mapping_slot(tip20_slots::BALANCES),
+        };
+        assert!(info.balance_slots().contains(&sender_balance));
+        assert!(info.balance_slots().contains(&recipient_balance));
+
+        for (index, slot) in info.balance_slots().iter().enumerate() {
+            assert!(
+                !info.balance_slots()[index + 1..].contains(slot),
+                "duplicate TIP20 balance prewarm slot: {slot:?}"
+            );
+        }
+        for (index, slot) in info.reward_slots().iter().enumerate() {
+            assert!(
+                !info.reward_slots()[index + 1..].contains(slot),
+                "duplicate TIP20 reward prewarm slot: {slot:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn tip20_static_info_is_limited_to_transfers() {
+        let sender = Address::random();
+        let token = DEFAULT_FEE_TOKEN;
+        let transfer = pooled_tip20_eip1559(
+            sender,
+            token,
+            Bytes::from(
+                ITIP20::transferCall {
+                    to: Address::random(),
+                    amount: U256::from(1),
+                }
+                .abi_encode(),
+            ),
+        );
+        let transfer_from = pooled_tip20_eip1559(
+            sender,
+            token,
+            Bytes::from(
+                ITIP20::transferFromCall {
+                    from: Address::random(),
+                    to: Address::random(),
+                    amount: U256::from(1),
+                }
+                .abi_encode(),
+            ),
+        );
+        let approve = pooled_tip20_eip1559(
+            sender,
+            token,
+            Bytes::from(
+                ITIP20::approveCall {
+                    spender: Address::random(),
+                    amount: U256::from(1),
+                }
+                .abi_encode(),
+            ),
+        );
+
+        assert!(transfer.tip20_static_info().is_some());
+        assert!(transfer_from.tip20_static_info().is_some());
+        assert!(approve.is_payment());
+        assert!(approve.tip20_static_info().is_none());
+    }
+
+    #[test]
+    fn tip20_static_info_waits_for_implicit_fee_token_resolution() {
+        let sender = Address::random();
+        let token = DEFAULT_FEE_TOKEN;
+        let tx = TxBuilder::aa(sender)
+            .calls(vec![Call {
+                to: TxKind::Call(token),
+                value: U256::ZERO,
+                input: Bytes::from(
+                    ITIP20::transferCall {
+                        to: Address::random(),
+                        amount: U256::from(1),
+                    }
+                    .abi_encode(),
+                ),
+            }])
+            .build();
+
+        assert!(tx.is_payment());
+        assert!(tx.tip20_static_info().is_none());
+
+        tx.set_resolved_fee_token(token);
+        assert!(tx.tip20_static_info().is_some());
     }
 
     #[test]

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -997,8 +997,6 @@ mod tests {
             .tip20_static_info()
             .expect("transfer payment has static TIP20 info");
 
-        assert_eq!(info.token_info(), &[token]);
-
         let sender_balance = Tip20StorageSlot {
             address: token,
             slot: sender.mapping_slot(tip20_slots::BALANCES),

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -560,6 +560,9 @@ where
                 // Warm the global keccak cache with storage slot hashes for this transaction.
                 transaction.transaction().precalculate_keccak_slots();
 
+                // Cache static TIP-20 prewarming metadata after fee-token resolution.
+                transaction.transaction().tip20_static_info();
+
                 TransactionValidationOutcome::Valid {
                     balance,
                     state_nonce,


### PR DESCRIPTION
Derives transfer-only TIP-20 prewarm metadata in the transaction pool and caches it on pooled transactions after fee-token resolution. Payload prewarming now consumes that static plan and only globally dedups shared token, fee-manager, and nonce-ring storage while warming per-transaction TIP-20 slots directly.