### PR TITLE
chore: patch reth to trace span PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10461,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10863,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11017,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11165,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=32ab8029da3cfd6408d4d73412919703823882fd#32ab8029da3cfd6408d4d73412919703823882fd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "32ab8029da3cfd6408d4d73412919703823882fd", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
## Summary
- Patch all workspace reth git dependencies from `259b8dc` to paradigmxyz/reth#24781 head commit `32ab8029da3cfd6408d4d73412919703823882fd`.
- Regenerate `Cargo.lock` for the new reth source revision.

## Verification
- `cargo update --workspace`
- `git diff --check`

Prompted by: @klkvr
