### PR TITLE
feat(chainspec): model active protocol features as set

### DIFF
--- a/.changelog/protocol-feature-set.md
+++ b/.changelog/protocol-feature-set.md
@@ -1,0 +1,5 @@
+---
+tempo-chainspec: minor
+---
+
+Treat protocol feature activation as an active feature set and bitmap instead of a highest-ID cursor.

--- a/crates/chainspec/src/features.rs
+++ b/crates/chainspec/src/features.rs
@@ -1,21 +1,22 @@
 //! Tempo protocol feature registry.
 //!
-//! Feature IDs are 1-indexed positions in [`PROTOCOL_FEATURE_REGISTRY`]. The chain currently stores
-//! only the highest active feature ID, so zero means no active protocol features.
+//! Feature IDs are globally unique registry keys and bitmap indexes. Activation order is chain
+//! history and is not encoded by local registry order.
 
 use core::fmt;
 
-/// No protocol feature is active.
-pub const NO_ACTIVE_PROTOCOL_FEATURE_ID: u64 = 0;
+use alloy_primitives::U256;
 
-/// Storage slot containing the highest active protocol feature ID.
-pub const HIGHEST_ACTIVE_PROTOCOL_FEATURE_ID_SLOT: alloy_primitives::U256 =
-    alloy_primitives::U256::ZERO;
+/// Feature ID reserved for "no feature".
+pub const RESERVED_PROTOCOL_FEATURE_ID: u64 = 0;
+
+/// Number of feature IDs represented by one feature bitmap word.
+pub const PROTOCOL_FEATURE_BITMAP_WORD_BITS: u64 = 256;
 
 /// A protocol feature supported by this binary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProtocolFeature {
-    /// 1-indexed feature ID. This must match the feature's registry position.
+    /// Globally unique feature ID and bitmap index.
     pub id: u64,
     /// Canonical dotted feature name used in off-chain metadata and operator tooling.
     pub name: &'static str,
@@ -23,7 +24,9 @@ pub struct ProtocolFeature {
     pub minimum_supported_version_key: u64,
 }
 
-/// Protocol features supported by this binary, in activation-cursor order.
+/// Protocol features supported by this binary.
+///
+/// Order is local metadata order only. It does not encode activation order.
 pub const PROTOCOL_FEATURE_REGISTRY: &[ProtocolFeature] = &[];
 
 /// Encodes a semver version as `(major << 32) | (minor << 16) | patch`.
@@ -32,89 +35,237 @@ pub const fn version_key(major: u16, minor: u16, patch: u16) -> u64 {
     ((major as u64) << 32) | ((minor as u64) << 16) | patch as u64
 }
 
-/// Highest protocol feature ID supported by this binary.
-#[allow(clippy::cast_possible_truncation, clippy::cast_lossless)]
-pub const fn highest_supported_protocol_feature_id() -> u64 {
-    PROTOCOL_FEATURE_REGISTRY.len() as u64
-}
-
-/// Returns true if this binary supports every feature up to `highest_active_feature_id`.
-pub const fn supports_protocol_feature_id(highest_active_feature_id: u64) -> bool {
-    highest_active_feature_id <= highest_supported_protocol_feature_id()
-}
-
 /// Returns the protocol feature with `id`.
 pub fn protocol_feature_by_id(id: u64) -> Option<&'static ProtocolFeature> {
-    if id == NO_ACTIVE_PROTOCOL_FEATURE_ID {
+    protocol_feature_by_id_in(PROTOCOL_FEATURE_REGISTRY, id)
+}
+
+fn protocol_feature_by_id_in(
+    registry: &'static [ProtocolFeature],
+    id: u64,
+) -> Option<&'static ProtocolFeature> {
+    if id == RESERVED_PROTOCOL_FEATURE_ID {
         return None;
     }
-    let index = usize::try_from(id.checked_sub(1)?).ok()?;
-    PROTOCOL_FEATURE_REGISTRY.get(index)
+
+    registry.iter().find(|feature| feature.id == id)
+}
+
+/// Returns true if this binary supports `feature_id`.
+pub fn supports_protocol_feature_id(feature_id: u64) -> bool {
+    supports_protocol_feature_id_in(PROTOCOL_FEATURE_REGISTRY, feature_id)
+}
+
+fn supports_protocol_feature_id_in(registry: &'static [ProtocolFeature], feature_id: u64) -> bool {
+    protocol_feature_by_id_in(registry, feature_id).is_some()
 }
 
 /// Error returned when chain history has activated a feature this binary does not support.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct UnsupportedProtocolFeature {
-    /// Highest active feature ID read from chain state.
-    pub active: u64,
-    /// Highest feature ID supported by this binary.
-    pub supported: u64,
+pub enum UnsupportedProtocolFeature {
+    /// An active feature ID is not in this binary's registry.
+    UnsupportedFeatureId {
+        /// Active feature ID read from chain state.
+        feature_id: u64,
+    },
+    /// A bitmap bit position cannot be represented as a `u64` feature ID.
+    FeatureIdOverflow {
+        /// Active bitmap word index.
+        word_index: usize,
+        /// Active bit index within the word.
+        bit_index: usize,
+    },
 }
 
 impl fmt::Display for UnsupportedProtocolFeature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "unsupported protocol feature active: chain requires feature {}, binary supports up to {}",
-            self.active, self.supported
-        )
+        match self {
+            Self::UnsupportedFeatureId { feature_id } => write!(
+                f,
+                "unsupported protocol feature active: chain requires feature {feature_id}"
+            ),
+            Self::FeatureIdOverflow {
+                word_index,
+                bit_index,
+            } => write!(
+                f,
+                "unsupported protocol feature active: bitmap position {word_index}:{bit_index} cannot be represented as a u64 feature ID"
+            ),
+        }
     }
 }
 
-/// Validates the on-chain protocol feature cursor against this binary.
-pub const fn ensure_supported_protocol_feature_id(
-    highest_active_feature_id: u64,
+/// Validates one active protocol feature ID against this binary.
+pub fn ensure_supported_protocol_feature_id(
+    feature_id: u64,
 ) -> Result<(), UnsupportedProtocolFeature> {
-    let supported = highest_supported_protocol_feature_id();
-    if highest_active_feature_id <= supported {
+    ensure_supported_protocol_feature_id_in(PROTOCOL_FEATURE_REGISTRY, feature_id)
+}
+
+fn ensure_supported_protocol_feature_id_in(
+    registry: &'static [ProtocolFeature],
+    feature_id: u64,
+) -> Result<(), UnsupportedProtocolFeature> {
+    if supports_protocol_feature_id_in(registry, feature_id) {
         Ok(())
     } else {
-        Err(UnsupportedProtocolFeature {
-            active: highest_active_feature_id,
-            supported,
-        })
+        Err(UnsupportedProtocolFeature::UnsupportedFeatureId { feature_id })
     }
+}
+
+/// Validates active protocol feature IDs against this binary.
+pub fn ensure_supported_protocol_feature_ids(
+    active_feature_ids: impl IntoIterator<Item = u64>,
+) -> Result<(), UnsupportedProtocolFeature> {
+    ensure_supported_protocol_feature_ids_in(PROTOCOL_FEATURE_REGISTRY, active_feature_ids)
+}
+
+fn ensure_supported_protocol_feature_ids_in(
+    registry: &'static [ProtocolFeature],
+    active_feature_ids: impl IntoIterator<Item = u64>,
+) -> Result<(), UnsupportedProtocolFeature> {
+    for feature_id in active_feature_ids {
+        ensure_supported_protocol_feature_id_in(registry, feature_id)?;
+    }
+
+    Ok(())
+}
+
+/// Returns the bitmap word and bit index for `feature_id`.
+pub fn protocol_feature_bitmap_position(feature_id: u64) -> Option<(usize, usize)> {
+    let word_index = usize::try_from(feature_id / PROTOCOL_FEATURE_BITMAP_WORD_BITS).ok()?;
+    let bit_index = usize::try_from(feature_id % PROTOCOL_FEATURE_BITMAP_WORD_BITS).ok()?;
+    Some((word_index, bit_index))
+}
+
+fn protocol_feature_id_from_bitmap_position(
+    word_index: usize,
+    bit_index: usize,
+) -> Result<u64, UnsupportedProtocolFeature> {
+    let original_word_index = word_index;
+    let original_bit_index = bit_index;
+    let word_index =
+        u64::try_from(word_index).map_err(|_| UnsupportedProtocolFeature::FeatureIdOverflow {
+            word_index: original_word_index,
+            bit_index: original_bit_index,
+        })?;
+    let bit_index =
+        u64::try_from(bit_index).map_err(|_| UnsupportedProtocolFeature::FeatureIdOverflow {
+            word_index: original_word_index,
+            bit_index: original_bit_index,
+        })?;
+
+    word_index
+        .checked_mul(PROTOCOL_FEATURE_BITMAP_WORD_BITS)
+        .and_then(|base| base.checked_add(bit_index))
+        .ok_or(UnsupportedProtocolFeature::FeatureIdOverflow {
+            word_index: original_word_index,
+            bit_index: original_bit_index,
+        })
+}
+
+/// Returns true if `active_feature_bitmap` contains `feature_id`.
+pub fn protocol_feature_bitmap_contains(active_feature_bitmap: &[U256], feature_id: u64) -> bool {
+    let Some((word_index, bit_index)) = protocol_feature_bitmap_position(feature_id) else {
+        return false;
+    };
+    let Some(word) = active_feature_bitmap.get(word_index) else {
+        return false;
+    };
+
+    (*word & (U256::ONE << bit_index)) != U256::ZERO
+}
+
+/// Validates an active protocol feature bitmap against this binary.
+pub fn ensure_supported_protocol_feature_bitmap(
+    active_feature_bitmap: &[U256],
+) -> Result<(), UnsupportedProtocolFeature> {
+    ensure_supported_protocol_feature_bitmap_in(PROTOCOL_FEATURE_REGISTRY, active_feature_bitmap)
+}
+
+fn ensure_supported_protocol_feature_bitmap_in(
+    registry: &'static [ProtocolFeature],
+    active_feature_bitmap: &[U256],
+) -> Result<(), UnsupportedProtocolFeature> {
+    for (word_index, word) in active_feature_bitmap.iter().enumerate() {
+        if *word == U256::ZERO {
+            continue;
+        }
+
+        for bit_index in 0..usize::try_from(PROTOCOL_FEATURE_BITMAP_WORD_BITS)
+            .expect("bitmap word bit count fits in usize")
+        {
+            if (*word & (U256::ONE << bit_index)) == U256::ZERO {
+                continue;
+            }
+
+            let feature_id = protocol_feature_id_from_bitmap_position(word_index, bit_index)?;
+            ensure_supported_protocol_feature_id_in(registry, feature_id)?;
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    const TEST_REGISTRY: &[ProtocolFeature] = &[
+        ProtocolFeature {
+            id: 2,
+            name: "tempo.two",
+            minimum_supported_version_key: version_key(1, 0, 0),
+        },
+        ProtocolFeature {
+            id: 9,
+            name: "tempo.nine",
+            minimum_supported_version_key: version_key(1, 1, 0),
+        },
+    ];
+
     #[test]
-    fn zero_means_no_active_feature() {
-        assert_eq!(NO_ACTIVE_PROTOCOL_FEATURE_ID, 0);
+    fn zero_is_reserved() {
+        assert_eq!(RESERVED_PROTOCOL_FEATURE_ID, 0);
         assert_eq!(protocol_feature_by_id(0), None);
-        assert!(supports_protocol_feature_id(0));
+        assert!(!supports_protocol_feature_id(0));
     }
 
     #[test]
-    fn feature_ids_match_registry_order() {
-        for (offset, feature) in PROTOCOL_FEATURE_REGISTRY.iter().enumerate() {
-            let expected_id = u64::try_from(offset).expect("feature offset fits in u64") + 1;
-            assert_eq!(feature.id, expected_id);
-            assert_eq!(protocol_feature_by_id(feature.id), Some(feature));
-        }
-    }
-
-    #[test]
-    fn rejects_active_feature_past_local_registry() {
-        let unsupported = highest_supported_protocol_feature_id() + 1;
+    fn feature_ids_are_registry_keys_not_positions() {
+        assert_eq!(protocol_feature_by_id_in(TEST_REGISTRY, 1), None);
         assert_eq!(
-            ensure_supported_protocol_feature_id(unsupported),
-            Err(UnsupportedProtocolFeature {
-                active: unsupported,
-                supported: highest_supported_protocol_feature_id(),
-            })
+            protocol_feature_by_id_in(TEST_REGISTRY, 2),
+            Some(&TEST_REGISTRY[0])
+        );
+        assert_eq!(
+            protocol_feature_by_id_in(TEST_REGISTRY, 9),
+            Some(&TEST_REGISTRY[1])
+        );
+    }
+
+    #[test]
+    fn validates_active_feature_ids_as_a_set() {
+        assert!(ensure_supported_protocol_feature_ids_in(TEST_REGISTRY, [2, 9]).is_ok());
+        assert_eq!(
+            ensure_supported_protocol_feature_ids_in(TEST_REGISTRY, [2, 4]),
+            Err(UnsupportedProtocolFeature::UnsupportedFeatureId { feature_id: 4 })
+        );
+    }
+
+    #[test]
+    fn validates_active_feature_bitmap_by_feature_id_bits() {
+        let bitmap = [U256::ONE << 2 | U256::ONE << 9];
+
+        assert!(protocol_feature_bitmap_contains(&bitmap, 2));
+        assert!(protocol_feature_bitmap_contains(&bitmap, 9));
+        assert!(!protocol_feature_bitmap_contains(&bitmap, 1));
+        assert!(ensure_supported_protocol_feature_bitmap_in(TEST_REGISTRY, &bitmap).is_ok());
+
+        let unsupported_bitmap = [bitmap[0] | (U256::ONE << 4)];
+        assert_eq!(
+            ensure_supported_protocol_feature_bitmap_in(TEST_REGISTRY, &unsupported_bitmap),
+            Err(UnsupportedProtocolFeature::UnsupportedFeatureId { feature_id: 4 })
         );
     }
 


### PR DESCRIPTION
Refs TIP-1063

Models active protocol features as a set of feature IDs and bitmap words instead of a highest active feature ID cursor. This keeps node-side validation aligned with TIP-1063, where feature IDs are registry keys and activation order comes from chain history.