### PR TITLE
perf(transaction-pool): cache fee payer recovery

### DIFF
--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -74,6 +74,8 @@ pub struct TempoPooledTransaction {
     /// Stores `(fee_token, balance_slot)` so the payload builder's state-aware iterator
     /// can check if the fee payer's balance was modified without recomputing the keccak.
     fee_balance_slot: OnceLock<Option<(Address, U256)>>,
+    /// Cached fee payer address; `None` when an AA `fee_payer_signature` fails to recover.
+    fee_payer: OnceLock<Option<Address>>,
 }
 
 impl TempoPooledTransaction {
@@ -109,6 +111,7 @@ impl TempoPooledTransaction {
             key_authorization_signer_subject: OnceLock::new(),
             key_authorization_target_subject: OnceLock::new(),
             fee_balance_slot: OnceLock::new(),
+            fee_payer: OnceLock::new(),
         }
     }
 
@@ -123,9 +126,15 @@ impl TempoPooledTransaction {
         &self.inner.transaction
     }
 
-    /// Resolves the transaction fee payer.
+    /// Resolves and caches the transaction fee payer.
     pub fn fee_payer(&self) -> Result<Address, RecoveryError> {
-        self.inner().fee_payer(self.inner().signer())
+        match self
+            .fee_payer
+            .get_or_init(|| self.inner().fee_payer(self.inner().signer()).ok())
+        {
+            Some(addr) => Ok(*addr),
+            None => Err(RecoveryError::new()),
+        }
     }
 
     /// Returns true if this is an AA transaction


### PR DESCRIPTION
Caches `TempoPooledTransaction::fee_payer()` via `OnceLock<Option<Address>>`, matching the shape of the existing memoized fields on the same struct.
`fee_payer()` does ECDSA recovery + keccak for AA txs with a fee_payer_signature. It's called per-tx inside `evict_invalidated_transactions` (via is_sender_paid_fee) and once more during fee_balance_slot init — uncached, so the same transaction pays the cost on every invalidation event.
 In the captured profile it accounted for ~0.4% of the tempo-txpool-ma track; scales linearly with the fraction of pool txs carrying a fee_payer_signature.
<img width="1710" height="1069" alt="Screenshot 2026-06-02 at 8 33 02 PM" src="https://github.com/user-attachments/assets/6290b634-e5a6-40a0-bf56-c6fb3c2881ed" />

