### PR TITLE
perf(revm): share tempo tx env batch calls

### DIFF
--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -9,13 +9,14 @@ use reth_rpc_convert::{
     FromConsensusHeader, SignTxRequestError, SignableTxRequest, TryIntoSimTx, TryIntoTxEnv,
 };
 use reth_rpc_eth_types::EthApiError;
+use std::sync::Arc;
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::TempoBlockEnv;
 use tempo_primitives::{
     SignatureType, TempoHeader, TempoSignature, TempoTxEnvelope, TempoTxType,
     transaction::{Call, RecoveredTempoAuthorization},
 };
-use tempo_revm::{TempoBatchCallEnv, TempoTxEnv};
+use tempo_revm::{TempoBatchCallEnv, TempoTxEnv, TempoTxEnvInner};
 
 /// Non-zero transaction identifier used only for RPC simulations.
 ///
@@ -136,7 +137,7 @@ impl TryIntoTxEnv<TempoTxEnv, TempoHardfork, TempoBlockEnv> for TempoTransaction
             fee_payer_signature: _,
         } = self;
 
-        Ok(TempoTxEnv {
+        Ok(TempoTxEnv::new(TempoTxEnvInner {
             fee_token,
             is_system_tx: false,
             unique_tx_identifier: Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER),
@@ -174,7 +175,7 @@ impl TryIntoTxEnv<TempoTxEnv, TempoHardfork, TempoBlockEnv> for TempoTransaction
                     return Err(EthApiError::InvalidParams("empty calls list".to_string()));
                 }
 
-                Some(Box::new(TempoBatchCallEnv {
+                Some(Arc::new(TempoBatchCallEnv {
                     aa_calls: calls,
                     signature: mock_signature,
                     tempo_authorization_list: tempo_authorization_list
@@ -189,13 +190,12 @@ impl TryIntoTxEnv<TempoTxEnv, TempoHardfork, TempoBlockEnv> for TempoTransaction
                     valid_after: valid_after.map(NonZeroU64::get),
                     subblock_transaction: false,
                     override_key_id: key_id,
-                    expiring_nonce_idx: None,
                 }))
             } else {
                 None
             },
             inner: inner.try_into_tx_env(evm_env)?,
-        })
+        }))
     }
 }
 
@@ -385,9 +385,9 @@ mod tests {
 
         let evm_env = EvmEnv::default();
         let tx_env = req.try_into_tx_env(&evm_env).expect("try_into_tx_env");
-        let estimated_calls = tx_env.tempo_tx_env.expect("tempo_tx_env").aa_calls;
+        let estimated_calls = &tx_env.tempo_tx_env.as_ref().expect("tempo_tx_env").aa_calls;
 
-        assert_eq!(estimated_calls, built_calls);
+        assert_eq!(estimated_calls, &built_calls);
     }
 
     #[test]
@@ -565,10 +565,10 @@ mod tests {
 
         let evm_env = EvmEnv::default();
         let tx_env = req.try_into_tx_env(&evm_env).expect("try_into_tx_env");
-        let aa_calls = tx_env.tempo_tx_env.expect("tempo_tx_env").aa_calls;
+        let aa_calls = &tx_env.tempo_tx_env.as_ref().expect("tempo_tx_env").aa_calls;
 
         assert_eq!(
-            aa_calls, calls,
+            aa_calls, &calls,
             "roundtrip via try_into_tx_env must preserve exact call list"
         );
     }

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -508,9 +508,7 @@ where
     ) -> Result<Self::Result, BlockExecutionError> {
         let (mut tx_env, recovered) = tx.into_parts();
         // Remove any prewarming-specific context that was added to the tx env.
-        if let Some(tempo_tx_env) = tx_env.tempo_tx_env.as_mut() {
-            tempo_tx_env.expiring_nonce_idx = None;
-        }
+        tx_env.expiring_nonce_idx = None;
         let next_section = self.validate_tx_pre_execution(recovered.tx())?;
 
         let beneficiary = self.evm_mut().ctx_mut().block.beneficiary;

--- a/crates/evm/src/engine.rs
+++ b/crates/evm/src/engine.rs
@@ -94,9 +94,7 @@ impl RecoveredTx<TempoTxEnvelope> for RecoveredInBlock {
 impl ToTxEnv<TempoTxEnv> for RecoveredInBlock {
     fn to_tx_env(&self) -> TempoTxEnv {
         let mut tx_env = TempoTxEnv::from_recovered_tx(self.tx(), *self.signer());
-        if let Some(tempo_tx_env) = tx_env.tempo_tx_env.as_mut() {
-            tempo_tx_env.expiring_nonce_idx = self.expiring_nonce_idx;
-        }
+        tx_env.expiring_nonce_idx = self.expiring_nonce_idx;
 
         tx_env
     }

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -200,13 +200,14 @@ where
             let TxKind::Call(to) = tx.inner.kind else {
                 return Err(TempoInvalidTransaction::SystemTransactionMustBeCall.into());
             };
+            let input = tx.inner.data.clone();
 
             let mut result = if self.inspect {
                 self.inner
-                    .inspect_system_call_with_caller(tx.inner.caller, to, tx.inner.data)?
+                    .inspect_system_call_with_caller(tx.inner.caller, to, input)?
             } else {
                 self.inner
-                    .system_call_with_caller(tx.inner.caller, to, tx.inner.data)?
+                    .system_call_with_caller(tx.inner.caller, to, input)?
             };
 
             // system transactions should not consume any gas
@@ -275,24 +276,31 @@ mod tests {
         database::{EmptyDB, in_memory_db::CacheDB},
     };
     use tempo_chainspec::hardfork::TempoHardfork;
-    use tempo_revm::gas_params::tempo_gas_params_with_amsterdam;
+    use tempo_revm::{TempoTxEnvInner, gas_params::tempo_gas_params_with_amsterdam};
 
     use super::*;
+
+    fn tx_env(inner: TxEnv, is_system_tx: bool) -> TempoTxEnv {
+        TempoTxEnv::new(TempoTxEnvInner {
+            inner,
+            is_system_tx,
+            ..Default::default()
+        })
+    }
 
     #[test]
     fn can_execute_system_tx() {
         let mut evm = test_evm(EmptyDB::default());
         let result = evm
-            .transact(TempoTxEnv {
-                inner: TxEnv {
+            .transact(tx_env(
+                TxEnv {
                     caller: Address::ZERO,
                     gas_price: 0,
                     gas_limit: 21000,
                     ..Default::default()
                 },
-                is_system_tx: true,
-                ..Default::default()
-            })
+                true,
+            ))
             .unwrap();
 
         assert!(result.result.is_success());
@@ -302,18 +310,16 @@ mod tests {
     fn test_transact_raw() {
         let mut evm = test_evm_with_basefee(EmptyDB::default(), 0);
 
-        let tx = TempoTxEnv {
-            inner: TxEnv {
+        let tx = tx_env(
+            TxEnv {
                 caller: Address::repeat_byte(0x01),
                 gas_price: 0,
                 gas_limit: 21000,
                 kind: TxKind::Call(Address::repeat_byte(0x02)),
                 ..Default::default()
             },
-            is_system_tx: false,
-            fee_token: None,
-            ..Default::default()
-        };
+            false,
+        );
 
         let result = evm.transact_raw(tx);
         assert!(result.is_ok());
@@ -328,17 +334,16 @@ mod tests {
         let mut evm = test_evm(EmptyDB::default());
 
         // System transaction
-        let tx = TempoTxEnv {
-            inner: TxEnv {
+        let tx = tx_env(
+            TxEnv {
                 caller: Address::ZERO,
                 gas_price: 0,
                 gas_limit: 21000,
                 kind: TxKind::Call(Address::repeat_byte(0x01)),
                 ..Default::default()
             },
-            is_system_tx: true,
-            ..Default::default()
-        };
+            true,
+        );
 
         let result = evm.transact_raw(tx);
         assert!(result.is_ok());
@@ -354,17 +359,16 @@ mod tests {
         let mut evm = test_evm(EmptyDB::default());
 
         // System transaction with Create kind
-        let tx = TempoTxEnv {
-            inner: TxEnv {
+        let tx = tx_env(
+            TxEnv {
                 caller: Address::ZERO,
                 gas_price: 0,
                 gas_limit: 21000,
                 kind: TxKind::Create,
                 ..Default::default()
             },
-            is_system_tx: true,
-            ..Default::default()
-        };
+            true,
+        );
 
         let result = evm.transact_raw(tx);
         assert!(result.is_err());
@@ -395,17 +399,16 @@ mod tests {
         let mut evm = test_evm(cache_db);
 
         // System transaction that will fail with call to contract that reverts
-        let tx = TempoTxEnv {
-            inner: TxEnv {
+        let tx = tx_env(
+            TxEnv {
                 caller: Address::ZERO,
                 gas_price: 0,
                 gas_limit: 1_000_000,
                 kind: TxKind::Call(contract_addr),
                 ..Default::default()
             },
-            is_system_tx: true,
-            ..Default::default()
-        };
+            true,
+        );
 
         let result = evm.transact_raw(tx);
         assert!(result.is_err());

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -219,9 +219,7 @@ impl BestTransactionsPrewarming {
                 }
 
                 let mut tx_env = tx.transaction.clone_tx_env();
-                if let Some(tempo_tx_env) = tx_env.tempo_tx_env.as_mut() {
-                    tempo_tx_env.expiring_nonce_idx = expiring_nonce_offset;
-                }
+                tx_env.expiring_nonce_idx = expiring_nonce_offset;
 
                 if let Err(err) = evm.transact_raw(tx_env) {
                     trace!(

--- a/crates/revm/src/common.rs
+++ b/crates/revm/src/common.rs
@@ -502,7 +502,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{TempoBlockEnv, TempoEvm};
+    use crate::{TempoBlockEnv, TempoEvm, TempoTxEnvInner};
     use alloy_primitives::{address, uint};
     use reth_evm::EvmInternals;
     use revm::{
@@ -527,11 +527,11 @@ mod tests {
             caller,
             ..Default::default()
         };
-        let tx = TempoTxEnv {
+        let tx = TempoTxEnv::new(TempoTxEnvInner {
             inner: tx_env,
             fee_token: Some(fee_token),
             ..Default::default()
-        };
+        });
 
         let mut db = EmptyDB::default();
         let token = db.get_fee_token(tx, caller, TempoHardfork::Genesis)?;
@@ -551,10 +551,7 @@ mod tests {
             caller,
             ..Default::default()
         };
-        let tx = TempoTxEnv {
-            inner: tx_env,
-            ..Default::default()
-        };
+        let tx = TempoTxEnv::from(tx_env);
 
         let mut db = EmptyDB::default();
         let result_token = db.get_fee_token(tx, caller, TempoHardfork::Genesis)?;
@@ -590,10 +587,7 @@ mod tests {
             caller,
             ..Default::default()
         };
-        let tx = TempoTxEnv {
-            inner: tx_env,
-            ..Default::default()
-        };
+        let tx = TempoTxEnv::from(tx_env);
 
         let mut db = EmptyDB::default();
         let result_token = db.get_fee_token(tx, caller, TempoHardfork::Genesis)?;
@@ -608,10 +602,7 @@ mod tests {
             caller,
             ..Default::default()
         };
-        let tx = TempoTxEnv {
-            inner: tx_env,
-            ..Default::default()
-        };
+        let tx = TempoTxEnv::from(tx_env);
 
         let mut db = EmptyDB::default();
         let result_token = db.get_fee_token(tx, caller, TempoHardfork::Genesis)?;
@@ -641,10 +632,7 @@ mod tests {
             caller,
             ..Default::default()
         };
-        let tx = TempoTxEnv {
-            inner: tx_env,
-            ..Default::default()
-        };
+        let tx = TempoTxEnv::from(tx_env);
 
         let mut db = EmptyDB::default();
         let token = db.get_fee_token(tx, caller, TempoHardfork::Genesis)?;
@@ -665,10 +653,7 @@ mod tests {
             ..Default::default()
         };
 
-        let tx = TempoTxEnv {
-            inner: tx_env,
-            ..Default::default()
-        };
+        let tx = TempoTxEnv::from(tx_env);
 
         let token = db.get_fee_token(tx, caller, TempoHardfork::Genesis)?;
         assert_eq!(token, token_in);

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -455,7 +455,6 @@ where
     fn prevalidate_keychain_call_scopes(
         &self,
         evm: &mut TempoEvm<DB, I>,
-        calls: &[tempo_primitives::transaction::Call],
         remaining_gas: &mut u64,
         reservoir: u64,
     ) -> Result<Option<FrameResult>, EVMError<DB::Error, TempoInvalidTransaction>> {
@@ -468,7 +467,7 @@ where
         // This keeps unpaid transaction validation bounded while still failing before the first
         // user call executes.
 
-        let (access_key_addr, user_address) = {
+        let (tempo_tx_env, access_key_addr, user_address) = {
             let ctx = evm.ctx();
             let tx = ctx.tx();
             let Some(tempo_tx_env) = tx.tempo_tx_env.as_ref() else {
@@ -490,9 +489,13 @@ where
                     })?
             };
 
-            (access_key_addr, keychain_sig.user_address)
+            (
+                Arc::clone(tempo_tx_env),
+                access_key_addr,
+                keychain_sig.user_address,
+            )
         };
-        let Some(kind) = calls.first().map(|call| call.to) else {
+        let Some(kind) = tempo_tx_env.aa_calls.first().map(|call| call.to) else {
             return Err(EVMError::Custom(
                 "AA transactions must contain at least one call".into(),
             ));
@@ -502,7 +505,7 @@ where
         let (validation, gas_used) =
             StorageCtx::enter_ctx_with_gas_limit(evm.ctx_mut(), *remaining_gas, reservoir, || {
                 let keychain = AccountKeychain::default();
-                for call in calls {
+                for call in &tempo_tx_env.aa_calls {
                     keychain.validate_call_scope_for_transaction(
                         user_address,
                         access_key_addr,
@@ -603,7 +606,6 @@ where
         evm: &mut TempoEvm<DB, I>,
         mut remaining_gas: u64,
         mut reservoir: u64,
-        calls: Vec<tempo_primitives::transaction::Call>,
         mut execute_single: F,
     ) -> Result<FrameResult, EVMError<DB::Error, TempoInvalidTransaction>>
     where
@@ -614,21 +616,29 @@ where
             u64,
         ) -> Result<FrameResult, EVMError<DB::Error, TempoInvalidTransaction>>,
     {
+        let tempo_tx_env = evm
+            .ctx()
+            .tx()
+            .tempo_tx_env
+            .as_ref()
+            .ok_or_else(|| EVMError::Custom("AA transaction missing tempo_tx_env".into()))?
+            .clone();
+        let call_count = tempo_tx_env.aa_calls.len();
+        let first_call_is_create = tempo_tx_env
+            .aa_calls
+            .first()
+            .map(|call| call.to.is_create())
+            .unwrap_or(false);
+
         // Create checkpoint for atomic execution - captures state before any calls
         let checkpoint = evm.ctx().journal_mut().checkpoint();
         let mut accumulated_gas_refund = 0i64;
         let mut accumulated_state_gas_spent = 0i64;
 
-        // Store original TxEnv values to restore after batch execution
-        let original_kind = evm.ctx().tx().kind();
-        let original_value = evm.ctx().tx().value();
-        let original_data = evm.ctx().tx().input().clone();
-        let original_gas_limit = evm.ctx().tx().gas_limit();
-
         let mut final_result = None;
 
         if let Some(mut frame_result) =
-            self.prevalidate_keychain_call_scopes(evm, &calls, &mut remaining_gas, reservoir)?
+            self.prevalidate_keychain_call_scopes(evm, &mut remaining_gas, reservoir)?
         {
             // This path only runs for keychain batches that already passed the structural CREATE
             // rejection in validation, so there is no first-call CREATE nonce to preserve here.
@@ -640,27 +650,15 @@ where
             return Ok(frame_result);
         }
 
-        for call in calls.iter() {
-            // Update TxEnv to point to this specific call
-            {
-                let tx = &mut evm.ctx().tx;
-                tx.inner.kind = call.to;
-                tx.inner.value = call.value;
-                tx.inner.data = call.input.clone();
-                tx.inner.gas_limit = remaining_gas;
-            }
+        for call_index in 0..call_count {
+            evm.ctx_mut()
+                .tx
+                .set_active_aa_call(call_index, remaining_gas);
 
             // Execute call with NO additional initial gas (already deducted upfront in validation)
             let frame_result = execute_single(self, evm, remaining_gas, reservoir);
 
-            // Restore original TxEnv immediately after execution, even if execution failed
-            {
-                let tx = &mut evm.ctx().tx;
-                tx.inner.kind = original_kind;
-                tx.inner.value = original_value;
-                tx.inner.data = original_data.clone();
-                tx.inner.gas_limit = original_gas_limit;
-            }
+            evm.ctx_mut().tx.clear_active_aa_call();
 
             let mut frame_result = frame_result?;
 
@@ -686,7 +684,7 @@ where
                     .map(|aa| aa.nonce_key.is_zero())
                     .unwrap_or(true);
 
-                if uses_protocol_nonce && calls.first().map(|c| c.to.is_create()).unwrap_or(false) {
+                if uses_protocol_nonce && first_call_is_create {
                     let caller = evm.ctx().tx().caller();
                     if let Ok(mut caller_acc) =
                         evm.ctx().journal_mut().load_account_with_code_mut(caller)
@@ -743,9 +741,8 @@ where
         evm: &mut TempoEvm<DB, I>,
         gas_limit: u64,
         reservoir: u64,
-        calls: Vec<tempo_primitives::transaction::Call>,
     ) -> Result<FrameResult, EVMError<DB::Error, TempoInvalidTransaction>> {
-        self.execute_multi_call_with(evm, gas_limit, reservoir, calls, Self::execute_single_call)
+        self.execute_multi_call_with(evm, gas_limit, reservoir, Self::execute_single_call)
     }
 
     /// Executes a standard single-call transaction with inspector support.
@@ -773,18 +770,11 @@ where
         evm: &mut TempoEvm<DB, I>,
         gas_limit: u64,
         reservoir: u64,
-        calls: Vec<tempo_primitives::transaction::Call>,
     ) -> Result<FrameResult, EVMError<DB::Error, TempoInvalidTransaction>>
     where
         I: Inspector<TempoContext<DB>, EthInterpreter>,
     {
-        self.execute_multi_call_with(
-            evm,
-            gas_limit,
-            reservoir,
-            calls,
-            Self::inspect_execute_single_call,
-        )
+        self.execute_multi_call_with(evm, gas_limit, reservoir, Self::inspect_execute_single_call)
     }
 }
 
@@ -822,9 +812,8 @@ where
 
         let (gas_limit, reservoir) = evm.initial_gas_and_reservoir(init_and_floor_gas);
 
-        if let Some(tempo_tx_env) = evm.ctx().tx().tempo_tx_env.as_ref() {
-            let calls = tempo_tx_env.aa_calls.clone();
-            self.execute_multi_call(evm, gas_limit, reservoir, calls)
+        if evm.ctx().tx().tempo_tx_env.is_some() {
+            self.execute_multi_call(evm, gas_limit, reservoir)
         } else {
             self.execute_single_call(evm, gas_limit, reservoir)
         }
@@ -1020,7 +1009,7 @@ where
             StorageCtx::enter_evm(journal, block, cfg, tx, || {
                 let mut nonce_manager = NonceManager::new();
 
-                let prev_ptr = if let Some(expiring_nonce_idx) = tempo_tx_env.expiring_nonce_idx {
+                let prev_ptr = if let Some(expiring_nonce_idx) = tx.expiring_nonce_idx {
                     let ptr = nonce_manager
                         .expiring_nonce_ring_ptr
                         .read()
@@ -2339,9 +2328,8 @@ where
 
         let (gas_limit, reservoir) = evm.initial_gas_and_reservoir(init_and_floor_gas);
 
-        if let Some(tempo_tx_env) = evm.ctx().tx().tempo_tx_env.as_ref() {
-            let calls = tempo_tx_env.aa_calls.clone();
-            self.inspect_execute_multi_call(evm, gas_limit, reservoir, calls)
+        if evm.ctx().tx().tempo_tx_env.is_some() {
+            self.inspect_execute_multi_call(evm, gas_limit, reservoir)
         } else {
             self.inspect_execute_single_call(evm, gas_limit, reservoir)
         }
@@ -2420,7 +2408,7 @@ pub fn validate_time_window(
 mod tests {
     use super::*;
     use crate::{
-        TempoBlockEnv, TempoTxEnv, evm::TempoEvm, gas_params::tempo_gas_params,
+        TempoBlockEnv, TempoTxEnv, TempoTxEnvInner, evm::TempoEvm, gas_params::tempo_gas_params,
         tx::TempoBatchCallEnv,
     };
     use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
@@ -2451,6 +2439,14 @@ mod tests {
         Journal::new(db)
     }
 
+    fn aa_tx_env(inner: revm::context::TxEnv, aa_env: TempoBatchCallEnv) -> TempoTxEnv {
+        TempoTxEnv::new(TempoTxEnvInner {
+            inner,
+            tempo_tx_env: Some(Arc::new(aa_env)),
+            ..Default::default()
+        })
+    }
+
     type TestHandlerEvmResult<T> =
         Result<T, EVMError<<CacheDB<EmptyDB> as revm::Database>::Error, TempoInvalidTransaction>>;
 
@@ -2471,10 +2467,7 @@ mod tests {
             aa_env: TempoBatchCallEnv,
             configure_tx_env: impl FnOnce(&mut TempoTxEnv),
         ) -> Self {
-            let mut tx_env = TempoTxEnv {
-                tempo_tx_env: Some(Box::new(aa_env)),
-                ..Default::default()
-            };
+            let mut tx_env = TempoTxEnv::default().with_batch_call_env(aa_env);
             configure_tx_env(&mut tx_env);
             Self::new(spec, tx_env)
         }
@@ -2660,7 +2653,7 @@ mod tests {
         let mut cfg = CfgEnv::<TempoHardfork>::default();
         cfg.spec = TempoHardfork::T1C;
 
-        let tx_env = TempoTxEnv {
+        let tx_env = TempoTxEnv::new(TempoTxEnvInner {
             inner: revm::context::TxEnv {
                 caller,
                 ..Default::default()
@@ -2668,7 +2661,7 @@ mod tests {
             fee_token: Some(invalid_token),
             fee_payer: Some(Some(caller)),
             ..Default::default()
-        };
+        });
 
         let mut evm: TempoEvm<CacheDB<EmptyDB>, ()> = TempoEvm::new(
             Context::mainnet()
@@ -3686,13 +3679,13 @@ mod tests {
                     .with_db(CacheDB::new(EmptyDB::default()))
                     .with_block(TempoBlockEnv::default())
                     .with_cfg(cfg)
-                    .with_tx(TempoTxEnv {
-                        inner: revm::context::TxEnv {
+                    .with_tx(aa_tx_env(
+                        revm::context::TxEnv {
                             gas_limit: 1_000_000,
                             nonce,
                             ..Default::default()
                         },
-                        tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                        TempoBatchCallEnv {
                             aa_calls: vec![Call {
                                 to: TxKind::Call(Address::random()),
                                 value: U256::ZERO,
@@ -3700,9 +3693,8 @@ mod tests {
                             }],
                             nonce_key,
                             ..Default::default()
-                        })),
-                        ..Default::default()
-                    })
+                        },
+                    ))
                     .with_new_journal(journal);
                 TempoEvm::<_, ()>::new(ctx, ())
             };
@@ -3802,13 +3794,13 @@ mod tests {
                     .with_db(CacheDB::new(EmptyDB::default()))
                     .with_block(TempoBlockEnv::default())
                     .with_cfg(cfg)
-                    .with_tx(TempoTxEnv {
-                        inner: revm::context::TxEnv {
+                    .with_tx(aa_tx_env(
+                        revm::context::TxEnv {
                             gas_limit,
                             nonce,
                             ..Default::default()
                         },
-                        tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                        TempoBatchCallEnv {
                             aa_calls: vec![Call {
                                 to: TxKind::Call(Address::random()),
                                 value: U256::ZERO,
@@ -3816,9 +3808,8 @@ mod tests {
                             }],
                             nonce_key: U256::ONE,
                             ..Default::default()
-                        })),
-                        ..Default::default()
-                    })
+                        },
+                    ))
                     .with_new_journal(journal);
 
                 let mut evm: TempoEvm<_, ()> = TempoEvm::new(ctx, ());
@@ -3867,7 +3858,7 @@ mod tests {
         let mut cfg = CfgEnv::<TempoHardfork>::default();
         cfg.spec = TempoHardfork::T3;
 
-        let tx_env = TempoTxEnv {
+        let tx_env = TempoTxEnv::new(TempoTxEnvInner {
             inner: revm::context::TxEnv {
                 caller,
                 gas_limit: 1_000_000,
@@ -3875,7 +3866,7 @@ mod tests {
                 ..Default::default()
             },
             fee_token: Some(DEFAULT_FEE_TOKEN),
-            tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+            tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                 signature,
                 aa_calls: vec![Call {
                     to: TxKind::Call(target),
@@ -3887,7 +3878,7 @@ mod tests {
                 ..Default::default()
             })),
             ..Default::default()
-        };
+        });
 
         let mut test = TestHandlerEvm::with_cfg(TempoHardfork::T3, tx_env, |cfg_override| {
             *cfg_override = cfg;
@@ -3983,7 +3974,7 @@ mod tests {
         let mut cfg = CfgEnv::<TempoHardfork>::default();
         cfg.spec = TempoHardfork::T3;
 
-        let tx_env = TempoTxEnv {
+        let tx_env = TempoTxEnv::new(TempoTxEnvInner {
             inner: revm::context::TxEnv {
                 caller,
                 gas_limit: 1_000_000,
@@ -3991,7 +3982,7 @@ mod tests {
                 ..Default::default()
             },
             fee_token: Some(DEFAULT_FEE_TOKEN),
-            tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+            tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                 signature,
                 aa_calls: vec![Call {
                     to: TxKind::Call(target),
@@ -4003,7 +3994,7 @@ mod tests {
                 ..Default::default()
             })),
             ..Default::default()
-        };
+        });
 
         let ctx = Context::mainnet()
             .with_db(CacheDB::new(EmptyDB::default()))
@@ -4086,21 +4077,20 @@ mod tests {
         let mut cfg = CfgEnv::<TempoHardfork>::default();
         cfg.spec = TempoHardfork::T3;
 
-        let tx_env = TempoTxEnv {
-            inner: revm::context::TxEnv {
+        let tx_env = aa_tx_env(
+            revm::context::TxEnv {
                 caller,
                 gas_limit: 1_000_000,
                 ..Default::default()
             },
-            tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+            TempoBatchCallEnv {
                 signature,
                 aa_calls: vec![],
                 signature_hash: B256::ZERO,
                 override_key_id: Some(access_key),
                 ..Default::default()
-            })),
-            ..Default::default()
-        };
+            },
+        );
 
         let ctx = Context::mainnet()
             .with_db(CacheDB::new(EmptyDB::default()))
@@ -4114,7 +4104,7 @@ mod tests {
         let mut remaining_gas = 100_000;
 
         let err = handler
-            .prevalidate_keychain_call_scopes(&mut evm, &[], &mut remaining_gas, 0)
+            .prevalidate_keychain_call_scopes(&mut evm, &mut remaining_gas, 0)
             .expect_err("empty calls should return an error instead of panicking");
 
         match err {
@@ -4144,25 +4134,6 @@ mod tests {
         const SPENT: (u64, u64) = (1000, 500);
         const REFUND: (i64, i64) = (100, 50);
 
-        // Create minimal EVM context
-        let db = CacheDB::new(EmptyDB::default());
-        let journal = Journal::new(db);
-        let ctx = Context::mainnet()
-            .with_db(CacheDB::new(EmptyDB::default()))
-            .with_block(TempoBlockEnv::default())
-            .with_cfg(CfgEnv::default())
-            .with_tx(TempoTxEnv {
-                inner: revm::context::TxEnv {
-                    gas_limit: GAS_LIMIT,
-                    ..Default::default()
-                },
-                ..Default::default()
-            })
-            .with_new_journal(journal);
-
-        let mut evm: TempoEvm<_, ()> = TempoEvm::new(ctx, ());
-        let mut handler: TempoEvmHandler<CacheDB<EmptyDB>, ()> = TempoEvmHandler::new();
-
         // Create mock calls
         let calls = vec![
             Call {
@@ -4177,12 +4148,33 @@ mod tests {
             },
         ];
 
+        // Create minimal EVM context
+        let db = CacheDB::new(EmptyDB::default());
+        let journal = Journal::new(db);
+        let ctx = Context::mainnet()
+            .with_db(CacheDB::new(EmptyDB::default()))
+            .with_block(TempoBlockEnv::default())
+            .with_cfg(CfgEnv::default())
+            .with_tx(aa_tx_env(
+                revm::context::TxEnv {
+                    gas_limit: GAS_LIMIT,
+                    ..Default::default()
+                },
+                TempoBatchCallEnv {
+                    aa_calls: calls,
+                    ..Default::default()
+                },
+            ))
+            .with_new_journal(journal);
+
+        let mut evm: TempoEvm<_, ()> = TempoEvm::new(ctx, ());
+        let mut handler: TempoEvmHandler<CacheDB<EmptyDB>, ()> = TempoEvmHandler::new();
+
         let (mut call_idx, calls_gas) = (0, [(SPENT.0, REFUND.0), (SPENT.1, REFUND.1)]);
         let result = handler.execute_multi_call_with(
             &mut evm,
             GAS_LIMIT - INTRINSIC_GAS,
             0,
-            calls,
             |_handler, _evm, gas, _reservoir| {
                 let (spent, refund) = calls_gas[call_idx];
                 call_idx += 1;
@@ -4487,16 +4479,15 @@ mod tests {
             let expected_addr = Address::with_last_byte(0);
             let expected_input = vec![0u8; 1];
 
-            let tx_env = TempoTxEnv {
-                inner: revm::context::TxEnv::default(),
-                tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+            let tx_env = aa_tx_env(
+                revm::context::TxEnv::default(),
+                TempoBatchCallEnv {
                     aa_calls: calls,
                     signature: secp256k1_sig(),
                     signature_hash: B256::ZERO,
                     ..Default::default()
-                })),
-                ..Default::default()
-            };
+                },
+            );
 
             let first = tx_env.first_call();
             prop_assert!(first.is_some(), "first_call should return Some for non-empty AA calls");
@@ -4509,16 +4500,15 @@ mod tests {
         /// Property: first_call returns None for AA transaction with zero calls
         #[test]
         fn proptest_first_call_empty_aa(_dummy in 0u8..1) {
-            let tx_env = TempoTxEnv {
-                inner: revm::context::TxEnv::default(),
-                tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+            let tx_env = aa_tx_env(
+                revm::context::TxEnv::default(),
+                TempoBatchCallEnv {
                     aa_calls: vec![],
                     signature: secp256k1_sig(),
                     signature_hash: B256::ZERO,
                     ..Default::default()
-                })),
-                ..Default::default()
-            };
+                },
+            );
 
             prop_assert!(tx_env.first_call().is_none(), "first_call should return None for empty AA calls");
         }
@@ -4529,15 +4519,11 @@ mod tests {
             let calldata = Bytes::from(vec![0xab_u8; calldata_len]);
             let target = Address::random();
 
-            let tx_env = TempoTxEnv {
-                inner: revm::context::TxEnv {
+            let tx_env = TempoTxEnv::from(revm::context::TxEnv {
                     kind: TxKind::Call(target),
                     data: calldata.clone(),
                     ..Default::default()
-                },
-                tempo_tx_env: None,
-                ..Default::default()
-            };
+            });
 
             let first = tx_env.first_call();
             prop_assert!(first.is_some(), "first_call should return Some for non-AA tx");
@@ -4683,13 +4669,13 @@ mod tests {
                 .with_db(CacheDB::new(EmptyDB::default()))
                 .with_block(TempoBlockEnv::default())
                 .with_cfg(cfg)
-                .with_tx(TempoTxEnv {
-                    inner: revm::context::TxEnv {
+                .with_tx(aa_tx_env(
+                    revm::context::TxEnv {
                         gas_limit: 1_000_000,
                         nonce,
                         ..Default::default()
                     },
-                    tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                    TempoBatchCallEnv {
                         aa_calls: vec![Call {
                             to: TxKind::Call(TEST_TARGET),
                             value: U256::ZERO,
@@ -4697,9 +4683,8 @@ mod tests {
                         }],
                         nonce_key,
                         ..Default::default()
-                    })),
-                    ..Default::default()
-                })
+                    },
+                ))
                 .with_new_journal(journal);
             TempoEvm::<_, ()>::new(ctx, ())
         };
@@ -4777,13 +4762,13 @@ mod tests {
                 .with_db(CacheDB::new(EmptyDB::default()))
                 .with_block(TempoBlockEnv::default())
                 .with_cfg(cfg)
-                .with_tx(TempoTxEnv {
-                    inner: revm::context::TxEnv {
+                .with_tx(aa_tx_env(
+                    revm::context::TxEnv {
                         gas_limit: 1_000_000,
                         nonce,
                         ..Default::default()
                     },
-                    tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                    TempoBatchCallEnv {
                         aa_calls: vec![Call {
                             to: TxKind::Call(TEST_TARGET),
                             value: U256::ZERO,
@@ -4791,9 +4776,8 @@ mod tests {
                         }],
                         nonce_key,
                         ..Default::default()
-                    })),
-                    ..Default::default()
-                })
+                    },
+                ))
                 .with_new_journal(journal);
             TempoEvm::<_, ()>::new(ctx, ())
         };
@@ -4883,7 +4867,7 @@ mod tests {
             let mut cfg = CfgEnv::<TempoHardfork>::default();
             cfg.spec = spec;
 
-            let tx = TempoTxEnv {
+            let tx = TempoTxEnv::new(TempoTxEnvInner {
                 inner: revm::context::TxEnv {
                     caller: user,
                     gas_limit: 1_000_000,
@@ -4891,7 +4875,7 @@ mod tests {
                     ..Default::default()
                 },
                 fee_token: Some(DEFAULT_FEE_TOKEN),
-                tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                     signature: sig,
                     aa_calls: vec![Call {
                         to: TxKind::Call(Address::ZERO),
@@ -4904,7 +4888,7 @@ mod tests {
                     ..Default::default()
                 })),
                 ..Default::default()
-            };
+            });
 
             let ctx = Context::mainnet()
                 .with_db(CacheDB::new(EmptyDB::default()))
@@ -4994,7 +4978,8 @@ mod tests {
 
                 if !spec.is_t1c()
                     && let Some(aa_env) = evm.tx.tempo_tx_env.as_mut()
-                    && let TempoSignature::Keychain(keychain_sig) = &mut aa_env.signature
+                    && let TempoSignature::Keychain(keychain_sig) =
+                        &mut Arc::make_mut(aa_env).signature
                 {
                     // Overwrite the signature version pre-T1C to bypass the version check.
                     keychain_sig.version = KeychainVersion::V1;
@@ -5910,15 +5895,12 @@ mod tests {
     fn test_state_gas_tx_gas_limit_above_cap_allowed() {
         let calldata = Bytes::from(vec![1, 2, 3]);
 
-        let tx_env = TempoTxEnv {
-            inner: revm::context::TxEnv {
-                gas_limit: 60_000_000,
-                kind: TxKind::Call(Address::random()),
-                data: calldata,
-                ..Default::default()
-            },
+        let tx_env = TempoTxEnv::from(revm::context::TxEnv {
+            gas_limit: 60_000_000,
+            kind: TxKind::Call(Address::random()),
+            data: calldata,
             ..Default::default()
-        };
+        });
 
         // TIP-1016 is opt-in via amsterdam_eip8037; manually enable for this test.
         let mut test = TestHandlerEvm::with_cfg(TempoHardfork::T4, tx_env, |cfg| {
@@ -5942,15 +5924,12 @@ mod tests {
     fn test_state_gas_tx_gas_limit_above_cap_rejected_pre_t4() {
         let calldata = Bytes::from(vec![1, 2, 3]);
 
-        let tx_env = TempoTxEnv {
-            inner: revm::context::TxEnv {
-                gas_limit: 60_000_000, // Double the cap
-                kind: TxKind::Call(Address::random()),
-                data: calldata,
-                ..Default::default()
-            },
+        let tx_env = TempoTxEnv::from(revm::context::TxEnv {
+            gas_limit: 60_000_000, // Double the cap
+            kind: TxKind::Call(Address::random()),
+            data: calldata,
             ..Default::default()
-        };
+        });
 
         let mut test = TestHandlerEvm::with_cfg(TempoHardfork::T1, tx_env, |cfg| {
             cfg.tx_gas_limit_cap = Some(30_000_000);
@@ -5974,15 +5953,14 @@ mod tests {
             subblock_transaction: true,
             ..Default::default()
         };
-        let tx_env = TempoTxEnv {
-            inner: revm::context::TxEnv {
+        let tx_env = aa_tx_env(
+            revm::context::TxEnv {
                 gas_limit: TX_GAS_LIMIT,
                 kind: TxKind::Call(Address::random()),
                 ..Default::default()
             },
-            tempo_tx_env: Some(Box::new(aa_env)),
-            ..Default::default()
-        };
+            aa_env,
+        );
 
         let mut test = TestHandlerEvm::with_cfg(TempoHardfork::T4, tx_env, |cfg| {
             cfg.tx_gas_limit_cap = Some(CAP);
@@ -6040,15 +6018,14 @@ mod tests {
             subblock_transaction: true,
             ..Default::default()
         };
-        let tx_env = TempoTxEnv {
-            inner: revm::context::TxEnv {
+        let tx_env = aa_tx_env(
+            revm::context::TxEnv {
                 gas_limit: 100_000,
                 kind: TxKind::Call(Address::random()),
                 ..Default::default()
             },
-            tempo_tx_env: Some(Box::new(aa_env)),
-            ..Default::default()
-        };
+            aa_env,
+        );
 
         let mut test = TestHandlerEvm::with_cfg(TempoHardfork::T4, tx_env, |cfg| {
             cfg.tx_gas_limit_cap = Some(30_000_000);
@@ -6100,15 +6077,12 @@ mod tests {
         let calldata = Bytes::from(vec![1, 2, 3]);
 
         let journal = Journal::new(CacheDB::new(EmptyDB::default()));
-        let tx_env = TempoTxEnv {
-            inner: revm::context::TxEnv {
-                gas_limit: 1_000_000,
-                kind: TxKind::Call(Address::random()),
-                data: calldata,
-                ..Default::default()
-            },
+        let tx_env = TempoTxEnv::from(revm::context::TxEnv {
+            gas_limit: 1_000_000,
+            kind: TxKind::Call(Address::random()),
+            data: calldata,
             ..Default::default()
-        };
+        });
 
         let ctx = Context::mainnet()
             .with_db(CacheDB::new(EmptyDB::default()))
@@ -6544,7 +6518,7 @@ mod tests {
             ],
         );
 
-        let aa_env = make_aa_env(calls.clone());
+        let aa_env = make_aa_env(calls);
         let mut test = TestHandlerEvm::aa(TempoHardfork::T4, aa_env, |tx_env| {
             tx_env.inner.caller = Address::random();
             tx_env.inner.gas_limit = tx_gas_limit;
@@ -6567,7 +6541,6 @@ mod tests {
                 &mut test.evm,
                 gas_limit,
                 reservoir,
-                calls,
                 |_handler, _evm, gas, _reservoir| {
                     // Feed the batch executor deterministic per-call outcomes without running real EVM code.
                     let (instruction_result, spent) = call_results[call_idx];

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -23,4 +23,4 @@ pub use error::{TempoHaltReason, TempoInvalidTransaction};
 pub use evm::TempoEvm;
 pub use handler::{ValidationContext, calculate_aa_batch_intrinsic_gas};
 pub use revm::interpreter::instructions::utility::IntoAddress;
-pub use tx::{TempoBatchCallEnv, TempoTxEnv};
+pub use tx::{ActiveAaCall, TempoBatchCallEnv, TempoTxEnv, TempoTxEnvInner};

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -12,6 +12,10 @@ use revm::context::{
         AccessList, AccessListItem, RecoveredAuthority, RecoveredAuthorization, SignedAuthorization,
     },
 };
+use std::{
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 use tempo_contracts::precompiles::ITIP20;
 use tempo_primitives::{
     AASigned, TempoAddressExt, TempoSignature, TempoTransaction, TempoTxEnvelope,
@@ -61,15 +65,21 @@ pub struct TempoBatchCallEnv {
     /// When provided in eth_call/eth_estimateGas, enables spending limits simulation
     /// This is not used in actual transaction execution - the key_id is recovered from the signature.
     pub override_key_id: Option<Address>,
-
-    /// Perf optimization for expiring nonce transactions.
-    ///
-    /// Stores how many other expiring nonce transactions are there in the block before this one.
-    pub expiring_nonce_idx: Option<usize>,
 }
-/// Tempo transaction environment.
+
+/// The AA batch call currently exposed as the EVM transaction call during execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ActiveAaCall {
+    /// Index into [`TempoBatchCallEnv::aa_calls`].
+    pub index: usize,
+
+    /// Remaining gas limit for this call.
+    pub gas_limit: u64,
+}
+
+/// Canonical Tempo transaction environment.
 #[derive(Debug, Clone, Default, derive_more::Deref, derive_more::DerefMut)]
-pub struct TempoTxEnv {
+pub struct TempoTxEnvInner {
     /// Inner Ethereum [`TxEnv`].
     #[deref]
     #[deref_mut]
@@ -93,11 +103,81 @@ pub struct TempoTxEnv {
     /// - None corresponds to a transaction without a fee payer
     pub fee_payer: Option<Option<Address>>,
 
-    /// AA-specific transaction environment (boxed to keep TempoTxEnv lean for non-AA tx)
-    pub tempo_tx_env: Option<Box<TempoBatchCallEnv>>,
+    /// AA-specific transaction environment (shared to keep cloned [`TempoTxEnv`] lean).
+    pub tempo_tx_env: Option<Arc<TempoBatchCallEnv>>,
+}
+
+/// Tempo transaction environment.
+///
+/// The canonical transaction payload is shared behind an [`Arc`]. Per-execution metadata stays on
+/// the outer value so cloned transaction environments do not need to deep-clone AA calldata when
+/// block execution annotates them.
+#[derive(Debug, Clone, Default)]
+pub struct TempoTxEnv {
+    /// Shared canonical transaction environment.
+    shared: Arc<TempoTxEnvInner>,
+
+    /// Current AA batch call exposed through the [`Transaction`] impl during execution.
+    pub active_aa_call: Option<ActiveAaCall>,
+
+    /// Perf optimization for expiring nonce transactions.
+    ///
+    /// Stores how many other expiring nonce transactions are there in the block before this one.
+    pub expiring_nonce_idx: Option<usize>,
 }
 
 impl TempoTxEnv {
+    /// Creates a new transaction environment from canonical transaction data.
+    pub fn new(inner: TempoTxEnvInner) -> Self {
+        Self {
+            shared: Arc::new(inner),
+            ..Default::default()
+        }
+    }
+
+    /// Returns this transaction environment with AA batch data attached.
+    pub fn with_batch_call_env(mut self, aa_env: TempoBatchCallEnv) -> Self {
+        self.inner_mut().tempo_tx_env = Some(Arc::new(aa_env));
+        self
+    }
+
+    /// Returns a mutable reference to the canonical transaction data.
+    ///
+    /// This uses copy-on-write if the canonical data is shared. Runtime AA subcall selection should
+    /// use [`Self::set_active_aa_call`] instead of mutating the canonical [`TxEnv`].
+    pub fn inner_mut(&mut self) -> &mut TempoTxEnvInner {
+        Arc::make_mut(&mut self.shared)
+    }
+
+    /// Exposes one AA batch call as the active EVM transaction call.
+    pub fn set_active_aa_call(&mut self, index: usize, gas_limit: u64) {
+        if let Some(aa) = self.tempo_tx_env.as_ref() {
+            debug_assert!(
+                index < aa.aa_calls.len(),
+                "active AA call index out of bounds"
+            );
+        }
+        self.active_aa_call = Some(ActiveAaCall { index, gas_limit });
+    }
+
+    /// Clears the active AA batch call override.
+    pub fn clear_active_aa_call(&mut self) {
+        self.active_aa_call = None;
+    }
+
+    fn active_call(&self) -> Option<&Call> {
+        let active = self.active_aa_call?;
+        let aa = self
+            .tempo_tx_env
+            .as_ref()
+            .expect("active AA call requires tempo_tx_env");
+        Some(
+            aa.aa_calls
+                .get(active.index)
+                .expect("active AA call index must refer to an existing call"),
+        )
+    }
+
     /// Resolves fee payer from the signature.
     pub fn fee_payer(&self) -> Result<Address, TempoInvalidTransaction> {
         if let Some(fee_payer) = self.fee_payer {
@@ -195,6 +275,20 @@ impl TempoTxEnv {
     }
 }
 
+impl Deref for TempoTxEnv {
+    type Target = TempoTxEnvInner;
+
+    fn deref(&self) -> &Self::Target {
+        self.shared.as_ref()
+    }
+}
+
+impl DerefMut for TempoTxEnv {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner_mut()
+    }
+}
+
 fn is_discounted_tip20_call(to: &TxKind, input: &[u8]) -> bool {
     matches!(to, TxKind::Call(to) if to.is_tip20())
         && ITIP20::ITIP20Calls::is_discounted_payment_call(input)
@@ -202,10 +296,16 @@ fn is_discounted_tip20_call(to: &TxKind, input: &[u8]) -> bool {
 
 impl From<TxEnv> for TempoTxEnv {
     fn from(inner: TxEnv) -> Self {
-        Self {
+        Self::new(TempoTxEnvInner {
             inner,
             ..Default::default()
-        }
+        })
+    }
+}
+
+impl From<TempoTxEnvInner> for TempoTxEnv {
+    fn from(inner: TempoTxEnvInner) -> Self {
+        Self::new(inner)
     }
 }
 
@@ -218,7 +318,9 @@ impl Transaction for TempoTxEnv {
     }
 
     fn kind(&self) -> TxKind {
-        self.inner.kind()
+        self.active_call()
+            .map(|call| call.to)
+            .unwrap_or_else(|| self.inner.kind())
     }
 
     fn caller(&self) -> Address {
@@ -226,7 +328,9 @@ impl Transaction for TempoTxEnv {
     }
 
     fn gas_limit(&self) -> u64 {
-        self.inner.gas_limit()
+        self.active_aa_call
+            .map(|call| call.gas_limit)
+            .unwrap_or_else(|| self.inner.gas_limit())
     }
 
     fn gas_price(&self) -> u128 {
@@ -234,7 +338,9 @@ impl Transaction for TempoTxEnv {
     }
 
     fn value(&self) -> U256 {
-        self.inner.value()
+        self.active_call()
+            .map(|call| call.value)
+            .unwrap_or_else(|| self.inner.value())
     }
 
     fn nonce(&self) -> u64 {
@@ -266,7 +372,9 @@ impl Transaction for TempoTxEnv {
     }
 
     fn input(&self) -> &Bytes {
-        self.inner.input()
+        self.active_call()
+            .map(|call| &call.input)
+            .unwrap_or_else(|| self.inner.input())
     }
 
     fn blob_versioned_hashes(&self) -> &[B256] {
@@ -296,15 +404,15 @@ impl Transaction for TempoTxEnv {
 
 impl TransactionEnvMut for TempoTxEnv {
     fn set_gas_limit(&mut self, gas_limit: u64) {
-        self.inner.set_gas_limit(gas_limit);
+        self.inner_mut().inner.set_gas_limit(gas_limit);
     }
 
     fn set_nonce(&mut self, nonce: u64) {
-        self.inner.set_nonce(nonce);
+        self.inner_mut().inner.set_nonce(nonce);
     }
 
     fn set_access_list(&mut self, access_list: AccessList) {
-        self.inner.set_access_list(access_list);
+        self.inner_mut().inner.set_access_list(access_list);
     }
 }
 
@@ -353,7 +461,7 @@ impl FromRecoveredTx<AASigned> for TempoTxEnv {
             )
         };
 
-        Self {
+        Self::new(TempoTxEnvInner {
             inner: TxEnv {
                 tx_type: tx.ty(),
                 caller,
@@ -388,7 +496,7 @@ impl FromRecoveredTx<AASigned> for TempoTxEnv {
                 secp256k1::recover_signer(&sig, tx.fee_payer_signature_hash(caller)).ok()
             }),
             // Bundle AA-specific fields into TempoBatchCallEnv
-            tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+            tempo_tx_env: Some(Arc::new(TempoBatchCallEnv {
                 signature: signature.clone(),
                 valid_before: valid_before.map(NonZeroU64::get),
                 valid_after: valid_after.map(NonZeroU64::get),
@@ -405,39 +513,37 @@ impl FromRecoveredTx<AASigned> for TempoTxEnv {
                 tx_hash: *aa_signed.hash(),
                 // override_key_id is only used for gas estimation, not actual execution
                 override_key_id: None,
-                // can only be derived when given an entire block
-                expiring_nonce_idx: None,
             })),
-        }
+        })
     }
 }
 
 impl FromRecoveredTx<TempoTxEnvelope> for TempoTxEnv {
     fn from_recovered_tx(tx: &TempoTxEnvelope, sender: Address) -> Self {
         match tx {
-            tx @ TempoTxEnvelope::Legacy(inner) => Self {
+            tx @ TempoTxEnvelope::Legacy(inner) => Self::new(TempoTxEnvInner {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
                 fee_token: None,
                 is_system_tx: tx.is_system_tx(),
                 unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 fee_payer: None,
                 tempo_tx_env: None, // Non-AA transaction
-            },
-            TempoTxEnvelope::Eip2930(inner) => Self {
+            }),
+            TempoTxEnvelope::Eip2930(inner) => Self::new(TempoTxEnvInner {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
                 unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 ..Default::default()
-            },
-            TempoTxEnvelope::Eip1559(inner) => Self {
+            }),
+            TempoTxEnvelope::Eip1559(inner) => Self::new(TempoTxEnvInner {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
                 unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 ..Default::default()
-            },
-            TempoTxEnvelope::Eip7702(inner) => Self {
+            }),
+            TempoTxEnvelope::Eip7702(inner) => Self::new(TempoTxEnvInner {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
                 unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 ..Default::default()
-            },
+            }),
             TempoTxEnvelope::AA(tx) => Self::from_recovered_tx(tx, sender),
         }
     }
@@ -464,6 +570,7 @@ mod tests {
     use core::num::NonZeroU64;
     use proptest::prelude::*;
     use revm::context::{Transaction, TxEnv, result::InvalidTransaction};
+    use std::sync::Arc;
     use tempo_contracts::precompiles::ITIP20;
     use tempo_primitives::{
         TempoTxEnvelope,
@@ -484,6 +591,10 @@ mod tests {
             value: alloy_primitives::U256::ZERO,
             input: alloy_primitives::Bytes::new(),
         }
+    }
+
+    fn tx_with_aa(aa_env: super::TempoBatchCallEnv) -> super::TempoTxEnv {
+        super::TempoTxEnv::default().with_batch_call_env(aa_env)
     }
 
     #[test]
@@ -657,24 +768,20 @@ mod tests {
     #[test]
     fn test_fee_payer_without_signature_uses_caller() {
         let caller = Address::repeat_byte(0xAB);
-        let tx_env = super::TempoTxEnv {
-            inner: TxEnv {
-                caller,
-                ..Default::default()
-            },
-            fee_payer: None,
+        let tx_env = super::TempoTxEnv::from(TxEnv {
+            caller,
             ..Default::default()
-        };
+        });
 
         assert_eq!(tx_env.fee_payer(), Ok(caller));
     }
 
     #[test]
     fn test_fee_payer_invalid_signature_rejected() {
-        let tx_env = super::TempoTxEnv {
+        let tx_env = super::TempoTxEnv::new(super::TempoTxEnvInner {
             fee_payer: Some(None),
             ..Default::default()
-        };
+        });
 
         assert!(matches!(
             tx_env.fee_payer(),
@@ -685,30 +792,27 @@ mod tests {
     #[test]
     fn test_fee_payer_resolving_to_sender_is_allowed_in_tx_env() {
         let caller = Address::repeat_byte(0xAB);
-        let tx_env = super::TempoTxEnv {
+        let tx_env = super::TempoTxEnv::new(super::TempoTxEnvInner {
             inner: TxEnv {
                 caller,
                 ..Default::default()
             },
             fee_payer: Some(Some(caller)),
             ..Default::default()
-        };
+        });
 
         assert_eq!(tx_env.fee_payer(), Ok(caller));
     }
 
     #[test]
     fn test_has_fee_payer_signature() {
-        let without_sig = super::TempoTxEnv {
-            fee_payer: None,
-            ..Default::default()
-        };
+        let without_sig = super::TempoTxEnv::default();
         assert!(!without_sig.has_fee_payer_signature());
 
-        let with_sig = super::TempoTxEnv {
+        let with_sig = super::TempoTxEnv::new(super::TempoTxEnvInner {
             fee_payer: Some(Some(Address::repeat_byte(0xAB))),
             ..Default::default()
-        };
+        });
         assert!(with_sig.has_fee_payer_signature());
     }
 
@@ -826,14 +930,11 @@ mod tests {
         let addr = Address::repeat_byte(0x42);
         let data = Bytes::from(vec![0x01, 0x02, 0x03]);
 
-        let tx_env = super::TempoTxEnv {
-            inner: TxEnv {
-                kind: TxKind::Call(addr),
-                data: data.clone(),
-                ..Default::default()
-            },
+        let tx_env = super::TempoTxEnv::from(TxEnv {
+            kind: TxKind::Call(addr),
+            data: data.clone(),
             ..Default::default()
-        };
+        });
 
         let first_call = tx_env.first_call();
         assert!(first_call.is_some());
@@ -853,24 +954,21 @@ mod tests {
         let input1 = Bytes::from(vec![0xAA, 0xBB]);
         let input2 = Bytes::from(vec![0xCC, 0xDD]);
 
-        let tx_env = super::TempoTxEnv {
-            tempo_tx_env: Some(Box::new(super::TempoBatchCallEnv {
-                aa_calls: vec![
-                    Call {
-                        to: TxKind::Call(addr1),
-                        value: U256::ZERO,
-                        input: input1.clone(),
-                    },
-                    Call {
-                        to: TxKind::Call(addr2),
-                        value: U256::from(100),
-                        input: input2,
-                    },
-                ],
-                ..Default::default()
-            })),
+        let tx_env = tx_with_aa(super::TempoBatchCallEnv {
+            aa_calls: vec![
+                Call {
+                    to: TxKind::Call(addr1),
+                    value: U256::ZERO,
+                    input: input1.clone(),
+                },
+                Call {
+                    to: TxKind::Call(addr2),
+                    value: U256::from(100),
+                    input: input2,
+                },
+            ],
             ..Default::default()
-        };
+        });
 
         let first_call = tx_env.first_call();
         assert!(first_call.is_some());
@@ -880,15 +978,66 @@ mod tests {
     }
 
     #[test]
-    fn test_first_call_with_empty_aa_calls() {
-        // Test with tempo_tx_env but empty calls list
-        let tx_env = super::TempoTxEnv {
-            tempo_tx_env: Some(Box::new(super::TempoBatchCallEnv {
-                aa_calls: vec![],
+    fn test_active_aa_call_overrides_transaction_view_without_mutating_inner() {
+        let canonical_addr = Address::repeat_byte(0x10);
+        let canonical_input = Bytes::from_static(b"canonical");
+        let call_addr = Address::repeat_byte(0x20);
+        let call_input = Bytes::from_static(b"active");
+
+        let tx_env = super::TempoTxEnv::new(super::TempoTxEnvInner {
+            inner: TxEnv {
+                kind: TxKind::Call(canonical_addr),
+                data: canonical_input.clone(),
+                gas_limit: 50_000,
+                value: U256::from(1),
+                ..Default::default()
+            },
+            tempo_tx_env: Some(Arc::new(super::TempoBatchCallEnv {
+                aa_calls: vec![
+                    Call {
+                        to: TxKind::Call(Address::repeat_byte(0x11)),
+                        value: U256::from(2),
+                        input: Bytes::from_static(b"first"),
+                    },
+                    Call {
+                        to: TxKind::Call(call_addr),
+                        value: U256::from(3),
+                        input: call_input.clone(),
+                    },
+                ],
                 ..Default::default()
             })),
             ..Default::default()
-        };
+        });
+
+        let mut active_tx = tx_env.clone();
+        active_tx.set_active_aa_call(1, 12_345);
+
+        assert_eq!(Transaction::kind(&active_tx), TxKind::Call(call_addr));
+        assert_eq!(Transaction::value(&active_tx), U256::from(3));
+        assert_eq!(Transaction::input(&active_tx), &call_input);
+        assert_eq!(Transaction::gas_limit(&active_tx), 12_345);
+
+        assert_eq!(active_tx.inner.kind, TxKind::Call(canonical_addr));
+        assert_eq!(active_tx.inner.data, canonical_input);
+        assert_eq!(active_tx.inner.gas_limit, 50_000);
+        assert_eq!(active_tx.inner.value, U256::from(1));
+
+        assert_eq!(Transaction::kind(&tx_env), TxKind::Call(canonical_addr));
+        assert_eq!(Transaction::input(&tx_env), &canonical_input);
+
+        active_tx.clear_active_aa_call();
+        assert_eq!(Transaction::kind(&active_tx), TxKind::Call(canonical_addr));
+        assert_eq!(Transaction::input(&active_tx), &canonical_input);
+    }
+
+    #[test]
+    fn test_first_call_with_empty_aa_calls() {
+        // Test with tempo_tx_env but empty calls list
+        let tx_env = tx_with_aa(super::TempoBatchCallEnv {
+            aa_calls: vec![],
+            ..Default::default()
+        });
 
         assert!(tx_env.first_call().is_none());
     }
@@ -906,43 +1055,37 @@ mod tests {
         let input3 = Bytes::from(vec![0x04, 0x05, 0x06]);
 
         // Non-AA transaction: returns single call from inner TxEnv
-        let non_aa_tx = super::TempoTxEnv {
-            inner: TxEnv {
-                kind: TxKind::Call(addr1),
-                data: input1.clone(),
-                ..Default::default()
-            },
+        let non_aa_tx = super::TempoTxEnv::from(TxEnv {
+            kind: TxKind::Call(addr1),
+            data: input1.clone(),
             ..Default::default()
-        };
+        });
         let calls: Vec<_> = non_aa_tx.calls().collect();
         assert_eq!(calls.len(), 1);
         assert_eq!(*calls[0].0, TxKind::Call(addr1));
         assert_eq!(calls[0].1, input1.as_ref());
 
         // AA transaction with multiple calls
-        let aa_tx = super::TempoTxEnv {
-            tempo_tx_env: Some(Box::new(super::TempoBatchCallEnv {
-                aa_calls: vec![
-                    Call {
-                        to: TxKind::Call(addr1),
-                        value: U256::ZERO,
-                        input: input1.clone(),
-                    },
-                    Call {
-                        to: TxKind::Call(addr2),
-                        value: U256::from(50),
-                        input: input2.clone(),
-                    },
-                    Call {
-                        to: TxKind::Create,
-                        value: U256::from(100),
-                        input: input3.clone(),
-                    },
-                ],
-                ..Default::default()
-            })),
+        let aa_tx = tx_with_aa(super::TempoBatchCallEnv {
+            aa_calls: vec![
+                Call {
+                    to: TxKind::Call(addr1),
+                    value: U256::ZERO,
+                    input: input1.clone(),
+                },
+                Call {
+                    to: TxKind::Call(addr2),
+                    value: U256::from(50),
+                    input: input2.clone(),
+                },
+                Call {
+                    to: TxKind::Create,
+                    value: U256::from(100),
+                    input: input3.clone(),
+                },
+            ],
             ..Default::default()
-        };
+        });
         let calls: Vec<_> = aa_tx.calls().collect();
         assert_eq!(calls.len(), 3);
         assert_eq!(*calls[0].0, TxKind::Call(addr1));
@@ -953,13 +1096,10 @@ mod tests {
         assert_eq!(calls[2].1, input3.as_ref());
 
         // AA transaction with empty calls list
-        let empty_aa_tx = super::TempoTxEnv {
-            tempo_tx_env: Some(Box::new(super::TempoBatchCallEnv {
-                aa_calls: vec![],
-                ..Default::default()
-            })),
+        let empty_aa_tx = tx_with_aa(super::TempoBatchCallEnv {
+            aa_calls: vec![],
             ..Default::default()
-        };
+        });
         let calls: Vec<_> = empty_aa_tx.calls().collect();
         assert!(calls.is_empty());
     }
@@ -998,13 +1138,12 @@ mod tests {
             .abi_encode(),
         );
 
-        let tx = |to, input: Bytes| super::TempoTxEnv {
-            inner: TxEnv {
+        let tx = |to, input: Bytes| {
+            super::TempoTxEnv::from(TxEnv {
                 kind: to,
                 data: input,
                 ..Default::default()
-            },
-            ..Default::default()
+            })
         };
 
         assert!(tx(TxKind::Call(PAYMENT_TKN), transfer.clone()).is_discounted_payment());
@@ -1021,43 +1160,34 @@ mod tests {
         }]);
         assert!(!access_list_tx.is_discounted_payment());
 
-        let aa_tx = super::TempoTxEnv {
-            tempo_tx_env: Some(Box::new(super::TempoBatchCallEnv {
-                aa_calls: vec![Call {
-                    to: TxKind::Call(PAYMENT_TKN),
-                    value: U256::ZERO,
-                    input: transfer.clone(),
-                }],
-                ..Default::default()
-            })),
+        let aa_tx = tx_with_aa(super::TempoBatchCallEnv {
+            aa_calls: vec![Call {
+                to: TxKind::Call(PAYMENT_TKN),
+                value: U256::ZERO,
+                input: transfer.clone(),
+            }],
             ..Default::default()
-        };
+        });
         assert!(aa_tx.is_discounted_payment());
 
-        let mixed_aa_tx = super::TempoTxEnv {
-            tempo_tx_env: Some(Box::new(super::TempoBatchCallEnv {
-                aa_calls: vec![
-                    Call {
-                        to: TxKind::Call(PAYMENT_TKN),
-                        value: U256::ZERO,
-                        input: transfer,
-                    },
-                    Call {
-                        to: TxKind::Call(PAYMENT_TKN),
-                        value: U256::ZERO,
-                        input: approve,
-                    },
-                ],
-                ..Default::default()
-            })),
+        let mixed_aa_tx = tx_with_aa(super::TempoBatchCallEnv {
+            aa_calls: vec![
+                Call {
+                    to: TxKind::Call(PAYMENT_TKN),
+                    value: U256::ZERO,
+                    input: transfer,
+                },
+                Call {
+                    to: TxKind::Call(PAYMENT_TKN),
+                    value: U256::ZERO,
+                    input: approve,
+                },
+            ],
             ..Default::default()
-        };
+        });
         assert!(!mixed_aa_tx.is_discounted_payment());
 
-        let empty_aa_tx = super::TempoTxEnv {
-            tempo_tx_env: Some(Box::new(super::TempoBatchCallEnv::default())),
-            ..Default::default()
-        };
+        let empty_aa_tx = tx_with_aa(super::TempoBatchCallEnv::default());
         assert!(!empty_aa_tx.is_discounted_payment());
     }
 
@@ -1072,15 +1202,12 @@ mod tests {
         gas_price: u128,
         value: alloy_primitives::U256,
     ) -> super::TempoTxEnv {
-        super::TempoTxEnv {
-            inner: revm::context::TxEnv {
-                gas_limit,
-                gas_price,
-                value,
-                ..Default::default()
-            },
+        super::TempoTxEnv::from(revm::context::TxEnv {
+            gas_limit,
+            gas_price,
+            value,
             ..Default::default()
-        }
+        })
     }
 
     proptest! {
@@ -1181,8 +1308,7 @@ mod tests {
         /// Property: calls() returns exactly aa_calls.len() for AA transactions
         #[test]
         fn proptest_calls_count_aa_tx(num_calls in 0usize..20) {
-            let aa_tx = super::TempoTxEnv {
-                tempo_tx_env: Some(Box::new(super::TempoBatchCallEnv {
+            let aa_tx = tx_with_aa(super::TempoBatchCallEnv {
                     aa_calls: (0..num_calls)
                         .map(|_| Call {
                             to: TxKind::Call(alloy_primitives::Address::ZERO),
@@ -1191,9 +1317,7 @@ mod tests {
                         })
                         .collect(),
                     ..Default::default()
-                })),
-                ..Default::default()
-            };
+            });
             prop_assert_eq!(aa_tx.calls().count(), num_calls);
         }
 


### PR DESCRIPTION
Wraps canonical `TempoTxEnv` data in `Arc<TempoTxEnvInner>` so cached transaction env clones do not duplicate AA batch calldata.

AA batch execution now uses `active_aa_call` to expose each subcall through the `Transaction` view without mutating the shared canonical tx env.