### PR TITLE
Add unactivated T7 hardfork

### DIFF
--- a/crates/chainspec/src/genesis/dev.json
+++ b/crates/chainspec/src/genesis/dev.json
@@ -30,6 +30,7 @@
     "t4Time": 0,
     "t5Time": 0,
     "t6Time": 0,
+    "t7Time": 0,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -199,6 +199,8 @@ tempo_hardfork! (
         T5,
         /// T6 hardfork
         T6,
+        /// T7 hardfork
+        T7,
     }
 );
 
@@ -305,6 +307,7 @@ impl TempoHardfork {
             Self::T4 => None,
             Self::T5 => None,
             Self::T6 => None,
+            Self::T7 => None,
         }
     }
 
@@ -323,6 +326,7 @@ impl TempoHardfork {
             Self::T4 => Some(MAINNET_T4_TIMESTAMP),
             Self::T5 => Some(MAINNET_T5_TIMESTAMP),
             Self::T6 => None,
+            Self::T7 => None,
         }
     }
 
@@ -341,6 +345,7 @@ impl TempoHardfork {
             Self::T4 => None,
             Self::T5 => None,
             Self::T6 => None,
+            Self::T7 => None,
         }
     }
 
@@ -359,6 +364,7 @@ impl TempoHardfork {
             Self::T4 => Some(MODERATO_T4_TIMESTAMP),
             Self::T5 => Some(MODERATO_T5_TIMESTAMP),
             Self::T6 => None,
+            Self::T7 => None,
         }
     }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -64,6 +64,9 @@ pub struct TempoGenesisInfo {
     /// Activation timestamp for T6 hardfork.
     #[serde(skip_serializing_if = "Option::is_none")]
     t6_time: Option<u64>,
+    /// Activation timestamp for T7 hardfork.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    t7_time: Option<u64>,
 }
 
 impl TempoGenesisInfo {
@@ -94,6 +97,7 @@ impl TempoGenesisInfo {
             TempoHardfork::T4 => self.t4_time,
             TempoHardfork::T5 => self.t5_time,
             TempoHardfork::T6 => self.t6_time,
+            TempoHardfork::T7 => self.t7_time,
         }
     }
 }

--- a/crates/node/tests/assets/test-genesis.json
+++ b/crates/node/tests/assets/test-genesis.json
@@ -30,6 +30,7 @@
     "t4Time": 0,
     "t5Time": 0,
     "t6Time": 0,
+    "t7Time": 0,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -185,6 +185,10 @@ pub(crate) struct GenesisArgs {
     /// T6 hardfork activation time.
     #[arg(long, default_value = "0")]
     t6_time: u64,
+
+    /// T7 hardfork activation time.
+    #[arg(long, default_value = "0")]
+    t7_time: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -560,6 +564,9 @@ impl GenesisArgs {
         chain_config
             .extra_fields
             .insert_value("t6Time".to_string(), self.t6_time)?;
+        chain_config
+            .extra_fields
+            .insert_value("t7Time".to_string(), self.t7_time)?;
         let mut extra_data = Bytes::from_static(b"tempo-genesis");
 
         if let Some(consensus_config) = &consensus_config {


### PR DESCRIPTION
## Summary
- add T7 to the Tempo hardfork enum and chainspec parsing
- leave T7 without mainnet/moderato activation metadata
- default generated/dev test genesis T7 activation to the disabled timestamp

## Tests
- cargo test -p tempo-chainspec

Prompted by: @0xalpharush