### PR TITLE
docs(tip-1063): clarify feature flag activation model

### DIFF
--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -16,7 +16,7 @@ This TIP defines protocol feature flags for Tempo protocol changes, decoupling c
 
 Each feature ships inactive in a Tempo release and is assigned a monotonically increasing feature ID. The chain stores a single active feature tip: the edge of the active feature-flag set and the highest active feature ID. A chain with feature tip `N` treats every feature ID in `1..=N` as active.
 
-The registry owner schedules a higher feature tip for a future activation epoch. The scheduled tip becomes active through deterministic epoch processing once the target epoch has been reached and the current active validator set has quorum for that tip.
+The registry owner schedules a higher feature tip for a future activation epoch. Feature activation occurs in the first block of that consensus epoch, and the scheduled tip becomes active if the current active validator set has quorum for it.
 
 ## Motivation
 
@@ -34,11 +34,11 @@ Feature IDs define a contiguous activation namespace. If a feature ID is skipped
 
 The active feature-flag set is represented by a single onchain cursor, `features_tip`, also called the active feature tip. If `features_tip == N`, every feature ID from `1` through `N` is active and every feature ID greater than `N` is inactive. The chain does not store per-feature activation structures or dependency metadata.
 
-Feature ordering is the dependency model. A feature that depends on another feature must receive a higher feature ID than the feature it depends on. Source-controlled metadata records human-readable feature names, descriptions, TIP references, and implementation notes keyed by `feature_id`; the chain stores only the state required for deterministic activation.
+Feature ordering is the dependency model. A feature that depends on another feature must receive a higher feature ID than the feature it depends on. Source-controlled metadata records human-readable feature names, descriptions, TIP references, and implementation notes keyed by `feature_id`; the chain stores only the state required for activation.
 
 Validators report the highest feature ID they support. A validator supports target tip `N` when its latest reported supported feature tip is greater than or equal to `N`. Feature support is monotonic by design: a validator that supports feature tip `N` also supports every lower feature ID.
 
-Activation eligibility is bound to epoch numbers rather than wall-clock timestamps. The registry owner schedules a target feature tip and an activation epoch. At the first block of that epoch, deterministic epoch processing advances `features_tip` if the current active validator set has quorum for the scheduled target. No external activation transaction is required.
+Activation eligibility is bound to consensus epochs rather than wall-clock timestamps. The registry owner schedules a target feature tip and an activation epoch. Feature activation occurs in the first block of that epoch, where the chain advances `features_tip` if the current active validator set has quorum for the scheduled target. No external activation transaction is required.
 
 ## Feature Registry
 
@@ -73,21 +73,21 @@ Registry state changes must be observable through events for scheduling, cancell
 
 The registry owner schedules activation by submitting a registry transaction with a target feature tip and a future activation epoch. The registry accepts the scheduling transaction only if the target tip is higher than the current `features_tip`, no other feature tip is scheduled, and the requested activation epoch is strictly greater than the current epoch.
 
-Scheduling writes `scheduled_features_tip` and `scheduled_activation_epoch`, then emits an event to notify network participants. The scheduled epoch is the earliest epoch in which the chain attempts to advance to the target tip. Operators should upgrade before that epoch if they are running a release that supports a lower feature tip.
+Scheduling writes `scheduled_features_tip` and `scheduled_activation_epoch`, then emits an event to notify network participants. The scheduled epoch is the earliest consensus epoch in which the chain attempts to advance to the target tip. Operators should upgrade before that epoch if they are running a release that supports a lower feature tip.
 
-At the first block of `scheduled_activation_epoch`, deterministic epoch processing evaluates whether the active validator set has quorum for `scheduled_features_tip`.
+Feature activation occurs in the first block of `scheduled_activation_epoch`. At feature activation, the chain evaluates whether the active validator set has quorum for `scheduled_features_tip`.
 
-For quorum checks, the active validator set is the canonical validator set for the epoch containing the activation-check block, derived from the chain's validator configuration state by the same rules used for consensus block validation. The registry does not keep a separate validator roster for feature activation.
+For quorum checks, the active validator set is the canonical validator set for `scheduled_activation_epoch`, derived from the chain's validator configuration state by the same rules used for consensus block validation. The registry does not keep a separate validator roster for feature activation.
 
-To evaluate support for target tip `N`, deterministic epoch processing iterates that active validator set and counts each validator whose `validator_supported_features_tip[validator] >= N`. A scheduled tip has quorum when at least 80% of active validators support it. The quorum denominator is the size of the active validator set at the activation-check block, and the required validator count is `ceil(4 * active_validator_count / 5)`.
+To evaluate support for target tip `N`, the quorum check iterates that active validator set and counts each validator whose `validator_supported_features_tip[validator] >= N`. A scheduled tip has quorum when at least 80% of active validators support it. The quorum denominator is the size of the active validator set at feature activation, and the required validator count is `ceil(4 * active_validator_count / 5)`.
 
-If quorum is satisfied, the chain sets `features_tip` to `scheduled_features_tip`, clears the scheduled tip fields, and emits an activation event. The block that records the new feature tip is the activation block; protocol behavior gated by newly active features applies to subsequent blocks unless a feature's own TIP specifies transition-block behavior.
+If quorum is satisfied at feature activation, the chain sets `features_tip` to `scheduled_features_tip`, clears the scheduled tip fields, and emits an activation event. Protocol behavior gated by newly active features applies to subsequent blocks unless a feature's own TIP specifies transition-block behavior.
 
-If quorum is not satisfied, the chain clears `scheduled_features_tip` and `scheduled_activation_epoch`, emits an activation failure event, and leaves `features_tip` unchanged. The registry owner can schedule the same or a higher feature tip for a later epoch after the missing quorum condition is resolved.
+If quorum is not satisfied at feature activation, the chain clears `scheduled_features_tip` and `scheduled_activation_epoch`, emits an activation failure event, and leaves `features_tip` unchanged. The registry owner can schedule the same or a higher feature tip for a later epoch after the missing quorum condition is resolved.
 
-Nodes derive the active feature set from registry state. Validators, RPC nodes, consensus-layer clients, and other infrastructure must use the same active feature tip when evaluating protocol behavior for a block. Once a feature is active, any node that validates, builds, simulates, or serves protocol behavior for later blocks must support the active feature tip that includes it.
+Nodes derive the active feature set from registry state. Validators, RPC nodes, consensus-layer clients, and other infrastructure must use the same active feature tip when evaluating protocol behavior for a block. After feature activation, any node that validates, builds, simulates, or serves protocol behavior for later blocks must support the active feature tip that includes it.
 
-Once a feature is active, support for the active feature tip that includes it is a requirement for any validator joining the active validator set. Tempo does not continuously recheck quorum after activation, and loss of support after activation does not roll back the active feature tip.
+Support for the active feature tip that includes an active feature is a requirement for any validator joining the active validator set. Tempo does not continuously recheck quorum after activation, and loss of support after activation does not roll back the active feature tip.
 
 ## Validator Feature Tip Reporting
 
@@ -167,10 +167,10 @@ event FeaturesTipScheduled(uint64 featuresTip, uint64 activationEpoch);
 /// @notice Emitted when the scheduled feature tip is cancelled.
 event FeaturesTipScheduleCancelled(uint64 featuresTip);
 
-/// @notice Emitted when a scheduled feature tip becomes active during epoch processing.
+/// @notice Emitted at feature activation when a scheduled feature tip becomes active.
 event FeaturesTipActivated(uint64 previousFeaturesTip, uint64 featuresTip, uint64 activationEpoch);
 
-/// @notice Emitted when a scheduled feature tip fails to activate during epoch processing.
+/// @notice Emitted at feature activation when a scheduled feature tip fails to activate.
 event FeaturesTipActivationFailed(uint64 featuresTip, uint64 activationEpoch, uint256 support, uint256 required);
 
 /// @notice Emitted when active validator support for a feature tip changes.

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -38,7 +38,7 @@ Feature ordering is the dependency model. A feature that depends on another feat
 
 Validators report the highest feature ID they support. A validator supports target tip `N` when its latest reported supported feature tip is greater than or equal to `N`. Feature support is monotonic by design: a validator that supports feature tip `N` also supports every lower feature ID.
 
-Activation eligibility is bound to epoch numbers rather than wall-clock timestamps. The registry owner schedules a target feature tip and an earliest activation epoch. During deterministic epoch processing at or after that epoch, the chain advances `features_tip` if the current active validator set has quorum for the scheduled target. No external activation transaction is required.
+Activation eligibility is bound to epoch numbers rather than wall-clock timestamps. The registry owner schedules a target feature tip and an activation epoch. At the first block of that epoch, deterministic epoch processing advances `features_tip` if the current active validator set has quorum for the scheduled target. No external activation transaction is required.
 
 ## Feature Registry
 
@@ -48,7 +48,7 @@ The registry stores:
 
 - `features_tip`: the highest active protocol feature ID
 - `scheduled_features_tip`: the next target feature tip, or `0` when no tip is scheduled
-- `scheduled_activation_epoch`: the earliest epoch in which the scheduled tip may activate, or `0` when no tip is scheduled
+- `scheduled_activation_epoch`: the epoch in which the scheduled tip is attempted, or `0` when no tip is scheduled
 - `validator_supported_features_tip`: the latest supported feature tip reported by each validator
 
 ```solidity
@@ -67,13 +67,13 @@ contract FeatureRegistry {
 
 The registry should expose read methods for nodes, indexers, and operators to inspect the active feature tip, scheduled feature tip, validator reports, current support counts, and the global activation quorum threshold. Callers should be able to determine whether a proposed feature tip has quorum before its activation epoch.
 
-Registry state changes must be observable through events for scheduling, cancellation, validator support updates, support count changes, and activation.
+Registry state changes must be observable through events for scheduling, cancellation, validator support updates, support count changes, activation, and activation failure.
 
 ## Scheduling and Activation
 
 The registry owner schedules activation by submitting a registry transaction with a target feature tip and a future activation epoch. The registry accepts the scheduling transaction only if the target tip is higher than the current `features_tip`, no other feature tip is scheduled, and the requested activation epoch is strictly greater than the current epoch.
 
-Scheduling writes `scheduled_features_tip` and `scheduled_activation_epoch`, then emits an event to notify network participants. The scheduled epoch is the earliest epoch in which the chain may advance to the target tip. Operators should upgrade before that epoch if they are running a release that supports a lower feature tip.
+Scheduling writes `scheduled_features_tip` and `scheduled_activation_epoch`, then emits an event to notify network participants. The scheduled epoch is the epoch in which the chain attempts to advance to the target tip. Operators should upgrade before that epoch if they are running a release that supports a lower feature tip.
 
 At the first block of `scheduled_activation_epoch`, deterministic epoch processing evaluates whether the active validator set has quorum for `scheduled_features_tip`.
 
@@ -83,7 +83,7 @@ To evaluate support for target tip `N`, deterministic epoch processing iterates 
 
 If quorum is satisfied, the chain sets `features_tip` to `scheduled_features_tip`, clears the scheduled tip fields, and emits an activation event. The block that records the new feature tip is the activation block; protocol behavior gated by newly active features applies to subsequent blocks unless a feature's own TIP specifies transition-block behavior.
 
-If quorum is not satisfied, the chain leaves `scheduled_features_tip` and `scheduled_activation_epoch` unchanged. The scheduled tip remains pending, deterministic epoch processing retries the quorum check at the first block of later epochs, and the registry owner can cancel the schedule if activation should no longer proceed.
+If quorum is not satisfied, the chain clears `scheduled_features_tip` and `scheduled_activation_epoch`, emits an activation failure event, and leaves `features_tip` unchanged. The registry owner can schedule the same or a higher feature tip for a later epoch after the missing quorum condition is resolved.
 
 Nodes derive the active feature set from registry state. Validators, RPC nodes, consensus-layer clients, and other infrastructure must use the same active feature tip when evaluating protocol behavior for a block. Once a feature is active, any node that validates, builds, simulates, or serves protocol behavior for later blocks must support the active feature tip that includes it.
 
@@ -132,7 +132,7 @@ interface IFeatureRegistry {
     /// @notice Returns the highest active protocol feature ID.
     function featuresTip() external view returns (uint64);
 
-    /// @notice Returns the scheduled feature tip and earliest activation epoch.
+    /// @notice Returns the scheduled feature tip and activation epoch.
     function scheduledFeaturesTip() external view returns (uint64 featuresTip, uint64 activationEpoch);
 
     /// @notice Records the highest protocol feature tip reported for a validator.
@@ -169,6 +169,9 @@ event FeaturesTipScheduleCancelled(uint64 featuresTip);
 
 /// @notice Emitted when a scheduled feature tip becomes active during epoch processing.
 event FeaturesTipActivated(uint64 previousFeaturesTip, uint64 featuresTip, uint64 activationEpoch);
+
+/// @notice Emitted when a scheduled feature tip fails to activate during epoch processing.
+event FeaturesTipActivationFailed(uint64 featuresTip, uint64 activationEpoch, uint256 support, uint256 required);
 
 /// @notice Emitted when active validator support for a feature tip changes.
 event FeaturesTipSupportUpdated(uint64 featuresTip, uint256 support, uint256 required);

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -30,6 +30,8 @@ Feature flags separate code distribution from feature activation. Validators upg
 
 A protocol feature controls whether a specific Tempo protocol change is active. Feature-gated code ships inactive in a release. Each feature is assigned a globally unique `uint64` feature ID in strictly increasing order. Feature ID `0` is reserved to represent the absence of active protocol features.
 
+Feature IDs define a contiguous activation namespace. If a feature ID is skipped, withdrawn, or intentionally left unused, it must be recorded as a reserved no-op feature slot before any higher feature tip activates. Reserved no-op slots have no protocol effect, but they are treated as active when `features_tip` advances past them.
+
 The active feature-flag set is represented by a single onchain cursor, `features_tip`, also called the active feature tip. If `features_tip == N`, every feature ID from `1` through `N` is active and every feature ID greater than `N` is inactive. The chain does not store per-feature activation structures or dependency metadata.
 
 Feature ordering is the dependency model. A feature that depends on another feature must receive a higher feature ID than the feature it depends on. Source-controlled metadata records human-readable feature names, descriptions, TIP references, and implementation notes keyed by `feature_id`; the chain stores only the state required for deterministic activation.
@@ -90,6 +92,8 @@ Once a feature is active, support for the active feature tip that includes it is
 ## Validator Feature Tip Reporting
 
 Validators report support by submitting the highest protocol feature ID they support. A report is valid only if it is deterministic from chain history and does not decrease the validator's previously reported supported feature tip.
+
+Validator feature-tip reports use the validator identity and authorization model defined by TIP-1070. The registry accepts `setSupportedFeaturesTip(validator, featuresTip)` only when the caller is authenticated as that validator under TIP-1070; otherwise it rejects the report as unauthorized. Reports are not owner-mediated and cannot be submitted on behalf of another validator by an arbitrary caller.
 
 ```solidity
 mapping(address validator => uint64 supported_features_tip) validator_supported_features_tip;

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -75,13 +75,13 @@ Scheduling writes `scheduled_features_tip` and `scheduled_activation_epoch`, the
 
 At the first deterministic activation check in each epoch greater than or equal to `scheduled_activation_epoch`, the chain evaluates whether the active validator set has quorum for `scheduled_features_tip`. A scheduled tip has quorum when at least 80% of active validators support it. The required validator count is `ceil(4 * active_validator_count / 5)`.
 
-If quorum is satisfied, the chain sets `features_tip` to `scheduled_features_tip`, clears the scheduled tip fields, and emits an activation event. The block that records the new feature tip is the activation block; protocol behavior gated by the new tip applies to subsequent blocks unless the feature's own TIP specifies transition-block behavior.
+If quorum is satisfied, the chain sets `features_tip` to `scheduled_features_tip`, clears the scheduled tip fields, and emits an activation event. The block that records the new feature tip is the activation block; protocol behavior gated by newly active features applies to subsequent blocks unless a feature's own TIP specifies transition-block behavior.
 
 If quorum is not satisfied, the scheduled tip remains pending. The chain can retry the deterministic activation check in later epochs, and the registry owner can cancel the schedule if the activation should no longer proceed.
 
-Nodes derive the active feature set from registry state. Validators, RPC nodes, consensus-layer clients, and other infrastructure must use the same active feature tip when evaluating protocol behavior for a block. Once a feature tip is active, any node that validates, builds, simulates, or serves protocol behavior for later blocks must support that tip.
+Nodes derive the active feature set from registry state. Validators, RPC nodes, consensus-layer clients, and other infrastructure must use the same active feature tip when evaluating protocol behavior for a block. Once a feature is active, any node that validates, builds, simulates, or serves protocol behavior for later blocks must support the active feature tip that includes it.
 
-Once a feature tip is active, support for that tip is a requirement for any validator joining the active validator set. Tempo does not continuously recheck quorum after activation, and loss of support after activation does not roll back the active feature tip.
+Once a feature is active, support for the active feature tip that includes it is a requirement for any validator joining the active validator set. Tempo does not continuously recheck quorum after activation, and loss of support after activation does not roll back the active feature tip.
 
 ## Validator Feature Tip Reporting
 
@@ -101,9 +101,9 @@ For a target tip `N`, a validator contributes to quorum when `validator_supporte
 
 Before activation, the registry owner can cancel a scheduled feature tip. Cancellation clears `scheduled_features_tip` and `scheduled_activation_epoch`. A new target tip can be scheduled later.
 
-After activation, a feature tip cannot be cancelled, lowered, or locally disabled. Active features are part of chain history, and removing or toggling off their code can break syncing, state assumptions, or protocol behavior where the feature was active.
+After activation, a feature cannot be cancelled or locally disabled, and the active feature tip cannot be lowered. Active features are part of chain history, and removing or toggling off their code can break syncing, state assumptions, or protocol behavior where the feature was active.
 
-If an active feature needs to be fixed, disabled, or replaced, the change ships as a new protocol feature with a higher feature ID. The active feature tip only moves forward; historical behavior remains available for blocks where the earlier feature tip was active.
+If an active feature needs to be fixed, disabled, or replaced, the change ships as a new protocol feature with a higher feature ID. The active feature tip only moves forward; historical behavior remains available for blocks where the earlier feature was active.
 
 ## Interfaces
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -48,7 +48,7 @@ The registry stores:
 
 - `features_tip`: the highest active protocol feature ID
 - `scheduled_features_tip`: the next target feature tip, or `0` when no tip is scheduled
-- `scheduled_activation_epoch`: the epoch in which the scheduled tip is attempted, or `0` when no tip is scheduled
+- `scheduled_activation_epoch`: the earliest epoch in which the scheduled tip may activate, or `0` when no tip is scheduled
 - `validator_supported_features_tip`: the latest supported feature tip reported by each validator
 
 ```solidity
@@ -73,7 +73,7 @@ Registry state changes must be observable through events for scheduling, cancell
 
 The registry owner schedules activation by submitting a registry transaction with a target feature tip and a future activation epoch. The registry accepts the scheduling transaction only if the target tip is higher than the current `features_tip`, no other feature tip is scheduled, and the requested activation epoch is strictly greater than the current epoch.
 
-Scheduling writes `scheduled_features_tip` and `scheduled_activation_epoch`, then emits an event to notify network participants. The scheduled epoch is the epoch in which the chain attempts to advance to the target tip. Operators should upgrade before that epoch if they are running a release that supports a lower feature tip.
+Scheduling writes `scheduled_features_tip` and `scheduled_activation_epoch`, then emits an event to notify network participants. The scheduled epoch is the earliest epoch in which the chain attempts to advance to the target tip. Operators should upgrade before that epoch if they are running a release that supports a lower feature tip.
 
 At the first block of `scheduled_activation_epoch`, deterministic epoch processing evaluates whether the active validator set has quorum for `scheduled_features_tip`.
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -1,143 +1,109 @@
 ---
 id: TIP-1063
-title: Protocol Feature Flags
-description: Defines feature flags for shipping protocol changes separately from activation.
+title: Protocol Feature Tips
+description: Defines feature tips for shipping protocol changes separately from activation.
 authors:
 status: Draft
 related: TIP-0000
 protocolVersion: TBD
 ---
 
-# TIP-1063: Protocol Feature Flags
+# TIP-1063: Protocol Feature Tips
 
 ## Abstract
 
-This TIP defines feature flags for Tempo protocol changes, decoupling individual feature activation from hardfork bundles.
+This TIP defines protocol feature tips for Tempo protocol changes, decoupling code distribution from activation.
 
-Each feature ships inactive in a Tempo release. Features later become active once the registry owner has scheduled an activation epoch and `activateFeature` is called at or after that epoch. Activation succeeds only if the current active validator set has quorum for the feature and all required features are already active.
+Each feature ships inactive in a Tempo release and is assigned a monotonically increasing feature ID. The chain stores a single active feature tip: the highest active feature ID. A chain with feature tip `N` treats every feature ID in `1..=N` as active.
+
+The registry owner schedules a higher feature tip for a future activation epoch. The scheduled tip becomes active through deterministic epoch processing once the target epoch has been reached and the current active validator set has quorum for that tip.
 
 ## Motivation
 
 Tempo currently ships protocol changes through hardfork bundles (e.g. T3, T4, T5). This requires multiple protocol changes to converge on the same activation epoch even if they are production ready on different timelines.
 
-Feature flags separate code distribution from feature activation. Validators upgrade on a regular release cadence, and each feature can activate independently once it is scheduled, its required features are active, and the active validator set has quorum for its minimum supported version. Activation can be scheduled, delayed, or cancelled without a subsequent release.
+Feature tips separate code distribution from feature activation. Validators upgrade on a regular release cadence, report the highest feature ID they support, and the chain can advance the active feature tip once the network has quorum for the scheduled target. Activation can be scheduled, delayed, or cancelled without a subsequent release.
 
 # Specification
 
 ## Overview
 
-A feature flag controls whether a specific Tempo protocol change is active. Feature-gated code ships inactive in a release. Each feature is recorded in an onchain feature registry keyed by a numeric feature ID, with a minimum supported Tempo version key and an immutable required feature bitmap. A validator supports the feature when its reported version key is greater than or equal to that `minimum_supported_version_key`.
+A protocol feature controls whether a specific Tempo protocol change is active. Feature-gated code ships inactive in a release. Each feature is assigned a globally unique `uint64` feature ID in strictly increasing order. Feature ID `0` is reserved to represent the absence of active protocol features.
 
-The registry owner schedules a feature by setting a future activation epoch in the registry. Scheduling announces the earliest epoch in which activation may be attempted. At or after the scheduled epoch, `activateFeature` evaluates two checks: the feature has reached activation quorum, and every feature listed in the required feature bitmap is already active. If both checks pass, `activateFeature` records the feature as active. Validators that have not upgraded must stop before processing blocks after the activation block.
+The active feature set is represented by a single onchain cursor, `features_tip`. If `features_tip == N`, every feature ID from `1` through `N` is active and every feature ID greater than `N` is inactive. The chain does not store per-feature activation structures or dependency metadata.
 
-Activation eligibility is bound to epoch numbers rather than wall-clock timestamps. The scheduled epoch is only the earliest epoch in which `activateFeature` may succeed. The activation block is the block that includes the successful `activateFeature` call, and the activation epoch is that block's epoch.
+Feature ordering is the dependency model. A feature that depends on another feature must receive a higher feature ID than the feature it depends on. Source-controlled metadata records human-readable feature names, descriptions, TIP references, and implementation notes keyed by `feature_id`; the chain stores only the state required for deterministic activation.
+
+Validators report the highest feature ID they support. A validator supports target tip `N` when its latest reported supported feature tip is greater than or equal to `N`. Feature support is monotonic by design: a validator that supports feature tip `N` also supports every lower feature ID.
+
+Activation eligibility is bound to epoch numbers rather than wall-clock timestamps. The registry owner schedules a target feature tip and an earliest activation epoch. During deterministic epoch processing at or after that epoch, the chain advances `features_tip` if the current active validator set has quorum for the scheduled target. No external activation transaction is required.
 
 ## Feature Registry
 
-Tempo stores protocol feature data in an onchain feature registry. Each feature is keyed by feature ID, and the registry records the minimum supported version key, required feature bitmap, status, and activation epoch for that feature. Feature activation is determined by registry state.
+Tempo stores protocol feature activation state in an onchain feature registry. The registry has an owner authorized to schedule or cancel feature tip activation.
 
-The registry has an owner authorized to register approved features onchain, register minimum version checkpoints, and schedule activation epochs.
+The registry stores:
 
-Human-readable feature metadata, including the canonical dotted feature name, description, and TIP reference, is maintained offchain in a source-controlled metadata file keyed by `feature_id`. Onchain registry state stores only the fields required for deterministic activation.
-
-Each registered feature is keyed by `feature_id`, a globally unique `uint64` identifier. The same value is used as the feature's bitmap index. Each registry entry includes:
-
-- `minimum_supported_version_key`: the encoded Tempo version expected to validate, build, simulate, and serve the feature correctly after activation
-- `required_feature_bitmap`: the immutable bitmap of feature IDs that must already be active before this feature can activate
-- `status`: the status of the feature. Available statuses are `pending` and `active`
-- `activation_epoch`: while pending, the earliest epoch in which activation may be attempted; after activation, the epoch in which the feature became active; set to 0 means the feature is not scheduled
+- `features_tip`: the highest active protocol feature ID
+- `scheduled_features_tip`: the next target feature tip, or `0` when no tip is scheduled
+- `scheduled_activation_epoch`: the earliest epoch in which the scheduled tip may activate, or `0` when no tip is scheduled
+- `validator_supported_features_tip`: the latest supported feature tip reported by each validator
 
 ```solidity
 contract FeatureRegistry {
   // --snip--
 
-  struct Feature {
-    uint64 minimum_supported_version_key;
-    uint256[] required_feature_bitmap;
-    Status status;
-    uint64 activation_epoch;
-  }
+  uint64 features_tip;
+  uint64 scheduled_features_tip;
+  uint64 scheduled_activation_epoch;
 
-  mapping(uint64 feature_id => Feature) features;
-  uint256[] active_feature_bitmap;
-  uint64[] active_feature_order;
-  mapping(uint64 activation_epoch => uint64[] feature_ids) scheduled_features_by_epoch;
+  mapping(address validator => uint64 supported_features_tip) validator_supported_features_tip;
 
   // --snip--
 }
 ```
 
-Registered feature identity, version requirement, and required feature set are immutable. After registration, the registry must not allow edits to the feature ID key, `minimum_supported_version_key`, or `required_feature_bitmap`.
+The registry should expose read methods for nodes, indexers, and operators to inspect the active feature tip, scheduled feature tip, validator reports, current support counts, and the global activation quorum threshold. Callers should be able to determine whether a proposed feature tip has quorum before its activation epoch.
 
-Feature lifecycle state is mutable. Mutable state is limited to `status` and `activation_epoch`.
-
-The registry also maintains `active_feature_bitmap` and `active_feature_order`. The active bitmap is optimized for dependency checks. The active order is an append-only audit log of feature IDs in the exact order they became active. A feature's audit position is its index in `active_feature_order`. Feature IDs and bitmap positions do not encode activation order.
-
-The registry maintains `scheduled_features_by_epoch` to enumerate features eligible for activation in a given epoch. For each activation epoch, `scheduled_features_by_epoch[activation_epoch]` stores unique feature IDs in strictly increasing order. Scheduling inserts the feature ID into the requested epoch's scheduled feature list, rescheduling moves it between scheduled feature lists, and cancellation removes it. List order is for deterministic enumeration; activation order is the order of successful `activateFeature` calls recorded in chain history.
-
-The required feature bitmap uses feature IDs as bit indexes. For a required feature ID `x`, the bit at `required_feature_bitmap[x / 256] & (1 << (x % 256))` is set. Missing words are treated as zero, and trailing zero words are omitted. A zero-length bitmap means the feature has no dependencies. A feature's required features are satisfied only when `(active_feature_bitmap & required_feature_bitmap) == required_feature_bitmap` for every bitmap word, and each required feature has `activation_epoch` strictly less than the current epoch.
-
-The registry must reject a feature registration whose required feature bitmap includes its own feature ID, references an unregistered required feature, or creates a dependency cycle. This keeps the feature graph acyclic and ensures every active feature's dependencies are also active.
-
-Pending feature ordering is not consensus state. Only activated features have a canonical order. Before activation, source-controlled metadata and local code order can change. If feature B activates before inactive feature A, the chain records B first in `active_feature_order`; a later release should reorder A after B before A activates, but B's release and activation are not blocked solely because A appeared earlier in an inactive release.
-
-The registry also tracks the Tempo version each validator reports. This is used to ensure that enough active validators are running a Tempo version that supports a given feature before the feature activates. A version report counts only if it is deterministic from chain history. For a given feature, a validator supports the feature when its latest reported Tempo version key is greater than or equal to the feature's `minimum_supported_version_key`.
-
-Releases are monotonic for feature support. A newer release supports every feature supported by earlier releases. Selectively opting out of features or non-monotonic support would require per-feature signaling and is not part of this design for simplicity.
-
-A feature has quorum when at least 80% of the active validator set supports it. The required validator count is `ceil(4 * active_validator_count / 5)`. This fixed activation quorum is intentionally higher than Tempo's consensus quorum so a small number of misconfigured validators cannot cause the chain to activate a feature without broad operator support. Quorum does not activate the feature by itself. It is rechecked when `activateFeature` is called against the then-current active validator set.
-
-The registry should expose read methods for nodes, indexers, and operators to inspect feature state, validator reported versions, current support counts, and the global activation quorum threshold. Callers should be able to determine whether a feature is known, scheduled, or active, including for a specific block or epoch.
-
-Registry state changes must be observable through events for registration, activation scheduling, schedule updates, support count changes, activation, activation failure, and cancellation.
+Registry state changes must be observable through events for scheduling, cancellation, validator support updates, support count changes, and activation.
 
 ## Scheduling and Activation
 
-A registered feature can be scheduled for activation by the registry owner. The owner schedules activation by submitting a registry transaction with the feature ID and a future activation epoch. The registry accepts the scheduling transaction only if the feature is registered, the status is `pending`, the feature is not already scheduled, and the requested activation epoch is strictly greater than the current epoch.
+The registry owner schedules activation by submitting a registry transaction with a target feature tip and a future activation epoch. The registry accepts the scheduling transaction only if the target tip is higher than the current `features_tip`, no other feature tip is scheduled, and the requested activation epoch is strictly greater than the current epoch.
 
-Scheduling writes the activation epoch to the feature metadata, inserts the feature ID into `scheduled_features_by_epoch[activation_epoch]` while preserving ascending feature ID order, and emits an event to notify network participants. The scheduled epoch is the earliest epoch in which activation may be attempted; operators should upgrade before that epoch if they are running a version older than the minimum supported version. Read methods should let operators check quorum and required-feature satisfaction before calling `activateFeature`.
+Scheduling writes `scheduled_features_tip` and `scheduled_activation_epoch`, then emits an event to notify network participants. The scheduled epoch is the earliest epoch in which the chain may advance to the target tip. Operators should upgrade before that epoch if they are running a release that supports a lower feature tip.
 
-Scheduled features become eligible for activation at the start of their activation epoch. Activation is attempted when `activateFeature(feature_id)` is called at or after the scheduled activation epoch. The registry accepts `activateFeature` only if the feature is registered, pending, scheduled, and the current epoch is greater than or equal to `activation_epoch`. The registry removes the feature ID from `scheduled_features_by_epoch[activation_epoch]` and evaluates two checks: the current active validator set has quorum for the feature's `minimum_supported_version_key`, and every feature in the required feature bitmap has already activated in an earlier epoch.
+At the first deterministic activation check in each epoch greater than or equal to `scheduled_activation_epoch`, the chain evaluates whether the active validator set has quorum for `scheduled_features_tip`. A scheduled tip has quorum when at least 80% of active validators support it. The required validator count is `ceil(4 * active_validator_count / 5)`.
 
-Required features activating in the same epoch do not count as active dependencies. A dependent feature must activate in a later epoch than the features it requires.
+If quorum is satisfied, the chain sets `features_tip` to `scheduled_features_tip`, clears the scheduled tip fields, and emits an activation event. The block that records the new feature tip is the activation block; protocol behavior gated by the new tip applies to subsequent blocks unless the feature's own TIP specifies transition-block behavior.
 
-If the activation checks pass, the registry marks the feature `active`, sets `activation_epoch` to the current epoch, sets its bit in `active_feature_bitmap`, appends its feature ID to `active_feature_order`, and emits the activation event. Blocks after the activation block are processed with the feature active. Because activation is recorded in chain history, every node observes the same activation block and activation epoch.
+If quorum is not satisfied, the scheduled tip remains pending. The chain can retry the deterministic activation check in later epochs, and the registry owner can cancel the schedule if the activation should no longer proceed.
 
-If the activation checks fail, the registry clears `activation_epoch`, leaves the feature `pending`, and emits an activation failure event. The feature can be scheduled again for a later epoch after the missing quorum or required-feature condition is resolved.
+Nodes derive the active feature set from registry state. Validators, RPC nodes, consensus-layer clients, and other infrastructure must use the same active feature tip when evaluating protocol behavior for a block. Once a feature tip is active, any node that validates, builds, simulates, or serves protocol behavior for later blocks must support that tip.
 
-Nodes derive the active feature set from registry state. Validators, RPC nodes, consensus-layer clients, and other infrastructure must use the same active feature state when evaluating protocol behavior for a block. Once a feature is active, any node that validates, builds, simulates, or serves protocol behavior for blocks after the activation block must support that feature.
+Once a feature tip is active, support for that tip is a requirement for any validator joining the active validator set. Tempo does not continuously recheck quorum after activation, and loss of support after activation does not roll back the active feature tip.
 
-Once a feature is active, support for that feature is a requirement for any validator joining the active validator set. Tempo does not continuously recheck quorum after activation, and loss of support after activation does not disable the feature.
+## Validator Feature Tip Reporting
 
-## Minimum Version Reporting
-
-The feature registry exposes a `minimum_required_version()` function for registering minimum version checkpoints. This function is only callable by the registry owner. The checkpoint represents the Tempo version the network is being asked to confirm support for.
+Validators report support by submitting the highest protocol feature ID they support. A report is valid only if it is deterministic from chain history and does not decrease the validator's previously reported supported feature tip.
 
 ```solidity
-struct MinimumVersionCheckpoint {
-    uint64 minimumVersionKey;
-    uint256 supportCount;
-}
+mapping(address validator => uint64 supported_features_tip) validator_supported_features_tip;
 
-mapping(uint64 minimumVersionKey => MinimumVersionCheckpoint) minimumVersionCheckpoints;
-mapping(address validator => mapping(uint64 minimumVersionKey => bool)) validatorSupportsMinimumVersion;
-
-function minimum_required_version(uint64 minimumVersionKey) external onlyOwner;
+function setSupportedFeaturesTip(address validator, uint64 featuresTip) external;
 ```
 
-Each `MinimumVersionCheckpoint` includes a `minimumVersionKey` and a `supportCount` indicating how many active validators have reported compatibility with the specified version. `minimumVersionKey` is an encoded semver value where a given `x.y.z` version is encoded as `(x << 32) | (y << 16) | z`.
+Support counts must track the active validator set. Exited validators stop contributing to quorum, and newly active validators contribute according to their latest reported supported feature tip. Validator-set transitions must update support counts deterministically.
 
-Validators read the latest registered MRV and report support through a system transaction. The system transaction succeeds when the MRV checkpoint exists, the validator's encoded version is greater than or equal to `minimumVersionKey`, and the validator has not already reported support for that checkpoint. The registry then records `validatorSupportsMinimumVersion[validator][minimumVersionKey] = true`. If the validator is in the active validator set, the registry also increments `minimumVersionCheckpoints[minimumVersionKey].supportCount`.
-
-Feature support is monotonic by version, so a validator running a newer Tempo version can report support for an older checkpoint. When `activateFeature` is called, the registry reads the feature's recorded `minimum_supported_version_key`, loads that checkpoint from `minimumVersionCheckpoints`, and compares the active validator `supportCount` against quorum. Support counts must track the active validator set: exited validators stop contributing to quorum, and newly active validators contribute only after reporting support. Validator-set transitions must update these counts deterministically: exits remove any previously counted reports, and joins add only reports already recorded for the joining validator.
+For a target tip `N`, a validator contributes to quorum when `validator_supported_features_tip[validator] >= N`. A validator running a newer Tempo release can therefore support older scheduled tips without additional per-feature signaling.
 
 ## Cancellation and Supersession
 
-Before activation, the registry owner can cancel a feature's scheduled activation. Cancellation clears `activation_epoch`, removes the feature ID from `scheduled_features_by_epoch`, and leaves the feature `pending`. The feature can be scheduled again later.
+Before activation, the registry owner can cancel a scheduled feature tip. Cancellation clears `scheduled_features_tip` and `scheduled_activation_epoch`. A new target tip can be scheduled later.
 
-After activation, a feature cannot be cancelled or locally disabled. Active features are part of chain history, and removing or toggling off their code can break syncing, state assumptions, or protocol behavior where the feature was active.
+After activation, a feature tip cannot be cancelled, lowered, or locally disabled. Active features are part of chain history, and removing or toggling off their code can break syncing, state assumptions, or protocol behavior where the feature was active.
 
-If an active feature needs to be fixed, disabled, or replaced, the change ships as a new protocol feature with its own `feature_id` and `minimum_supported_version_key`. A replacement feature's required feature bitmap should include the feature it replaces unless the replacement is explicitly independent. The original feature remains available for historical execution, and the new feature gates the corrected behavior from its own activation point.
+If an active feature needs to be fixed, disabled, or replaced, the change ships as a new protocol feature with a higher feature ID. The active feature tip only moves forward; historical behavior remains available for blocks where the earlier feature tip was active.
 
 ## Interfaces
 
@@ -146,148 +112,58 @@ If an active feature needs to be fixed, disabled, or replaced, the change ships 
 The feature registry exposes the following interface:
 
 ```solidity
-
 /// @title IFeatureRegistry
-/// @notice Registry for Tempo protocol feature activation.
+/// @notice Registry for Tempo protocol feature tip scheduling.
 interface IFeatureRegistry {
-    enum FeatureStatus {
-        Pending,
-        Active
-    }
-
-    struct Feature {
-        uint64 minimumSupportedVersionKey;
-        uint256[] requiredFeatureBitmap;
-        FeatureStatus status;
-        uint64 activationEpoch;
-    }
-
-    struct MinimumVersionCheckpoint {
-        uint64 minimumVersionKey;
-        uint256 supportCount;
-    }
-
-    /// @notice Returns the registry owner authorized to register features and schedule activation.
+    /// @notice Returns the registry owner authorized to schedule feature tip activation.
     function owner() external view returns (address);
 
     /// @notice Returns the fixed global activation quorum threshold: 4/5, or 80%.
     function activationQuorum() external view returns (uint256 numerator, uint256 denominator);
 
-    /// @notice Registers a new pending feature.
-    function registerFeature(
-        uint64 featureId,
-        uint64 minimumSupportedVersionKey,
-        uint256[] calldata requiredFeatureBitmap
-    ) external;
+    /// @notice Returns the highest active protocol feature ID.
+    function featuresTip() external view returns (uint64);
 
-    /// @notice Registers a minimum version checkpoint that can be used for feature activation.
-    function minimum_required_version(uint64 minimumVersionKey) external;
+    /// @notice Returns the scheduled feature tip and earliest activation epoch.
+    function scheduledFeaturesTip() external view returns (uint64 featuresTip, uint64 activationEpoch);
 
-    /// @notice Reports that an active validator is running at least the checkpoint version.
-    function reportMinimumVersionSupport(address validator, uint64 minimumVersionKey, uint64 validatorVersionKey) external;
+    /// @notice Reports the highest protocol feature ID a validator supports.
+    function setSupportedFeaturesTip(address validator, uint64 featuresTip) external;
 
-    /// @notice Schedules activation for a pending feature.
-    function scheduleActivation(uint64 featureId, uint64 activationEpoch) external;
+    /// @notice Schedules a higher feature tip for activation at the target epoch.
+    function scheduleFeaturesTip(uint64 featuresTip, uint64 activationEpoch) external;
 
-    /// @notice Activates a scheduled feature at or after its activation epoch if all checks pass.
-    function activateFeature(uint64 featureId) external;
+    /// @notice Cancels the scheduled feature tip before activation.
+    function cancelScheduledFeaturesTip() external;
 
-    /// @notice Replaces the activation epoch for a scheduled pending feature.
-    function rescheduleActivation(uint64 featureId, uint64 activationEpoch) external;
+    /// @notice Returns the latest feature tip reported by a validator.
+    function validatorSupportedFeaturesTip(address validator) external view returns (uint64);
 
-    /// @notice Cancels a scheduled activation before the feature becomes active.
-    function cancelScheduledActivation(uint64 featureId) external;
+    /// @notice Returns current active-validator support for a feature tip.
+    function featuresTipSupportCount(uint64 featuresTip) external view returns (uint256 support, uint256 required);
 
-    /// @notice Returns the registered feature metadata and current status.
-    function getFeature(uint64 featureId) external view returns (Feature memory);
-
-    /// @notice Returns whether a feature is registered.
-    function isFeatureRegistered(uint64 featureId) external view returns (bool);
-
-    /// @notice Returns whether a feature is active at the current block.
-    function isFeatureActive(uint64 featureId) external view returns (bool);
-
-    /// @notice Returns one word from the active feature bitmap.
-    function activeFeatureBitmapWord(uint256 wordIndex) external view returns (uint256);
-
-    /// @notice Returns the number of active features recorded in activation order.
-    function activeFeatureCount() external view returns (uint256);
-
-    /// @notice Returns the active feature ID at a zero-based activation-order index.
-    function activeFeatureAt(uint256 index) external view returns (uint64);
-
-    /// @notice Returns the number of features scheduled for a given activation epoch.
-    function scheduledFeatureCount(uint64 activationEpoch) external view returns (uint256);
-
-    /// @notice Returns the scheduled feature ID at a zero-based index for an activation epoch.
-    function scheduledFeatureAt(uint64 activationEpoch, uint256 index) external view returns (uint64);
-
-    /// @notice Returns the latest Tempo version key reported by a validator.
-    function validatorVersionKey(address validator) external view returns (uint64);
-
-    /// @notice Returns a registered minimum version checkpoint.
-    function minimumVersionCheckpoint(uint64 minimumVersionKey) external view returns (MinimumVersionCheckpoint memory);
-
-    /// @notice Returns whether a minimum version checkpoint is registered.
-    function isMinimumVersionCheckpointRegistered(uint64 minimumVersionKey) external view returns (bool);
-
-    /// @notice Returns whether a validator has reported support for a minimum version.
-    function validatorSupportsMinimumVersion(address validator, uint64 minimumVersionKey) external view returns (bool);
-
-    /// @notice Returns current support for a minimum version.
-    function minimumVersionSupportCount(uint64 minimumVersionKey) external view returns (uint256 support, uint256 required);
-
-    /// @notice Returns whether a minimum version has quorum support.
-    function hasMinimumVersionQuorum(uint64 minimumVersionKey) external view returns (bool);
-
-    /// @notice Returns whether a validator's reported version supports a feature.
-    function validatorSupportsFeature(address validator, uint64 featureId) external view returns (bool);
-
-    /// @notice Returns current active-validator support for a feature.
-    function featureSupportCount(uint64 featureId) external view returns (uint256 support, uint256 required);
-
-    /// @notice Returns whether a feature has quorum support from the active validator set.
-    function hasQuorum(uint64 featureId) external view returns (bool);
-
-    /// @notice Returns whether a feature's required features are already active from earlier epochs.
-    function requiredFeaturesSatisfied(uint64 featureId) external view returns (bool);
+    /// @notice Returns whether a feature tip has quorum support from the active validator set.
+    function hasFeaturesTipQuorum(uint64 featuresTip) external view returns (bool);
 }
 ```
 
 ### Events
 
 ```solidity
-/// @notice Emitted when a feature is registered.
-event FeatureRegistered(uint64 featureId, uint64 minimumSupportedVersionKey, uint256[] requiredFeatureBitmap);
+/// @notice Emitted when a validator reports support for a feature tip.
+event SupportedFeaturesTipSet(address indexed validator, uint64 featuresTip, uint256 supportCount);
 
-/// @notice Emitted when a minimum version checkpoint is registered.
-event MinimumVersionCheckpointRegistered(uint64 minimumVersionKey);
+/// @notice Emitted when a higher feature tip is scheduled for activation.
+event FeaturesTipScheduled(uint64 featuresTip, uint64 activationEpoch);
 
-/// @notice Emitted when a validator reports support for a minimum version.
-event MinimumVersionSupportReported(address indexed validator, uint64 minimumVersionKey, uint256 supportCount);
+/// @notice Emitted when the scheduled feature tip is cancelled.
+event FeaturesTipScheduleCancelled(uint64 featuresTip);
 
-/// @notice Emitted when a pending feature is scheduled for activation.
-event FeatureScheduled(uint64 featureId, uint64 activationEpoch);
+/// @notice Emitted when a scheduled feature tip becomes active during epoch processing.
+event FeaturesTipActivated(uint64 previousFeaturesTip, uint64 featuresTip, uint64 activationEpoch);
 
-/// @notice Emitted when a pending feature's activation epoch is replaced.
-event FeatureRescheduled(uint64 featureId, uint64 activationEpoch);
-
-/// @notice Emitted when a scheduled feature is cancelled.
-event FeatureScheduleCancelled(uint64 featureId);
-
-/// @notice Emitted when a scheduled feature becomes active.
-event FeatureActivated(uint64 featureId, uint64 activationEpoch);
-
-/// @notice Emitted when a scheduled feature remains pending after an activation attempt fails.
-event FeatureActivationFailed(
-    uint64 featureId,
-    uint64 activationEpoch,
-    bool requiredFeaturesSatisfied,
-    bool quorumSatisfied
-);
-
-/// @notice Emitted when the active validator support count changes.
-event FeatureSupportUpdated(uint64 featureId, uint256 support, uint256 required);
+/// @notice Emitted when active validator support for a feature tip changes.
+event FeaturesTipSupportUpdated(uint64 featuresTip, uint256 support, uint256 required);
 ```
 
 ### Errors
@@ -296,45 +172,21 @@ event FeatureSupportUpdated(uint64 featureId, uint256 support, uint256 required)
 /// @notice Caller is not authorized to update feature registry state.
 error Unauthorized();
 
-/// @notice Feature ID is invalid or reserved.
-error InvalidFeatureId();
+/// @notice Feature tip is invalid or reserved.
+error InvalidFeaturesTip();
 
-/// @notice Tempo version is not canonical or cannot be encoded.
-error InvalidVersion();
+/// @notice Feature tip must be higher than the current active feature tip.
+error FeaturesTipNotIncreasing();
 
-/// @notice Minimum version checkpoint is already registered.
-error MinimumVersionCheckpointAlreadyRegistered();
+/// @notice Validator cannot lower its reported supported feature tip.
+error SupportedFeaturesTipDecreased();
 
-/// @notice Minimum version checkpoint is not registered.
-error MinimumVersionCheckpointNotRegistered();
+/// @notice A feature tip is already scheduled for activation.
+error FeaturesTipAlreadyScheduled();
 
-/// @notice Validator has already reported support for this minimum version.
-error MinimumVersionSupportAlreadyReported();
-
-/// @notice Validator's reported version is below the minimum version.
-error ValidatorVersionBelowMinimum();
-
-/// @notice Feature is already registered.
-error FeatureAlreadyRegistered();
-
-/// @notice Feature is not registered.
-error FeatureNotRegistered();
-
-/// @notice Required feature bitmap is malformed, self-referential, cyclic, or references an unregistered feature.
-error InvalidRequiredFeatureBitmap();
-
-/// @notice Feature is not pending.
-error FeatureNotPending();
-
-/// @notice Feature already has a scheduled activation epoch.
-error FeatureAlreadyScheduled();
-
-/// @notice Feature does not have a scheduled activation epoch.
-error FeatureNotScheduled();
+/// @notice No feature tip is scheduled for activation.
+error FeaturesTipNotScheduled();
 
 /// @notice Requested activation epoch is not strictly greater than the current epoch.
 error ActivationEpochNotFuture();
-
-/// @notice Feature cannot be activated before its scheduled activation epoch.
-error ActivationEpochNotReached();
 ```

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -140,7 +140,7 @@ interface IFeatureRegistry {
     function validatorSupportedFeaturesTip(address validator) external view returns (uint64);
 
     /// @notice Returns current active-validator support for a feature tip.
-    function featuresTipSupportCount(uint64 featuresTip) external view returns (uint256 support, uint256 required);
+    function featuresTipSupport(uint64 featuresTip) external view returns (uint256 support, uint256 required);
 
     /// @notice Returns whether a feature tip has quorum support from the active validator set.
     function hasFeaturesTipQuorum(uint64 featuresTip) external view returns (bool);

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -73,11 +73,15 @@ The registry owner schedules activation by submitting a registry transaction wit
 
 Scheduling writes `scheduled_features_tip` and `scheduled_activation_epoch`, then emits an event to notify network participants. The scheduled epoch is the earliest epoch in which the chain may advance to the target tip. Operators should upgrade before that epoch if they are running a release that supports a lower feature tip.
 
-At the first deterministic activation check in each epoch greater than or equal to `scheduled_activation_epoch`, the chain evaluates whether the active validator set has quorum for `scheduled_features_tip`. A scheduled tip has quorum when at least 80% of active validators support it. The required validator count is `ceil(4 * active_validator_count / 5)`.
+At the first block of `scheduled_activation_epoch`, deterministic epoch processing evaluates whether the active validator set has quorum for `scheduled_features_tip`.
+
+For quorum checks, the active validator set is the canonical validator set for the epoch containing the activation-check block, derived from the chain's validator configuration state by the same rules used for consensus block validation. The registry does not keep a separate validator roster for feature activation.
+
+To evaluate support for target tip `N`, deterministic epoch processing iterates that active validator set and counts each validator whose `validator_supported_features_tip[validator] >= N`. A scheduled tip has quorum when at least 80% of active validators support it. The quorum denominator is the size of the active validator set at the activation-check block, and the required validator count is `ceil(4 * active_validator_count / 5)`.
 
 If quorum is satisfied, the chain sets `features_tip` to `scheduled_features_tip`, clears the scheduled tip fields, and emits an activation event. The block that records the new feature tip is the activation block; protocol behavior gated by newly active features applies to subsequent blocks unless a feature's own TIP specifies transition-block behavior.
 
-If quorum is not satisfied, the scheduled tip remains pending. The chain can retry the deterministic activation check in later epochs, and the registry owner can cancel the schedule if the activation should no longer proceed.
+If quorum is not satisfied, the chain leaves `scheduled_features_tip` and `scheduled_activation_epoch` unchanged. The scheduled tip remains pending, deterministic epoch processing retries the quorum check at the first block of later epochs, and the registry owner can cancel the schedule if activation should no longer proceed.
 
 Nodes derive the active feature set from registry state. Validators, RPC nodes, consensus-layer clients, and other infrastructure must use the same active feature tip when evaluating protocol behavior for a block. Once a feature is active, any node that validates, builds, simulates, or serves protocol behavior for later blocks must support the active feature tip that includes it.
 
@@ -127,7 +131,7 @@ interface IFeatureRegistry {
     /// @notice Returns the scheduled feature tip and earliest activation epoch.
     function scheduledFeaturesTip() external view returns (uint64 featuresTip, uint64 activationEpoch);
 
-    /// @notice Reports the highest protocol feature ID a validator supports.
+    /// @notice Records the highest protocol feature tip reported for a validator.
     function setSupportedFeaturesTip(address validator, uint64 featuresTip) external;
 
     /// @notice Schedules a higher feature tip for activation at the target epoch.

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -1,20 +1,20 @@
 ---
 id: TIP-1063
-title: Protocol Feature Tips
-description: Defines feature tips for shipping protocol changes separately from activation.
+title: Protocol Feature Flags
+description: Defines protocol feature flags and the active feature tip used to activate them.
 authors:
 status: Draft
 related: TIP-0000
 protocolVersion: TBD
 ---
 
-# TIP-1063: Protocol Feature Tips
+# TIP-1063: Protocol Feature Flags
 
 ## Abstract
 
-This TIP defines protocol feature tips for Tempo protocol changes, decoupling code distribution from activation.
+This TIP defines protocol feature flags for Tempo protocol changes, decoupling code distribution from activation.
 
-Each feature ships inactive in a Tempo release and is assigned a monotonically increasing feature ID. The chain stores a single active feature tip: the highest active feature ID. A chain with feature tip `N` treats every feature ID in `1..=N` as active.
+Each feature ships inactive in a Tempo release and is assigned a monotonically increasing feature ID. The chain stores a single active feature tip: the edge of the active feature-flag set and the highest active feature ID. A chain with feature tip `N` treats every feature ID in `1..=N` as active.
 
 The registry owner schedules a higher feature tip for a future activation epoch. The scheduled tip becomes active through deterministic epoch processing once the target epoch has been reached and the current active validator set has quorum for that tip.
 
@@ -22,7 +22,7 @@ The registry owner schedules a higher feature tip for a future activation epoch.
 
 Tempo currently ships protocol changes through hardfork bundles (e.g. T3, T4, T5). This requires multiple protocol changes to converge on the same activation epoch even if they are production ready on different timelines.
 
-Feature tips separate code distribution from feature activation. Validators upgrade on a regular release cadence, report the highest feature ID they support, and the chain can advance the active feature tip once the network has quorum for the scheduled target. Activation can be scheduled, delayed, or cancelled without a subsequent release.
+Feature flags separate code distribution from feature activation. Validators upgrade on a regular release cadence, report the highest feature ID they support, and the chain can advance the active feature tip once the network has quorum for the scheduled target. Activation can be scheduled, delayed, or cancelled without a subsequent release.
 
 # Specification
 
@@ -30,7 +30,7 @@ Feature tips separate code distribution from feature activation. Validators upgr
 
 A protocol feature controls whether a specific Tempo protocol change is active. Feature-gated code ships inactive in a release. Each feature is assigned a globally unique `uint64` feature ID in strictly increasing order. Feature ID `0` is reserved to represent the absence of active protocol features.
 
-The active feature set is represented by a single onchain cursor, `features_tip`. If `features_tip == N`, every feature ID from `1` through `N` is active and every feature ID greater than `N` is inactive. The chain does not store per-feature activation structures or dependency metadata.
+The active feature-flag set is represented by a single onchain cursor, `features_tip`, also called the active feature tip. If `features_tip == N`, every feature ID from `1` through `N` is active and every feature ID greater than `N` is inactive. The chain does not store per-feature activation structures or dependency metadata.
 
 Feature ordering is the dependency model. A feature that depends on another feature must receive a higher feature ID than the feature it depends on. Source-controlled metadata records human-readable feature names, descriptions, TIP references, and implementation notes keyed by `feature_id`; the chain stores only the state required for deterministic activation.
 


### PR DESCRIPTION
Refs TIP-1063

Updates TIP-1063 to keep protocol feature flags as the public model while defining the active feature tip as the highest active feature ID. Validators report their supported feature tip, and scheduled activation advances that edge once quorum is reached.