### PR TITLE
fix(localnet): pass consensus signing key secret

### DIFF
--- a/tempo.nu
+++ b/tempo.nu
@@ -33,11 +33,16 @@ def log-filter-args [loud: bool] {
     if $loud { [] } else { ["--log.stdout.filter" "info"] }
 }
 
-def ensure-localnet-consensus-secret [] {
-    let secret_path = $"($LOCALNET_DIR)/consensus-secret.txt"
-    $"($LOCALNET_SIGNING_KEY_SECRET)\n" | save -f $secret_path
+def prepare-localnet-consensus-secret-fifo [node_dir: string] {
+    let secret_path = $"($node_dir)/consensus-secret.fifo"
+    rm -f $secret_path
+    mkfifo $secret_path
     chmod 600 $secret_path
     $secret_path
+}
+
+def start-localnet-consensus-secret-writer [secret_path: string] {
+    job spawn { $"($LOCALNET_SIGNING_KEY_SECRET)\n" | save -f $secret_path } | ignore
 }
 
 # Wrap command with samply if enabled
@@ -1855,7 +1860,6 @@ def run-consensus-nodes [nodes: int, accounts: int, epoch_length: int, genesis: 
     } | str join ",")
 
     print $"Found ($validator_dirs | length) validator configs"
-    let consensus_secret = (ensure-localnet-consensus-secret)
 
     let tempo_bin = if $profile == "dev" {
         "./target/debug/tempo"
@@ -1898,11 +1902,11 @@ def run-consensus-nodes [nodes: int, accounts: int, epoch_length: int, genesis: 
     let background_nodes = $validator_dirs | skip 1
 
     for node in $background_nodes {
-        run-consensus-node $node $genesis_path $trusted_peers $tempo_bin $loud false [] $extra_args $consensus_secret true
+        run-consensus-node $node $genesis_path $trusted_peers $tempo_bin $loud false [] $extra_args true
     }
 
     # Run node 0 in foreground (receives Ctrl+C directly)
-    run-consensus-node $foreground_node $genesis_path $trusted_peers $tempo_bin $loud $samply $samply_args $extra_args $consensus_secret false
+    run-consensus-node $foreground_node $genesis_path $trusted_peers $tempo_bin $loud $samply $samply_args $extra_args false
 }
 
 # Run a single consensus node (foreground or background)
@@ -1915,13 +1919,13 @@ def run-consensus-node [
     samply: bool
     samply_args: list<string>
     extra_args: list<string>
-    consensus_secret: string
     background: bool
 ] {
     let addr = ($node_dir | path basename)
     let port = ($addr | split row ":" | get 1 | into int)
     let node_index = (port-to-node-index $port)
     let http_port = 8545 + $node_index
+    let consensus_secret = (prepare-localnet-consensus-secret-fifo $node_dir)
 
     let log_dir = $"($LOGS_DIR)/($addr)"
     mkdir $log_dir
@@ -1935,9 +1939,11 @@ def run-consensus-node [
     print $"  Node ($addr) -> http://localhost:($http_port)(if $background { '' } else { ' (foreground)' })"
 
     if $background {
+        start-localnet-consensus-secret-writer $consensus_secret
         job spawn { sh -c $"($cmd | str join ' ') 2>&1" | lines | each { |line| print $"[($addr)] ($line)" } }
     } else {
         print $"  Running: ($cmd | str join ' ')"
+        start-localnet-consensus-secret-writer $consensus_secret
         run-external ($cmd | first) ...($cmd | skip 1)
     }
 }

--- a/tempo.nu
+++ b/tempo.nu
@@ -14,6 +14,7 @@ const BENCH_WORKTREES_DIR = ".bench-worktrees"
 const BENCH_RESULTS_DIR = "bench-results"
 const MINIO_BUCKET = "minio/tempo-binaries"
 const BENCH_META_SUBDIR = ".bench-meta"
+const LOCALNET_SIGNING_KEY_SECRET = "tempo-localnet-signing-key-secret"
 
 # TIP20 token IDs created by localnet genesis (pathUSD, AlphaUSD, BetaUSD, ThetaUSD)
 const TIP20_TOKEN_IDS = [0, 1, 2, 3]
@@ -30,6 +31,13 @@ def port-to-node-index [port: int] {
 # Build log filter args based on --loud flag
 def log-filter-args [loud: bool] {
     if $loud { [] } else { ["--log.stdout.filter" "info"] }
+}
+
+def ensure-localnet-consensus-secret [] {
+    let secret_path = $"($LOCALNET_DIR)/consensus-secret.txt"
+    $"($LOCALNET_SIGNING_KEY_SECRET)\n" | save -f $secret_path
+    chmod 600 $secret_path
+    $secret_path
 }
 
 # Wrap command with samply if enabled
@@ -1847,6 +1855,7 @@ def run-consensus-nodes [nodes: int, accounts: int, epoch_length: int, genesis: 
     } | str join ",")
 
     print $"Found ($validator_dirs | length) validator configs"
+    let consensus_secret = (ensure-localnet-consensus-secret)
 
     let tempo_bin = if $profile == "dev" {
         "./target/debug/tempo"
@@ -1889,11 +1898,11 @@ def run-consensus-nodes [nodes: int, accounts: int, epoch_length: int, genesis: 
     let background_nodes = $validator_dirs | skip 1
 
     for node in $background_nodes {
-        run-consensus-node $node $genesis_path $trusted_peers $tempo_bin $loud false [] $extra_args true
+        run-consensus-node $node $genesis_path $trusted_peers $tempo_bin $loud false [] $extra_args $consensus_secret true
     }
 
     # Run node 0 in foreground (receives Ctrl+C directly)
-    run-consensus-node $foreground_node $genesis_path $trusted_peers $tempo_bin $loud $samply $samply_args $extra_args false
+    run-consensus-node $foreground_node $genesis_path $trusted_peers $tempo_bin $loud $samply $samply_args $extra_args $consensus_secret false
 }
 
 # Run a single consensus node (foreground or background)
@@ -1906,6 +1915,7 @@ def run-consensus-node [
     samply: bool
     samply_args: list<string>
     extra_args: list<string>
+    consensus_secret: string
     background: bool
 ] {
     let addr = ($node_dir | path basename)
@@ -1916,7 +1926,7 @@ def run-consensus-node [
     let log_dir = $"($LOGS_DIR)/($addr)"
     mkdir $log_dir
 
-    let args = (build-consensus-node-args $node_dir $genesis_path $trusted_peers $port $log_dir)
+    let args = (build-consensus-node-args $node_dir $genesis_path $trusted_peers $port $log_dir $consensus_secret)
         | append (log-filter-args $loud)
         | append $extra_args
 
@@ -1933,17 +1943,17 @@ def run-consensus-node [
 }
 
 # Build full node arguments for consensus mode
-def build-consensus-node-args [node_dir: string, genesis_path: string, trusted_peers: string, port: int, log_dir: string] {
+def build-consensus-node-args [node_dir: string, genesis_path: string, trusted_peers: string, port: int, log_dir: string, consensus_secret: string] {
     let node_index = (port-to-node-index $port)
     let http_port = 8545 + $node_index
     let reth_metrics_port = 9001 + $node_index
 
     (build-base-args $genesis_path $node_dir $log_dir "0.0.0.0" $http_port $reth_metrics_port)
-        | append (build-consensus-args $node_dir $trusted_peers $port)
+        | append (build-consensus-args $node_dir $trusted_peers $port $consensus_secret)
 }
 
 # Build consensus mode specific arguments
-def build-consensus-args [node_dir: string, trusted_peers: string, port: int] {
+def build-consensus-args [node_dir: string, trusted_peers: string, port: int, consensus_secret: string] {
     let addr = ($node_dir | path basename)
     let ip = ($addr | split row ":" | get 0)
     let signing_key = $"($node_dir)/signing.key"
@@ -1957,6 +1967,7 @@ def build-consensus-args [node_dir: string, trusted_peers: string, port: int] {
 
     [
         "--consensus.signing-key" $signing_key
+        "--consensus.secret" $consensus_secret
         "--consensus.signing-share" $signing_share
         "--consensus.listen-address" $"($ip):($port)"
         "--consensus.metrics-address" $"0.0.0.0:($metrics_port)"


### PR DESCRIPTION
Passes the generated localnet signing-key secret into consensus node startup so encrypted validator signing keys can be read. This keeps the local consensus bench path aligned with the localnet generator output.