### PR TITLE
feat(precompiles): read scheduled features tip

### DIFF
--- a/.changelog/feature-registry-schedule-read.md
+++ b/.changelog/feature-registry-schedule-read.md
@@ -1,0 +1,5 @@
+---
+tempo-precompiles: minor
+---
+
+Add the TIP-1063 feature registry `scheduledFeaturesTip` read.

--- a/crates/precompiles/src/feature_registry/dispatch.rs
+++ b/crates/precompiles/src/feature_registry/dispatch.rs
@@ -32,8 +32,8 @@ impl Precompile for FeatureRegistry {
                 IFeatureRegistryCalls::activationQuorum(_) => {
                     unsupported::<IFeatureRegistry::activationQuorumCall>()
                 }
-                IFeatureRegistryCalls::scheduledFeaturesTip(_) => {
-                    unsupported::<IFeatureRegistry::scheduledFeaturesTipCall>()
+                IFeatureRegistryCalls::scheduledFeaturesTip(call) => {
+                    view(call, |_| self.scheduled_features_tip())
                 }
                 IFeatureRegistryCalls::setSupportedFeaturesTip(_) => {
                     unsupported::<IFeatureRegistry::setSupportedFeaturesTipCall>()
@@ -94,6 +94,52 @@ mod tests {
     }
 
     #[test]
+    fn scheduled_features_tip_defaults_to_zero() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let registry = FeatureRegistry::new();
+            let scheduled = registry.scheduled_features_tip()?;
+            assert_eq!(scheduled.featuresTip, 0);
+            assert_eq!(scheduled.activationEpoch, 0);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn scheduled_features_tip_reads_schedule_fields() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            registry.scheduled_features_tip.write(13)?;
+            registry.scheduled_activation_epoch.write(21)?;
+
+            let scheduled = registry.scheduled_features_tip()?;
+            assert_eq!(scheduled.featuresTip, 13);
+            assert_eq!(scheduled.activationEpoch, 21);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn scheduled_features_tip_preserves_active_features_tip() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            registry.features_tip.write(7)?;
+            registry.scheduled_features_tip.write(13)?;
+            registry.scheduled_activation_epoch.write(21)?;
+
+            assert_eq!(registry.features_tip()?, 7);
+            let scheduled = registry.scheduled_features_tip()?;
+            assert_eq!(scheduled.featuresTip, 13);
+            assert_eq!(scheduled.activationEpoch, 21);
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn features_tip_dispatch_returns_encoded_cursor() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
@@ -104,6 +150,26 @@ mod tests {
             let result = registry.call(&call.abi_encode(), Address::ZERO)?;
             assert!(!result.is_revert());
             assert_eq!(u64::abi_decode(&result.bytes)?, 11);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn scheduled_features_tip_dispatch_returns_encoded_schedule() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            registry.scheduled_features_tip.write(34)?;
+            registry.scheduled_activation_epoch.write(55)?;
+
+            let call = IFeatureRegistry::scheduledFeaturesTipCall {};
+            let result = registry.call(&call.abi_encode(), Address::ZERO)?;
+            assert!(!result.is_revert());
+            let decoded =
+                IFeatureRegistry::scheduledFeaturesTipCall::abi_decode_returns(&result.bytes)?;
+            assert_eq!(decoded.featuresTip, 34);
+            assert_eq!(decoded.activationEpoch, 55);
 
             Ok(())
         })

--- a/crates/precompiles/src/feature_registry/mod.rs
+++ b/crates/precompiles/src/feature_registry/mod.rs
@@ -3,16 +3,21 @@
 pub mod dispatch;
 
 use crate::{FEATURE_REGISTRY_ADDRESS, error::Result, storage::Handler};
+use tempo_contracts::precompiles::IFeatureRegistry;
 use tempo_precompiles_macros::contract;
 
 /// Protocol feature registry.
 ///
-/// The first implementation exposes the active feature tip cursor. The cursor lives at storage
-/// slot zero and represents the highest active protocol feature ID.
+/// The first implementation exposes feature tip cursors. The active feature tip cursor lives at
+/// storage slot zero and represents the highest active protocol feature ID.
 #[contract(addr = FEATURE_REGISTRY_ADDRESS)]
 pub struct FeatureRegistry {
     /// Highest active protocol feature ID.
     features_tip: u64,
+    /// Scheduled target feature tip, or zero when no target is scheduled.
+    scheduled_features_tip: u64,
+    /// Earliest activation epoch for the scheduled feature tip, or zero when none is scheduled.
+    scheduled_activation_epoch: u64,
 }
 
 impl FeatureRegistry {
@@ -24,5 +29,14 @@ impl FeatureRegistry {
     /// Returns the highest active protocol feature ID.
     pub fn features_tip(&self) -> Result<u64> {
         self.features_tip.read()
+    }
+
+    /// Returns the scheduled target feature tip and earliest activation epoch.
+    pub fn scheduled_features_tip(&self) -> Result<IFeatureRegistry::scheduledFeaturesTipReturn> {
+        Ok((
+            self.scheduled_features_tip.read()?,
+            self.scheduled_activation_epoch.read()?,
+        )
+            .into())
     }
 }


### PR DESCRIPTION
Adds the FeatureRegistry `scheduledFeaturesTip()` read path and storage fields for the scheduled target tip and activation epoch.

This keeps the TIP-1063 registry implementation read-only while exposing the scheduled cursor.