### PR TITLE
feat(contracts): add feature tip ABI

### DIFF
--- a/.changelog/feature-registry-abi.md
+++ b/.changelog/feature-registry-abi.md
@@ -1,0 +1,5 @@
+---
+tempo-contracts: minor
+---
+
+Add the TIP-1063 feature registry ABI and exported event and error aliases.

--- a/.changelog/feature-registry-abi.md
+++ b/.changelog/feature-registry-abi.md
@@ -2,4 +2,4 @@
 tempo-contracts: minor
 ---
 
-Add the TIP-1063 feature registry ABI and exported event and error aliases.
+Add the TIP-1063 feature tip ABI and exported event and error aliases.

--- a/crates/contracts/src/precompiles/feature_registry.rs
+++ b/crates/contracts/src/precompiles/feature_registry.rs
@@ -3,182 +3,77 @@ pub use IFeatureRegistry::{
 };
 
 crate::sol! {
-    /// Registry for Tempo protocol feature activation.
+    /// Registry for Tempo protocol feature tip scheduling.
+    ///
+    /// The feature tip is the highest active protocol feature ID. A chain with feature tip `N`
+    /// treats every feature ID in `1..=N` as active.
     #[derive(Debug, PartialEq, Eq)]
     #[sol(abi)]
     interface IFeatureRegistry {
-        enum FeatureStatus {
-            Pending,
-            Active
-        }
-
-        struct Feature {
-            uint64 minimumSupportedVersionKey;
-            FeatureStatus status;
-            uint64 activationEpoch;
-        }
-
-        struct MinimumVersionCheckpoint {
-            uint64 minimumVersionKey;
-            uint256 supportCount;
-        }
-
-        /// @notice Returns the registry owner authorized to register features and schedule activation.
+        /// @notice Returns the registry owner authorized to schedule feature tip activation.
         function owner() external view returns (address);
 
         /// @notice Returns the fixed global activation quorum threshold: 4/5, or 80%.
         function activationQuorum() external view returns (uint256 numerator, uint256 denominator);
 
-        /// @notice Registers a new pending feature.
-        function registerFeature(
-            uint64 featureId,
-            uint64 minimumSupportedVersionKey
-        ) external;
+        /// @notice Returns the highest active protocol feature ID.
+        function featuresTip() external view returns (uint64);
 
-        /// @notice Registers a minimum version checkpoint that can be used for feature activation.
-        function minimum_required_version(uint64 minimumVersionKey) external;
+        /// @notice Returns the scheduled feature tip and earliest activation epoch.
+        function scheduledFeaturesTip() external view returns (uint64 featuresTip, uint64 activationEpoch);
 
-        /// @notice Reports that an active validator is running at least the checkpoint version.
-        function reportMinimumVersionSupport(
-            address validator,
-            uint64 minimumVersionKey,
-            uint64 validatorVersionKey
-        ) external;
+        /// @notice Reports the highest protocol feature ID a validator supports.
+        function setSupportedFeaturesTip(address validator, uint64 featuresTip) external;
 
-        /// @notice Schedules activation for a pending feature.
-        function scheduleActivation(uint64 featureId, uint64 activationEpoch) external;
+        /// @notice Schedules a higher feature tip for activation at the target epoch.
+        function scheduleFeaturesTip(uint64 featuresTip, uint64 activationEpoch) external;
 
-        /// @notice Activates a scheduled feature at or after its activation epoch if all checks pass.
-        function activateFeature(uint64 featureId) external;
+        /// @notice Cancels the scheduled feature tip before activation.
+        function cancelScheduledFeaturesTip() external;
 
-        /// @notice Replaces the activation epoch for a scheduled pending feature.
-        function rescheduleActivation(uint64 featureId, uint64 activationEpoch) external;
+        /// @notice Returns the latest feature tip reported by a validator.
+        function validatorSupportedFeaturesTip(address validator) external view returns (uint64);
 
-        /// @notice Cancels a scheduled activation before the feature becomes active.
-        function cancelScheduledActivation(uint64 featureId) external;
+        /// @notice Returns current active-validator support for a feature tip.
+        function featuresTipSupportCount(uint64 featuresTip) external view returns (uint256 support, uint256 required);
 
-        /// @notice Returns the registered feature metadata and current status.
-        function getFeature(uint64 featureId) external view returns (Feature memory);
+        /// @notice Returns whether a feature tip has quorum support from the active validator set.
+        function hasFeaturesTipQuorum(uint64 featuresTip) external view returns (bool);
 
-        /// @notice Returns whether a feature is registered.
-        function isFeatureRegistered(uint64 featureId) external view returns (bool);
+        /// @notice Emitted when a validator reports support for a feature tip.
+        event SupportedFeaturesTipSet(address indexed validator, uint64 featuresTip, uint256 supportCount);
 
-        /// @notice Returns whether a feature is active at the current block.
-        function isFeatureActive(uint64 featureId) external view returns (bool);
+        /// @notice Emitted when a higher feature tip is scheduled for activation.
+        event FeaturesTipScheduled(uint64 featuresTip, uint64 activationEpoch);
 
-        /// @notice Returns one word from the active feature bitmap.
-        function activeFeatureBitmapWord(uint256 wordIndex) external view returns (uint256);
+        /// @notice Emitted when the scheduled feature tip is cancelled.
+        event FeaturesTipScheduleCancelled(uint64 featuresTip);
 
-        /// @notice Returns the number of active features recorded in activation order.
-        function activeFeatureCount() external view returns (uint256);
+        /// @notice Emitted when a scheduled feature tip becomes active during epoch processing.
+        event FeaturesTipActivated(uint64 previousFeaturesTip, uint64 featuresTip, uint64 activationEpoch);
 
-        /// @notice Returns the active feature ID at a zero-based activation-order index.
-        function activeFeatureAt(uint256 index) external view returns (uint64);
-
-        /// @notice Returns the number of features scheduled for a given activation epoch.
-        function scheduledFeatureCount(uint64 activationEpoch) external view returns (uint256);
-
-        /// @notice Returns the scheduled feature ID at a zero-based index for an activation epoch.
-        function scheduledFeatureAt(uint64 activationEpoch, uint256 index) external view returns (uint64);
-
-        /// @notice Returns the latest Tempo version key reported by a validator.
-        function validatorVersionKey(address validator) external view returns (uint64);
-
-        /// @notice Returns a registered minimum version checkpoint.
-        function minimumVersionCheckpoint(uint64 minimumVersionKey) external view returns (MinimumVersionCheckpoint memory);
-
-        /// @notice Returns whether a minimum version checkpoint is registered.
-        function isMinimumVersionCheckpointRegistered(uint64 minimumVersionKey) external view returns (bool);
-
-        /// @notice Returns whether a validator has reported support for a minimum version.
-        function validatorSupportsMinimumVersion(address validator, uint64 minimumVersionKey) external view returns (bool);
-
-        /// @notice Returns current support for a minimum version.
-        function minimumVersionSupportCount(uint64 minimumVersionKey) external view returns (uint256 support, uint256 required);
-
-        /// @notice Returns whether a minimum version has quorum support.
-        function hasMinimumVersionQuorum(uint64 minimumVersionKey) external view returns (bool);
-
-        /// @notice Returns whether a validator's reported version supports a feature.
-        function validatorSupportsFeature(address validator, uint64 featureId) external view returns (bool);
-
-        /// @notice Returns current active-validator support for a feature.
-        function featureSupportCount(uint64 featureId) external view returns (uint256 support, uint256 required);
-
-        /// @notice Returns whether a feature has quorum support from the active validator set.
-        function hasQuorum(uint64 featureId) external view returns (bool);
-
-        /// @notice Emitted when a feature is registered.
-        event FeatureRegistered(uint64 featureId, uint64 minimumSupportedVersionKey);
-
-        /// @notice Emitted when a minimum version checkpoint is registered.
-        event MinimumVersionCheckpointRegistered(uint64 minimumVersionKey);
-
-        /// @notice Emitted when a validator reports support for a minimum version.
-        event MinimumVersionSupportReported(address indexed validator, uint64 minimumVersionKey, uint256 supportCount);
-
-        /// @notice Emitted when a pending feature is scheduled for activation.
-        event FeatureScheduled(uint64 featureId, uint64 activationEpoch);
-
-        /// @notice Emitted when a pending feature's activation epoch is replaced.
-        event FeatureRescheduled(uint64 featureId, uint64 activationEpoch);
-
-        /// @notice Emitted when a scheduled feature is cancelled.
-        event FeatureScheduleCancelled(uint64 featureId);
-
-        /// @notice Emitted when a scheduled feature becomes active.
-        event FeatureActivated(uint64 featureId, uint64 activationEpoch);
-
-        /// @notice Emitted when a scheduled feature remains pending after an activation attempt fails.
-        event FeatureActivationFailed(
-            uint64 featureId,
-            uint64 activationEpoch,
-            bool quorumSatisfied
-        );
-
-        /// @notice Emitted when the active validator support count changes.
-        event FeatureSupportUpdated(uint64 featureId, uint256 support, uint256 required);
+        /// @notice Emitted when active validator support for a feature tip changes.
+        event FeaturesTipSupportUpdated(uint64 featuresTip, uint256 support, uint256 required);
 
         /// @notice Caller is not authorized to update feature registry state.
         error Unauthorized();
 
-        /// @notice Feature ID is invalid or reserved.
-        error InvalidFeatureId();
+        /// @notice Feature tip is invalid or reserved.
+        error InvalidFeaturesTip();
 
-        /// @notice Tempo version is not canonical or cannot be encoded.
-        error InvalidVersion();
+        /// @notice Feature tip must be higher than the current active feature tip.
+        error FeaturesTipNotIncreasing();
 
-        /// @notice Minimum version checkpoint is already registered.
-        error MinimumVersionCheckpointAlreadyRegistered();
+        /// @notice Validator cannot lower its reported supported feature tip.
+        error SupportedFeaturesTipDecreased();
 
-        /// @notice Minimum version checkpoint is not registered.
-        error MinimumVersionCheckpointNotRegistered();
+        /// @notice A feature tip is already scheduled for activation.
+        error FeaturesTipAlreadyScheduled();
 
-        /// @notice Validator has already reported support for this minimum version.
-        error MinimumVersionSupportAlreadyReported();
-
-        /// @notice Validator's reported version is below the minimum version.
-        error ValidatorVersionBelowMinimum();
-
-        /// @notice Feature is already registered.
-        error FeatureAlreadyRegistered();
-
-        /// @notice Feature is not registered.
-        error FeatureNotRegistered();
-
-        /// @notice Feature is not pending.
-        error FeatureNotPending();
-
-        /// @notice Feature already has a scheduled activation epoch.
-        error FeatureAlreadyScheduled();
-
-        /// @notice Feature does not have a scheduled activation epoch.
-        error FeatureNotScheduled();
+        /// @notice No feature tip is scheduled for activation.
+        error FeaturesTipNotScheduled();
 
         /// @notice Requested activation epoch is not strictly greater than the current epoch.
         error ActivationEpochNotFuture();
-
-        /// @notice Feature cannot be activated before its scheduled activation epoch.
-        error ActivationEpochNotReached();
     }
 }

--- a/crates/contracts/src/precompiles/feature_registry.rs
+++ b/crates/contracts/src/precompiles/feature_registry.rs
@@ -14,7 +14,6 @@ crate::sol! {
 
         struct Feature {
             uint64 minimumSupportedVersionKey;
-            uint256[] requiredFeatureBitmap;
             FeatureStatus status;
             uint64 activationEpoch;
         }
@@ -33,8 +32,7 @@ crate::sol! {
         /// @notice Registers a new pending feature.
         function registerFeature(
             uint64 featureId,
-            uint64 minimumSupportedVersionKey,
-            uint256[] calldata requiredFeatureBitmap
+            uint64 minimumSupportedVersionKey
         ) external;
 
         /// @notice Registers a minimum version checkpoint that can be used for feature activation.
@@ -110,11 +108,8 @@ crate::sol! {
         /// @notice Returns whether a feature has quorum support from the active validator set.
         function hasQuorum(uint64 featureId) external view returns (bool);
 
-        /// @notice Returns whether a feature's required features are already active from earlier epochs.
-        function requiredFeaturesSatisfied(uint64 featureId) external view returns (bool);
-
         /// @notice Emitted when a feature is registered.
-        event FeatureRegistered(uint64 featureId, uint64 minimumSupportedVersionKey, uint256[] requiredFeatureBitmap);
+        event FeatureRegistered(uint64 featureId, uint64 minimumSupportedVersionKey);
 
         /// @notice Emitted when a minimum version checkpoint is registered.
         event MinimumVersionCheckpointRegistered(uint64 minimumVersionKey);
@@ -138,7 +133,6 @@ crate::sol! {
         event FeatureActivationFailed(
             uint64 featureId,
             uint64 activationEpoch,
-            bool requiredFeaturesSatisfied,
             bool quorumSatisfied
         );
 
@@ -171,9 +165,6 @@ crate::sol! {
 
         /// @notice Feature is not registered.
         error FeatureNotRegistered();
-
-        /// @notice Required feature bitmap is malformed, self-referential, cyclic, or references an unregistered feature.
-        error InvalidRequiredFeatureBitmap();
 
         /// @notice Feature is not pending.
         error FeatureNotPending();

--- a/crates/contracts/src/precompiles/feature_registry.rs
+++ b/crates/contracts/src/precompiles/feature_registry.rs
@@ -1,0 +1,193 @@
+pub use IFeatureRegistry::{
+    IFeatureRegistryErrors as FeatureRegistryError, IFeatureRegistryEvents as FeatureRegistryEvent,
+};
+
+crate::sol! {
+    /// Registry for Tempo protocol feature activation.
+    #[derive(Debug, PartialEq, Eq)]
+    #[sol(abi)]
+    interface IFeatureRegistry {
+        enum FeatureStatus {
+            Pending,
+            Active
+        }
+
+        struct Feature {
+            uint64 minimumSupportedVersionKey;
+            uint256[] requiredFeatureBitmap;
+            FeatureStatus status;
+            uint64 activationEpoch;
+        }
+
+        struct MinimumVersionCheckpoint {
+            uint64 minimumVersionKey;
+            uint256 supportCount;
+        }
+
+        /// @notice Returns the registry owner authorized to register features and schedule activation.
+        function owner() external view returns (address);
+
+        /// @notice Returns the fixed global activation quorum threshold: 4/5, or 80%.
+        function activationQuorum() external view returns (uint256 numerator, uint256 denominator);
+
+        /// @notice Registers a new pending feature.
+        function registerFeature(
+            uint64 featureId,
+            uint64 minimumSupportedVersionKey,
+            uint256[] calldata requiredFeatureBitmap
+        ) external;
+
+        /// @notice Registers a minimum version checkpoint that can be used for feature activation.
+        function minimum_required_version(uint64 minimumVersionKey) external;
+
+        /// @notice Reports that an active validator is running at least the checkpoint version.
+        function reportMinimumVersionSupport(
+            address validator,
+            uint64 minimumVersionKey,
+            uint64 validatorVersionKey
+        ) external;
+
+        /// @notice Schedules activation for a pending feature.
+        function scheduleActivation(uint64 featureId, uint64 activationEpoch) external;
+
+        /// @notice Activates a scheduled feature at or after its activation epoch if all checks pass.
+        function activateFeature(uint64 featureId) external;
+
+        /// @notice Replaces the activation epoch for a scheduled pending feature.
+        function rescheduleActivation(uint64 featureId, uint64 activationEpoch) external;
+
+        /// @notice Cancels a scheduled activation before the feature becomes active.
+        function cancelScheduledActivation(uint64 featureId) external;
+
+        /// @notice Returns the registered feature metadata and current status.
+        function getFeature(uint64 featureId) external view returns (Feature memory);
+
+        /// @notice Returns whether a feature is registered.
+        function isFeatureRegistered(uint64 featureId) external view returns (bool);
+
+        /// @notice Returns whether a feature is active at the current block.
+        function isFeatureActive(uint64 featureId) external view returns (bool);
+
+        /// @notice Returns one word from the active feature bitmap.
+        function activeFeatureBitmapWord(uint256 wordIndex) external view returns (uint256);
+
+        /// @notice Returns the number of active features recorded in activation order.
+        function activeFeatureCount() external view returns (uint256);
+
+        /// @notice Returns the active feature ID at a zero-based activation-order index.
+        function activeFeatureAt(uint256 index) external view returns (uint64);
+
+        /// @notice Returns the number of features scheduled for a given activation epoch.
+        function scheduledFeatureCount(uint64 activationEpoch) external view returns (uint256);
+
+        /// @notice Returns the scheduled feature ID at a zero-based index for an activation epoch.
+        function scheduledFeatureAt(uint64 activationEpoch, uint256 index) external view returns (uint64);
+
+        /// @notice Returns the latest Tempo version key reported by a validator.
+        function validatorVersionKey(address validator) external view returns (uint64);
+
+        /// @notice Returns a registered minimum version checkpoint.
+        function minimumVersionCheckpoint(uint64 minimumVersionKey) external view returns (MinimumVersionCheckpoint memory);
+
+        /// @notice Returns whether a minimum version checkpoint is registered.
+        function isMinimumVersionCheckpointRegistered(uint64 minimumVersionKey) external view returns (bool);
+
+        /// @notice Returns whether a validator has reported support for a minimum version.
+        function validatorSupportsMinimumVersion(address validator, uint64 minimumVersionKey) external view returns (bool);
+
+        /// @notice Returns current support for a minimum version.
+        function minimumVersionSupportCount(uint64 minimumVersionKey) external view returns (uint256 support, uint256 required);
+
+        /// @notice Returns whether a minimum version has quorum support.
+        function hasMinimumVersionQuorum(uint64 minimumVersionKey) external view returns (bool);
+
+        /// @notice Returns whether a validator's reported version supports a feature.
+        function validatorSupportsFeature(address validator, uint64 featureId) external view returns (bool);
+
+        /// @notice Returns current active-validator support for a feature.
+        function featureSupportCount(uint64 featureId) external view returns (uint256 support, uint256 required);
+
+        /// @notice Returns whether a feature has quorum support from the active validator set.
+        function hasQuorum(uint64 featureId) external view returns (bool);
+
+        /// @notice Returns whether a feature's required features are already active from earlier epochs.
+        function requiredFeaturesSatisfied(uint64 featureId) external view returns (bool);
+
+        /// @notice Emitted when a feature is registered.
+        event FeatureRegistered(uint64 featureId, uint64 minimumSupportedVersionKey, uint256[] requiredFeatureBitmap);
+
+        /// @notice Emitted when a minimum version checkpoint is registered.
+        event MinimumVersionCheckpointRegistered(uint64 minimumVersionKey);
+
+        /// @notice Emitted when a validator reports support for a minimum version.
+        event MinimumVersionSupportReported(address indexed validator, uint64 minimumVersionKey, uint256 supportCount);
+
+        /// @notice Emitted when a pending feature is scheduled for activation.
+        event FeatureScheduled(uint64 featureId, uint64 activationEpoch);
+
+        /// @notice Emitted when a pending feature's activation epoch is replaced.
+        event FeatureRescheduled(uint64 featureId, uint64 activationEpoch);
+
+        /// @notice Emitted when a scheduled feature is cancelled.
+        event FeatureScheduleCancelled(uint64 featureId);
+
+        /// @notice Emitted when a scheduled feature becomes active.
+        event FeatureActivated(uint64 featureId, uint64 activationEpoch);
+
+        /// @notice Emitted when a scheduled feature remains pending after an activation attempt fails.
+        event FeatureActivationFailed(
+            uint64 featureId,
+            uint64 activationEpoch,
+            bool requiredFeaturesSatisfied,
+            bool quorumSatisfied
+        );
+
+        /// @notice Emitted when the active validator support count changes.
+        event FeatureSupportUpdated(uint64 featureId, uint256 support, uint256 required);
+
+        /// @notice Caller is not authorized to update feature registry state.
+        error Unauthorized();
+
+        /// @notice Feature ID is invalid or reserved.
+        error InvalidFeatureId();
+
+        /// @notice Tempo version is not canonical or cannot be encoded.
+        error InvalidVersion();
+
+        /// @notice Minimum version checkpoint is already registered.
+        error MinimumVersionCheckpointAlreadyRegistered();
+
+        /// @notice Minimum version checkpoint is not registered.
+        error MinimumVersionCheckpointNotRegistered();
+
+        /// @notice Validator has already reported support for this minimum version.
+        error MinimumVersionSupportAlreadyReported();
+
+        /// @notice Validator's reported version is below the minimum version.
+        error ValidatorVersionBelowMinimum();
+
+        /// @notice Feature is already registered.
+        error FeatureAlreadyRegistered();
+
+        /// @notice Feature is not registered.
+        error FeatureNotRegistered();
+
+        /// @notice Required feature bitmap is malformed, self-referential, cyclic, or references an unregistered feature.
+        error InvalidRequiredFeatureBitmap();
+
+        /// @notice Feature is not pending.
+        error FeatureNotPending();
+
+        /// @notice Feature already has a scheduled activation epoch.
+        error FeatureAlreadyScheduled();
+
+        /// @notice Feature does not have a scheduled activation epoch.
+        error FeatureNotScheduled();
+
+        /// @notice Requested activation epoch is not strictly greater than the current epoch.
+        error ActivationEpochNotFuture();
+
+        /// @notice Feature cannot be activated before its scheduled activation epoch.
+        error ActivationEpochNotReached();
+    }
+}

--- a/crates/contracts/src/precompiles/feature_registry.rs
+++ b/crates/contracts/src/precompiles/feature_registry.rs
@@ -35,7 +35,7 @@ crate::sol! {
         function validatorSupportedFeaturesTip(address validator) external view returns (uint64);
 
         /// @notice Returns current active-validator support for a feature tip.
-        function featuresTipSupportCount(uint64 featuresTip) external view returns (uint256 support, uint256 required);
+        function featuresTipSupport(uint64 featuresTip) external view returns (uint256 support, uint256 required);
 
         /// @notice Returns whether a feature tip has quorum support from the active validator set.
         function hasFeaturesTipQuorum(uint64 featuresTip) external view returns (bool);

--- a/crates/contracts/src/precompiles/mod.rs
+++ b/crates/contracts/src/precompiles/mod.rs
@@ -1,6 +1,7 @@
 pub mod account_keychain;
 pub mod address_registry;
 pub mod common_errors;
+pub mod feature_registry;
 pub mod nonce;
 pub mod receive_policy_guard;
 pub mod signature_verifier;
@@ -17,6 +18,7 @@ pub use account_keychain::*;
 pub use address_registry::*;
 use alloy_primitives::{Address, address};
 pub use common_errors::*;
+pub use feature_registry::*;
 pub use nonce::*;
 pub use receive_policy_guard::*;
 pub use signature_verifier::*;


### PR DESCRIPTION
Refs TIP-1063

Adds a feature tip ABI for the protocol feature registry. The feature tip is the highest active feature ID; validator support, scheduling, activation state, and quorum reads are exposed around that cursor instead of per-feature registration.