### PR TITLE
fix(tempoup): use gh for release lookup and write logs to stderr

### DIFF
--- a/tempoup/tempoup
+++ b/tempoup/tempoup
@@ -6,7 +6,7 @@ set -e
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-TEMPOUP_INSTALLER_VERSION="0.0.11"
+TEMPOUP_INSTALLER_VERSION="0.0.12"
 
 REPO="tempoxyz/tempo"
 # GPG key fingerprint for release signing verification
@@ -22,15 +22,15 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 info() {
-    echo -e "${GREEN}info${NC}: $1"
+    echo -e "${GREEN}info${NC}: $1" >&2
 }
 
 warn() {
-    echo -e "${YELLOW}warn${NC}: $1"
+    echo -e "${YELLOW}warn${NC}: $1" >&2
 }
 
 error() {
-    echo -e "${RED}error${NC}: $1"
+    echo -e "${RED}error${NC}: $1" >&2
     exit 1
 }
 
@@ -337,10 +337,17 @@ get_latest_version() {
     # "v" (binary releases). The /releases/latest endpoint can return crate-publish
     # tags (e.g. tempo-primitives@1.6.0) which carry no binary assets.
     # We also match only strict "vN.N.N" to skip prerelease tags like v1.6.0-rc.1.
-    local api_url="https://api.github.com/repos/$REPO/releases?per_page=100"
-    local version=$(curl -sSL "$api_url" 2>/dev/null | \
-        grep '"tag_name":' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/' | \
-        grep '^v[0-9]*\.[0-9]*\.[0-9]*$' | head -n 1)
+    # Prefer authenticated gh to avoid the 60 req/hr anonymous rate-limit.
+    local version
+    if gh_authenticated; then
+        version=$(gh release list --repo "$REPO" --limit 100 --json tagName --jq '.[].tagName' 2>/dev/null | \
+            grep '^v[0-9]*\.[0-9]*\.[0-9]*$' | head -n 1)
+    else
+        local api_url="https://api.github.com/repos/$REPO/releases?per_page=100"
+        version=$(curl -sSL "$api_url" 2>/dev/null | \
+            grep '"tag_name":' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/' | \
+            grep '^v[0-9]*\.[0-9]*\.[0-9]*$' | head -n 1)
+    fi
 
     if [[ -z "$version" ]]; then
         error "Failed to fetch latest version from GitHub"


### PR DESCRIPTION
Fixes silent `tempoup` exit after `info: Fetching latest release version...` when the user crosses GitHub's 60 req/hr anonymous API limit.

Three bugs:

1. `info`/`warn`/`error` wrote to **stdout**, so `error()` called inside `VERSION=$(get_latest_version)` was captured into the variable instead of shown — silent failure under `set -e`.
2. `get_latest_version` always used unauthenticated `curl`, even when `gh` was authenticated.
3. Latent: `gh api` returns minified single-line JSON; the line-based `grep | sed` parser's greedy `.*` then captured the **oldest** tag (e.g. `v0.1.0`) instead of the latest. Switched to `gh release list --json tagName --jq` (no system `jq` required — `gh --jq` is built in). Anonymous `curl` fallback unchanged.

Bumps `TEMPOUP_INSTALLER_VERSION` 0.0.11 → 0.0.12 so existing installs pick this up via `tempoup --update`.

Workaround for users on the broken version: `tempoup -i v1.8.1`.

Verified locally: patched script installs `v1.8.1` with attestation in a sandbox `TEMPO_DIR`.
