### PR TITLE
fix(payload-builder): enforce tracked RLP size estimate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13322,11 +13322,15 @@ dependencies = [
 name = "tempo-payload-types"
 version = "1.8.1"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "derive_more",
+ "proptest",
+ "proptest-arbitrary-interop",
  "reth-ethereum-engine-primitives",
  "reth-node-api",
  "reth-payload-primitives",
@@ -13493,6 +13497,7 @@ dependencies = [
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -764,8 +764,8 @@ impl Inner<Init> {
         let payload_build_elapsed = payload_build_start.elapsed();
         let payload_validation_work_elapsed = payload.validation_work_duration();
         let validation_latency_elapsed = payload.validation_latency_duration();
+        let execution_block_rlp_size_bytes = payload.rlp_block_size_bytes();
         let (block, block_access_list) = payload.into_execution_payload();
-        let execution_block_rlp_size_bytes = block.rlp_length();
         let proposal = Block::from_execution_block_with_encoded_size(
             block,
             block_access_list,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -401,14 +401,7 @@ where
         let mut cumulative_gas_used = 0;
         let mut cumulative_state_gas_used = 0u64;
         let mut non_payment_gas_used = 0;
-        // initial block size usage - size of withdrawals plus 1Kb of overhead for the block header
-        let mut block_size_used = attributes
-            .withdrawals
-            .as_ref()
-            .map(|w| w.length())
-            .unwrap_or(0)
-            + 1024
-            + attributes.extra_data().length();
+        let mut payload_size = attributes.payload_size_tracker();
         let mut payment_transactions = 0u64;
         let mut pool_transactions_yielded = 0u64;
         let mut pool_transactions_included = 0u64;
@@ -437,8 +430,7 @@ where
                 return false;
             }
 
-            // Account for the subblock's size
-            block_size_used += subblock.total_tx_size();
+            payload_size.add_subblock(subblock);
 
             true
         });
@@ -511,12 +503,20 @@ where
         let prepare_system_txs_start = Instant::now();
         let system_txs = self.build_seal_block_txs(executor.evm(), &subblocks);
         for tx in &system_txs {
-            block_size_used += tx.inner().length();
+            payload_size.add_transaction_length(tx.inner().length());
         }
         let prepare_system_txs_elapsed = prepare_system_txs_start.elapsed();
         self.metrics
             .prepare_system_transactions_duration_seconds
             .record(prepare_system_txs_elapsed);
+
+        let estimated_block_size = payload_size.estimated_block_size();
+        if is_osaka && estimated_block_size > MAX_RLP_BLOCK_SIZE {
+            return Err(PayloadBuilderError::other(ConsensusError::BlockTooLarge {
+                rlp_length: estimated_block_size,
+                max_rlp_length: MAX_RLP_BLOCK_SIZE,
+            }));
+        }
 
         let base_fee = executor.evm().block().basefee;
         let pool_fetch_start = Instant::now();
@@ -572,7 +572,7 @@ where
                     normal_transaction_fill_idle_elapsed,
                     build_time_multiplier,
                     marshal_persist,
-                    block_size_used,
+                    payload_size.estimated_block_size(),
                     validation_latency,
                     current_workload,
                 );
@@ -589,7 +589,7 @@ where
                         ?current_workload,
                         gas_used = cumulative_gas_used,
                         transactions = pool_transactions_included,
-                        block_size_used,
+                        estimated_rlp_block_size = payload_size.estimated_block_size(),
                         build_time_multiplier = build_time_multiplier as f64
                             / BUILD_TIME_MULTIPLIER_SCALE as f64,
                         "stopping pool transaction execution before payload build budget is exhausted"
@@ -667,7 +667,8 @@ where
             }
 
             let tx_rlp_length = pool_tx.transaction.encoded_length();
-            let estimated_block_size_with_tx = block_size_used + tx_rlp_length;
+            let estimated_block_size_with_tx =
+                payload_size.estimated_block_size_with_transaction_length(tx_rlp_length);
 
             if is_osaka && estimated_block_size_with_tx > MAX_RLP_BLOCK_SIZE {
                 best_txs.mark_invalid(
@@ -736,7 +737,7 @@ where
             executor.evm_mut().db_mut().bump_bal_index();
 
             pool_transactions_included += 1;
-            block_size_used += tx_rlp_length;
+            payload_size.add_transaction_length(tx_rlp_length);
             let _ = roots_tx.send((
                 BuilderTx::Pooled(pool_tx),
                 executor.receipts().last().unwrap().clone(),
@@ -1020,15 +1021,6 @@ where
             .is_prague_active_at_timestamp(attributes.timestamp)
             .then(|| execution_result.requests.clone());
 
-        let rlp_length = block.rlp_length();
-
-        if is_osaka && rlp_length > MAX_RLP_BLOCK_SIZE {
-            return Err(PayloadBuilderError::other(ConsensusError::BlockTooLarge {
-                rlp_length,
-                max_rlp_length: MAX_RLP_BLOCK_SIZE,
-            }));
-        }
-
         let pool_transactions_inclusion_ratio = if pool_transactions_yielded == 0 {
             0.0
         } else {
@@ -1064,8 +1056,17 @@ where
                 validation_work_at_tx_cutoff,
             );
         }
+        let rlp_block_size_bytes = payload_size.finalize(&block);
+
+        if is_osaka && rlp_block_size_bytes > MAX_RLP_BLOCK_SIZE {
+            return Err(PayloadBuilderError::other(ConsensusError::BlockTooLarge {
+                rlp_length: rlp_block_size_bytes,
+                max_rlp_length: MAX_RLP_BLOCK_SIZE,
+            }));
+        }
+
         let recorded_block_size_bytes =
-            rlp_length + block_access_list.as_ref().map_or(0, Encodable::length);
+            rlp_block_size_bytes + block_access_list.as_ref().map_or(0, Encodable::length);
         let final_workload = ValidationLatencyWorkload::new(gas_used, total_transactions);
         let validation_latency_duration = validation_latency
             .and_then(|estimate| estimate.estimate(final_workload))
@@ -1135,6 +1136,7 @@ where
             Some(executed_block),
             validation_work_duration,
             validation_latency_duration,
+            rlp_block_size_bytes,
         );
 
         drop(db);
@@ -1378,8 +1380,9 @@ mod tests {
         }
         .try_into_recovered()
         .unwrap();
+        let rlp_length = block.rlp_length();
         let eth = EthBuiltPayload::new(Arc::new(block), U256::ZERO, None, None);
-        TempoBuiltPayload::new(eth, None, None, Duration::ZERO, Duration::ZERO)
+        TempoBuiltPayload::new(eth, None, None, Duration::ZERO, Duration::ZERO, rlp_length)
     }
 
     #[test]

--- a/crates/payload/types/Cargo.toml
+++ b/crates/payload/types/Cargo.toml
@@ -20,6 +20,7 @@ reth-primitives-traits.workspace = true
 
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
+alloy-rlp.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-types-engine.workspace = true
 
@@ -29,4 +30,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 tempo-primitives = { workspace = true, features = ["arbitrary", "reth-codec", "serde"] }
+alloy-consensus.workspace = true
+proptest.workspace = true
+proptest-arbitrary-interop.workspace = true
 serde_json.workspace = true

--- a/crates/payload/types/src/attrs.rs
+++ b/crates/payload/types/src/attrs.rs
@@ -1,5 +1,6 @@
-use crate::ValidationLatencyEstimate;
+use crate::{PayloadSizeTracker, ValidationLatencyEstimate};
 use alloy_primitives::{Address, B256, Bytes, Keccak256};
+use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::PayloadId;
 use alloy_rpc_types_eth::Withdrawal;
 use reth_ethereum_engine_primitives::EthPayloadAttributes;
@@ -95,6 +96,17 @@ impl TempoPayloadAttributes {
     /// Returns the extra data to be included in the block header.
     pub fn extra_data(&self) -> &Bytes {
         &self.extra_data
+    }
+
+    /// Creates a payload size tracker initialized with attribute-provided RLP sizes.
+    pub fn payload_size_tracker(&self) -> PayloadSizeTracker {
+        PayloadSizeTracker::new(
+            self.withdrawals
+                .as_ref()
+                .map(Encodable::length)
+                .unwrap_or(0),
+            self.extra_data.length(),
+        )
     }
 
     /// Returns the proposer's public key.

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod attrs;
 mod budget;
+mod payload_size;
 
 use alloy_primitives::{B256, Bytes};
 pub use attrs::TempoPayloadAttributes;
@@ -12,6 +13,7 @@ pub use budget::{
     MarshalPersistEstimator, ValidationLatencyEstimate, ValidationLatencyEstimator,
     ValidationLatencyWorkload, marshal_persist_estimate, observe_marshal_persist,
 };
+pub use payload_size::PayloadSizeTracker;
 use std::{sync::Arc, time::Duration};
 
 use alloy_eips::eip7685::Requests;
@@ -48,6 +50,8 @@ pub struct TempoBuiltPayload {
     validation_work_duration: Duration,
     /// Time validators are expected to spend validating this payload.
     validation_latency_duration: Duration,
+    /// RLP-encoded execution block size in bytes.
+    rlp_block_size_bytes: usize,
 }
 
 impl TempoBuiltPayload {
@@ -58,6 +62,7 @@ impl TempoBuiltPayload {
         executed_block: Option<BuiltPayloadExecutedBlock<TempoPrimitives>>,
         validation_work_duration: Duration,
         validation_latency_duration: Duration,
+        rlp_block_size_bytes: usize,
     ) -> Self {
         Self {
             inner,
@@ -65,6 +70,7 @@ impl TempoBuiltPayload {
             executed_block,
             validation_work_duration,
             validation_latency_duration,
+            rlp_block_size_bytes,
         }
     }
 
@@ -84,6 +90,11 @@ impl TempoBuiltPayload {
     /// Returns the time validators are expected to spend validating this payload.
     pub fn validation_latency_duration(&self) -> Duration {
         self.validation_latency_duration
+    }
+
+    /// Returns the RLP-encoded execution block size in bytes.
+    pub fn rlp_block_size_bytes(&self) -> usize {
+        self.rlp_block_size_bytes
     }
 
     /// Converts the built payload into [`TempoExecutionData`].

--- a/crates/payload/types/src/payload_size.rs
+++ b/crates/payload/types/src/payload_size.rs
@@ -1,0 +1,253 @@
+use alloy_rlp::{Encodable, Header as RlpHeader};
+use reth_primitives_traits::RecoveredBlock;
+use tempo_primitives::{Block as TempoBlock, RecoveredSubBlock};
+
+/// Conservative allowance for non-transaction block RLP overhead used while the
+/// final header is not available yet.
+const NON_TRANSACTION_SIZE_ESTIMATE: usize = 2048;
+
+/// Tracks payload RLP size while a block is being built.
+///
+/// During payload construction this starts with a conservative estimate for the
+/// non-transaction portion of the final block. That estimate is used with the
+/// recorded transaction payload length to decide whether another candidate
+/// transaction can fit under the RLP block size limit.
+///
+/// Each included transaction's encoded length is recorded as the payload is
+/// assembled. Once the block is built, [`Self::finalize`] combines those
+/// recorded transaction lengths with the block's actual header, ommers, and
+/// withdrawals lengths so the final payload can reuse the tracked size instead
+/// of recomputing every transaction length.
+#[derive(Debug, Clone)]
+pub struct PayloadSizeTracker {
+    /// Exact sum of the RLP lengths for transactions already selected for the block.
+    ///
+    /// This excludes the surrounding RLP transaction-list header. During payload
+    /// filling, it is wrapped as a transaction list and combined with
+    /// [`Self::estimated_non_transaction_length`] to estimate how much of the
+    /// block-size budget remains. At finalization, this is reused as the
+    /// transaction list payload length when the tracked transaction count still
+    /// matches the built block.
+    transactions_payload_length: usize,
+    /// Number of transactions represented by [`Self::transactions_payload_length`].
+    ///
+    /// This is the cheap consistency check that tells [`Self::finalize`] whether
+    /// the recorded transaction lengths still describe the built block's
+    /// transaction list. If it does not match, finalization falls back to
+    /// computing the block's actual RLP length.
+    transaction_count: usize,
+    /// Conservative fill-time allowance for every non-transaction part of the block.
+    ///
+    /// Unlike [`Self::transactions_payload_length`], this is not the final exact
+    /// header/ommers/withdrawals size. It is the known withdrawals and
+    /// `extra_data` RLP length plus a fixed overhead estimate, used only while
+    /// deciding whether another candidate transaction can fit within the
+    /// remaining RLP block-size budget.
+    estimated_non_transaction_length: usize,
+}
+
+impl PayloadSizeTracker {
+    /// Creates a tracker with the RLP lengths known before transactions are selected.
+    ///
+    /// `withdrawals_length` must be the RLP encoded withdrawals field length, or
+    /// zero when withdrawals are absent. `extra_data_length` must be the RLP
+    /// encoded header `extra_data` field length.
+    pub fn new(withdrawals_length: usize, extra_data_length: usize) -> Self {
+        Self {
+            transactions_payload_length: 0,
+            transaction_count: 0,
+            estimated_non_transaction_length: NON_TRANSACTION_SIZE_ESTIMATE
+                + withdrawals_length
+                + extra_data_length,
+        }
+    }
+
+    /// Adds one already-encoded transaction length to the tracked transaction list payload.
+    ///
+    /// The length must match [`Encodable::length`] for the transaction that will
+    /// be included in the final block.
+    pub fn add_transaction_length(&mut self, transaction_length: usize) {
+        self.transactions_payload_length += transaction_length;
+        self.transaction_count += 1;
+    }
+
+    /// Adds all transaction lengths from a recovered subblock.
+    ///
+    /// This records each transaction in the subblock exactly once, which lets
+    /// [`Self::finalize`] use the tracked length when the built block has the
+    /// same transaction count.
+    pub fn add_subblock(&mut self, subblock: &RecoveredSubBlock) {
+        self.transaction_count += subblock.transactions.len();
+        self.transactions_payload_length += subblock
+            .transactions
+            .iter()
+            .map(Encodable::length)
+            .sum::<usize>();
+    }
+
+    /// Returns a conservative block size estimate for the transactions tracked so far.
+    ///
+    /// This is intended for in-progress payload building, before the final
+    /// header and exact non-transaction fields are available.
+    pub fn estimated_block_size(&self) -> usize {
+        self.estimated_block_size_with_transaction_length(0)
+    }
+
+    /// Returns a conservative block size estimate including a candidate transaction.
+    ///
+    /// `transaction_length` is included only in the returned estimate and is not
+    /// recorded in the tracker.
+    pub fn estimated_block_size_with_transaction_length(&self, transaction_length: usize) -> usize {
+        self.estimated_non_transaction_length
+            + RlpHeader {
+                list: true,
+                payload_length: self.transactions_payload_length + transaction_length,
+            }
+            .length_with_payload()
+    }
+
+    /// Returns the final block RLP length using the tracked transaction payload length.
+    ///
+    /// This uses the built block's actual header, ommers, and withdrawals
+    /// lengths, then combines them with the tracked transaction list payload.
+    /// If the tracked transaction count does not match the built block, this
+    /// falls back to computing the block's actual RLP length.
+    pub fn finalize(&self, block: &RecoveredBlock<TempoBlock>) -> usize {
+        let body = block.body();
+        if self.transaction_count != body.transactions.len() {
+            return block.rlp_length();
+        }
+
+        Self::block_length(
+            block.header().length(),
+            self.transactions_payload_length,
+            body.ommers.length(),
+            body.withdrawals.as_ref().map_or(0, Encodable::length),
+        )
+    }
+
+    /// Computes the outer block RLP list length from encoded field lengths.
+    fn block_length(
+        header_length: usize,
+        transactions_payload_length: usize,
+        ommers_length: usize,
+        withdrawals_length: usize,
+    ) -> usize {
+        let payload_length = header_length
+            + RlpHeader {
+                list: true,
+                payload_length: transactions_payload_length,
+            }
+            .length_with_payload()
+            + ommers_length
+            + withdrawals_length;
+        RlpHeader {
+            list: true,
+            payload_length,
+        }
+        .length_with_payload()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{BlockBody, Signed, TxLegacy};
+    use alloy_primitives::{Address, Bytes, U256};
+    use proptest::prelude::*;
+    use proptest_arbitrary_interop::arb_sized;
+    use reth_primitives_traits::RecoveredBlock;
+    use tempo_primitives::{
+        Block, TempoHeader, TempoTxEnvelope, transaction::envelope::TEMPO_SYSTEM_TX_SIGNATURE,
+    };
+
+    fn legacy_tx(input: Bytes) -> TempoTxEnvelope {
+        TempoTxEnvelope::Legacy(Signed::new_unhashed(
+            TxLegacy {
+                chain_id: None,
+                nonce: 0,
+                gas_price: 0,
+                gas_limit: 0,
+                to: Address::random().into(),
+                value: U256::ZERO,
+                input,
+            },
+            TEMPO_SYSTEM_TX_SIGNATURE,
+        ))
+    }
+
+    fn block_with_transactions(transactions: Vec<TempoTxEnvelope>) -> RecoveredBlock<Block> {
+        let senders = vec![Address::ZERO; transactions.len()];
+        RecoveredBlock::new_unhashed(
+            Block {
+                header: TempoHeader::default(),
+                body: BlockBody {
+                    transactions,
+                    ommers: vec![],
+                    withdrawals: None,
+                },
+            },
+            senders,
+        )
+    }
+
+    fn arb_block() -> impl Strategy<Value = RecoveredBlock<Block>> {
+        // `RecoveredBlock<Block>` has an `Arbitrary` impl, but it recovers arbitrary
+        // transaction signatures and can panic. The tracker only needs the body,
+        // so wrap an arbitrary block with dummy senders.
+        arb_sized::<Block>(4096).prop_map(|block| {
+            let senders = vec![Address::ZERO; block.body.transactions.len()];
+            RecoveredBlock::new_unhashed(block, senders)
+        })
+    }
+
+    #[test]
+    fn final_size_matches_block_rlp_length() {
+        let transactions = vec![
+            legacy_tx(Bytes::from(vec![1; 8])),
+            legacy_tx(Bytes::from(vec![2; 128])),
+            legacy_tx(Bytes::from(vec![3; 1024])),
+        ];
+        let mut tracker = PayloadSizeTracker::new(0, 0);
+        for tx in &transactions {
+            tracker.add_transaction_length(tx.length());
+        }
+
+        let block = block_with_transactions(transactions);
+        assert_eq!(tracker.finalize(&block), block.rlp_length());
+    }
+
+    #[test]
+    fn final_size_falls_back_when_transaction_count_mismatches() {
+        let block = block_with_transactions(vec![legacy_tx(Bytes::from(vec![1; 8]))]);
+
+        assert_eq!(
+            PayloadSizeTracker::new(0, 0).finalize(&block),
+            block.rlp_length()
+        );
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(500))]
+
+        #[test]
+        fn proptest_final_size_matches_rlp_length_for_random_blocks(block in arb_block()) {
+            let body = block.body();
+            let mut tracker = PayloadSizeTracker::new(
+                body.withdrawals.as_ref().map_or(0, Encodable::length),
+                block.header().inner.extra_data.length(),
+            );
+
+            for tx in &body.transactions {
+                tracker.add_transaction_length(tx.length());
+            }
+
+            prop_assert_eq!(tracker.transaction_count, body.transactions.len());
+            prop_assert_eq!(tracker.finalize(&block), block.rlp_length());
+            let sealed = block.clone_sealed_block();
+            let mut encoded = Vec::new();
+            sealed.encode(&mut encoded);
+            prop_assert_eq!(tracker.finalize(&block), encoded.len());
+        }
+    }
+}

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -36,6 +36,7 @@ alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-eips.workspace = true
 alloy-evm = { workspace = true, features = ["std"] }
+alloy-rlp.workspace = true
 alloy-sol-types.workspace = true
 
 futures.workspace = true

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -13,6 +13,7 @@ use alloy_evm::FromRecoveredTx;
 use alloy_primitives::{
     Address, B256, Bytes, TxHash, TxKind, U256, bytes, keccak256, map::AddressMap,
 };
+use alloy_rlp::Encodable;
 use alloy_sol_types::SolInterface;
 use reth_evm::execute::WithTxEnv;
 use reth_primitives_traits::{InMemorySize, Recovered};
@@ -77,7 +78,7 @@ pub struct TempoPooledTransaction {
 }
 
 impl TempoPooledTransaction {
-    /// Create new instance of [Self] from the given consensus transactions and the encoded size.
+    /// Create new instance of [Self] from the given consensus transaction.
     pub fn new(transaction: Recovered<TempoTxEnvelope>) -> Self {
         let is_payment = transaction.is_payment_v2();
         let sender = transaction.signer();
@@ -94,7 +95,7 @@ impl TempoPooledTransaction {
         Self {
             inner: EthPooledTransaction {
                 cost,
-                encoded_length: transaction.encode_2718_len(),
+                encoded_length: transaction.length(),
                 blob_sidecar: EthBlobTransactionSidecar::None,
                 transaction,
             },
@@ -1244,6 +1245,17 @@ mod tests {
         let pooled = TempoPooledTransaction::from_pooled(recovered);
         assert_eq!(pooled.sender(), sender);
         assert_eq!(pooled.nonce(), nonce);
+    }
+
+    #[test]
+    fn test_encoded_length_is_block_rlp_length_for_typed_transactions() {
+        let aa = TxBuilder::aa(Address::random()).build();
+        assert_eq!(aa.encoded_length(), aa.inner().length());
+        assert!(aa.encoded_length() > aa.encode_2718_len());
+
+        let eip1559 = TxBuilder::eip1559(Address::random()).build_eip1559();
+        assert_eq!(eip1559.encoded_length(), eip1559.inner().length());
+        assert!(eip1559.encoded_length() > eip1559.encode_2718_len());
     }
 
     #[test]


### PR DESCRIPTION
Uses the tracked RLP size estimate only for Osaka block-size admission, with a doubled non-transaction safety margin and an early baseline validation before pool filling.

`TempoBuiltPayload` no longer carries block-size data. When consensus needs proposal sizing for marshal timing, it constructs the commonware block without seeding the encoded-size cache from builder data and derives the size from the actual proposal.