### PR TITLE
deps: update reth from main (2026-06-08)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10863,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11165,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
+source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.36.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
+checksum = "58673bde58f17022886547b618346aeae9b147ed398f9c847105fa91c49f97eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10863,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11165,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12813,7 +12813,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -12894,7 +12894,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
-version = "1.8.0"
+version = "1.7.3"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -12960,7 +12960,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13021,7 +13021,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node-config"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13038,7 +13038,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -13057,7 +13057,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.8.0"
+version = "1.7.3"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -13069,7 +13069,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13083,7 +13083,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13134,14 +13134,13 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -13173,7 +13172,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13192,7 +13191,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "eyre",
  "indenter",
@@ -13200,7 +13199,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13213,7 +13212,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13282,15 +13281,12 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
- "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
- "crossbeam-channel",
  "metrics",
  "reth-basic-payload-builder",
  "reth-chainspec",
@@ -13314,13 +13310,12 @@ dependencies = [
  "tempo-precompiles",
  "tempo-primitives",
  "tempo-transaction-pool",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13339,7 +13334,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13371,7 +13366,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13381,7 +13376,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.8.0"
+version = "1.7.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13419,7 +13414,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13453,7 +13448,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "clap",
@@ -13478,7 +13473,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "eyre",
  "jiff",
@@ -13487,7 +13482,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13526,7 +13521,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13538,7 +13533,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-json-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10222,7 +10222,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10246,7 +10246,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10270,7 +10270,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "bytes",
  "eyre",
@@ -10299,7 +10299,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10311,7 +10311,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10335,7 +10335,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10347,7 +10347,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10370,7 +10370,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10413,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10462,7 +10462,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10490,7 +10490,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10506,7 +10506,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10521,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10597,7 +10597,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10627,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10670,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10721,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10768,7 +10768,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10819,7 +10819,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10833,7 +10833,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10864,7 +10864,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10915,7 +10915,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10943,7 +10943,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10957,7 +10957,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10992,7 +10992,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11018,7 +11018,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11036,7 +11036,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11057,7 +11057,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11073,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11083,7 +11083,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "clap",
  "eyre",
@@ -11091,6 +11091,7 @@ dependencies = [
  "rolling-file",
  "tracing",
  "tracing-appender",
+ "tracing-chrome",
  "tracing-journald",
  "tracing-logfmt",
  "tracing-samply",
@@ -11102,7 +11103,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11121,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11166,7 +11167,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11192,7 +11193,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11219,7 +11220,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11239,7 +11240,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11268,7 +11269,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
+source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14075,6 +14076,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10863,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11165,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b07219#8b07219eb87163b58763a712a422aa66c5a59486"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3828,7 +3828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8803,9 +8803,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f54468f34d9ed03356dee71bb182a2815a490934f1a291f58158053eee946ba"
+checksum = "f9c37bb4d1bac98661bf9128e1141b969034640d68697b22f70377e492fd332c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8824,9 +8824,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80c0516faf1698c57f91f07c98ecd9f3a9d3f163f1ad4bb263d9c495b3928e0"
+checksum = "ceeb8dab90194305d3f7e3f043a22d2db1fb54b6dcf5d8e75c5a4fa8540e1f57"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10202,6 +10202,7 @@ dependencies = [
  "reth-network",
  "reth-node-api",
  "reth-node-builder",
+ "reth-node-core",
  "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-provider",
@@ -10215,6 +10216,8 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "revm",
+ "serde",
+ "serde_json",
  "tokio",
  "tower",
 ]
@@ -10222,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10246,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10270,7 +10273,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "bytes",
  "eyre",
@@ -10299,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10311,7 +10314,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10335,7 +10338,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10347,7 +10350,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10370,7 +10373,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10379,9 +10382,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1216ba179909d41d8d55c5eae6c1c33698bc7a3053c35fd425c7789a5de3c1"
+checksum = "9102518f0bbf99bc8f0e656a56fb2a7513248630275b608d3706076a82fde42b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10413,7 +10416,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10462,7 +10465,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10490,7 +10493,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10506,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10521,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10597,7 +10600,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10627,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10670,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10690,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10721,7 +10724,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10768,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10819,7 +10822,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10833,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10848,9 +10851,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75186b77fef29e0160f476c9a6bde3363e503f0f32ac4ef47726ef1e3da81118"
+checksum = "9fa03a2c9681c385ae1c72b169ac9c3525163b71db0b3362f16e8929e19e45fd"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10864,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10915,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10943,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10957,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10977,7 +10980,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10992,7 +10995,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11018,7 +11021,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11036,7 +11039,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11057,7 +11060,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11073,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11083,7 +11086,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "clap",
  "eyre",
@@ -11103,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11122,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11167,7 +11170,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11193,7 +11196,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11220,7 +11223,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11240,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11269,7 +11272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=87fc4cf#87fc4cf4355ddbc59220f691a46d9f9d354adfa0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11290,9 +11293,9 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80dcfa0327b7642cc41c71d8cd3626a48ac76fb8304c28bcbdf416a45615d020"
+checksum = "dc0e86cf594718932d42cebce1fa48292fb7b92721f7c914631add1ca970e814"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10863,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11165,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
+source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10863,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11165,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=3be7f28#3be7f289c2fbbaf9eb3c9f0dd2ad20e84f194a44"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10863,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11165,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
+source = "git+https://github.com/paradigmxyz/reth?rev=2e80931#2e80931e22bee51c6d6fbc2df95386df2c046641"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12818,7 +12818,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -12965,7 +12965,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13026,7 +13026,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node-config"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13043,7 +13043,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -13074,7 +13074,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13088,7 +13088,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13139,7 +13139,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13178,7 +13178,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13197,7 +13197,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "eyre",
  "indenter",
@@ -13205,7 +13205,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13218,7 +13218,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13287,7 +13287,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -13325,7 +13325,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13344,7 +13344,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13376,7 +13376,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13424,7 +13424,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13458,7 +13458,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy",
  "clap",
@@ -13483,7 +13483,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "eyre",
  "jiff",
@@ -13492,7 +13492,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13531,7 +13531,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13543,7 +13543,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloy",
  "alloy-json-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.35.1"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58673bde58f17022886547b618346aeae9b147ed398f9c847105fa91c49f97eb"
+checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10863,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11165,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8afd481#8afd4817ba9a6ea9f3806f1850cdbbb0cae16813"
+source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12894,7 +12894,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13057,7 +13057,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -13141,6 +13141,7 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -13284,9 +13285,12 @@ name = "tempo-payload-builder"
 version = "1.8.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
+ "crossbeam-channel",
  "metrics",
  "reth-basic-payload-builder",
  "reth-chainspec",
@@ -13310,6 +13314,7 @@ dependencies = [
  "tempo-precompiles",
  "tempo-primitives",
  "tempo-transaction-pool",
+ "tokio",
  "tracing",
 ]
 
@@ -13376,7 +13381,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,8 +10178,9 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-network",
  "alloy-primitives",
@@ -10221,7 +10222,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10246,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10270,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10299,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10311,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10335,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10347,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10370,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10462,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10490,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10506,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10597,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10768,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10819,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10833,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10864,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10915,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10943,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10957,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10992,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11018,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11036,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11057,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11083,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11121,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11166,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11192,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11219,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11239,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11268,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92347d#e92347d244e550131d69a765f9ee646d68b9d037"
+source = "git+https://github.com/paradigmxyz/reth?rev=9468154#9468154552cdd135b73bbf3afa2ee53a8b8df364"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10863,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11165,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=84fb800#84fb8008a38f5e46f314f568656fec28f4b82d61"
+source = "git+https://github.com/paradigmxyz/reth?rev=d80418f#d80418f84e43ea46627d89a2c159fbd0dca49866"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.8.0"
+version = "1.8.1"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-codecs = { version = "0.4.1", default-features = false }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-primitives-traits = { version = "0.4.1", default-features = false }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9468154", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9468154", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9468154", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9468154", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,8 +208,9 @@ revm = { version = "40.0.3", features = ["optional_fee_charge"], default-feature
 alloy = { version = "2.0.5", default-features = false }
 alloy-consensus = { version = "2.0.5", default-features = false }
 alloy-contract = { version = "2.0.5", default-features = false }
+alloy-eip7928 = { version = "0.4.1", default-features = false }
 alloy-eips = { version = "2.0.5", default-features = false }
-alloy-evm = { version = "0.35.1", default-features = false }
+alloy-evm = { version = "0.36.0", default-features = false }
 revm-inspectors = "0.40.0"
 alloy-genesis = { version = "2.0.5", default-features = false }
 alloy-hardforks = "0.4.7"
@@ -305,6 +306,7 @@ tracy-client = "0.18.4"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
 paste = "1"
+crossbeam-channel = "0.5"
 secp256k1 = { version = "0.30.0", default-features = false }
 pyroscope = "0.5.8"
 pyroscope_pprofrs = "0.2.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "d80418f", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "2e80931", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8b07219", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "84fb800", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "3be7f28", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "e92347d", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.8.1"
+version = "1.8.0"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8afd481", features = [
   "std",
   "optional-checks",
 ] }
@@ -208,9 +208,8 @@ revm = { version = "40.0.3", features = ["optional_fee_charge"], default-feature
 alloy = { version = "2.0.5", default-features = false }
 alloy-consensus = { version = "2.0.5", default-features = false }
 alloy-contract = { version = "2.0.5", default-features = false }
-alloy-eip7928 = { version = "0.4.0", default-features = false }
 alloy-eips = { version = "2.0.5", default-features = false }
-alloy-evm = { version = "0.36.0", default-features = false }
+alloy-evm = { version = "0.35.1", default-features = false }
 revm-inspectors = "0.40.0"
 alloy-genesis = { version = "2.0.5", default-features = false }
 alloy-hardforks = "0.4.7"
@@ -262,7 +261,6 @@ criterion = { package = "codspeed-criterion-compat", version = "4.6.0" }
 dashmap = "6"
 dirs-next = "2.0.0"
 derive_more = { version = "2.1.1", default-features = false }
-crossbeam-channel = "0.5.13"
 
 ed25519-consensus = { version = "2.1.0", default-features = false }
 ed25519-dalek = { version = "2", features = ["rand_core"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9468154", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9468154", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9468154", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9468154" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9468154", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "87fc4cf", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -886,6 +886,11 @@ where
         let (evm, execution_result) = executor.finish()?;
         let evm_env = evm.into_env();
 
+        // Drop the state hook so the underlying `StateHookSender` is dropped, which
+        // signals `FinishedStateUpdates` to the background sparse trie task. Without
+        // this, `handle.state_root()` below would deadlock waiting for the sentinel.
+        db.set_state_hook(None);
+
         // merge all transitions into bundle state before deriving the hashed post-state
         db.merge_transitions(BundleRetention::Reverts);
 

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -886,11 +886,6 @@ where
         let (evm, execution_result) = executor.finish()?;
         let evm_env = evm.into_env();
 
-        // Drop the state hook so the underlying `StateHookSender` is dropped, which
-        // signals `FinishedStateUpdates` to the background sparse trie task. Without
-        // this, `handle.state_root()` below would deadlock waiting for the sentinel.
-        db.set_state_hook(None);
-
         // merge all transitions into bundle state before deriving the hashed post-state
         db.merge_transitions(BundleRetention::Reverts);
 


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`259b8dc...8b902fe`](https://github.com/paradigmxyz/reth/compare/259b8dc...8b902fe)

::warning::Failed to summarize upstream reth commits with Amp (exit 1)

- chore(hive): update bal fixture and branch version to 7 (#24734)
- ci: update benchmark RPC endpoint (#24735)
- fix(provider): reject expired recovered blocks (#24760)
- chore(docs): bump Vocs to v2 (#24732)
- fix(docs): deploy Vocs v2 output root (#24765)
- fix(docs): handle Vocs search index fallback path (#24766)
- feat(era): add ere types (#24718)
- fix(rpc): expose simulated block hashes (#24705)
- chore: bump fixed-cache to 0.1.10 (#24775)
- perf: remove updates count cap (#24777)
- chore(cli): log latest re-executed block (#24785)
- fix(docs): publish Vocs v2 static output (#24789)
- fix(docs): improve reth vocs homepage buttons (#24800)
- chore: downgrade tx execution span to trace (#24781)
- feat(payload): make state pre-cache optional (#24670)
- fix(docs): load homepage styles in Vocs v2 (#24804)
- fix(docs): simplify homepage hero layout (#24805)
- feat(rpc): allow disabling rpc metrics (#24803)
- fix(docs): polish homepage layout (#24810)
- feat(db): allow disabling database metrics (#24806)
- feat(era): add `ere` group and `DynamicBlockIndex` (#24791)
- feat(payload): wire target gas limit attributes (#24502)
- fix(rpc): align eth_simulate fork handling (#24724)
- ci(bench): allow rkrasiuk to trigger PR benches (#24819)
- fix(engine): update ssz proxy endpoint paths (#24844)
- chore(docs): upgrade Vocs to v2 (#24849)
- chore(era): remove per-reader `FileReader` impls (#24854)
- fix(engine): derive SSZ newPayload versioned hashes (#24850)
- feat(era): add ere file writer and reader (#24856)
- feat(engine-ssz): add supports for `engine_getBlobsVX` methods in ssz proxy (#24887)
- fix: docs Mermaid rendering (#24892)
- chore(era): reorg tests files folders (#24898)
- feat(bench): add chrome trace profiles (#24879)
- fix(engine-ssz): accept ssz fcu v4 custody columns (#24907)
- chore(deps): bump reth-core crates to 0.4.1 (#24897)
- feat(engine-ssz): add engine capabilities and identity methods (#24906)
- feat(engine): add into_block_arc to built payload (#24960)
- feat: extend era-downloader to ere files (#24899)
- fix(payload): defer resolved job drop until after send (#24967)

## Migrations

::warning::Failed to summarize source migrations with Amp (exit 1)

 Cargo.toml | 124 ++++++++++++++++++++++++++++++-------------------------------
 1 file changed, 62 insertions(+), 62 deletions(-)

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/27116121287)
