### PR TITLE
fix(bench): exclude warmup blocks from summary

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1089,6 +1089,7 @@ def e2e-write-summary-config [
     duration: int
     benchmark_id: string
     reference_epoch: int
+    summary_warmup_blocks: int
     baseline_hardfork: string
     feature_hardfork: string
     baseline_removed_args: string
@@ -1103,6 +1104,7 @@ def e2e-write-summary-config [
         duration: $duration
         benchmark_id: $benchmark_id
         reference_epoch: $reference_epoch
+        summary_warmup_blocks: $summary_warmup_blocks
         baseline_hardfork: $baseline_hardfork
         feature_hardfork: $feature_hardfork
         baseline_removed_args: $baseline_removed_args
@@ -1120,7 +1122,8 @@ def e2e-generate-summary [results_dir: string] {
     let config = (open $config_path)
     let baseline_hardfork = ($config | get -o baseline_hardfork | default "")
     let feature_hardfork = ($config | get -o feature_hardfork | default "")
-    generate-summary $results_dir $config.baseline_label $config.feature_label ($config.bloat_mib | into int) $config.preset ($config.tps | into int) ($config.duration | into int) --benchmark-id ($config.benchmark_id | default "") --reference-epoch ($config.reference_epoch | default 0 | into int) --baseline-hardfork $baseline_hardfork --feature-hardfork $feature_hardfork
+    let summary_warmup_blocks = ($config | get -o summary_warmup_blocks | default 0 | into int)
+    generate-summary $results_dir $config.baseline_label $config.feature_label ($config.bloat_mib | into int) $config.preset ($config.tps | into int) ($config.duration | into int) --benchmark-id ($config.benchmark_id | default "") --reference-epoch ($config.reference_epoch | default 0 | into int) --baseline-hardfork $baseline_hardfork --feature-hardfork $feature_hardfork --summary-warmup-blocks $summary_warmup_blocks
     let summary_path = $"($results_dir)/summary.json"
     if ($summary_path | path exists) {
         let baseline_removed_args = ($config | get -o baseline_removed_args | default "")
@@ -1156,6 +1159,7 @@ def "main e2e" [
     --preset: string = ""                               # Txgen preset name
     --tps: int = 50000                                  # Target TPS
     --duration: int = 90                                # Duration in seconds
+    --summary-warmup-blocks: int = 5                    # Initial blocks per run excluded from summary metrics
     --accounts: int = 1000                              # Number of accounts
     --max-concurrent-requests: int = 500                # Max concurrent requests
     --bloat: int = $E2E_DEFAULT_BLOAT                   # State bloat snapshot size in GiB: 1, 10, or 100
@@ -1204,6 +1208,10 @@ def "main e2e" [
     }
     if $run_pairs <= 0 {
         print "Error: --run-pairs must be a positive integer"
+        exit 1
+    }
+    if $summary_warmup_blocks < 0 {
+        print "Error: --summary-warmup-blocks must be non-negative"
         exit 1
     }
     let bloat_mib = (e2e-bloat-gib-to-mib $bloat)
@@ -1530,7 +1538,7 @@ def "main e2e" [
         exit 1
     }
     $valid_run_labels | str join "\n" | save -f $"($results_dir)/run-order.txt"
-    e2e-write-summary-config $results_dir $baseline_base_label $feature_base_label $bloat_mib $preset $tps $duration $benchmark_id $reference_epoch $baseline_hardfork_name $feature_hardfork_name (removed-node-args-label $baseline_arg_filter.removed) (removed-node-args-label $feature_arg_filter.removed)
+    e2e-write-summary-config $results_dir $baseline_base_label $feature_base_label $bloat_mib $preset $tps $duration $benchmark_id $reference_epoch $summary_warmup_blocks $baseline_hardfork_name $feature_hardfork_name (removed-node-args-label $baseline_arg_filter.removed) (removed-node-args-label $feature_arg_filter.removed)
     let num_phases = ($runs | length)
     mut e2e_exit = 0
     for idx in 0..<$num_phases {

--- a/tempo.nu
+++ b/tempo.nu
@@ -878,7 +878,12 @@ def generate-summary [
     --reference-epoch: int = 0,
     --baseline-hardfork: string = "",
     --feature-hardfork: string = "",
+    --summary-warmup-blocks: int = 0,
 ] {
+    if $summary_warmup_blocks < 0 {
+        error make { msg: "--summary-warmup-blocks must be non-negative" }
+    }
+
     let run_order_path = $"($results_dir)/run-order.txt"
     let candidate_run_labels = if ($run_order_path | path exists) {
         open $run_order_path | lines | where { |label| $label != "" }
@@ -1105,9 +1110,59 @@ def generate-summary [
             continue
         }
         let report = (open $report_path)
+        let report_blocks = ($report | get blocks | each { |b|
+            let tx_count = ($b | get tx_count)
+            let timestamp = if (($b | get -o timestamp | default null) != null) {
+                $b | get timestamp
+            } else {
+                $b | get timestamp_ms
+            }
+            {
+                number: ($b | get number)
+                timestamp: $timestamp
+                tx_count: $tx_count
+                ok_count: ($b | get -o ok_count | default $tx_count)
+                err_count: ($b | get -o err_count | default 0)
+                gas_used: ($b | get gas_used)
+                block_time_ms: ($b | get -o block_time_ms | default null)
+            }
+        })
+        if ($report_blocks | length) == 0 {
+            print $"Warning: ($label) report has no blocks, skipping"
+            continue
+        }
+
+        let sorted_blocks = ($report_blocks | sort-by timestamp)
+        let warmup_blocks = ([$summary_warmup_blocks ($sorted_blocks | length)] | math min)
+        let blocks = ($sorted_blocks | skip $warmup_blocks)
+        if ($blocks | length) == 0 {
+            print $"Warning: ($label) report has no summary blocks after excluding ($warmup_blocks) warmup blocks, skipping"
+            continue
+        }
+
+        let first_report_block_ms = ($sorted_blocks | first | get timestamp)
+        let timestamps = ($blocks | get timestamp)
+        let summary_from_ms = ($timestamps | first)
+        let summary_from_offset_ms = $summary_from_ms - $first_report_block_ms
+        let block_interval_blocks = if $warmup_blocks > 0 { $blocks | skip 1 } else { $blocks }
+        let block_intervals = ($block_interval_blocks | where block_time_ms != null | get block_time_ms)
+
         let samples_path = $"($results_dir)/report-($label).samples.ndjson"
         let samples_gz_path = $"($samples_path).gz"
-        let metric_samples = (do $load_metric_samples $samples_path $samples_gz_path)
+        let raw_metric_samples = (do $load_metric_samples $samples_path $samples_gz_path)
+        let metric_samples = if $warmup_blocks > 0 {
+            $raw_metric_samples | where { |sample|
+                let offset_ms = ($sample | get -o offset_ms | default null)
+                if $offset_ms != null {
+                    ($offset_ms | into int) >= $summary_from_offset_ms
+                } else {
+                    let unix_ms = ($sample | get -o unix_ms | default 0 | into int)
+                    $unix_ms >= $summary_from_ms
+                }
+            }
+        } else {
+            $raw_metric_samples
+        }
         let optional_counter_metric_values = { |metric: string, scale: float|
             do $optional_counter_values (do $counter_delta_values $metric_samples $metric $scale) $label $metric
         }
@@ -1132,31 +1187,6 @@ def generate-summary [
         let serialized_block_size_values = (do $optional_counter_metric_values "reth_tempo_payload_builder_rlp_block_size_bytes" 1.0)
         let serialized_block_tx_count_values = (do $optional_counter_metric_values "reth_tempo_payload_builder_total_transactions" 1.0)
         let serialized_block_size_per_tx_values = do $paired_ratio_values $serialized_block_size_values $serialized_block_tx_count_values $label
-        let blocks = ($report | get blocks | each { |b|
-            let tx_count = ($b | get tx_count)
-            let timestamp = if (($b | get -o timestamp | default null) != null) {
-                $b | get timestamp
-            } else {
-                $b | get timestamp_ms
-            }
-            {
-                number: ($b | get number)
-                timestamp: $timestamp
-                tx_count: $tx_count
-                ok_count: ($b | get -o ok_count | default $tx_count)
-                err_count: ($b | get -o err_count | default 0)
-                gas_used: ($b | get gas_used)
-                block_time_ms: ($b | get -o block_time_ms | default null)
-            }
-        })
-        if ($blocks | length) == 0 {
-            print $"Warning: ($label) report has no blocks, skipping"
-            continue
-        }
-
-        let sorted_blocks = ($blocks | sort-by timestamp)
-        let timestamps = ($sorted_blocks | get timestamp)
-        let block_intervals = ($sorted_blocks | where block_time_ms != null | get block_time_ms)
 
         let run_bt = do $compute_block_time_stats $block_intervals
 
@@ -1224,6 +1254,7 @@ def generate-summary [
 
         $run_data = ($run_data | append [{
             label: $label
+            summary_warmup_blocks: $warmup_blocks
             blocks: $num_blocks
             total_tx: $total_tx
             ok: $total_ok
@@ -1408,6 +1439,9 @@ def generate-summary [
         $"- Baseline blocks: ($b_block_time.n)"
         $"- Feature blocks: ($f_block_time.n)"
     ])
+    if $summary_warmup_blocks > 0 {
+        $config_lines = ($config_lines | append $"- Summary warmup blocks: ($summary_warmup_blocks)")
+    }
     if $baseline_hardfork != "" {
         $config_lines = ($config_lines | append $"- Baseline hardfork: ($baseline_hardfork)")
     }
@@ -1493,6 +1527,7 @@ def generate-summary [
             tps: $tps
             duration: $duration
             run_pairs: $run_pairs
+            summary_warmup_blocks: $summary_warmup_blocks
             derek_command: $derek_bench_command
             baseline_hardfork: $baseline_hardfork
             feature_hardfork: $feature_hardfork


### PR DESCRIPTION
Adds a summary warmup block window so generated benchmark summaries can exclude startup blocks from per-run and aggregate metrics. E2E runs now default to excluding the first five blocks per phase while preserving zero-warmup behavior for older summary configs and direct generate-summary calls.