### PR TITLE
feat(precompiles): implement feature registry tip read

### DIFF
--- a/.changelog/feature-registry-read.md
+++ b/.changelog/feature-registry-read.md
@@ -1,0 +1,5 @@
+---
+tempo-precompiles: minor
+---
+
+Add the TIP-1063 feature registry precompile with the `featuresTip` read.

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -27,8 +27,8 @@ use reth_revm::{
 use std::collections::{HashMap, HashSet};
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_contracts::precompiles::{
-    ADDRESS_REGISTRY_ADDRESS, RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS,
-    TIP20_CHANNEL_RESERVE_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
+    ADDRESS_REGISTRY_ADDRESS, FEATURE_REGISTRY_ADDRESS, RECEIVE_POLICY_GUARD_ADDRESS,
+    SIGNATURE_VERIFIER_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
 use tempo_primitives::{
     SubBlock, SubBlockMetadata, TempoReceipt, TempoTxEnvelope, TempoTxType,
@@ -493,6 +493,8 @@ where
         }
         if self.inner.spec.is_t6_active_at_timestamp(timestamp) {
             self.deploy_precompile_at_boundary(RECEIVE_POLICY_GUARD_ADDRESS)?;
+            // TODO(TIP-1063): update this gate to T7 before merging.
+            self.deploy_precompile_at_boundary(FEATURE_REGISTRY_ADDRESS)?;
         }
 
         Ok(())

--- a/crates/precompiles/src/feature_registry/dispatch.rs
+++ b/crates/precompiles/src/feature_registry/dispatch.rs
@@ -1,0 +1,129 @@
+//! ABI dispatch for the [`FeatureRegistry`] precompile.
+
+use super::*;
+use crate::{
+    Precompile, charge_input_cost, dispatch_call, error::TempoPrecompileError, storage::StorageCtx,
+    view,
+};
+use alloy::{
+    primitives::Address,
+    sol_types::{SolCall, SolInterface},
+};
+use revm::precompile::PrecompileResult;
+use tempo_contracts::precompiles::IFeatureRegistry::{self, IFeatureRegistryCalls};
+
+fn unsupported<T: SolCall>() -> PrecompileResult {
+    StorageCtx.error_result(TempoPrecompileError::UnknownFunctionSelector(T::SELECTOR))
+}
+
+impl Precompile for FeatureRegistry {
+    fn call(&mut self, calldata: &[u8], _msg_sender: Address) -> PrecompileResult {
+        if let Some(err) = charge_input_cost(&mut self.storage, calldata) {
+            return err;
+        }
+
+        dispatch_call(
+            calldata,
+            &[],
+            IFeatureRegistryCalls::abi_decode,
+            |call| match call {
+                IFeatureRegistryCalls::featuresTip(call) => view(call, |_| self.features_tip()),
+                IFeatureRegistryCalls::owner(_) => unsupported::<IFeatureRegistry::ownerCall>(),
+                IFeatureRegistryCalls::activationQuorum(_) => {
+                    unsupported::<IFeatureRegistry::activationQuorumCall>()
+                }
+                IFeatureRegistryCalls::scheduledFeaturesTip(_) => {
+                    unsupported::<IFeatureRegistry::scheduledFeaturesTipCall>()
+                }
+                IFeatureRegistryCalls::setSupportedFeaturesTip(_) => {
+                    unsupported::<IFeatureRegistry::setSupportedFeaturesTipCall>()
+                }
+                IFeatureRegistryCalls::scheduleFeaturesTip(_) => {
+                    unsupported::<IFeatureRegistry::scheduleFeaturesTipCall>()
+                }
+                IFeatureRegistryCalls::cancelScheduledFeaturesTip(_) => {
+                    unsupported::<IFeatureRegistry::cancelScheduledFeaturesTipCall>()
+                }
+                IFeatureRegistryCalls::validatorSupportedFeaturesTip(_) => {
+                    unsupported::<IFeatureRegistry::validatorSupportedFeaturesTipCall>()
+                }
+                IFeatureRegistryCalls::featuresTipSupport(_) => {
+                    unsupported::<IFeatureRegistry::featuresTipSupportCall>()
+                }
+                IFeatureRegistryCalls::hasFeaturesTipQuorum(_) => {
+                    unsupported::<IFeatureRegistry::hasFeaturesTipQuorumCall>()
+                }
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{StorageCtx, hashmap::HashMapStorageProvider};
+    use alloy::sol_types::{SolCall, SolError, SolValue};
+    use tempo_chainspec::features::HIGHEST_ACTIVE_PROTOCOL_FEATURE_ID_SLOT;
+    use tempo_contracts::precompiles::UnknownFunctionSelector;
+
+    #[test]
+    fn features_tip_defaults_to_zero() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let registry = FeatureRegistry::new();
+            assert_eq!(registry.features_tip()?, 0);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn features_tip_reads_cursor_slot() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            assert_eq!(
+                registry.features_tip.slot(),
+                HIGHEST_ACTIVE_PROTOCOL_FEATURE_ID_SLOT
+            );
+
+            registry.features_tip.write(7)?;
+            assert_eq!(registry.features_tip()?, 7);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn features_tip_dispatch_returns_encoded_cursor() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            registry.features_tip.write(11)?;
+
+            let call = IFeatureRegistry::featuresTipCall {};
+            let result = registry.call(&call.abi_encode(), Address::ZERO)?;
+            assert!(!result.is_revert());
+            assert_eq!(u64::abi_decode(&result.bytes)?, 11);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn unimplemented_selectors_remain_unknown() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let call = IFeatureRegistry::hasFeaturesTipQuorumCall { featuresTip: 1 };
+            let result = registry.call(&call.abi_encode(), Address::ZERO)?;
+            assert!(result.is_revert());
+            let decoded = UnknownFunctionSelector::abi_decode(&result.bytes)?;
+            assert_eq!(
+                decoded.selector.0,
+                IFeatureRegistry::hasFeaturesTipQuorumCall::SELECTOR
+            );
+
+            Ok(())
+        })
+    }
+}

--- a/crates/precompiles/src/feature_registry/mod.rs
+++ b/crates/precompiles/src/feature_registry/mod.rs
@@ -1,0 +1,28 @@
+//! TIP-1063 protocol feature registry precompile.
+
+pub mod dispatch;
+
+use crate::{FEATURE_REGISTRY_ADDRESS, error::Result, storage::Handler};
+use tempo_precompiles_macros::contract;
+
+/// Protocol feature registry.
+///
+/// The first implementation exposes the active feature tip cursor. The cursor lives at storage
+/// slot zero and represents the highest active protocol feature ID.
+#[contract(addr = FEATURE_REGISTRY_ADDRESS)]
+pub struct FeatureRegistry {
+    /// Highest active protocol feature ID.
+    features_tip: u64,
+}
+
+impl FeatureRegistry {
+    /// Initializes the registry contract by setting its bytecode marker.
+    pub fn initialize(&mut self) -> Result<()> {
+        self.__initialize()
+    }
+
+    /// Returns the highest active protocol feature ID.
+    pub fn features_tip(&self) -> Result<u64> {
+        self.features_tip.read()
+    }
+}

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -144,7 +144,8 @@ pub fn extend_tempo_precompiles(precompiles: &mut PrecompilesMap, cfg: &CfgEnv<T
             Some(AccountKeychain::create_precompile(&cfg))
         } else if *address == VALIDATOR_CONFIG_V2_ADDRESS {
             Some(ValidatorConfigV2::create_precompile(&cfg))
-        } else if *address == FEATURE_REGISTRY_ADDRESS {
+        // TODO(TIP-1063): update this gate to T7 before merging.
+        } else if *address == FEATURE_REGISTRY_ADDRESS && cfg.spec.is_t6() {
             Some(FeatureRegistry::create_precompile(&cfg))
         } else if *address == SIGNATURE_VERIFIER_ADDRESS && cfg.spec.is_t3() {
             Some(SignatureVerifier::create_precompile(&cfg))

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -11,6 +11,7 @@ pub(crate) mod ip_validation;
 
 pub mod account_keychain;
 pub mod address_registry;
+pub mod feature_registry;
 pub mod nonce;
 pub mod receive_policy_guard;
 pub mod signature_verifier;
@@ -27,7 +28,8 @@ pub mod validator_config_v2;
 pub mod test_util;
 
 use crate::{
-    account_keychain::AccountKeychain, address_registry::AddressRegistry, nonce::NonceManager,
+    account_keychain::AccountKeychain, address_registry::AddressRegistry,
+    feature_registry::FeatureRegistry, nonce::NonceManager,
     receive_policy_guard::ReceivePolicyGuard, signature_verifier::SignatureVerifier,
     stablecoin_dex::StablecoinDEX, storage::StorageCtx, tip_fee_manager::TipFeeManager,
     tip20::TIP20Token, tip20_channel_reserve::TIP20ChannelReserve, tip20_factory::TIP20Factory,
@@ -54,10 +56,10 @@ use revm::{
 
 pub use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, DEFAULT_FEE_TOKEN,
-    NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS, RECEIVE_POLICY_GUARD_ADDRESS,
-    SIGNATURE_VERIFIER_ADDRESS, STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
-    TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS,
-    VALIDATOR_CONFIG_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
+    FEATURE_REGISTRY_ADDRESS, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS,
+    RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS, STABLECOIN_DEX_ADDRESS,
+    TIP_FEE_MANAGER_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_FACTORY_ADDRESS,
+    TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
 
 // Re-export storage layout helpers for read-only contexts (e.g., pool validation)
@@ -142,6 +144,8 @@ pub fn extend_tempo_precompiles(precompiles: &mut PrecompilesMap, cfg: &CfgEnv<T
             Some(AccountKeychain::create_precompile(&cfg))
         } else if *address == VALIDATOR_CONFIG_V2_ADDRESS {
             Some(ValidatorConfigV2::create_precompile(&cfg))
+        } else if *address == FEATURE_REGISTRY_ADDRESS {
+            Some(FeatureRegistry::create_precompile(&cfg))
         } else if *address == SIGNATURE_VERIFIER_ADDRESS && cfg.spec.is_t3() {
             Some(SignatureVerifier::create_precompile(&cfg))
         } else if *address == RECEIVE_POLICY_GUARD_ADDRESS && cfg.spec.is_t6() {
@@ -255,6 +259,13 @@ impl ValidatorConfigV2 {
     /// Creates the EVM precompile for this type.
     pub fn create_precompile(cfg: &CfgEnv<TempoHardfork>) -> DynPrecompile {
         tempo_precompile!("ValidatorConfigV2", cfg, |input| { Self::new() })
+    }
+}
+
+impl FeatureRegistry {
+    /// Creates the EVM precompile for this type.
+    pub fn create_precompile(cfg: &CfgEnv<TempoHardfork>) -> DynPrecompile {
+        tempo_precompile!("FeatureRegistry", cfg, |input| { Self::new() })
     }
 }
 


### PR DESCRIPTION
Refs TIP-1063

Adds the feature registry precompile implementation for the active feature tip cursor. Only featuresTip() is live in this first implementation; the remaining registry ABI selectors continue to return unknown until their storage and quorum semantics are added.