### PR TITLE
feat(precompiles): scaffold supported feature tip reports

### DIFF
--- a/.changelog/feature-registry-support-report-write.md
+++ b/.changelog/feature-registry-support-report-write.md
@@ -1,0 +1,5 @@
+---
+tempo-precompiles: minor
+---
+
+Add the TIP-1063 feature registry `setSupportedFeaturesTip` write scaffold.

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -19,12 +19,11 @@ use revm::{
     context::journaled_state::JournalLoadError,
     precompile::{PrecompileError, PrecompileHalt, PrecompileOutput, PrecompileResult},
 };
-use tempo_contracts::precompiles::FeatureRegistryError;
 use tempo_contracts::precompiles::{
-    AccountKeychainError, AddrRegistryError, FeeManagerError, NonceError, ReceivePolicyGuardError,
-    RolesAuthError, SignatureVerifierError, StablecoinDEXError, TIP20ChannelReserveError,
-    TIP20FactoryError, TIP403RegistryError, TIPFeeAMMError, UnknownFunctionSelector,
-    ValidatorConfigError, ValidatorConfigV2Error,
+    AccountKeychainError, AddrRegistryError, FeatureRegistryError, FeeManagerError, NonceError,
+    ReceivePolicyGuardError, RolesAuthError, SignatureVerifierError, StablecoinDEXError,
+    TIP20ChannelReserveError, TIP20FactoryError, TIP403RegistryError, TIPFeeAMMError,
+    UnknownFunctionSelector, ValidatorConfigError, ValidatorConfigV2Error,
 };
 
 /// Top-level error type for all Tempo precompile operations

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -19,6 +19,7 @@ use revm::{
     context::journaled_state::JournalLoadError,
     precompile::{PrecompileError, PrecompileHalt, PrecompileOutput, PrecompileResult},
 };
+use tempo_contracts::precompiles::FeatureRegistryError;
 use tempo_contracts::precompiles::{
     AccountKeychainError, AddrRegistryError, FeeManagerError, NonceError, ReceivePolicyGuardError,
     RolesAuthError, SignatureVerifierError, StablecoinDEXError, TIP20ChannelReserveError,
@@ -95,6 +96,10 @@ pub enum TempoPrecompileError {
     #[error("TIP1028 blocked transfers error: {0:?}")]
     ReceivePolicyGuardError(ReceivePolicyGuardError),
 
+    /// Error from feature registry precompile
+    #[error("Feature registry error: {0:?}")]
+    FeatureRegistryError(FeatureRegistryError),
+
     /// Gas limit exceeded during precompile execution.
     #[error("Gas limit exceeded")]
     OutOfGas,
@@ -157,6 +162,7 @@ impl TempoPrecompileError {
             Self::AccountKeychainError(e) => e.selector(),
             Self::SignatureVerifierError(e) => e.selector(),
             Self::ReceivePolicyGuardError(e) => e.selector(),
+            Self::FeatureRegistryError(e) => e.selector(),
             Self::UnknownFunctionSelector(selector) => *selector,
             Self::Panic(_) => Panic::SELECTOR,
             Self::OutOfGas | Self::Fatal(_) => [0, 0, 0, 0],
@@ -184,6 +190,7 @@ impl TempoPrecompileError {
             | Self::AccountKeychainError(_)
             | Self::SignatureVerifierError(_)
             | Self::ReceivePolicyGuardError(_)
+            | Self::FeatureRegistryError(_)
             | Self::UnknownFunctionSelector(_) => false,
         }
     }
@@ -232,6 +239,7 @@ impl TempoPrecompileError {
             Self::AccountKeychainError(e) => e.abi_encode().into(),
             Self::SignatureVerifierError(e) => e.abi_encode().into(),
             Self::ReceivePolicyGuardError(e) => e.abi_encode().into(),
+            Self::FeatureRegistryError(e) => e.abi_encode().into(),
             Self::OutOfGas => {
                 return Ok(PrecompileOutput::halt(PrecompileHalt::OutOfGas, reservoir));
             }
@@ -304,6 +312,7 @@ pub fn error_decoder_registry() -> TempoPrecompileErrorRegistry {
     add_errors_to_registry(&mut registry, TempoPrecompileError::AccountKeychainError);
     add_errors_to_registry(&mut registry, TempoPrecompileError::SignatureVerifierError);
     add_errors_to_registry(&mut registry, TempoPrecompileError::ReceivePolicyGuardError);
+    add_errors_to_registry(&mut registry, TempoPrecompileError::FeatureRegistryError);
 
     registry
 }

--- a/crates/precompiles/src/feature_registry/dispatch.rs
+++ b/crates/precompiles/src/feature_registry/dispatch.rs
@@ -2,8 +2,8 @@
 
 use super::*;
 use crate::{
-    Precompile, charge_input_cost, dispatch_call, error::TempoPrecompileError, storage::StorageCtx,
-    view,
+    Precompile, charge_input_cost, dispatch_call, error::TempoPrecompileError, mutate_void,
+    storage::StorageCtx, view,
 };
 use alloy::{
     primitives::Address,
@@ -17,7 +17,7 @@ fn unsupported<T: SolCall>() -> PrecompileResult {
 }
 
 impl Precompile for FeatureRegistry {
-    fn call(&mut self, calldata: &[u8], _msg_sender: Address) -> PrecompileResult {
+    fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
         if let Some(err) = charge_input_cost(&mut self.storage, calldata) {
             return err;
         }
@@ -35,8 +35,10 @@ impl Precompile for FeatureRegistry {
                 IFeatureRegistryCalls::scheduledFeaturesTip(call) => {
                     view(call, |_| self.scheduled_features_tip())
                 }
-                IFeatureRegistryCalls::setSupportedFeaturesTip(_) => {
-                    unsupported::<IFeatureRegistry::setSupportedFeaturesTipCall>()
+                IFeatureRegistryCalls::setSupportedFeaturesTip(call) => {
+                    mutate_void(call, msg_sender, |_, call| {
+                        self.set_supported_features_tip(call)
+                    })
                 }
                 IFeatureRegistryCalls::scheduleFeaturesTip(_) => {
                     unsupported::<IFeatureRegistry::scheduleFeaturesTipCall>()
@@ -67,7 +69,7 @@ mod tests {
         sol_types::{SolCall, SolError, SolValue},
     };
     use tempo_chainspec::features::HIGHEST_ACTIVE_PROTOCOL_FEATURE_ID_SLOT;
-    use tempo_contracts::precompiles::UnknownFunctionSelector;
+    use tempo_contracts::precompiles::{FeatureRegistryError, UnknownFunctionSelector};
 
     #[test]
     fn features_tip_defaults_to_zero() -> eyre::Result<()> {
@@ -183,6 +185,48 @@ mod tests {
     }
 
     #[test]
+    fn set_supported_features_tip_writes_validator_report() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let validator = Address::repeat_byte(0x01);
+            let call = IFeatureRegistry::setSupportedFeaturesTipCall {
+                validator,
+                featuresTip: 13,
+            };
+
+            registry.set_supported_features_tip(call)?;
+
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 13);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn set_supported_features_tip_rejects_decrease() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let validator = Address::repeat_byte(0x01);
+            registry.validator_supported_features_tip[validator].write(13)?;
+
+            let call = IFeatureRegistry::setSupportedFeaturesTipCall {
+                validator,
+                featuresTip: 7,
+            };
+
+            assert_eq!(
+                registry.set_supported_features_tip(call),
+                Err(FeatureRegistryError::supported_features_tip_decreased().into())
+            );
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 13);
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn features_tip_dispatch_returns_encoded_cursor() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
@@ -248,6 +292,51 @@ mod tests {
             let result = registry.call(&call.abi_encode(), Address::ZERO)?;
             assert!(!result.is_revert());
             assert_eq!(u64::abi_decode(&result.bytes)?, 34);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn set_supported_features_tip_dispatch_writes_report() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let validator = Address::repeat_byte(0x01);
+            let call = IFeatureRegistry::setSupportedFeaturesTipCall {
+                validator,
+                featuresTip: 34,
+            };
+
+            let result = registry.call(&call.abi_encode(), Address::ZERO)?;
+            assert!(!result.is_revert());
+            assert!(result.bytes.is_empty());
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 34);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn set_supported_features_tip_dispatch_rejects_decrease() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let validator = Address::repeat_byte(0x01);
+            registry.validator_supported_features_tip[validator].write(34)?;
+            let call = IFeatureRegistry::setSupportedFeaturesTipCall {
+                validator,
+                featuresTip: 13,
+            };
+
+            let result = registry.call(&call.abi_encode(), Address::ZERO)?;
+            assert!(result.is_revert());
+            let decoded = FeatureRegistryError::abi_decode(&result.bytes)?;
+            assert_eq!(
+                decoded,
+                FeatureRegistryError::supported_features_tip_decreased()
+            );
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 34);
 
             Ok(())
         })

--- a/crates/precompiles/src/feature_registry/mod.rs
+++ b/crates/precompiles/src/feature_registry/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     storage::{Handler, Mapping},
 };
 use alloy::primitives::{Address, U256};
-use tempo_contracts::precompiles::IFeatureRegistry;
+use tempo_contracts::precompiles::{FeatureRegistryError, IFeatureRegistry};
 use tempo_precompiles_macros::contract;
 
 // Activation requires 80% support from the active validator set, represented exactly as 4/5.
@@ -63,5 +63,18 @@ impl FeatureRegistry {
     /// Returns the latest feature tip reported as supported by `validator`.
     pub fn validator_supported_features_tip(&self, validator: Address) -> Result<u64> {
         self.validator_supported_features_tip[validator].read()
+    }
+
+    /// Records the highest protocol feature tip reported as supported by a validator.
+    pub fn set_supported_features_tip(
+        &mut self,
+        call: IFeatureRegistry::setSupportedFeaturesTipCall,
+    ) -> Result<()> {
+        let previous = self.validator_supported_features_tip[call.validator].read()?;
+        if call.featuresTip < previous {
+            return Err(FeatureRegistryError::supported_features_tip_decreased().into());
+        }
+
+        self.validator_supported_features_tip[call.validator].write(call.featuresTip)
     }
 }


### PR DESCRIPTION
Adds the `setSupportedFeaturesTip` precompile write scaffold. It records validator-reported feature tips and rejects attempts to lower an existing report while leaving support counting/events for the quorum follow-up.