### PR TITLE
refactor(tip1060): move opcode gas-state policy into tip1060 module

### DIFF
--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -4,22 +4,13 @@ use alloy_primitives::{Address, U256};
 use revm::{
     Context, Inspector,
     context::{Cfg, CfgEnv, ContextError, Evm, FrameStack},
-    context_interface::cfg::GasParams,
     handler::{
         EthFrame, EvmTr, FrameInitOrResult, FrameTr, ItemOrResult, instructions::EthInstructions,
     },
     inspector::InspectorEvmTr,
-    interpreter::{
-        Host, InitialAndFloorGas, InstructionContext, InstructionResult, SStoreResult, StateLoad,
-        instruction_context::{GasStateOutcome, GasStateTr},
-        interpreter::EthInterpreter,
-    },
+    interpreter::{InitialAndFloorGas, interpreter::EthInterpreter},
 };
 use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_precompiles::{
-    STORAGE_GAS_TOKENS_ADDRESS as GAS_TOKEN,
-    tip1060_storage_gas_token::{GasStateBackend, sstore_gas_state},
-};
 
 /// The Tempo EVM context type.
 pub type TempoContext<DB> = Context<TempoBlockEnv, TempoTxEnv, CfgEnv<TempoHardfork>, DB>;
@@ -225,101 +216,6 @@ where
         &mut Self::Inspector,
     ) {
         self.inner.all_mut_inspector()
-    }
-}
-
-/// Opcode-level [`GasStateBackend`] adapter over an [`InstructionContext`].
-///
-/// Bridges the revm host/interpreter to the backend-agnostic
-/// [`sstore_gas_state`] so the SSTORE opcode runs the same TIP-1060
-/// gas-token policy as precompile-driven storage writes.
-struct InterpreterGasState<'a, 'b, DB: Database> {
-    context: &'a mut InstructionContext<'b, TempoContext<DB>, EthInterpreter>,
-}
-
-impl<DB: Database> GasStateBackend for InterpreterGasState<'_, '_, DB> {
-    type Error = InstructionResult;
-
-    #[inline]
-    fn out_of_gas() -> Self::Error {
-        InstructionResult::OutOfGas
-    }
-
-    #[inline]
-    fn fatal_external() -> Self::Error {
-        InstructionResult::FatalExternalError
-    }
-
-    #[inline]
-    fn gas_params(&self) -> &GasParams {
-        self.context.host.gas_params()
-    }
-
-    #[inline]
-    fn remaining_gas(&self) -> u64 {
-        self.context.interpreter.gas.remaining()
-    }
-
-    #[inline]
-    fn charge_gas(&mut self, cost: u64) -> Result<(), Self::Error> {
-        if self.context.interpreter.gas.record_regular_cost(cost) {
-            Ok(())
-        } else {
-            Err(InstructionResult::OutOfGas)
-        }
-    }
-
-    #[inline]
-    fn load_gas_token_account(&mut self) -> Result<(), Self::Error> {
-        self.context
-            .host
-            .load_account_info_skip_cold_load(GAS_TOKEN, false, false)?;
-        Ok(())
-    }
-
-    #[inline]
-    fn gas_token_sload(
-        &mut self,
-        key: U256,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, Self::Error> {
-        Ok(self
-            .context
-            .host
-            .sload_skip_cold_load(GAS_TOKEN, key, skip_cold_load)?)
-    }
-
-    #[inline]
-    fn gas_token_sstore(&mut self, key: U256, value: U256) -> Result<(), Self::Error> {
-        self.context
-            .host
-            .sstore_skip_cold_load(GAS_TOKEN, key, value, false)?;
-        Ok(())
-    }
-
-    #[inline]
-    fn token_tstore_increment(&mut self, key: U256) {
-        let pending = self.context.host.tload(GAS_TOKEN, key);
-        self.context
-            .host
-            .tstore(GAS_TOKEN, key, pending.saturating_add(U256::from(1)));
-    }
-}
-
-/// Tempo SSTORE gas-state policy.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub(crate) struct TempoGasState;
-
-impl<DB> GasStateTr<EthInterpreter, TempoContext<DB>> for TempoGasState
-where
-    DB: Database,
-{
-    fn sstore_gas_state(
-        context: &mut InstructionContext<'_, TempoContext<DB>, EthInterpreter>,
-        owner: Address,
-        values: &SStoreResult,
-    ) -> Result<GasStateOutcome, InstructionResult> {
-        sstore_gas_state(&mut InterpreterGasState { context }, owner, values)
     }
 }
 

--- a/crates/revm/src/instructions.rs
+++ b/crates/revm/src/instructions.rs
@@ -1,4 +1,4 @@
-use crate::evm::{TempoContext, TempoGasState};
+use crate::{evm::TempoContext, tip1060::TIP1060StorageGasTokenState};
 use alloy_evm::Database;
 use revm::{
     handler::instructions::EthInstructions,
@@ -37,7 +37,11 @@ pub(crate) fn tempo_instructions<DB: Database>(
     // +T6: Enable TIP-1060 sstore hook
     let mut instructions = if spec.is_t6() {
         EthInstructions::new(
-            instruction_table_with_gas_state::<TempoGasState, EthInterpreter, TempoContext<DB>>(),
+            instruction_table_with_gas_state::<
+                TIP1060StorageGasTokenState,
+                EthInterpreter,
+                TempoContext<DB>,
+            >(),
             gas_table_spec(evm_spec),
             evm_spec,
         )

--- a/crates/revm/src/tip1060.rs
+++ b/crates/revm/src/tip1060.rs
@@ -1,9 +1,21 @@
 //! TIP-1060 specific implementations.
 
-use crate::evm::TempoEvm;
+use crate::evm::{TempoContext, TempoEvm};
 use alloy_evm::Database;
-use revm::context::JournalTr;
-use tempo_precompiles::STORAGE_GAS_TOKENS_ADDRESS as GAS_TOKEN;
+use alloy_primitives::{Address, U256};
+use revm::{
+    context::{Host as _, JournalTr},
+    context_interface::cfg::GasParams,
+    interpreter::{
+        InstructionContext, InstructionResult, SStoreResult, StateLoad,
+        instruction_context::{GasStateOutcome, GasStateTr},
+        interpreter::EthInterpreter,
+    },
+};
+use tempo_precompiles::{
+    STORAGE_GAS_TOKENS_ADDRESS as GAS_TOKEN,
+    tip1060_storage_gas_token::{GasStateBackend, sstore_gas_state},
+};
 
 /// Applies the storage gas-token refund accrued during a transaction.
 ///
@@ -38,4 +50,99 @@ pub fn apply_refund<DB: Database, I>(evm: &mut TempoEvm<DB, I>) -> Result<(), DB
     }
 
     Ok(())
+}
+
+/// Opcode-level [`GasStateBackend`] adapter over an [`InstructionContext`].
+///
+/// Bridges the revm host/interpreter to the backend-agnostic
+/// [`sstore_gas_state`] so the SSTORE opcode runs the same TIP-1060
+/// gas-token policy as precompile-driven storage writes.
+struct InterpreterGasState<'a, 'b, DB: Database> {
+    context: &'a mut InstructionContext<'b, TempoContext<DB>, EthInterpreter>,
+}
+
+impl<DB: Database> GasStateBackend for InterpreterGasState<'_, '_, DB> {
+    type Error = InstructionResult;
+
+    #[inline]
+    fn out_of_gas() -> Self::Error {
+        InstructionResult::OutOfGas
+    }
+
+    #[inline]
+    fn fatal_external() -> Self::Error {
+        InstructionResult::FatalExternalError
+    }
+
+    #[inline]
+    fn gas_params(&self) -> &GasParams {
+        self.context.host.gas_params()
+    }
+
+    #[inline]
+    fn remaining_gas(&self) -> u64 {
+        self.context.interpreter.gas.remaining()
+    }
+
+    #[inline]
+    fn charge_gas(&mut self, cost: u64) -> Result<(), Self::Error> {
+        if self.context.interpreter.gas.record_regular_cost(cost) {
+            Ok(())
+        } else {
+            Err(InstructionResult::OutOfGas)
+        }
+    }
+
+    #[inline]
+    fn load_gas_token_account(&mut self) -> Result<(), Self::Error> {
+        self.context
+            .host
+            .load_account_info_skip_cold_load(GAS_TOKEN, false, false)?;
+        Ok(())
+    }
+
+    #[inline]
+    fn gas_token_sload(
+        &mut self,
+        key: U256,
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<U256>, Self::Error> {
+        Ok(self
+            .context
+            .host
+            .sload_skip_cold_load(GAS_TOKEN, key, skip_cold_load)?)
+    }
+
+    #[inline]
+    fn gas_token_sstore(&mut self, key: U256, value: U256) -> Result<(), Self::Error> {
+        self.context
+            .host
+            .sstore_skip_cold_load(GAS_TOKEN, key, value, false)?;
+        Ok(())
+    }
+
+    #[inline]
+    fn token_tstore_increment(&mut self, key: U256) {
+        let pending = self.context.host.tload(GAS_TOKEN, key);
+        self.context
+            .host
+            .tstore(GAS_TOKEN, key, pending.saturating_add(U256::from(1)));
+    }
+}
+
+/// Tempo SSTORE gas-state policy.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub(crate) struct TIP1060StorageGasTokenState;
+
+impl<DB> GasStateTr<EthInterpreter, TempoContext<DB>> for TIP1060StorageGasTokenState
+where
+    DB: Database,
+{
+    fn sstore_gas_state(
+        context: &mut InstructionContext<'_, TempoContext<DB>, EthInterpreter>,
+        owner: Address,
+        values: &SStoreResult,
+    ) -> Result<GasStateOutcome, InstructionResult> {
+        sstore_gas_state(&mut InterpreterGasState { context }, owner, values)
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #5232. Moves the opcode-level SSTORE gas-state policy out of `evm.rs` and into the `tip1060` module, next to the rest of the TIP-1060 logic:

- `InterpreterGasState` (the `GasStateBackend` adapter over the revm `InstructionContext`) moves from `crates/revm/src/evm.rs` to `crates/revm/src/tip1060.rs`.
- The gas-state policy struct is renamed `TempoGasState` → `TIP1060StorageGasTokenState` and also moves to `tip1060.rs`.
- `instructions.rs` updated to reference `tip1060::TIP1060StorageGasTokenState` (still T6-gated, unchanged behavior).

Pure code move + rename — no behavior change.

## Testing

- `cargo build -p tempo-revm`