### PR TITLE
perf: drop state hook earlier

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -729,9 +729,6 @@ where
             ));
         };
 
-        // cancel pre-warming, if any, by dropping the iter
-        drop(best_txs);
-
         let elapsed_at_tx_cutoff = start.elapsed();
         let validation_work_at_tx_cutoff =
             elapsed_at_tx_cutoff.saturating_sub(normal_transaction_fill_idle_elapsed);
@@ -869,12 +866,15 @@ where
         // Drop the roots task handle to trigger finalization
         drop(roots_tx);
 
-        let (evm, execution_result) = executor.finish()?;
-        let evm_env = evm.into_env();
-
         // Drop the state hook to signal that execution is complete and the sparse trie task can
         // finalize the state root.
         db.set_state_hook(None);
+
+        // cancel pre-warming, if any, by dropping the iter
+        drop(best_txs);
+
+        let (evm, execution_result) = executor.finish()?;
+        let evm_env = evm.into_env();
 
         // merge all transitions into bundle state before deriving the hashed post-state
         db.merge_transitions(BundleRetention::Reverts);

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -872,12 +872,12 @@ where
         let (evm, execution_result) = executor.finish()?;
         let evm_env = evm.into_env();
 
-        // merge all transitions into bundle state before deriving the hashed post-state
-        db.merge_transitions(BundleRetention::Reverts);
-
         // Drop the state hook to signal that execution is complete and the sparse trie task can
         // finalize the state root.
         db.set_state_hook(None);
+
+        // merge all transitions into bundle state before deriving the hashed post-state
+        db.merge_transitions(BundleRetention::Reverts);
 
         let hashed_state = if let Some(Ok(hashed_state)) = trie_handle
             .as_mut()

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -868,7 +868,7 @@ where
 
         // Drop the state hook to signal that execution is complete and the sparse trie task can
         // finalize the state root.
-        db.set_state_hook(None);
+        executor.evm_mut().db_mut().set_state_hook(None);
 
         // cancel pre-warming, if any, by dropping the iter
         drop(best_txs);


### PR DESCRIPTION
moves state hook drop before the `best_txs` drop and `merge_transitions` call