### PR TITLE
feat(precompiles): read validator supported features tip

### DIFF
--- a/.changelog/feature-registry-validator-support-read.md
+++ b/.changelog/feature-registry-validator-support-read.md
@@ -1,0 +1,5 @@
+---
+tempo-precompiles: minor
+---
+
+Add the TIP-1063 feature registry `validatorSupportedFeaturesTip` read.

--- a/crates/precompiles/src/feature_registry/dispatch.rs
+++ b/crates/precompiles/src/feature_registry/dispatch.rs
@@ -44,9 +44,9 @@ impl Precompile for FeatureRegistry {
                 IFeatureRegistryCalls::cancelScheduledFeaturesTip(_) => {
                     unsupported::<IFeatureRegistry::cancelScheduledFeaturesTipCall>()
                 }
-                IFeatureRegistryCalls::validatorSupportedFeaturesTip(_) => {
-                    unsupported::<IFeatureRegistry::validatorSupportedFeaturesTipCall>()
-                }
+                IFeatureRegistryCalls::validatorSupportedFeaturesTip(call) => view(call, |call| {
+                    self.validator_supported_features_tip(call.validator)
+                }),
                 IFeatureRegistryCalls::featuresTipSupport(_) => {
                     unsupported::<IFeatureRegistry::featuresTipSupportCall>()
                 }
@@ -155,6 +155,34 @@ mod tests {
     }
 
     #[test]
+    fn validator_supported_features_tip_defaults_to_zero() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let registry = FeatureRegistry::new();
+            let validator = Address::repeat_byte(0x01);
+
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 0);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn validator_supported_features_tip_reads_validator_report() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let validator = Address::repeat_byte(0x01);
+
+            registry.validator_supported_features_tip[validator].write(13)?;
+
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 13);
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn features_tip_dispatch_returns_encoded_cursor() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
@@ -203,6 +231,23 @@ mod tests {
                 IFeatureRegistry::scheduledFeaturesTipCall::abi_decode_returns(&result.bytes)?;
             assert_eq!(decoded.featuresTip, 34);
             assert_eq!(decoded.activationEpoch, 55);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn validator_supported_features_tip_dispatch_returns_encoded_report() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let validator = Address::repeat_byte(0x01);
+            registry.validator_supported_features_tip[validator].write(34)?;
+
+            let call = IFeatureRegistry::validatorSupportedFeaturesTipCall { validator };
+            let result = registry.call(&call.abi_encode(), Address::ZERO)?;
+            assert!(!result.is_revert());
+            assert_eq!(u64::abi_decode(&result.bytes)?, 34);
 
             Ok(())
         })

--- a/crates/precompiles/src/feature_registry/mod.rs
+++ b/crates/precompiles/src/feature_registry/mod.rs
@@ -2,8 +2,12 @@
 
 pub mod dispatch;
 
-use crate::{FEATURE_REGISTRY_ADDRESS, error::Result, storage::Handler};
-use alloy::primitives::U256;
+use crate::{
+    FEATURE_REGISTRY_ADDRESS,
+    error::Result,
+    storage::{Handler, Mapping},
+};
+use alloy::primitives::{Address, U256};
 use tempo_contracts::precompiles::IFeatureRegistry;
 use tempo_precompiles_macros::contract;
 
@@ -23,6 +27,8 @@ pub struct FeatureRegistry {
     scheduled_features_tip: u64,
     /// Earliest activation epoch for the scheduled feature tip, or zero when none is scheduled.
     scheduled_activation_epoch: u64,
+    /// Latest feature tip reported as supported by each validator.
+    validator_supported_features_tip: Mapping<Address, u64>,
 }
 
 impl FeatureRegistry {
@@ -52,5 +58,10 @@ impl FeatureRegistry {
             self.scheduled_activation_epoch.read()?,
         )
             .into())
+    }
+
+    /// Returns the latest feature tip reported as supported by `validator`.
+    pub fn validator_supported_features_tip(&self, validator: Address) -> Result<u64> {
+        self.validator_supported_features_tip[validator].read()
     }
 }


### PR DESCRIPTION
Adds the FeatureRegistry `validatorSupportedFeaturesTip(address)` read path backed by per-validator support storage.

The support reporting write remains unsupported while the update/auth semantics are still being settled.