### PR TITLE
chore: bump fixed-cache to 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4467,9 +4467,9 @@ dependencies = [
 
 [[package]]
 name = "fixed-cache"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41c7aa69c00ebccf06c3fa7ffe2a6cf26a58b5fe4deabfe646285ff48136a8f"
+checksum = "2fe63500644ef0269fe6b744e7e5dc5c20b5eebf3d881bc2be53f194636f6583"
 dependencies = [
  "equivalent",
  "rapidhash",


### PR DESCRIPTION
## Summary
- refresh Cargo.lock for fixed-cache 0.1.10

## Validation
- cargo metadata --locked --no-deps --format-version 1

Prompted by: @shekhirin