### PR TITLE
fix(follower/driver): always allow using the fallback

### DIFF
--- a/crates/commonware-node/src/follow/driver.rs
+++ b/crates/commonware-node/src/follow/driver.rs
@@ -364,8 +364,9 @@ where
             Some(scheme) => scheme,
             None if can_use_network_identity_fallback => self.network_scheme.clone(),
             None => bail!(
-                "finalization epoch `{finalization_epoch}` behind network identity epoch {}",
-                self.config.network_identity.from_epoch
+                "finalization epoch `{finalization_epoch}` behind network identity starting epoch `{}`; current epoch `{}`",
+                self.config.network_identity.from_epoch,
+                self.current_epoch
             ),
         };
 

--- a/crates/commonware-node/src/follow/driver.rs
+++ b/crates/commonware-node/src/follow/driver.rs
@@ -357,8 +357,8 @@ where
             }
         }
 
-        let can_use_network_identity_fallback = finalization_epoch > self.current_epoch
-            && finalization_epoch.get() >= self.config.network_identity.from_epoch;
+        let can_use_network_identity_fallback =
+            finalization_epoch.get() >= self.config.network_identity.from_epoch;
 
         let scheme = match self.config.scheme_provider.scoped(finalization_epoch) {
             Some(scheme) => scheme,


### PR DESCRIPTION
Since we can skip epoch boundaries, we might not have registered the scheme. Even for the current epoch we should allow using the fallback network identity