### PR TITLE
Patch alloy-evm for dynamic precompile bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.36.0"
-source = "git+https://github.com/alloy-rs/evm?rev=90a1111#90a111102c9a89c88edbcb75ffb8d9d86600db59"
+source = "git+https://github.com/alloy-rs/evm?rev=58ef4d9#58ef4d9f77404f3adc165860cd0bd6749556e02f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3827,7 +3827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8596,7 +8596,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8623,7 +8623,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8676,7 +8676,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8689,7 +8689,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8772,7 +8772,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8782,7 +8782,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8851,7 +8851,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8865,7 +8865,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8878,7 +8878,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8903,7 +8903,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8932,7 +8932,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8958,7 +8958,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8988,7 +8988,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9003,7 +9003,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9028,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9052,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9076,7 +9076,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9111,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9168,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9196,7 +9196,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9219,7 +9219,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9244,7 +9244,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9303,7 +9303,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9333,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9365,7 +9365,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9387,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9398,7 +9398,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9448,7 +9448,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "clap",
  "eyre",
@@ -9512,7 +9512,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9528,7 +9528,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9544,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9557,7 +9557,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9587,7 +9587,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9601,7 +9601,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9636,7 +9636,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9656,7 +9656,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9674,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9687,7 +9687,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9744,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9758,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "serde",
  "serde_json",
@@ -9768,7 +9768,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9796,7 +9796,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "bytes",
  "futures",
@@ -9816,7 +9816,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9833,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "bindgen",
  "cc",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "futures",
  "metrics",
@@ -9855,7 +9855,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9864,7 +9864,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9878,7 +9878,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9936,7 +9936,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9961,7 +9961,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9984,7 +9984,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9999,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10013,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10030,7 +10030,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10054,7 +10054,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10122,7 +10122,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10177,7 +10177,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10220,7 +10220,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10244,7 +10244,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10268,7 +10268,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "bytes",
  "eyre",
@@ -10297,7 +10297,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10309,7 +10309,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10345,7 +10345,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10368,7 +10368,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10460,7 +10460,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10488,7 +10488,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10504,7 +10504,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10519,7 +10519,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10595,7 +10595,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10668,7 +10668,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10688,7 +10688,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10719,7 +10719,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10766,7 +10766,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10817,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10831,7 +10831,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10862,7 +10862,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10913,7 +10913,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10941,7 +10941,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10955,7 +10955,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10975,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10990,7 +10990,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11016,7 +11016,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11034,7 +11034,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11071,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11081,7 +11081,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "clap",
  "eyre",
@@ -11100,7 +11100,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11119,7 +11119,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11164,7 +11164,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11190,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11217,7 +11217,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11237,7 +11237,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11266,7 +11266,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=91657e9#91657e954ea80e484b6a5a3028ac217d9e7cab30"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,8 +393,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
+source = "git+https://github.com/alloy-rs/evm?rev=90a1111#90a111102c9a89c88edbcb75ffb8d9d86600db59"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,66 +140,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "259b8dc", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "91657e9", features = [
   "std",
   "optional-checks",
 ] }
@@ -395,7 +395,7 @@ vergen-git2 = "9.1.0"
 # reth-trie-sparse = { path = "../reth/crates/trie/sparse" }
 
 [patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "90a1111" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "58ef4d9" }
 
 # Commonware at HEAD after PR #3588 was merged
 commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -395,6 +395,8 @@ vergen-git2 = "9.1.0"
 # reth-trie-sparse = { path = "../reth/crates/trie/sparse" }
 
 [patch.crates-io]
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "90a1111" }
+
 # Commonware at HEAD after PR #3588 was merged
 commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }


### PR DESCRIPTION
## Summary
- patch `alloy-evm` to alloy-rs/evm PR #373 commit `90a1111`
- update the lockfile so Tempo and reth resolve the patched `alloy-evm` source

## Test
- `cargo check -p tempo-precompiles`

Prompted by: @klkvr