### PR TITLE
feat(precompiles): add TIP-1069 stealth transfers

### DIFF
--- a/.changelog/tip-1069-stealth-transfers.md
+++ b/.changelog/tip-1069-stealth-transfers.md
@@ -1,0 +1,8 @@
+---
+tempo-contracts: minor
+tempo-precompiles: minor
+tempo-evm: minor
+tempo-node: patch
+---
+
+Added TIP-1069 stealth-address transfer support with `TIP20Stealth`, T6 `transferAsSystem`, payment-lane classification, and recipient/custody protections.

--- a/crates/contracts/src/precompiles/mod.rs
+++ b/crates/contracts/src/precompiles/mod.rs
@@ -8,6 +8,7 @@ pub mod stablecoin_dex;
 pub mod tip20;
 pub mod tip20_channel_reserve;
 pub mod tip20_factory;
+pub mod tip20_stealth;
 pub mod tip403_registry;
 pub mod tip_fee_manager;
 pub mod validator_config;
@@ -25,6 +26,7 @@ pub use tip_fee_manager::*;
 pub use tip20::*;
 pub use tip20_channel_reserve::*;
 pub use tip20_factory::*;
+pub use tip20_stealth::*;
 pub use tip403_registry::*;
 pub use validator_config::*;
 pub use validator_config_v2::*;
@@ -49,3 +51,4 @@ pub const SIGNATURE_VERIFIER_ADDRESS: Address =
     address!("0x5165300000000000000000000000000000000000");
 pub const RECEIVE_POLICY_GUARD_ADDRESS: Address =
     address!("0xB10C000000000000000000000000000000000000");
+pub const TIP20_STEALTH_ADDRESS: Address = address!("0x537465616c746800000000000000000000000000");

--- a/crates/contracts/src/precompiles/tip20.rs
+++ b/crates/contracts/src/precompiles/tip20.rs
@@ -77,6 +77,7 @@ crate::sol! {
         function approve(address spender, uint256 amount) external returns (bool);
         function allowance(address owner, address spender) external view returns (uint256);
         function transferFrom(address from, address to, uint256 amount) external returns (bool);
+        function transferAsSystem(address from, address to, uint256 amount) external returns (bool);
         function mint(address to, uint256 amount) external;
         function burn(uint256 amount) external;
 

--- a/crates/contracts/src/precompiles/tip20_stealth.rs
+++ b/crates/contracts/src/precompiles/tip20_stealth.rs
@@ -1,0 +1,32 @@
+pub use ITIP20Stealth::{
+    ITIP20StealthErrors as TIP20StealthError, ITIP20StealthEvents as TIP20StealthEvent,
+};
+use alloy_sol_types::SolInterface;
+
+crate::sol! {
+    /// TIP-1069 canonical stealth-address transfer precompile.
+    #[derive(Debug, PartialEq, Eq)]
+    #[sol(abi)]
+    interface ITIP20Stealth {
+        /// @notice Emitted for each stealth payment routed through TIP20Stealth.
+        /// @param token TIP-20 token transferred.
+        /// @param stealthAddress Derived stealth Tempo account receiving funds.
+        /// @param metadata Packed scheme, ephemeral public key, and view tag.
+        /// @param memo Opaque memo bytes.
+        event Announce(address indexed token, address indexed stealthAddress, bytes metadata, bytes memo);
+
+        /// @notice Atomically transfer `amount` of `token` from msg.sender to `stealthAddress`.
+        function transfer(address token, address stealthAddress, uint256 amount, bytes calldata metadata, bytes calldata memo) external returns (bool);
+
+        error InvalidMetadata();
+        error UnknownScheme();
+        error PrecompileCustody();
+    }
+}
+
+impl ITIP20Stealth::ITIP20StealthCalls {
+    /// Returns true when `input` is an ABI-valid `TIP20Stealth.transfer` call.
+    pub fn is_payment(input: &[u8]) -> bool {
+        matches!(Self::abi_decode(input), Ok(Self::transfer(_)))
+    }
+}

--- a/crates/contracts/src/precompiles/tip20_stealth.rs
+++ b/crates/contracts/src/precompiles/tip20_stealth.rs
@@ -1,3 +1,4 @@
+use super::tip20_channel_reserve::MAX_PAYMENT_CALLDATA_LEN;
 pub use ITIP20Stealth::{
     ITIP20StealthErrors as TIP20StealthError, ITIP20StealthEvents as TIP20StealthEvent,
 };
@@ -24,9 +25,97 @@ crate::sol! {
     }
 }
 
+/// secp256k1 stealth-address derivation scheme.
+pub const TIP20_STEALTH_SCHEME_SECP256K1: u8 = 0x01;
+/// P-256 stealth-address derivation scheme.
+pub const TIP20_STEALTH_SCHEME_P256: u8 = 0x02;
+/// Metadata length for all TIP-1069 v1 schemes.
+pub const TIP20_STEALTH_V1_METADATA_LEN: usize = 35;
+
 impl ITIP20Stealth::ITIP20StealthCalls {
     /// Returns true when `input` is an ABI-valid `TIP20Stealth.transfer` call.
     pub fn is_payment(input: &[u8]) -> bool {
-        matches!(Self::abi_decode(input), Ok(Self::transfer(_)))
+        if input.len() > MAX_PAYMENT_CALLDATA_LEN {
+            return false;
+        }
+
+        matches!(
+            Self::abi_decode(input),
+            Ok(Self::transfer(call)) if is_valid_payment_metadata(&call.metadata)
+        )
+    }
+}
+
+fn is_valid_payment_metadata(metadata: &[u8]) -> bool {
+    let Some((&scheme, _)) = metadata.split_first() else {
+        return false;
+    };
+
+    matches!(
+        scheme,
+        TIP20_STEALTH_SCHEME_SECP256K1 | TIP20_STEALTH_SCHEME_P256
+    ) && metadata.len() == TIP20_STEALTH_V1_METADATA_LEN
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::{vec, vec::Vec};
+    use alloy_primitives::{Address, Bytes, U256};
+    use alloy_sol_types::SolCall;
+
+    fn metadata(scheme: u8) -> Bytes {
+        let mut metadata = vec![0u8; TIP20_STEALTH_V1_METADATA_LEN];
+        metadata[0] = scheme;
+        metadata[1] = 0x02;
+        metadata[34] = 0xa7;
+        metadata.into()
+    }
+
+    fn transfer_calldata(metadata: Bytes, memo: Bytes) -> Vec<u8> {
+        ITIP20Stealth::transferCall {
+            token: Address::random(),
+            stealthAddress: Address::random(),
+            amount: U256::ONE,
+            metadata,
+            memo,
+        }
+        .abi_encode()
+    }
+
+    #[test]
+    fn test_is_payment_accepts_valid_metadata_schemes() {
+        for scheme in [TIP20_STEALTH_SCHEME_SECP256K1, TIP20_STEALTH_SCHEME_P256] {
+            assert!(ITIP20Stealth::ITIP20StealthCalls::is_payment(
+                &transfer_calldata(metadata(scheme), Bytes::new())
+            ));
+        }
+    }
+
+    #[test]
+    fn test_is_payment_rejects_invalid_metadata() {
+        assert!(!ITIP20Stealth::ITIP20StealthCalls::is_payment(
+            &transfer_calldata(Bytes::new(), Bytes::new())
+        ));
+
+        assert!(!ITIP20Stealth::ITIP20StealthCalls::is_payment(
+            &transfer_calldata(metadata(0xff), Bytes::new())
+        ));
+
+        let mut short = metadata(TIP20_STEALTH_SCHEME_SECP256K1).to_vec();
+        short.pop();
+        assert!(!ITIP20Stealth::ITIP20StealthCalls::is_payment(
+            &transfer_calldata(short.into(), Bytes::new())
+        ));
+    }
+
+    #[test]
+    fn test_is_payment_rejects_oversized_calldata() {
+        let calldata = transfer_calldata(
+            metadata(TIP20_STEALTH_SCHEME_SECP256K1),
+            vec![0; MAX_PAYMENT_CALLDATA_LEN].into(),
+        );
+        assert!(calldata.len() > MAX_PAYMENT_CALLDATA_LEN);
+        assert!(!ITIP20Stealth::ITIP20StealthCalls::is_payment(&calldata));
     }
 }

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -28,7 +28,7 @@ use std::collections::{HashMap, HashSet};
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_contracts::precompiles::{
     ADDRESS_REGISTRY_ADDRESS, RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS,
-    TIP20_CHANNEL_RESERVE_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
+    TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_STEALTH_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
 use tempo_primitives::{
     SubBlock, SubBlockMetadata, TempoReceipt, TempoTxEnvelope, TempoTxType,
@@ -493,6 +493,7 @@ where
         }
         if self.inner.spec.is_t6_active_at_timestamp(timestamp) {
             self.deploy_precompile_at_boundary(RECEIVE_POLICY_GUARD_ADDRESS)?;
+            self.deploy_precompile_at_boundary(TIP20_STEALTH_ADDRESS)?;
         }
 
         Ok(())
@@ -1676,6 +1677,10 @@ mod tests {
         executor.apply_pre_execution_changes().unwrap();
 
         let acc = db.load_cache_account(RECEIVE_POLICY_GUARD_ADDRESS).unwrap();
+        let info = acc.account_info().unwrap();
+        assert!(!info.is_empty_code_hash());
+
+        let acc = db.load_cache_account(TIP20_STEALTH_ADDRESS).unwrap();
         let info = acc.account_info().unwrap();
         assert!(!info.is_empty_code_hash());
     }

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -20,6 +20,7 @@ mod tempo_transaction;
 mod tip20;
 mod tip20_factory;
 mod tip20_gas_fees;
+mod tip20_stealth;
 mod tip_fee_amm;
 mod tip_fee_manager;
 mod utils;

--- a/crates/node/tests/it/tip20_stealth.rs
+++ b/crates/node/tests/it/tip20_stealth.rs
@@ -1,0 +1,224 @@
+use alloy::{
+    primitives::{Address, Bytes, U256},
+    providers::{Provider, ProviderBuilder},
+    signers::local::MnemonicBuilder,
+    sol_types::SolEvent,
+};
+use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
+use tempo_contracts::precompiles::{ITIP20, ITIP20Stealth, TIP20Error, TIP20StealthError};
+use tempo_precompiles::TIP20_STEALTH_ADDRESS;
+
+use crate::utils::{TEST_MNEMONIC, TestNodeBuilder, setup_test_token};
+
+fn metadata(scheme: u8) -> Bytes {
+    let mut metadata = vec![0u8; 35];
+    metadata[0] = scheme;
+    metadata[1] = 0x02;
+    metadata[34] = 0xa7;
+    metadata.into()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tip20_stealth_transfer_e2e() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let http_url = setup.http_url;
+
+    let admin = MnemonicBuilder::from_phrase(TEST_MNEMONIC).build()?;
+    let sender = MnemonicBuilder::from_phrase(TEST_MNEMONIC)
+        .index(1)?
+        .build()?;
+    let admin_provider = ProviderBuilder::new()
+        .wallet(admin.clone())
+        .connect_http(http_url.clone());
+    let sender_provider = ProviderBuilder::new()
+        .wallet(sender.clone())
+        .connect_http(http_url);
+
+    let token = setup_test_token(admin_provider.clone(), admin.address()).await?;
+    let sender_token = ITIP20::new(*token.address(), sender_provider.clone());
+    let stealth = ITIP20Stealth::new(TIP20_STEALTH_ADDRESS, sender_provider.clone());
+
+    let initial_balance = U256::from(1_000);
+    token
+        .mint(sender.address(), initial_balance)
+        .gas_price(TEMPO_T1_BASE_FEE as u128)
+        .gas(1_000_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    let code = sender_provider.get_code_at(TIP20_STEALTH_ADDRESS).await?;
+    assert_eq!(code.as_ref(), &[0xef], "TIP20Stealth marker code missing");
+
+    let stealth_address = Address::repeat_byte(0x42);
+    let amount = U256::from(250);
+    let metadata = metadata(0x01);
+    let memo = Bytes::from_static(b"encrypted memo");
+
+    assert_eq!(
+        sender_token
+            .allowance(sender.address(), TIP20_STEALTH_ADDRESS)
+            .call()
+            .await?,
+        U256::ZERO
+    );
+    assert!(
+        stealth
+            .transfer(
+                *token.address(),
+                stealth_address,
+                amount,
+                metadata.clone(),
+                memo.clone()
+            )
+            .call()
+            .await?
+    );
+
+    let receipt = stealth
+        .transfer(
+            *token.address(),
+            stealth_address,
+            amount,
+            metadata.clone(),
+            memo.clone(),
+        )
+        .gas_price(TEMPO_T1_BASE_FEE as u128)
+        .gas(1_000_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(receipt.status(), "stealth transfer tx failed");
+
+    assert_eq!(
+        sender_token.balanceOf(sender.address()).call().await?,
+        initial_balance - amount
+    );
+    assert_eq!(
+        sender_token.balanceOf(stealth_address).call().await?,
+        amount
+    );
+    assert_eq!(
+        sender_token.balanceOf(TIP20_STEALTH_ADDRESS).call().await?,
+        U256::ZERO
+    );
+    assert_eq!(
+        sender_token
+            .allowance(sender.address(), TIP20_STEALTH_ADDRESS)
+            .call()
+            .await?,
+        U256::ZERO
+    );
+
+    let transfer = receipt
+        .logs()
+        .iter()
+        .filter(|log| log.inner.address == *token.address())
+        .find_map(|log| ITIP20::Transfer::decode_log(&log.inner).ok())
+        .expect("TIP-20 Transfer event missing");
+    assert_eq!(transfer.from, sender.address());
+    assert_eq!(transfer.to, stealth_address);
+    assert_eq!(transfer.amount, amount);
+
+    let announce = receipt
+        .logs()
+        .iter()
+        .filter(|log| log.inner.address == TIP20_STEALTH_ADDRESS)
+        .find_map(|log| ITIP20Stealth::Announce::decode_log(&log.inner).ok())
+        .expect("Announce event missing");
+    assert_eq!(announce.token, *token.address());
+    assert_eq!(announce.stealthAddress, stealth_address);
+    assert_eq!(announce.metadata, metadata);
+    assert_eq!(announce.memo, memo);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tip20_stealth_reverts_do_not_move_funds_e2e() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let http_url = setup.http_url;
+
+    let admin = MnemonicBuilder::from_phrase(TEST_MNEMONIC).build()?;
+    let sender = MnemonicBuilder::from_phrase(TEST_MNEMONIC)
+        .index(2)?
+        .build()?;
+    let admin_provider = ProviderBuilder::new()
+        .wallet(admin.clone())
+        .connect_http(http_url.clone());
+    let sender_provider = ProviderBuilder::new()
+        .wallet(sender.clone())
+        .connect_http(http_url);
+
+    let token = setup_test_token(admin_provider.clone(), admin.address()).await?;
+    let sender_token = ITIP20::new(*token.address(), sender_provider.clone());
+    let stealth = ITIP20Stealth::new(TIP20_STEALTH_ADDRESS, sender_provider);
+
+    let initial_balance = U256::from(1_000);
+    token
+        .mint(sender.address(), initial_balance)
+        .gas_price(TEMPO_T1_BASE_FEE as u128)
+        .gas(1_000_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    let stealth_address = Address::repeat_byte(0x77);
+    let amount = U256::from(250);
+    let err = stealth
+        .transfer(
+            *token.address(),
+            stealth_address,
+            amount,
+            Bytes::new(),
+            Bytes::new(),
+        )
+        .call()
+        .await
+        .expect_err("empty metadata must revert");
+    assert_eq!(
+        err.as_decoded_interface_error::<TIP20StealthError>(),
+        Some(TIP20StealthError::invalid_metadata())
+    );
+    assert_eq!(
+        sender_token.balanceOf(sender.address()).call().await?,
+        initial_balance
+    );
+    assert_eq!(
+        sender_token.balanceOf(stealth_address).call().await?,
+        U256::ZERO
+    );
+
+    let err = sender_token
+        .transferAsSystem(sender.address(), stealth_address, U256::ONE)
+        .call()
+        .await
+        .expect_err("direct transferAsSystem must revert");
+    assert_eq!(
+        err.as_decoded_interface_error::<TIP20Error>(),
+        Some(TIP20Error::unauthorized())
+    );
+
+    let err = sender_token
+        .transfer(TIP20_STEALTH_ADDRESS, U256::ONE)
+        .call()
+        .await
+        .expect_err("TIP20Stealth must not be a token recipient");
+    assert_eq!(
+        err.as_decoded_interface_error::<TIP20Error>(),
+        Some(TIP20Error::invalid_recipient())
+    );
+    assert_eq!(
+        sender_token.balanceOf(TIP20_STEALTH_ADDRESS).call().await?,
+        U256::ZERO
+    );
+
+    Ok(())
+}

--- a/crates/precompiles/src/address_registry/mod.rs
+++ b/crates/precompiles/src/address_registry/mod.rs
@@ -19,7 +19,7 @@ use alloy::{
 use tempo_chainspec::hardfork::TempoHardfork;
 pub use tempo_contracts::precompiles::{
     AddrRegistryError, AddrRegistryEvent, IAddressRegistry, STABLECOIN_DEX_ADDRESS,
-    TIP_FEE_MANAGER_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS,
+    TIP_FEE_MANAGER_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_STEALTH_ADDRESS,
 };
 use tempo_precompiles_macros::{Storable, contract};
 pub use tempo_primitives::{MasterId, TempoAddressExt, UserTag};
@@ -35,14 +35,15 @@ pub const IMPLICIT_APPROVAL_LIST: &[Address] = &[
     TIP20_CHANNEL_RESERVE_ADDRESS,
 ];
 
+/// TIP-1069 additions to the Implicit Approval List.
+pub const T6_IMPLICIT_APPROVAL_LIST: &[Address] = &[TIP20_STEALTH_ADDRESS];
+
 /// Returns `true` iff `addr` is on the [`IMPLICIT_APPROVAL_LIST`] for the given hardfork.
 ///
 /// Before `TempoHardfork::T5` (TIP-1035 activation), returns `false` for all addresses.
 pub fn is_implicitly_approved(addr: Address, hardfork: TempoHardfork) -> bool {
-    if !hardfork.is_t5() {
-        return false;
-    }
-    IMPLICIT_APPROVAL_LIST.contains(&addr)
+    (hardfork.is_t5() && IMPLICIT_APPROVAL_LIST.contains(&addr))
+        || (hardfork.is_t6() && T6_IMPLICIT_APPROVAL_LIST.contains(&addr))
 }
 
 /// [TIP-1022] virtual address registry contract.
@@ -202,6 +203,7 @@ mod tests {
             assert!(!registry.is_implicitly_approved(TIP_FEE_MANAGER_ADDRESS));
             assert!(!registry.is_implicitly_approved(STABLECOIN_DEX_ADDRESS));
             assert!(!registry.is_implicitly_approved(TIP20_CHANNEL_RESERVE_ADDRESS));
+            assert!(!registry.is_implicitly_approved(TIP20_STEALTH_ADDRESS));
             assert!(!registry.is_implicitly_approved(Address::random()));
             Ok(())
         })
@@ -214,6 +216,19 @@ mod tests {
             let registry = AddressRegistry::new();
             assert!(registry.is_implicitly_approved(TIP_FEE_MANAGER_ADDRESS));
             assert!(registry.is_implicitly_approved(STABLECOIN_DEX_ADDRESS));
+            assert!(registry.is_implicitly_approved(TIP20_CHANNEL_RESERVE_ADDRESS));
+            assert!(!registry.is_implicitly_approved(TIP20_STEALTH_ADDRESS));
+            assert!(!registry.is_implicitly_approved(Address::random()));
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_is_implicitly_approved_t6_adds_stealth() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let registry = AddressRegistry::new();
+            assert!(registry.is_implicitly_approved(TIP20_STEALTH_ADDRESS));
             assert!(registry.is_implicitly_approved(TIP20_CHANNEL_RESERVE_ADDRESS));
             assert!(!registry.is_implicitly_approved(Address::random()));
             Ok(())

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -22,8 +22,8 @@ use revm::{
 use tempo_contracts::precompiles::{
     AccountKeychainError, AddrRegistryError, FeeManagerError, NonceError, ReceivePolicyGuardError,
     RolesAuthError, SignatureVerifierError, StablecoinDEXError, TIP20ChannelReserveError,
-    TIP20FactoryError, TIP403RegistryError, TIPFeeAMMError, UnknownFunctionSelector,
-    ValidatorConfigError, ValidatorConfigV2Error,
+    TIP20FactoryError, TIP20StealthError, TIP403RegistryError, TIPFeeAMMError,
+    UnknownFunctionSelector, ValidatorConfigError, ValidatorConfigV2Error,
 };
 
 /// Top-level error type for all Tempo precompile operations
@@ -95,6 +95,10 @@ pub enum TempoPrecompileError {
     #[error("TIP1028 blocked transfers error: {0:?}")]
     ReceivePolicyGuardError(ReceivePolicyGuardError),
 
+    /// Error from TIP-1069 stealth transfers precompile
+    #[error("TIP20 stealth error: {0:?}")]
+    TIP20StealthError(TIP20StealthError),
+
     /// Gas limit exceeded during precompile execution.
     #[error("Gas limit exceeded")]
     OutOfGas,
@@ -157,6 +161,7 @@ impl TempoPrecompileError {
             Self::AccountKeychainError(e) => e.selector(),
             Self::SignatureVerifierError(e) => e.selector(),
             Self::ReceivePolicyGuardError(e) => e.selector(),
+            Self::TIP20StealthError(e) => e.selector(),
             Self::UnknownFunctionSelector(selector) => *selector,
             Self::Panic(_) => Panic::SELECTOR,
             Self::OutOfGas | Self::Fatal(_) => [0, 0, 0, 0],
@@ -184,6 +189,7 @@ impl TempoPrecompileError {
             | Self::AccountKeychainError(_)
             | Self::SignatureVerifierError(_)
             | Self::ReceivePolicyGuardError(_)
+            | Self::TIP20StealthError(_)
             | Self::UnknownFunctionSelector(_) => false,
         }
     }
@@ -232,6 +238,7 @@ impl TempoPrecompileError {
             Self::AccountKeychainError(e) => e.abi_encode().into(),
             Self::SignatureVerifierError(e) => e.abi_encode().into(),
             Self::ReceivePolicyGuardError(e) => e.abi_encode().into(),
+            Self::TIP20StealthError(e) => e.abi_encode().into(),
             Self::OutOfGas => {
                 return Ok(PrecompileOutput::halt(PrecompileHalt::OutOfGas, reservoir));
             }
@@ -304,6 +311,7 @@ pub fn error_decoder_registry() -> TempoPrecompileErrorRegistry {
     add_errors_to_registry(&mut registry, TempoPrecompileError::AccountKeychainError);
     add_errors_to_registry(&mut registry, TempoPrecompileError::SignatureVerifierError);
     add_errors_to_registry(&mut registry, TempoPrecompileError::ReceivePolicyGuardError);
+    add_errors_to_registry(&mut registry, TempoPrecompileError::TIP20StealthError);
 
     registry
 }

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -18,6 +18,7 @@ pub mod stablecoin_dex;
 pub mod tip20;
 pub mod tip20_channel_reserve;
 pub mod tip20_factory;
+pub mod tip20_stealth;
 pub mod tip403_registry;
 pub mod tip_fee_manager;
 pub mod validator_config;
@@ -31,8 +32,8 @@ use crate::{
     receive_policy_guard::ReceivePolicyGuard, signature_verifier::SignatureVerifier,
     stablecoin_dex::StablecoinDEX, storage::StorageCtx, tip_fee_manager::TipFeeManager,
     tip20::TIP20Token, tip20_channel_reserve::TIP20ChannelReserve, tip20_factory::TIP20Factory,
-    tip403_registry::TIP403Registry, validator_config::ValidatorConfig,
-    validator_config_v2::ValidatorConfigV2,
+    tip20_stealth::TIP20Stealth, tip403_registry::TIP403Registry,
+    validator_config::ValidatorConfig, validator_config_v2::ValidatorConfigV2,
 };
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_primitives::TempoAddressExt;
@@ -56,8 +57,8 @@ pub use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, DEFAULT_FEE_TOKEN,
     NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS, RECEIVE_POLICY_GUARD_ADDRESS,
     SIGNATURE_VERIFIER_ADDRESS, STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
-    TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS,
-    VALIDATOR_CONFIG_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
+    TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_FACTORY_ADDRESS, TIP20_STEALTH_ADDRESS,
+    TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
 
 // Re-export storage layout helpers for read-only contexts (e.g., pool validation)
@@ -146,6 +147,8 @@ pub fn extend_tempo_precompiles(precompiles: &mut PrecompilesMap, cfg: &CfgEnv<T
             Some(SignatureVerifier::create_precompile(&cfg))
         } else if *address == RECEIVE_POLICY_GUARD_ADDRESS && cfg.spec.is_t6() {
             Some(ReceivePolicyGuard::create_precompile(&cfg))
+        } else if *address == TIP20_STEALTH_ADDRESS && cfg.spec.is_t6() {
+            Some(TIP20Stealth::create_precompile(&cfg))
         } else {
             None
         }
@@ -276,6 +279,13 @@ impl ReceivePolicyGuard {
     /// Creates the EVM precompile for this type.
     pub fn create_precompile(cfg: &CfgEnv<TempoHardfork>) -> DynPrecompile {
         tempo_precompile!("ReceivePolicyGuard", cfg, |input| { Self::new() })
+    }
+}
+
+impl TIP20Stealth {
+    /// Creates the EVM precompile for this type.
+    pub fn create_precompile(cfg: &CfgEnv<TempoHardfork>) -> DynPrecompile {
+        tempo_precompile!("TIP20Stealth", cfg, |input| { Self::new() })
     }
 }
 
@@ -1167,6 +1177,13 @@ mod tests {
             "TIP20 channel reserve should not be registered before T5"
         );
 
+        // TIP20Stealth should be registered at T6
+        let stealth_precompile = precompiles.get(&TIP20_STEALTH_ADDRESS);
+        assert!(
+            stealth_precompile.is_none(),
+            "TIP20Stealth should not be registered before T6"
+        );
+
         // TIP20 tokens with prefix should be registered
         let tip20_precompile = precompiles.get(&PATH_USD_ADDRESS);
         assert!(
@@ -1211,6 +1228,25 @@ mod tests {
                 .get(&TIP20_CHANNEL_RESERVE_ADDRESS)
                 .is_some(),
             "TIP20 channel reserve should be registered at T5"
+        );
+    }
+
+    #[test]
+    fn test_tip20_stealth_registered_at_t6_only() {
+        let mut pre_t6 = CfgEnv::<TempoHardfork>::default();
+        pre_t6.set_spec_and_mainnet_gas_params(TempoHardfork::T5);
+        assert!(
+            tempo_precompiles(&pre_t6)
+                .get(&TIP20_STEALTH_ADDRESS)
+                .is_none(),
+            "TIP20Stealth should NOT be registered before T6"
+        );
+
+        let mut t6 = CfgEnv::<TempoHardfork>::default();
+        t6.set_spec_and_mainnet_gas_params(TempoHardfork::T6);
+        assert!(
+            tempo_precompiles(&t6).get(&TIP20_STEALTH_ADDRESS).is_some(),
+            "TIP20Stealth should be registered at T6"
         );
     }
 

--- a/crates/precompiles/src/tip20/dispatch.rs
+++ b/crates/precompiles/src/tip20/dispatch.rs
@@ -26,6 +26,9 @@ const T5_ADDED: &[[u8; 4]] = &[
     ITIP20::setLogoURICall::SELECTOR,
 ];
 
+/// Selectors added at T6: TIP-1069 system transfer.
+const T6_ADDED: &[[u8; 4]] = &[ITIP20::transferAsSystemCall::SELECTOR];
+
 /// Decoded call variant — either a TIP-20 token call or a role-management call.
 enum TIP20Call {
     TIP20(ITIP20Calls),
@@ -66,6 +69,7 @@ impl Precompile for TIP20Token {
             &[
                 SelectorSchedule::new(TempoHardfork::T2).with_added(T2_ADDED),
                 SelectorSchedule::new(TempoHardfork::T5).with_added(T5_ADDED),
+                SelectorSchedule::new(TempoHardfork::T6).with_added(T6_ADDED),
             ],
             TIP20Call::decode,
             |call| match call {
@@ -125,6 +129,9 @@ impl Precompile for TIP20Token {
                 // State changing functions
                 TIP20Call::TIP20(ITIP20Calls::transferFrom(call)) => {
                     mutate(call, msg_sender, |s, c| self.transfer_from(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::transferAsSystem(call)) => {
+                    mutate(call, msg_sender, |s, c| self.transfer_as_system(s, c))
                 }
                 TIP20Call::TIP20(ITIP20Calls::transfer(call)) => {
                     mutate(call, msg_sender, |s, c| self.transfer(s, c))
@@ -772,8 +779,8 @@ mod tests {
         use crate::test_util::{assert_full_coverage, check_selector_coverage};
         use tempo_contracts::precompiles::{IRolesAuth::IRolesAuthCalls, ITIP20::ITIP20Calls};
 
-        // Use T5 hardfork so all selectors are active.
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T5);
+        // Use T6 hardfork so all selectors are active.
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
         let admin = Address::random();
 
         StorageCtx::enter(&mut storage, || {
@@ -821,6 +828,42 @@ mod tests {
             assert!(UnknownFunctionSelector::abi_decode(&result.bytes).is_ok());
 
             Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_as_system_selector_gated_behind_t6() -> eyre::Result<()> {
+        let admin = Address::random();
+        let from = Address::random();
+        let to = Address::random();
+        let amount = U256::from(1);
+        let calldata = ITIP20::transferAsSystemCall { from, to, amount }.abi_encode();
+
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T5);
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::create("Test", "TST", admin)
+                .with_issuer(admin)
+                .with_mint(from, amount)
+                .apply()?;
+            let result = token.call(&calldata, from)?;
+            assert!(result.is_revert());
+            assert!(UnknownFunctionSelector::abi_decode(&result.bytes).is_ok());
+            Ok::<_, eyre::Report>(())
+        })?;
+
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::create("Test", "TST", admin)
+                .with_issuer(admin)
+                .with_mint(from, amount)
+                .apply()?;
+            let result = token.call(&calldata, from)?;
+            assert!(result.is_revert());
+            assert_eq!(
+                TIP20Error::abi_decode(&result.bytes)?,
+                TIP20Error::unauthorized()
+            );
+            Ok::<_, eyre::Report>(())
         })
     }
 

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     address_registry::AddressRegistry,
     error::{Result, TempoPrecompileError},
     receive_policy_guard::{InboundKind, ReceivePolicyGuard, RecoveryMode},
-    storage::{Handler, Mapping},
+    storage::{Handler, Mapping, StorageCtx},
     tip20::{rewards::UserRewardInfo, roles::DEFAULT_ADMIN_ROLE},
     tip20_factory::TIP20Factory,
     tip403_registry::{AuthRole, ITIP403Registry, TIP403Registry},
@@ -41,7 +41,7 @@ use std::sync::LazyLock;
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::{
     DECIMALS as TIP20_DECIMALS, ReceivePolicyGuardError, STABLECOIN_DEX_ADDRESS,
-    TIP20_CHANNEL_RESERVE_ADDRESS,
+    TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_STEALTH_ADDRESS,
 };
 use tempo_precompiles_macros::contract;
 use tempo_primitives::TempoAddressExt;
@@ -901,6 +901,48 @@ impl TIP20Token {
         Ok(true)
     }
 
+    /// Transfers `amount` from `from` to `to` without checking allowances. For use by trusted
+    /// system precompiles that must credit a caller-specified recipient exactly.
+    pub fn system_transfer_as(
+        &mut self,
+        caller: Address,
+        from: Address,
+        to: Address,
+        amount: U256,
+    ) -> Result<bool> {
+        let spec = self.storage.spec();
+        if !crate::address_registry::is_implicitly_approved(caller, spec) {
+            return Err(TIP20Error::unauthorized().into());
+        }
+
+        let to = Recipient::direct(to);
+        self.check_not_paused()?;
+        to.validate()?;
+        self.ensure_transfer_authorized(from, to.target)?;
+        self.check_and_update_spending_limit(from, amount)?;
+
+        if self.storage.spec().is_t6()
+            && TIP403Registry::new()
+                .validate_receive_policy(self.address, from, to.target)?
+                .is_some()
+        {
+            return Err(TIP20Error::policy_forbids().into());
+        }
+
+        self._transfer(from, &to, amount)?;
+        Ok(true)
+    }
+
+    /// ABI-facing system transfer primitive. Direct user calls revert unless the caller is a
+    /// trusted system precompile.
+    pub fn transfer_as_system(
+        &mut self,
+        msg_sender: Address,
+        call: ITIP20::transferAsSystemCall,
+    ) -> Result<bool> {
+        self.system_transfer_as(msg_sender, call.from, call.to, call.amount)
+    }
+
     /// Debits `spender`'s allowance on `owner`. No-op when unlimited.
     fn consume_allowance(&mut self, owner: Address, spender: Address, amount: U256) -> Result<()> {
         let allowed = self.get_allowance(owner, spender)?;
@@ -1398,7 +1440,10 @@ impl Recipient {
     /// - the zero address (preventing accidental burns)
     /// - an address with the TIP-20 prefix (preventing transfers to token contracts)
     pub(crate) fn validate(&self) -> Result<()> {
-        if self.target.is_zero() || self.target.is_tip20() {
+        if self.target.is_zero()
+            || self.target.is_tip20()
+            || (StorageCtx.spec().is_t6() && self.target == TIP20_STEALTH_ADDRESS)
+        {
             return Err(TIP20Error::invalid_recipient().into());
         }
         Ok(())
@@ -2608,6 +2653,104 @@ pub(crate) mod tests {
                 token.system_transfer_from(unlisted, from, amount),
                 Err(TempoPrecompileError::TIP20(TIP20Error::Unauthorized(_)))
             ));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_system_transfer_as_t6_authorized() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        let admin = Address::random();
+        let from = Address::random();
+        let to = Address::random();
+        let amount = U256::from(123);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::create("Test", "TST", admin)
+                .with_issuer(admin)
+                .with_mint(from, amount)
+                .apply()?;
+
+            token.system_transfer_as(TIP20_STEALTH_ADDRESS, from, to, amount)?;
+
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: from })?,
+                U256::ZERO
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: to })?,
+                amount
+            );
+            assert_eq!(
+                token.emitted_events().last().unwrap(),
+                &TIP20Event::transfer(from, to, amount).into_log_data()
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_as_system_t6_direct_user_call_reverts() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        let admin = Address::random();
+        let from = Address::random();
+        let to = Address::random();
+        let amount = U256::from(123);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::create("Test", "TST", admin)
+                .with_issuer(admin)
+                .with_mint(from, amount)
+                .apply()?;
+
+            assert!(matches!(
+                token.transfer_as_system(from, ITIP20::transferAsSystemCall { from, to, amount }),
+                Err(TempoPrecompileError::TIP20(TIP20Error::Unauthorized(_)))
+            ));
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: from })?,
+                amount
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: to })?,
+                U256::ZERO
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t6_transfer_to_tip20_stealth_address_reverts() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        let admin = Address::random();
+        let from = Address::random();
+        let amount = U256::from(123);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::create("Test", "TST", admin)
+                .with_issuer(admin)
+                .with_mint(from, amount)
+                .apply()?;
+
+            assert!(matches!(
+                token.transfer(
+                    from,
+                    ITIP20::transferCall {
+                        to: TIP20_STEALTH_ADDRESS,
+                        amount
+                    }
+                ),
+                Err(TempoPrecompileError::TIP20(TIP20Error::InvalidRecipient(_)))
+            ));
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: TIP20_STEALTH_ADDRESS
+                })?,
+                U256::ZERO
+            );
 
             Ok(())
         })

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     address_registry::AddressRegistry,
     error::{Result, TempoPrecompileError},
     receive_policy_guard::{InboundKind, ReceivePolicyGuard, RecoveryMode},
-    storage::{Handler, Mapping, StorageCtx},
+    storage::{Handler, Mapping},
     tip20::{rewards::UserRewardInfo, roles::DEFAULT_ADMIN_ROLE},
     tip20_factory::TIP20Factory,
     tip403_registry::{AuthRole, ITIP403Registry, TIP403Registry},
@@ -915,9 +915,12 @@ impl TIP20Token {
             return Err(TIP20Error::unauthorized().into());
         }
 
-        let to = Recipient::direct(to);
+        let to = Recipient::resolve(to)?;
         self.check_not_paused()?;
         to.validate()?;
+        if to.target == RECEIVE_POLICY_GUARD_ADDRESS {
+            return Err(ReceivePolicyGuardError::address_reserved().into());
+        }
         self.ensure_transfer_authorized(from, to.target)?;
         self.check_and_update_spending_limit(from, amount)?;
 
@@ -930,6 +933,9 @@ impl TIP20Token {
         }
 
         self._transfer(from, &to, amount)?;
+        if let Some(hop) = to.build_virtual_transfer_event(amount) {
+            self.emit_event(hop)?;
+        }
         Ok(true)
     }
 
@@ -1440,10 +1446,7 @@ impl Recipient {
     /// - the zero address (preventing accidental burns)
     /// - an address with the TIP-20 prefix (preventing transfers to token contracts)
     pub(crate) fn validate(&self) -> Result<()> {
-        if self.target.is_zero()
-            || self.target.is_tip20()
-            || (StorageCtx.spec().is_t6() && self.target == TIP20_STEALTH_ADDRESS)
-        {
+        if self.target.is_zero() || self.target.is_tip20() || self.target == TIP20_STEALTH_ADDRESS {
             return Err(TIP20Error::invalid_recipient().into());
         }
         Ok(())
@@ -1588,11 +1591,12 @@ pub(crate) mod tests {
         account_keychain::{
             AccountKeychain, KeyRestrictions, SignatureType, TokenLimit, getRemainingLimitCall,
         },
-        address_registry::{AddressRegistry, MasterId, UserTag},
+        address_registry::{AddrRegistryError, AddressRegistry, MasterId, UserTag},
         error::TempoPrecompileError,
         receive_policy_guard::ReceivePolicyGuard,
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{TIP20Setup, VIRTUAL_MASTER, register_virtual_master, setup_storage},
+        tip20_stealth::TIP20Stealth,
         tip403_registry::REJECT_ALL_POLICY_ID,
     };
     use alloy::primitives::{Address, FixedBytes, IntoLogData, U256, hex};
@@ -2692,6 +2696,119 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_system_transfer_as_t6_virtual_recipient_credits_master() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        let admin = Address::random();
+        let from = Address::random();
+        let amount = U256::from(123);
+
+        StorageCtx::enter(&mut storage, || {
+            let (_, virtual_addr) = register_virtual_master(&mut AddressRegistry::new())?;
+            let mut token = TIP20Setup::create("Test", "TST", admin)
+                .with_issuer(admin)
+                .with_mint(from, amount)
+                .clear_events()
+                .apply()?;
+
+            token.system_transfer_as(TIP20_STEALTH_ADDRESS, from, virtual_addr, amount)?;
+
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: from })?,
+                U256::ZERO
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: virtual_addr
+                })?,
+                U256::ZERO
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: VIRTUAL_MASTER
+                })?,
+                amount
+            );
+            token.assert_emitted_events(vec![
+                TIP20Event::transfer(from, virtual_addr, amount),
+                TIP20Event::transfer(virtual_addr, VIRTUAL_MASTER, amount),
+            ]);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_system_transfer_as_t6_unregistered_virtual_recipient_reverts() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        let admin = Address::random();
+        let from = Address::random();
+        let amount = U256::from(123);
+        let virtual_addr = Address::new_virtual(MasterId::ZERO, UserTag::ZERO);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::create("Test", "TST", admin)
+                .with_issuer(admin)
+                .with_mint(from, amount)
+                .apply()?;
+
+            let result =
+                token.system_transfer_as(TIP20_STEALTH_ADDRESS, from, virtual_addr, amount);
+            assert!(matches!(
+                result,
+                Err(TempoPrecompileError::AddrRegistryError(
+                    AddrRegistryError::VirtualAddressUnregistered(_)
+                ))
+            ));
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: from })?,
+                amount
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_system_transfer_as_t6_receive_policy_guard_recipient_reverts() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        let admin = Address::random();
+        let from = Address::random();
+        let amount = U256::from(123);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::create("Test", "TST", admin)
+                .with_issuer(admin)
+                .with_mint(from, amount)
+                .apply()?;
+
+            let result = token.system_transfer_as(
+                TIP20_STEALTH_ADDRESS,
+                from,
+                RECEIVE_POLICY_GUARD_ADDRESS,
+                amount,
+            );
+            assert!(matches!(
+                result,
+                Err(TempoPrecompileError::ReceivePolicyGuardError(
+                    ReceivePolicyGuardError::AddressReserved(_)
+                ))
+            ));
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: from })?,
+                amount
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: RECEIVE_POLICY_GUARD_ADDRESS
+                })?,
+                U256::ZERO
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_transfer_as_system_t6_direct_user_call_reverts() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
         let admin = Address::random();
@@ -2723,33 +2840,91 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_t6_transfer_to_tip20_stealth_address_reverts() -> eyre::Result<()> {
+    fn test_transfer_to_tip20_stealth_address_reverts_across_specs() -> eyre::Result<()> {
+        for spec in [TempoHardfork::T4, TempoHardfork::T5, TempoHardfork::T6] {
+            let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
+            let admin = Address::random();
+            let from = Address::random();
+            let amount = U256::from(123);
+
+            StorageCtx::enter(&mut storage, || {
+                let mut token = TIP20Setup::create("Test", "TST", admin)
+                    .with_issuer(admin)
+                    .with_mint(from, amount)
+                    .apply()?;
+
+                assert!(matches!(
+                    token.transfer(
+                        from,
+                        ITIP20::transferCall {
+                            to: TIP20_STEALTH_ADDRESS,
+                            amount
+                        }
+                    ),
+                    Err(TempoPrecompileError::TIP20(TIP20Error::InvalidRecipient(_)))
+                ));
+                assert_eq!(
+                    token.balance_of(ITIP20::balanceOfCall {
+                        account: TIP20_STEALTH_ADDRESS
+                    })?,
+                    U256::ZERO
+                );
+
+                Ok::<_, eyre::Report>(())
+            })?;
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_tip20_stealth_transfer_tolerates_preexisting_custody_balance() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
         let admin = Address::random();
         let from = Address::random();
+        let to = Address::random();
         let amount = U256::from(123);
+        let preexisting_dust = U256::ONE;
+        let mut metadata = vec![0u8; crate::tip20_stealth::V1_METADATA_LEN];
+        metadata[0] = crate::tip20_stealth::SCHEME_SECP256K1;
+        metadata[1] = 0x02;
 
         StorageCtx::enter(&mut storage, || {
             let mut token = TIP20Setup::create("Test", "TST", admin)
                 .with_issuer(admin)
                 .with_mint(from, amount)
+                .clear_events()
                 .apply()?;
+            token.set_balance(
+                TIP20_STEALTH_ADDRESS,
+                UserState::new(preexisting_dust, RewardFlag::OptedOut)?,
+            )?;
+            let mut stealth = TIP20Stealth::new();
 
-            assert!(matches!(
-                token.transfer(
-                    from,
-                    ITIP20::transferCall {
-                        to: TIP20_STEALTH_ADDRESS,
-                        amount
-                    }
-                ),
-                Err(TempoPrecompileError::TIP20(TIP20Error::InvalidRecipient(_)))
-            ));
+            stealth.transfer(
+                from,
+                crate::tip20_stealth::ITIP20Stealth::transferCall {
+                    token: token.address,
+                    stealthAddress: to,
+                    amount,
+                    metadata: metadata.into(),
+                    memo: Default::default(),
+                },
+            )?;
+
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: from })?,
+                U256::ZERO
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: to })?,
+                amount
+            );
             assert_eq!(
                 token.balance_of(ITIP20::balanceOfCall {
                     account: TIP20_STEALTH_ADDRESS
                 })?,
-                U256::ZERO
+                preexisting_dust
             );
 
             Ok(())

--- a/crates/precompiles/src/tip20_stealth/dispatch.rs
+++ b/crates/precompiles/src/tip20_stealth/dispatch.rs
@@ -1,0 +1,25 @@
+//! ABI dispatch for the [`TIP20Stealth`] precompile.
+
+use crate::{Precompile, charge_input_cost, dispatch_call, mutate, tip20_stealth::TIP20Stealth};
+use alloy::{primitives::Address, sol_types::SolInterface};
+use revm::precompile::PrecompileResult;
+use tempo_contracts::precompiles::ITIP20Stealth::ITIP20StealthCalls;
+
+impl Precompile for TIP20Stealth {
+    fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
+        if let Some(err) = charge_input_cost(&mut self.storage, calldata) {
+            return err;
+        }
+
+        dispatch_call(
+            calldata,
+            &[],
+            ITIP20StealthCalls::abi_decode,
+            |call| match call {
+                ITIP20StealthCalls::transfer(call) => {
+                    mutate(call, msg_sender, |sender, c| self.transfer(sender, c))
+                }
+            },
+        )
+    }
+}

--- a/crates/precompiles/src/tip20_stealth/mod.rs
+++ b/crates/precompiles/src/tip20_stealth/mod.rs
@@ -8,15 +8,12 @@ use crate::{
     tip20::{ITIP20, TIP20Token},
 };
 use alloy::primitives::{Address, U256};
-pub use tempo_contracts::precompiles::{ITIP20Stealth, TIP20StealthError, TIP20StealthEvent};
+pub use tempo_contracts::precompiles::{
+    ITIP20Stealth, TIP20_STEALTH_SCHEME_P256 as SCHEME_P256,
+    TIP20_STEALTH_SCHEME_SECP256K1 as SCHEME_SECP256K1,
+    TIP20_STEALTH_V1_METADATA_LEN as V1_METADATA_LEN, TIP20StealthError, TIP20StealthEvent,
+};
 use tempo_precompiles_macros::contract;
-
-/// secp256k1 stealth-address derivation scheme.
-pub const SCHEME_SECP256K1: u8 = 0x01;
-/// P-256 stealth-address derivation scheme.
-pub const SCHEME_P256: u8 = 0x02;
-/// Metadata length for all TIP-1069 v1 schemes.
-pub const V1_METADATA_LEN: usize = 35;
 
 #[contract(addr = TIP20_STEALTH_ADDRESS)]
 pub struct TIP20Stealth {}
@@ -36,7 +33,7 @@ impl TIP20Stealth {
         validate_metadata(&call.metadata)?;
 
         let mut token = TIP20Token::from_address(call.token)?;
-        self.ensure_no_custody(&token)?;
+        let initial_custody_balance = self.custody_balance(&token)?;
 
         token.transfer_as_system(
             self.address,
@@ -47,7 +44,7 @@ impl TIP20Stealth {
             },
         )?;
 
-        self.ensure_no_custody(&token)?;
+        self.ensure_no_custody_increase(&token, initial_custody_balance)?;
         self.emit_event(TIP20StealthEvent::announce(
             call.token,
             call.stealthAddress,
@@ -58,11 +55,15 @@ impl TIP20Stealth {
         Ok(true)
     }
 
-    fn ensure_no_custody(&self, token: &TIP20Token) -> Result<()> {
-        let balance = token.balance_of(ITIP20::balanceOfCall {
+    fn custody_balance(&self, token: &TIP20Token) -> Result<U256> {
+        token.balance_of(ITIP20::balanceOfCall {
             account: self.address,
-        })?;
-        if balance != U256::ZERO {
+        })
+    }
+
+    fn ensure_no_custody_increase(&self, token: &TIP20Token, initial_balance: U256) -> Result<()> {
+        let balance = self.custody_balance(token)?;
+        if balance > initial_balance {
             return Err(TIP20StealthError::precompile_custody().into());
         }
         Ok(())

--- a/crates/precompiles/src/tip20_stealth/mod.rs
+++ b/crates/precompiles/src/tip20_stealth/mod.rs
@@ -1,0 +1,247 @@
+//! TIP-1069 canonical stealth-address transfer precompile.
+
+pub mod dispatch;
+
+use crate::{
+    TIP20_STEALTH_ADDRESS,
+    error::Result,
+    tip20::{ITIP20, TIP20Token},
+};
+use alloy::primitives::{Address, U256};
+pub use tempo_contracts::precompiles::{ITIP20Stealth, TIP20StealthError, TIP20StealthEvent};
+use tempo_precompiles_macros::contract;
+
+/// secp256k1 stealth-address derivation scheme.
+pub const SCHEME_SECP256K1: u8 = 0x01;
+/// P-256 stealth-address derivation scheme.
+pub const SCHEME_P256: u8 = 0x02;
+/// Metadata length for all TIP-1069 v1 schemes.
+pub const V1_METADATA_LEN: usize = 35;
+
+#[contract(addr = TIP20_STEALTH_ADDRESS)]
+pub struct TIP20Stealth {}
+
+impl TIP20Stealth {
+    /// Initializes the precompile marker bytecode.
+    pub fn initialize(&mut self) -> Result<()> {
+        self.__initialize()
+    }
+
+    /// Transfers TIP-20 funds from `msg_sender` to a derived stealth address and announces it.
+    pub fn transfer(
+        &mut self,
+        msg_sender: Address,
+        call: ITIP20Stealth::transferCall,
+    ) -> Result<bool> {
+        validate_metadata(&call.metadata)?;
+
+        let mut token = TIP20Token::from_address(call.token)?;
+        self.ensure_no_custody(&token)?;
+
+        token.transfer_as_system(
+            self.address,
+            ITIP20::transferAsSystemCall {
+                from: msg_sender,
+                to: call.stealthAddress,
+                amount: call.amount,
+            },
+        )?;
+
+        self.ensure_no_custody(&token)?;
+        self.emit_event(TIP20StealthEvent::announce(
+            call.token,
+            call.stealthAddress,
+            call.metadata,
+            call.memo,
+        ))?;
+
+        Ok(true)
+    }
+
+    fn ensure_no_custody(&self, token: &TIP20Token) -> Result<()> {
+        let balance = token.balance_of(ITIP20::balanceOfCall {
+            account: self.address,
+        })?;
+        if balance != U256::ZERO {
+            return Err(TIP20StealthError::precompile_custody().into());
+        }
+        Ok(())
+    }
+}
+
+/// Validates TIP-1069 metadata without parsing or curve-validating the ephemeral pubkey.
+pub fn validate_metadata(metadata: &[u8]) -> Result<()> {
+    let Some((&scheme, _)) = metadata.split_first() else {
+        return Err(TIP20StealthError::invalid_metadata().into());
+    };
+
+    match scheme {
+        SCHEME_SECP256K1 | SCHEME_P256 => {
+            if metadata.len() != V1_METADATA_LEN {
+                return Err(TIP20StealthError::invalid_metadata().into());
+            }
+        }
+        _ => return Err(TIP20StealthError::unknown_scheme().into()),
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        error::TempoPrecompileError,
+        storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
+        test_util::TIP20Setup,
+        tip20::{ITIP20, TIP20Event},
+    };
+    use alloy::primitives::{Bytes, U256};
+    use tempo_chainspec::hardfork::TempoHardfork;
+
+    fn metadata(scheme: u8) -> Bytes {
+        let mut metadata = vec![0u8; V1_METADATA_LEN];
+        metadata[0] = scheme;
+        metadata[1] = 0x02;
+        metadata[34] = 0xa7;
+        metadata.into()
+    }
+
+    #[test]
+    fn test_validate_metadata_accepts_v1_schemes() -> eyre::Result<()> {
+        validate_metadata(&metadata(SCHEME_SECP256K1))?;
+        validate_metadata(&metadata(SCHEME_P256))?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_validate_metadata_rejects_empty_unknown_and_wrong_length() {
+        assert!(matches!(
+            validate_metadata(&[]),
+            Err(TempoPrecompileError::TIP20StealthError(
+                TIP20StealthError::InvalidMetadata(_)
+            ))
+        ));
+
+        assert!(matches!(
+            validate_metadata(&metadata(0xff)),
+            Err(TempoPrecompileError::TIP20StealthError(
+                TIP20StealthError::UnknownScheme(_)
+            ))
+        ));
+
+        let mut short = metadata(SCHEME_SECP256K1).to_vec();
+        short.pop();
+        assert!(matches!(
+            validate_metadata(&short),
+            Err(TempoPrecompileError::TIP20StealthError(
+                TIP20StealthError::InvalidMetadata(_)
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_transfer_moves_funds_and_emits_announce() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        let admin = Address::random();
+        let sender = Address::random();
+        let stealth_address = Address::random();
+        let amount = U256::from(250);
+        let metadata = metadata(SCHEME_SECP256K1);
+        let memo = Bytes::from_static(b"encrypted memo");
+
+        StorageCtx::enter(&mut storage, || {
+            let token = TIP20Setup::create("Test", "TST", admin)
+                .with_issuer(admin)
+                .with_mint(sender, amount)
+                .clear_events()
+                .apply()?;
+            let mut stealth = TIP20Stealth::new();
+
+            let ok = stealth.transfer(
+                sender,
+                ITIP20Stealth::transferCall {
+                    token: token.address(),
+                    stealthAddress: stealth_address,
+                    amount,
+                    metadata: metadata.clone(),
+                    memo: memo.clone(),
+                },
+            )?;
+            assert!(ok);
+
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: sender })?,
+                U256::ZERO
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: stealth_address
+                })?,
+                amount
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: TIP20_STEALTH_ADDRESS
+                })?,
+                U256::ZERO
+            );
+
+            token.assert_emitted_events(vec![TIP20Event::transfer(
+                sender,
+                stealth_address,
+                amount,
+            )]);
+            stealth.assert_emitted_events(vec![TIP20StealthEvent::announce(
+                token.address(),
+                stealth_address,
+                metadata,
+                memo,
+            )]);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_rejects_invalid_metadata_before_moving_funds() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        let admin = Address::random();
+        let sender = Address::random();
+        let stealth_address = Address::random();
+        let amount = U256::from(250);
+
+        StorageCtx::enter(&mut storage, || {
+            let token = TIP20Setup::create("Test", "TST", admin)
+                .with_issuer(admin)
+                .with_mint(sender, amount)
+                .clear_events()
+                .apply()?;
+            let mut stealth = TIP20Stealth::new();
+
+            let result = stealth.transfer(
+                sender,
+                ITIP20Stealth::transferCall {
+                    token: token.address(),
+                    stealthAddress: stealth_address,
+                    amount,
+                    metadata: Bytes::new(),
+                    memo: Bytes::new(),
+                },
+            );
+            assert!(matches!(
+                result,
+                Err(TempoPrecompileError::TIP20StealthError(
+                    TIP20StealthError::InvalidMetadata(_)
+                ))
+            ));
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: sender })?,
+                amount
+            );
+            assert!(stealth.emitted_events().is_empty());
+
+            Ok(())
+        })
+    }
+}

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -10,7 +10,10 @@ use alloy_consensus::{
 use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256};
 use alloy_rlp::Encodable;
 use core::fmt;
-use tempo_contracts::precompiles::{ITIP20, ITIP20ChannelReserve, TIP20_CHANNEL_RESERVE_ADDRESS};
+use tempo_contracts::precompiles::{
+    ITIP20, ITIP20ChannelReserve, ITIP20Stealth, TIP20_CHANNEL_RESERVE_ADDRESS,
+    TIP20_STEALTH_ADDRESS,
+};
 
 /// Maximum RLP-encoded size of a `key_authorization` permitted in a payment transaction
 /// (TIP-1045). Comfortably fits realistic provisioning payloads with limits and scopes.
@@ -508,6 +511,9 @@ fn is_tip1045_call(to: Option<&Address>, input: &[u8]) -> bool {
                 |signature| super::tt_signature::PrimitiveSignature::from_bytes(signature).is_ok(),
             )
         }
+        Some(to) if *to == TIP20_STEALTH_ADDRESS => {
+            ITIP20Stealth::ITIP20StealthCalls::is_payment(input)
+        }
         _ => false,
     }
 }
@@ -600,6 +606,22 @@ mod tests {
             ITIP20ChannelReserve::requestCloseCall { descriptor: descriptor.clone() }.abi_encode().into(),
             ITIP20ChannelReserve::withdrawCall { descriptor }.abi_encode().into(),
         ]
+    }
+
+    fn stealth_payment_calldata() -> Bytes {
+        let mut metadata = vec![0u8; 35];
+        metadata[0] = 0x01;
+        metadata[1] = 0x02;
+        metadata[34] = 0xa7;
+        ITIP20Stealth::transferCall {
+            token: PAYMENT_TKN,
+            stealthAddress: Address::random(),
+            amount: U256::from(1),
+            metadata: metadata.into(),
+            memo: Bytes::from_static(b"memo"),
+        }
+        .abi_encode()
+        .into()
     }
 
     /// Returns one envelope per tx type, all targeting `PAYMENT_TKN` with the given calldata.
@@ -850,12 +872,31 @@ mod tests {
     }
 
     #[test]
+    fn test_payment_v2_accepts_valid_tip20_stealth_calldata() {
+        for envelope in payment_envelopes_to(TIP20_STEALTH_ADDRESS, stealth_payment_calldata()) {
+            assert!(!envelope.is_payment_v1(), "V1 only accepts TIP-20 prefix");
+            assert!(
+                envelope.is_payment_v2(),
+                "V2 must accept valid TIP20Stealth calldata"
+            );
+        }
+    }
+
+    #[test]
     fn test_payment_v2_rejects_channel_reserve_calldata_to_tip20() {
         for calldata in channel_reserve_payment_calldatas() {
             for envelope in payment_envelopes_to(PAYMENT_TKN, calldata) {
                 assert!(envelope.is_payment_v1(), "V1 accepts TIP-20 prefix");
                 assert!(!envelope.is_payment_v2(), "V2 only accepts allowed combos");
             }
+        }
+    }
+
+    #[test]
+    fn test_payment_v2_rejects_stealth_calldata_to_tip20() {
+        for envelope in payment_envelopes_to(PAYMENT_TKN, stealth_payment_calldata()) {
+            assert!(envelope.is_payment_v1(), "V1 accepts TIP-20 prefix");
+            assert!(!envelope.is_payment_v2(), "V2 only accepts allowed combos");
         }
     }
 

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -561,7 +561,7 @@ mod tests {
     };
     use alloy_primitives::{Bytes, Signature, TxKind, U256, address, aliases::U96};
     use alloy_sol_types::SolCall;
-    use tempo_contracts::precompiles::ITIP20ChannelReserve;
+    use tempo_contracts::precompiles::{ITIP20ChannelReserve, MAX_PAYMENT_CALLDATA_LEN};
 
     const PAYMENT_TKN: Address = address!("20c0000000000000000000000000000000000001");
 
@@ -609,16 +609,24 @@ mod tests {
     }
 
     fn stealth_payment_calldata() -> Bytes {
+        stealth_payment_calldata_with(metadata(0x01), Bytes::from_static(b"memo"))
+    }
+
+    fn metadata(scheme: u8) -> Bytes {
         let mut metadata = vec![0u8; 35];
-        metadata[0] = 0x01;
+        metadata[0] = scheme;
         metadata[1] = 0x02;
         metadata[34] = 0xa7;
+        metadata.into()
+    }
+
+    fn stealth_payment_calldata_with(metadata: Bytes, memo: Bytes) -> Bytes {
         ITIP20Stealth::transferCall {
             token: PAYMENT_TKN,
             stealthAddress: Address::random(),
             amount: U256::from(1),
-            metadata: metadata.into(),
-            memo: Bytes::from_static(b"memo"),
+            metadata,
+            memo,
         }
         .abi_encode()
         .into()
@@ -878,6 +886,34 @@ mod tests {
             assert!(
                 envelope.is_payment_v2(),
                 "V2 must accept valid TIP20Stealth calldata"
+            );
+        }
+    }
+
+    #[test]
+    fn test_payment_v2_rejects_invalid_tip20_stealth_metadata() {
+        for calldata in [
+            stealth_payment_calldata_with(Bytes::new(), Bytes::new()),
+            stealth_payment_calldata_with(metadata(0xff), Bytes::new()),
+        ] {
+            for envelope in payment_envelopes_to(TIP20_STEALTH_ADDRESS, calldata) {
+                assert!(
+                    !envelope.is_payment_v2(),
+                    "V2 rejects invalid TIP20Stealth metadata"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_payment_v2_rejects_oversized_tip20_stealth_calldata() {
+        let calldata =
+            stealth_payment_calldata_with(metadata(0x01), vec![0; MAX_PAYMENT_CALLDATA_LEN].into());
+        assert!(calldata.len() > MAX_PAYMENT_CALLDATA_LEN);
+        for envelope in payment_envelopes_to(TIP20_STEALTH_ADDRESS, calldata) {
+            assert!(
+                !envelope.is_payment_v2(),
+                "V2 rejects oversized TIP20Stealth calldata"
             );
         }
     }


### PR DESCRIPTION
Implements https://tips.sh/1069.

Adds the `TIP20Stealth` precompile for metadata-validated TIP-20 transfers to derived stealth addresses. It routes funds from the caller to the recipient through T6-gated `transferAsSystem`, emits `Announce`, and prevents custody at the precompile address.

Updates payment classification and T6 marker deployment so stealth transfer calldata is eligible where plain TIP-20 payments are accepted. Direct `transferAsSystem` calls and transfers to the stealth precompile remain blocked.