### PR TITLE
ci(bench): add TIP-20 2D nonce preset

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -58,6 +58,7 @@ on:
         default: tip20
         options:
           - tip20
+          - tip20_2d_nonces
           - tip20_random_recipients
           - tip20_existing_recipients
           - mpp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4467,9 +4467,9 @@ dependencies = [
 
 [[package]]
 name = "fixed-cache"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41c7aa69c00ebccf06c3fa7ffe2a6cf26a58b5fe4deabfe646285ff48136a8f"
+checksum = "2fe63500644ef0269fe6b744e7e5dc5c20b5eebf3d881bc2be53f194636f6583"
 dependencies = [
  "equivalent",
  "rapidhash",

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -28,6 +28,7 @@ const E2E_LOCAL_RETH_ARGS = [
     "--consensus.no-legacy-archive"
     "--engine.share-execution-cache-with-payload-builder"
     "--builder.enable-prewarming"
+    "--rpc.max-connections" "10000"
     "--txpool.pending-max-count" "200000"
     "--txpool.basefee-max-count" "200000"
     "--txpool.queued-max-count" "200000"

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -4,7 +4,7 @@ const TXGEN_HELPER_SCRAPE_INTERVAL_MS = 200
 const TXGEN_HELPER_DRAIN_TIMEOUT_SECS = 300
 const TXGEN_HELPER_FUND_DRAIN_TIMEOUT_SECS = 120
 const TXGEN_HELPER_PRESETS_DIR = "contrib/bench/txgen/presets"
-const TXGEN_HELPER_EXISTING_RECIPIENTS_PRESET = "tip20_existing_recipients"
+const TXGEN_HELPER_EXISTING_RECIPIENTS_PRESETS = ["tip20_existing_recipients" "tip20_2d_nonces"]
 const TXGEN_HELPER_EXISTING_RECIPIENTS_START = 10000
 
 def txgen-shell-quote [value: any] {
@@ -142,7 +142,7 @@ def txgen-bloat-accounts-per-token [bloat_mib: int, token_count: int] {
 
 def --env txgen-configure-existing-recipients-env [preset_path: string, bloat_mib: int, token_count: int] {
     let preset_name = ($preset_path | path basename | str replace --regex '\.yml$' '')
-    if $preset_name != $TXGEN_HELPER_EXISTING_RECIPIENTS_PRESET {
+    if $preset_name not-in $TXGEN_HELPER_EXISTING_RECIPIENTS_PRESETS {
         return
     }
 

--- a/contrib/bench/txgen/presets/tip20_2d_nonces.yml
+++ b/contrib/bench/txgen/presets/tip20_2d_nonces.yml
@@ -1,0 +1,49 @@
+chain_id: 1337
+
+gas:
+  max_fee_per_gas: 100000000000
+  max_priority_fee_per_gas: 100000000000
+
+accounts:
+  users:
+    mnemonic: "test test test test test test test test test test test junk"
+    range:
+      - 0
+      - ${TXGEN_ACCOUNTS}
+
+address_pools:
+  existing_recipients:
+    fast:
+      seed: "test test test test test test test test test test test junk"
+      range:
+        - ${TXGEN_EXISTING_RECIPIENTS_START}
+        - ${TXGEN_EXISTING_RECIPIENTS_END}
+
+artifacts:
+  ERC20: ../erc20.abi.json
+
+templates:
+  tip20_transfer:
+    type: tempo
+    from:
+      pool: users
+      select: random
+    gas_limit: 350000
+    max_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 100000000000
+    fee_token: "0x20c0000000000000000000000000000000000000"
+    nonce_key:
+      uniform: [1, 18446744073709551615]
+    call:
+      to: "0x20c0000000000000000000000000000000000000"
+      abi: ERC20
+      function: transfer
+      args:
+        - address_pool:
+            pool: existing_recipients
+            select: random
+        - 1
+
+mix:
+  - template: tip20_transfer
+    weight: 100


### PR DESCRIPTION
Adds a `tip20_2d_nonces` txgen preset that sends direct TIP-20 transfers with random non-expiring 2D nonce keys against the existing-recipient bloat range.

The e2e bench harness also defaults local nodes to `--rpc.max-connections 10000` so this workload can fetch parallel nonces without requiring extra caller args. Keeps execution-cache sharing enabled by default and bumps `fixed-cache` to `0.1.10`.