### PR TITLE
chore: bump revm to tip1060

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,8 +393,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
+source = "git+https://github.com/alloy-rs/evm?rev=24d6a2bb220d4238e60da9ca90a0257038efea15#24d6a2bb220d4238e60da9ca90a0257038efea15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1177,7 +1176,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1188,7 +1187,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3828,7 +3827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4293,7 +4292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4796,8 +4795,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -5489,7 +5488,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5885,7 +5884,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7055,7 +7054,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8597,7 +8596,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8623,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8676,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8689,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8772,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8782,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8804,8 +8803,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f54468f34d9ed03356dee71bb182a2815a490934f1a291f58158053eee946ba"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=ee80f4b060017e49024cfcb35a3256ac454fc3ff#ee80f4b060017e49024cfcb35a3256ac454fc3ff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8825,8 +8823,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80c0516faf1698c57f91f07c98ecd9f3a9d3f163f1ad4bb263d9c495b3928e0"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=ee80f4b060017e49024cfcb35a3256ac454fc3ff#ee80f4b060017e49024cfcb35a3256ac454fc3ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8836,7 +8833,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8849,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8863,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8876,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8901,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8930,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8956,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8986,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9001,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9026,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9074,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9166,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9194,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9217,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9301,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9385,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9424,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9446,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9510,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9542,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9599,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9609,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9634,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9685,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9704,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9756,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9766,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9814,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9831,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9853,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9862,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9876,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9934,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9982,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10011,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10028,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10052,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10218,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10295,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10307,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10366,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10379,8 +10376,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1216ba179909d41d8d55c5eae6c1c33698bc7a3053c35fd425c7789a5de3c1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=ee80f4b060017e49024cfcb35a3256ac454fc3ff#ee80f4b060017e49024cfcb35a3256ac454fc3ff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10412,7 +10408,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10457,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10485,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10501,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10516,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10592,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10622,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10665,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10685,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10716,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10763,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10814,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10828,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10848,8 +10844,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-traits"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75186b77fef29e0160f476c9a6bde3363e503f0f32ac4ef47726ef1e3da81118"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=ee80f4b060017e49024cfcb35a3256ac454fc3ff#ee80f4b060017e49024cfcb35a3256ac454fc3ff"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10863,7 +10858,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10909,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10937,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10951,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10971,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10986,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11030,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11051,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11067,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11077,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11096,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11115,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11160,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11186,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11213,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11262,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8083dfe1ad98a4ad624b44d553ac9feb15765af9#8083dfe1ad98a4ad624b44d553ac9feb15765af9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11289,8 +11284,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80dcfa0327b7642cc41c71d8cd3626a48ac76fb8304c28bcbdf416a45615d020"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=ee80f4b060017e49024cfcb35a3256ac454fc3ff#ee80f4b060017e49024cfcb35a3256ac454fc3ff"
 dependencies = [
  "zstd",
 ]
@@ -11298,8 +11292,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "40.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
+source = "git+https://github.com/bluealloy/revm?rev=d9ff851f6350f047238bcfdf5a31b0f76e41e2f9#d9ff851f6350f047238bcfdf5a31b0f76e41e2f9"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11317,8 +11310,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "11.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b378c2653331fe60969d9745e802cd773d82a20d8aaced914dfcf26ab8f0d9"
+source = "git+https://github.com/bluealloy/revm?rev=d9ff851f6350f047238bcfdf5a31b0f76e41e2f9#d9ff851f6350f047238bcfdf5a31b0f76e41e2f9"
 dependencies = [
  "bitvec",
  "phf",
@@ -11329,8 +11321,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "18.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafa298114f3cab706945de14c04e73e6e6d7896302e4183dae273f968e52f80"
+source = "git+https://github.com/bluealloy/revm?rev=d9ff851f6350f047238bcfdf5a31b0f76e41e2f9#d9ff851f6350f047238bcfdf5a31b0f76e41e2f9"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11346,8 +11337,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "19.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9c13f1dfc79425931fd184b6bd373dfac7baba50859b01107d5c0e20549cbb"
+source = "git+https://github.com/bluealloy/revm?rev=d9ff851f6350f047238bcfdf5a31b0f76e41e2f9#d9ff851f6350f047238bcfdf5a31b0f76e41e2f9"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11362,8 +11352,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "15.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69c3ce73454a09ef89a66177239d7c4f5f697227ae27254c99451866603b19d"
+source = "git+https://github.com/bluealloy/revm?rev=d9ff851f6350f047238bcfdf5a31b0f76e41e2f9#d9ff851f6350f047238bcfdf5a31b0f76e41e2f9"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -11377,8 +11366,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "12.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a2656187f9f9c22ef9dd9300ed71aeaeca3506a6a0a229a07f264649b960d68"
+source = "git+https://github.com/bluealloy/revm?rev=d9ff851f6350f047238bcfdf5a31b0f76e41e2f9#d9ff851f6350f047238bcfdf5a31b0f76e41e2f9"
 dependencies = [
  "auto_impl",
  "either",
@@ -11391,8 +11379,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "20.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce1d66037ca1394128313bb995fa9f50d834927a389386bb34f8f0ef914648f"
+source = "git+https://github.com/bluealloy/revm?rev=d9ff851f6350f047238bcfdf5a31b0f76e41e2f9#d9ff851f6350f047238bcfdf5a31b0f76e41e2f9"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11410,8 +11397,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "21.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
+source = "git+https://github.com/bluealloy/revm?rev=d9ff851f6350f047238bcfdf5a31b0f76e41e2f9#d9ff851f6350f047238bcfdf5a31b0f76e41e2f9"
 dependencies = [
  "auto_impl",
  "either",
@@ -11428,8 +11414,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2854f2c48cecac90e8ad48fe8d8842707f79df2b748913b67bd2439a9ea3b4ab"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=39867d2e4a0d2d8ba1206792a04dc07b90826126#39867d2e4a0d2d8ba1206792a04dc07b90826126"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11448,8 +11433,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "37.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
+source = "git+https://github.com/bluealloy/revm?rev=d9ff851f6350f047238bcfdf5a31b0f76e41e2f9#d9ff851f6350f047238bcfdf5a31b0f76e41e2f9"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11461,8 +11445,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "36.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191db865091e07ecb80b12ce3048192c76071ca3d2b0a315b111b271cd4ced37"
+source = "git+https://github.com/bluealloy/revm?rev=d9ff851f6350f047238bcfdf5a31b0f76e41e2f9#d9ff851f6350f047238bcfdf5a31b0f76e41e2f9"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11487,8 +11470,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "24.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5102d804892908d4ebf68da29b8562895922dffa26c230ff2c4dadcf93916f"
+source = "git+https://github.com/bluealloy/revm?rev=d9ff851f6350f047238bcfdf5a31b0f76e41e2f9#d9ff851f6350f047238bcfdf5a31b0f76e41e2f9"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -11498,8 +11480,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "12.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eff6067185cf80932e06f6a9c8045b012ecb6f99a8d6edc618ec2792373e14"
+source = "git+https://github.com/bluealloy/revm?rev=d9ff851f6350f047238bcfdf5a31b0f76e41e2f9#d9ff851f6350f047238bcfdf5a31b0f76e41e2f9"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "bitflags 2.11.1",
@@ -11800,7 +11781,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11880,7 +11861,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12532,7 +12513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12808,7 +12789,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14867,7 +14848,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8083dfe1ad98a4ad624b44d553ac9feb15765af9", features = [
   "std",
   "optional-checks",
 ] }
@@ -408,3 +408,27 @@ commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev =
 commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
+
+# revm tip1060 (d9ff851f)
+revm = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+# revm-inspectors tip1060
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "39867d2e4a0d2d8ba1206792a04dc07b90826126" }
+# alloy-evm tip1060
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "24d6a2bb220d4238e60da9ca90a0257038efea15" }
+# reth-core tip1060
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "ee80f4b060017e49024cfcb35a3256ac454fc3ff" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "ee80f4b060017e49024cfcb35a3256ac454fc3ff" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "ee80f4b060017e49024cfcb35a3256ac454fc3ff" }
+reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "ee80f4b060017e49024cfcb35a3256ac454fc3ff" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "ee80f4b060017e49024cfcb35a3256ac454fc3ff" }


### PR DESCRIPTION
Bumps the full revm/alloy/reth dependency chain to the `tip1060` integration.

- reth git rev `259b8dc` -> `8083dfe1ad98a4ad624b44d553ac9feb15765af9` (57 deps)
- revm -> `d9ff851f6350f047238bcfdf5a31b0f76e41e2f9` (v40.0.3) via `[patch.crates-io]`
- revm-inspectors -> `39867d2e4a0d2d8ba1206792a04dc07b90826126`
- alloy-evm -> `24d6a2bb220d4238e60da9ca90a0257038efea15`
- reth-core -> `ee80f4b060017e49024cfcb35a3256ac454fc3ff`

`cargo check --workspace --exclude tempo-e2e` passes cleanly.