### PR TITLE
feat(precompiles): read activation quorum

### DIFF
--- a/.changelog/feature-registry-activation-quorum.md
+++ b/.changelog/feature-registry-activation-quorum.md
@@ -1,0 +1,5 @@
+---
+tempo-precompiles: minor
+---
+
+Add the TIP-1063 feature registry `activationQuorum` read.

--- a/crates/precompiles/src/feature_registry/dispatch.rs
+++ b/crates/precompiles/src/feature_registry/dispatch.rs
@@ -29,8 +29,8 @@ impl Precompile for FeatureRegistry {
             |call| match call {
                 IFeatureRegistryCalls::featuresTip(call) => view(call, |_| self.features_tip()),
                 IFeatureRegistryCalls::owner(_) => unsupported::<IFeatureRegistry::ownerCall>(),
-                IFeatureRegistryCalls::activationQuorum(_) => {
-                    unsupported::<IFeatureRegistry::activationQuorumCall>()
+                IFeatureRegistryCalls::activationQuorum(call) => {
+                    view(call, |_| self.activation_quorum())
                 }
                 IFeatureRegistryCalls::scheduledFeaturesTip(call) => {
                     view(call, |_| self.scheduled_features_tip())
@@ -62,7 +62,10 @@ impl Precompile for FeatureRegistry {
 mod tests {
     use super::*;
     use crate::storage::{StorageCtx, hashmap::HashMapStorageProvider};
-    use alloy::sol_types::{SolCall, SolError, SolValue};
+    use alloy::{
+        primitives::U256,
+        sol_types::{SolCall, SolError, SolValue},
+    };
     use tempo_chainspec::features::HIGHEST_ACTIVE_PROTOCOL_FEATURE_ID_SLOT;
     use tempo_contracts::precompiles::UnknownFunctionSelector;
 
@@ -89,6 +92,18 @@ mod tests {
             registry.features_tip.write(7)?;
             assert_eq!(registry.features_tip()?, 7);
 
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn activation_quorum_returns_fixed_threshold() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let registry = FeatureRegistry::new();
+            let quorum = registry.activation_quorum()?;
+            assert_eq!(quorum.numerator, U256::from(4));
+            assert_eq!(quorum.denominator, U256::from(5));
             Ok(())
         })
     }
@@ -150,6 +165,24 @@ mod tests {
             let result = registry.call(&call.abi_encode(), Address::ZERO)?;
             assert!(!result.is_revert());
             assert_eq!(u64::abi_decode(&result.bytes)?, 11);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn activation_quorum_dispatch_returns_encoded_threshold() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+
+            let call = IFeatureRegistry::activationQuorumCall {};
+            let result = registry.call(&call.abi_encode(), Address::ZERO)?;
+            assert!(!result.is_revert());
+            let decoded =
+                IFeatureRegistry::activationQuorumCall::abi_decode_returns(&result.bytes)?;
+            assert_eq!(decoded.numerator, U256::from(4));
+            assert_eq!(decoded.denominator, U256::from(5));
 
             Ok(())
         })

--- a/crates/precompiles/src/feature_registry/mod.rs
+++ b/crates/precompiles/src/feature_registry/mod.rs
@@ -3,8 +3,13 @@
 pub mod dispatch;
 
 use crate::{FEATURE_REGISTRY_ADDRESS, error::Result, storage::Handler};
+use alloy::primitives::U256;
 use tempo_contracts::precompiles::IFeatureRegistry;
 use tempo_precompiles_macros::contract;
+
+// Activation requires 80% support from the active validator set, represented exactly as 4/5.
+const ACTIVATION_QUORUM_NUMERATOR: u64 = 4;
+const ACTIVATION_QUORUM_DENOMINATOR: u64 = 5;
 
 /// Protocol feature registry.
 ///
@@ -29,6 +34,15 @@ impl FeatureRegistry {
     /// Returns the highest active protocol feature ID.
     pub fn features_tip(&self) -> Result<u64> {
         self.features_tip.read()
+    }
+
+    /// Returns the fixed activation quorum threshold as an exact fraction: 4/5, or 80%.
+    pub fn activation_quorum(&self) -> Result<IFeatureRegistry::activationQuorumReturn> {
+        Ok((
+            U256::from(ACTIVATION_QUORUM_NUMERATOR),
+            U256::from(ACTIVATION_QUORUM_DENOMINATOR),
+        )
+            .into())
     }
 
     /// Returns the scheduled target feature tip and earliest activation epoch.


### PR DESCRIPTION
Adds the FeatureRegistry `activationQuorum()` read path for the fixed 80% activation threshold.

The threshold is returned as the exact fraction `4/5` to avoid percent rounding ambiguity.