### PR TITLE
Remove builder prewarming from bench e2e defaults

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -27,7 +27,6 @@ const E2E_LOCAL_RETH_ARGS = [
     "--tempo.bootnodes-endpoint" "none"
     "--consensus.no-legacy-archive"
     "--engine.share-execution-cache-with-payload-builder"
-    "--builder.enable-prewarming"
     "--txpool.pending-max-count" "200000"
     "--txpool.basefee-max-count" "200000"
     "--txpool.queued-max-count" "200000"


### PR DESCRIPTION
## Summary
- remove `--builder.enable-prewarming` from `E2E_LOCAL_RETH_ARGS` in `bench-e2e.nu`

## Testing
- not run; config-only default argument removal

Prompted by: @shekhirin