### PR TITLE
fix: decode packed TIP-1060 state during refund settlement

### DIFF
--- a/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
+++ b/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
@@ -70,7 +70,9 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
     owner: Address,
     values: &SStoreResult,
 ) -> Result<GasStateOutcome, B::Error> {
+    // TIP-1060 removes the legacy storage-clearing gas refunds.
     let mut outcome = GasStateOutcome::default();
+    outcome.skip_refund = true;
 
     if values.is_new_eq_present() {
         return Ok(outcome);
@@ -110,25 +112,20 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
     } else {
         match storage_credits.mode {
             CreditMode::Direct => {
+                // Only if there is a credit available, skip gas
                 if storage_credits.balance > 0 {
                     // Consume the storage credit and charge 20k for the SSTORE.
                     backend.charge_gas(20_000)?;
                     storage_credits.balance -= 1;
                     was_changed = true;
-
-                    // only if there is a credit available, skip refund and gas
-                    outcome.skip_refund = true;
                     outcome.skip_gas = true;
                 }
-                // If no token is available, leave both regular and state gas enabled so
-                // revm charges the full zero-to-nonzero creation cost after this hook.
+                // Otherwise, leave gas enabled so revm charges full creation costs.
             }
             CreditMode::Preserve => {
                 // Do nothing, so revm takes care of gas accounting after this hook.
             }
             CreditMode::Refund => {
-                // Skip refund as it will happen at the end of the transaction.
-                outcome.skip_refund = true;
                 backend.credit_tstore_increment(account_slot);
             }
         }

--- a/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
+++ b/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
@@ -71,8 +71,10 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
     values: &SStoreResult,
 ) -> Result<GasStateOutcome, B::Error> {
     // TIP-1060 removes the legacy storage-clearing gas refunds.
-    let mut outcome = GasStateOutcome::default();
-    outcome.skip_refund = true;
+    let mut outcome = GasStateOutcome {
+        skip_gas: false,
+        skip_refund: true,
+    };
 
     if values.is_new_eq_present() {
         return Ok(outcome);

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -386,7 +386,6 @@ mod tests {
     /// Creates a T6-enabled EVM with a funded account.
     /// This activates the TIP-1060 SSTORE gas-token hook while keeping the
     /// TIP-1016 state-gas split disabled to match production.
-
     fn create_funded_evm_t6(address: Address) -> TempoEvm<CacheDB<EmptyDB>, ()> {
         let db = CacheDB::new(EmptyDB::new());
         let mut cfg = CfgEnv::<TempoHardfork>::default();
@@ -2112,9 +2111,9 @@ mod tests {
         // `apply_refund` consumes the minted token against that credit, so it lands at 0 while the
         // others keep the minted token at 1.
         let cases = [
-            (CreditMode::Refund, 283_268u64, 0u64),
-            (CreditMode::Preserve, 513_268u64, 1u64),
-            (CreditMode::Direct, 513_268u64, 1u64),
+            (CreditMode::Refund, 303_168u64, 0u64),
+            (CreditMode::Preserve, 533_168u64, 1u64),
+            (CreditMode::Direct, 533_168u64, 1u64),
         ];
 
         for (mode, expected_gas, expected_balance) in cases {

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -2034,6 +2034,52 @@ mod tests {
         Ok(())
     }
 
+    /// TIP-1060 clearing regression: deleting a nonzero slot should mint one token, but the
+    /// pre-existing SSTORE clearing refund must be removed.
+    #[test]
+    fn test_tip1060_sstore_clear_mints_token_without_legacy_refund() -> eyre::Result<()> {
+        // PUSH1 0x00 PUSH1 0x00 SSTORE STOP: clear slot 0.
+        let clear_bytecode = Bytecode::new_raw(bytes!("600060005500"));
+
+        let key_pair = P256KeyPair::random();
+        let caller = key_pair.address;
+        let contract = Address::repeat_byte(0x63);
+
+        let mut evm = create_funded_evm_t6(caller);
+        evm.ctx.db_mut().insert_account_info(
+            contract,
+            AccountInfo {
+                code: Some(clear_bytecode),
+                ..Default::default()
+            },
+        );
+        evm.ctx
+            .db_mut()
+            .insert_account_storage(contract, U256::ZERO, U256::ONE)?;
+
+        let tx = TxBuilder::new()
+            .call(contract, &[])
+            .gas_limit(500_000)
+            .build();
+        let signed_tx = key_pair.sign_tx(tx)?;
+        let tx_env = TempoTxEnv::from_recovered_tx(&signed_tx, caller);
+
+        let result = evm.transact_commit(tx_env)?;
+        assert!(result.is_success(), "clear tx should succeed");
+        assert_eq!(
+            result.gas().inner_refunded(),
+            0,
+            "TIP-1060 removes the legacy SSTORE clearing refund"
+        );
+        assert_eq!(
+            gas_token_balance(&evm, contract),
+            1,
+            "clearing a nonzero slot should mint one storage gas token"
+        );
+
+        Ok(())
+    }
+
     /// TIP-1060: a single transaction that creates then clears the same storage slot
     /// (SSTORE 0->1 followed by SSTORE 1->0), exercised under the three storage-creation modes.
     /// Only the create (0->x) leg is mode-sensitive, so the gas used differs per mode:

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -246,6 +246,7 @@ mod tests {
     };
     use sha2::{Digest, Sha256};
     use tempo_chainspec::hardfork::TempoHardfork;
+    use tempo_contracts::precompiles::ITIP1060StorageCredits::{self, Mode};
     use tempo_precompiles::{
         AuthorizedKey, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS, STORAGE_CREDITS_ADDRESS,
         nonce::NonceManager,
@@ -1929,20 +1930,132 @@ mod tests {
             .unwrap();
     }
 
-    /// Read back the TIP-1060 token balance stored for `owner` from the gas-token contract.
-    fn gas_token_balance(evm: &TempoEvm<CacheDB<EmptyDB>, ()>, owner: Address) -> u64 {
+    /// Read back the TIP-1060 token state stored for `owner` from the gas-token contract.
+    fn gas_token_state(evm: &TempoEvm<CacheDB<EmptyDB>, ()>, owner: Address) -> AccountState {
         let slot = TIP1060StorageCredits::slot(owner);
         let word = evm
             .ctx
             .db()
             .storage_ref(STORAGE_CREDITS_ADDRESS, slot)
             .unwrap();
-        AccountState::from_word(word).unwrap().balance
+        AccountState::from_word(word).unwrap()
+    }
+
+    /// Read back the TIP-1060 token balance stored for `owner` from the gas-token contract.
+    fn gas_token_balance(evm: &TempoEvm<CacheDB<EmptyDB>, ()>, owner: Address) -> u64 {
+        gas_token_state(evm, owner).balance
+    }
+
+    fn tip1060_abi_mode(mode: CreditMode) -> Mode {
+        match mode {
+            CreditMode::Refund => Mode::Refund,
+            CreditMode::Preserve => Mode::Preserve,
+            CreditMode::Direct => Mode::Direct,
+        }
+    }
+
+    /// Appends bytecode that calls the TIP-1060 precompile's `setMode(mode)` as the
+    /// currently executing contract.
+    fn append_tip1060_set_mode_call(bytecode_bytes: &mut Vec<u8>, mode: CreditMode) {
+        let input_bytes = ITIP1060StorageCredits::setModeCall {
+            newMode: tip1060_abi_mode(mode),
+        }
+        .abi_encode();
+
+        for (i, &byte) in input_bytes.iter().enumerate() {
+            assert!(i <= u8::MAX as usize);
+            bytecode_bytes.extend_from_slice(&[
+                opcode::PUSH1,
+                byte,
+                opcode::PUSH1,
+                i as u8,
+                opcode::MSTORE8,
+            ]);
+        }
+
+        bytecode_bytes.extend_from_slice(&[
+            opcode::PUSH1,
+            0x00, // retSize
+            opcode::PUSH1,
+            0x00, // retOffset
+            opcode::PUSH1,
+            input_bytes.len() as u8, // argsSize
+            opcode::PUSH1,
+            0x00, // argsOffset
+            opcode::PUSH1,
+            0x00, // value
+        ]);
+        bytecode_bytes.push(opcode::PUSH20);
+        bytecode_bytes.extend_from_slice(STORAGE_CREDITS_ADDRESS.as_slice());
+        bytecode_bytes.extend_from_slice(&[
+            opcode::PUSH3,
+            0x0f,
+            0x42,
+            0x40, // gas = 1_000_000
+            opcode::CALL,
+            opcode::POP,
+        ]);
+    }
+
+    fn create_then_set_mode_bytecode(mode: CreditMode) -> Bytecode {
+        let mut bytecode_bytes = vec![opcode::PUSH1, 0x01, opcode::PUSH1, 0x00, opcode::SSTORE];
+        append_tip1060_set_mode_call(&mut bytecode_bytes, mode);
+        bytecode_bytes.push(opcode::STOP);
+        Bytecode::new_raw(bytecode_bytes.into())
+    }
+
+    /// TIP-1060 settlement regression: a RefundTokens-mode create records a pending
+    /// refund-eligible creation, but if the account ends the transaction with zero token balance,
+    /// settlement must not treat mode bits as spendable tokens.
+    #[test]
+    fn test_tip1060_pending_refund_settlement_ignores_mode_bits() -> eyre::Result<()> {
+        for mode in [CreditMode::Refund, CreditMode::Preserve, CreditMode::Direct] {
+            let key_pair = P256KeyPair::random();
+            let caller = key_pair.address;
+            let contract = Address::repeat_byte(0x62);
+
+            let mut evm = create_funded_evm_t6(caller);
+            evm.ctx.db_mut().insert_account_info(
+                contract,
+                AccountInfo {
+                    code: Some(create_then_set_mode_bytecode(mode)),
+                    ..Default::default()
+                },
+            );
+
+            // The first SSTORE runs in the default RefundTokens mode and creates one pending
+            // refund-eligible creation. The subsequent precompile call selects the final mode;
+            // no storage is cleared, so the account has no token to settle against.
+            let tx = TxBuilder::new()
+                .call(contract, &[])
+                .gas_limit(2_000_000)
+                .build();
+            let signed_tx = key_pair.sign_tx(tx)?;
+            let tx_env = TempoTxEnv::from_recovered_tx(&signed_tx, caller);
+
+            let result = evm.transact_commit(tx_env)?;
+            assert!(
+                result.is_success(),
+                "pending-refund mode-change tx should succeed in {mode:?} mode"
+            );
+
+            let state = gas_token_state(&evm, contract);
+            assert_eq!(
+                state.balance, 0,
+                "settlement must not consume mode bits as token balance in {mode:?} mode"
+            );
+            assert_eq!(
+                state.mode, mode,
+                "settlement must preserve the final storage-creation mode in {mode:?} mode"
+            );
+        }
+
+        Ok(())
     }
 
     /// TIP-1060: a single transaction that creates then clears the same storage slot
-    /// (SSTORE 0->1 followed by SSTORE 1->0), exercised under the three storage-creation
-    /// modes. Only the create (0->x) leg is mode-sensitive, so the gas used differs per mode:
+    /// (SSTORE 0->1 followed by SSTORE 1->0), exercised under the three storage-creation modes.
+    /// Only the create (0->x) leg is mode-sensitive, so the gas used differs per mode:
     /// - `PreserveTokens` charges the full EVM/state gas as normal,
     /// - `DirectTokens` has no token to spend at create time (balance starts at 0), so it also
     ///   charges the full create cost,

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -1954,8 +1954,7 @@ mod tests {
         }
     }
 
-    /// Appends bytecode that calls the TIP-1060 precompile's `setMode(mode)` as the
-    /// currently executing contract.
+    /// Appends bytecode that calls TIP-1060 precompile's `setMode(mode)` as the executing contract.
     fn append_tip1060_set_mode_call(bytecode_bytes: &mut Vec<u8>, mode: CreditMode) {
         let input_bytes = ITIP1060StorageCredits::setModeCall {
             newMode: tip1060_abi_mode(mode),
@@ -1964,6 +1963,7 @@ mod tests {
 
         for (i, &byte) in input_bytes.iter().enumerate() {
             assert!(i <= u8::MAX as usize);
+            // PUSH1 <byte> PUSH1 <offset> MSTORE8  (write calldata byte at memory[offset])
             bytecode_bytes.extend_from_slice(&[
                 opcode::PUSH1,
                 byte,
@@ -1973,40 +1973,21 @@ mod tests {
             ]);
         }
 
-        bytecode_bytes.extend_from_slice(&[
-            opcode::PUSH1,
-            0x00, // retSize
-            opcode::PUSH1,
-            0x00, // retOffset
-            opcode::PUSH1,
-            input_bytes.len() as u8, // argsSize
-            opcode::PUSH1,
-            0x00, // argsOffset
-            opcode::PUSH1,
-            0x00, // value
-        ]);
+        // PUSH1 0x00 PUSH1 0x00 PUSH1 <argsSize> PUSH1 0x00 PUSH1 0x00
+        // (retSize=0, retOffset=0, argsSize=input length, argsOffset=0, value=0)
+        bytecode_bytes.extend_from_slice(&bytes!("60006000"));
+        bytecode_bytes.extend_from_slice(&[opcode::PUSH1, input_bytes.len() as u8]);
+        bytecode_bytes.extend_from_slice(&bytes!("60006000"));
+        // PUSH20 <STORAGE_CREDITS_ADDRESS>
         bytecode_bytes.push(opcode::PUSH20);
         bytecode_bytes.extend_from_slice(STORAGE_CREDITS_ADDRESS.as_slice());
-        bytecode_bytes.extend_from_slice(&[
-            opcode::PUSH3,
-            0x0f,
-            0x42,
-            0x40, // gas = 1_000_000
-            opcode::CALL,
-            opcode::POP,
-        ]);
+        // PUSH3 0x0f4240 CALL POP  (call with 1_000_000 gas and discard success flag)
+        bytecode_bytes.extend_from_slice(&bytes!("620f4240f150"));
     }
 
-    fn create_then_set_mode_bytecode(mode: CreditMode) -> Bytecode {
-        let mut bytecode_bytes = vec![opcode::PUSH1, 0x01, opcode::PUSH1, 0x00, opcode::SSTORE];
-        append_tip1060_set_mode_call(&mut bytecode_bytes, mode);
-        bytecode_bytes.push(opcode::STOP);
-        Bytecode::new_raw(bytecode_bytes.into())
-    }
-
-    /// TIP-1060 settlement regression: a RefundTokens-mode create records a pending
-    /// refund-eligible creation, but if the account ends the transaction with zero token balance,
-    /// settlement must not treat mode bits as spendable tokens.
+    /// TIP-1060: First SSTORE runs in Refund (default) mode  and creates a pending refund-eligible
+    /// creation, then a precompile call selects the final mode. Since no account slot is cleared,
+    /// it ends the transaction with zero token balance.
     #[test]
     fn test_tip1060_pending_refund_settlement_ignores_mode_bits() -> eyre::Result<()> {
         for mode in [CreditMode::Refund, CreditMode::Preserve, CreditMode::Direct] {
@@ -2014,18 +1995,21 @@ mod tests {
             let caller = key_pair.address;
             let contract = Address::repeat_byte(0x62);
 
+            // Bytecode starts with a 0->1 create in RefundTokens mode:
+            // PUSH1 0x01 PUSH1 0x00 SSTORE  (store 0x01 at slot 0)
+            let mut bytecode = bytes!("6001600055").to_vec();
+            append_tip1060_set_mode_call(&mut bytecode, mode);
+            bytecode.push(opcode::STOP);
+
             let mut evm = create_funded_evm_t6(caller);
             evm.ctx.db_mut().insert_account_info(
                 contract,
                 AccountInfo {
-                    code: Some(create_then_set_mode_bytecode(mode)),
+                    code: Some(Bytecode::new_raw(bytecode.into())),
                     ..Default::default()
                 },
             );
 
-            // The first SSTORE runs in the default RefundTokens mode and creates one pending
-            // refund-eligible creation. The subsequent precompile call selects the final mode;
-            // no storage is cleared, so the account has no token to settle against.
             let tx = TxBuilder::new()
                 .call(contract, &[])
                 .gas_limit(2_000_000)
@@ -2034,10 +2018,7 @@ mod tests {
             let tx_env = TempoTxEnv::from_recovered_tx(&signed_tx, caller);
 
             let result = evm.transact_commit(tx_env)?;
-            assert!(
-                result.is_success(),
-                "pending-refund mode-change tx should succeed in {mode:?} mode"
-            );
+            assert!(result.is_success());
 
             let state = gas_token_state(&evm, contract);
             assert_eq!(

--- a/crates/revm/src/tip1060.rs
+++ b/crates/revm/src/tip1060.rs
@@ -1,10 +1,13 @@
 //! TIP-1060 specific implementations.
 
-use crate::evm::{TempoContext, TempoEvm};
+use crate::{
+    TempoInvalidTransaction,
+    evm::{TempoContext, TempoEvm},
+};
 use alloy_evm::Database;
 use alloy_primitives::{Address, U256};
 use revm::{
-    context::{Host as _, JournalTr},
+    context::{Host as _, JournalTr, result::EVMError},
     context_interface::cfg::GasParams,
     interpreter::{
         Gas, InstructionContext, InstructionResult, SStoreResult, StateLoad,
@@ -14,7 +17,7 @@ use revm::{
 };
 use tempo_precompiles::{
     STORAGE_CREDITS_ADDRESS,
-    tip1060_storage_credits::{StorageCreditsBackend, sstore_storage_credits},
+    tip1060_storage_credits::{AccountState, StorageCreditsBackend, sstore_storage_credits},
 };
 
 /// Applies the storage credits refund accrued during a transaction.
@@ -29,7 +32,7 @@ use tempo_precompiles::{
 pub fn apply_refund<DB: Database, I>(
     evm: &mut TempoEvm<DB, I>,
     gas: &mut Gas,
-) -> Result<(), DB::Error> {
+) -> Result<(), EVMError<DB::Error, TempoInvalidTransaction>> {
     let journal = &mut evm.inner.ctx.journaled_state;
 
     // Snapshot the transient (key, sstores) pairs at the storage credits contract written during this
@@ -49,20 +52,25 @@ pub fn apply_refund<DB: Database, I>(
         }
 
         // SLOAD the current persistent value and add the transient credit on top.
-        let credit = journal.sload(STORAGE_CREDITS_ADDRESS, key)?.data;
+        let old_word = journal.sload(STORAGE_CREDITS_ADDRESS, key)?.data;
+        let mut state =
+            AccountState::from_word(old_word).map_err(|err| EVMError::Custom(err.to_string()))?;
 
-        let new_credit = if credit > sstores_num {
-            refunds += sstores_num.as_limbs()[0];
-            credit - sstores_num
-        } else {
-            refunds += credit.as_limbs()[0];
-            U256::ZERO
-        };
+        let pending = sstores_num.as_limbs()[0];
+        let settled = pending.min(state.balance);
+
+        if settled == 0 {
+            continue;
+        }
 
         // SSTORE the accumulated total back into the contract's persistent storage.
-        if new_credit != credit {
-            journal.sstore(STORAGE_CREDITS_ADDRESS, key, new_credit)?;
-        }
+        state.balance -= settled;
+        refunds += settled;
+
+        let new_word = state.into_word();
+        debug_assert_ne!(new_word, old_word);
+
+        journal.sstore(STORAGE_CREDITS_ADDRESS, key, new_word)?;
     }
 
     // TODO use gas_params for proper constant.


### PR DESCRIPTION
this PR properly decodes TIP1060 account state during refund settlement.
it also disables legacy refunds, as required by the spec