### PR TITLE
fix: gate receive policy type cache behind t6

### DIFF
--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -1266,36 +1266,73 @@ mod tests {
     }
 
     #[test]
-    fn test_receive_policy_pre_t6_reads_types_from_policy_ids() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T2);
-        let account = Address::random();
-        StorageCtx::enter(&mut storage, || {
-            let mut registry = TIP403Registry::new();
-            registry.receive_policies[account]
-                .config
-                .write(ReceivePolicyConfig {
-                    has_receive_policy: true,
-                    sender_policy_id: ALLOW_ALL_POLICY_ID,
-                    sender_policy_type: PolicyType::WHITELIST as u8,
-                    token_filter_id: ALLOW_ALL_POLICY_ID,
-                    token_filter_type: PolicyType::WHITELIST as u8,
-                    recovery_mode: RecoveryMode::Originator,
-                })?;
+    fn test_receive_policy_type_cache_t5_t6_boundary() -> eyre::Result<()> {
+        for (hardfork, expected_sender_type, expected_token_type, expected_sloads) in [
+            (
+                TempoHardfork::T5,
+                ITIP403Registry::PolicyType::BLACKLIST,
+                ITIP403Registry::PolicyType::WHITELIST,
+                3,
+            ),
+            (
+                TempoHardfork::T6,
+                ITIP403Registry::PolicyType::WHITELIST,
+                ITIP403Registry::PolicyType::BLACKLIST,
+                1,
+            ),
+        ] {
+            let mut storage = HashMapStorageProvider::new_with_spec(1, hardfork);
+            let account = Address::random();
+            let admin = Address::random();
+            let (sender_policy_id, token_filter_id) = StorageCtx::enter(&mut storage, || {
+                let mut registry = TIP403Registry::new();
+                let sender_policy_id = registry.create_policy(
+                    admin,
+                    ITIP403Registry::createPolicyCall {
+                        admin,
+                        policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                    },
+                )?;
+                let token_filter_id = registry.create_policy(
+                    admin,
+                    ITIP403Registry::createPolicyCall {
+                        admin,
+                        policyType: ITIP403Registry::PolicyType::WHITELIST,
+                    },
+                )?;
+                registry.receive_policies[account]
+                    .config
+                    .write(ReceivePolicyConfig {
+                        has_receive_policy: true,
+                        sender_policy_id,
+                        sender_policy_type: PolicyType::WHITELIST as u8,
+                        token_filter_id,
+                        token_filter_type: PolicyType::BLACKLIST as u8,
+                        recovery_mode: RecoveryMode::Originator,
+                    })?;
 
-            let policy = registry.receive_policy(account)?;
-            assert_eq!(policy.senderPolicyId, ALLOW_ALL_POLICY_ID);
-            assert_eq!(
-                policy.senderPolicyType,
-                ITIP403Registry::PolicyType::BLACKLIST
-            );
-            assert_eq!(policy.tokenFilterId, ALLOW_ALL_POLICY_ID);
-            assert_eq!(
-                policy.tokenFilterType,
-                ITIP403Registry::PolicyType::BLACKLIST
-            );
+                Ok::<_, TempoPrecompileError>((sender_policy_id, token_filter_id))
+            })?;
 
-            Ok(())
-        })
+            storage.reset_counters();
+            StorageCtx::enter(&mut storage, || {
+                let registry = TIP403Registry::new();
+                let policy = registry.receive_policy(account)?;
+                assert_eq!(policy.senderPolicyId, sender_policy_id);
+                assert_eq!(policy.senderPolicyType, expected_sender_type);
+                assert_eq!(policy.tokenFilterId, token_filter_id);
+                assert_eq!(policy.tokenFilterType, expected_token_type);
+
+                Ok::<_, TempoPrecompileError>(())
+            })?;
+            assert_eq!(
+                storage.counter_sload(),
+                expected_sloads,
+                "{hardfork:?} receive_policy SLOAD count"
+            );
+        }
+
+        Ok(())
     }
 
     #[test]

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -185,12 +185,12 @@ impl ReceivePolicyConfig {
             admin: Address::ZERO,
         }
     }
+}
 
-    fn receive_policy_type(policy_type: u8) -> Result<PolicyType> {
-        policy_type
-            .try_into()
-            .map_err(|_| TIP403RegistryError::invalid_receive_policy_type().into())
-    }
+fn policy_type(policy_type: u8) -> Result<PolicyType> {
+    policy_type
+        .try_into()
+        .map_err(|_| TIP403RegistryError::invalid_receive_policy_type().into())
 }
 
 impl TIP403Registry {
@@ -296,8 +296,8 @@ impl TIP403Registry {
         let config = self.receive_policies[account].config.read()?;
         let (sender_policy_type, token_filter_type) = if self.storage.spec().is_t6() {
             (
-                ReceivePolicyConfig::receive_policy_type(config.sender_policy_type)?,
-                ReceivePolicyConfig::receive_policy_type(config.token_filter_type)?,
+                policy_type(config.sender_policy_type)?,
+                policy_type(config.token_filter_type)?,
             )
         } else {
             (
@@ -850,9 +850,7 @@ impl TIP403Registry {
     /// Returns the [`PolicyType`] of a receive-policy slot.
     fn receive_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
         if self.builtin_authorization(policy_id).is_some() {
-            return (policy_id as u8)
-                .try_into()
-                .map_err(|_| TIP403RegistryError::invalid_receive_policy_type().into());
+            return policy_type(policy_id as u8);
         }
 
         let data = self.get_policy_data(policy_id)?;

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -1262,20 +1262,7 @@ mod tests {
 
     #[test]
     fn test_receive_policy_type_cache_t5_t6_boundary() -> eyre::Result<()> {
-        for (hardfork, expected_sender_type, expected_token_type, expected_sloads) in [
-            (
-                TempoHardfork::T5,
-                ITIP403Registry::PolicyType::BLACKLIST,
-                ITIP403Registry::PolicyType::WHITELIST,
-                3,
-            ),
-            (
-                TempoHardfork::T6,
-                ITIP403Registry::PolicyType::WHITELIST,
-                ITIP403Registry::PolicyType::BLACKLIST,
-                1,
-            ),
-        ] {
+        for (hardfork, expected_sloads) in [(TempoHardfork::T5, 3), (TempoHardfork::T6, 1)] {
             let mut storage = HashMapStorageProvider::new_with_spec(1, hardfork);
             let account = Address::random();
             let admin = Address::random();
@@ -1313,6 +1300,17 @@ mod tests {
             StorageCtx::enter(&mut storage, || {
                 let registry = TIP403Registry::new();
                 let policy = registry.receive_policy(account)?;
+                let (expected_sender_type, expected_token_type) = if hardfork.is_t6() {
+                    (
+                        ITIP403Registry::PolicyType::WHITELIST,
+                        ITIP403Registry::PolicyType::BLACKLIST,
+                    )
+                } else {
+                    (
+                        ITIP403Registry::PolicyType::BLACKLIST,
+                        ITIP403Registry::PolicyType::WHITELIST,
+                    )
+                };
                 assert_eq!(policy.senderPolicyId, sender_policy_id);
                 assert_eq!(policy.senderPolicyType, expected_sender_type);
                 assert_eq!(policy.tokenFilterId, token_filter_id);

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -300,12 +300,21 @@ impl TIP403Registry {
     /// Returns `account`'s receive-policy configuration.
     pub fn receive_policy(&self, account: Address) -> Result<ITIP403Registry::receivePolicyReturn> {
         let config = self.receive_policies[account].config.read()?;
+        let (sender_policy_type, token_filter_type) = if self.storage.spec().is_t6() {
+            (config.sender_policy_type()?, config.token_filter_type()?)
+        } else {
+            (
+                self.receive_policy_type(config.sender_policy_id)?,
+                self.receive_policy_type(config.token_filter_id)?,
+            )
+        };
+
         Ok(ITIP403Registry::receivePolicyReturn {
             hasReceivePolicy: config.has_receive_policy,
             senderPolicyId: config.sender_policy_id,
-            senderPolicyType: config.sender_policy_type()?,
+            senderPolicyType: sender_policy_type,
             tokenFilterId: config.token_filter_id,
-            tokenFilterType: config.token_filter_type()?,
+            tokenFilterType: token_filter_type,
             recoveryAuthority: self.receive_policy_recovery(account, config.recovery_mode)?,
         })
     }
@@ -841,6 +850,21 @@ impl TIP403Registry {
         Ok(data.policy_type)
     }
 
+    /// Returns the [`PolicyType`] of a receive-policy slot.
+    fn receive_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
+        if self.builtin_authorization(policy_id).is_some() {
+            return (policy_id as u8)
+                .try_into()
+                .map_err(|_| TIP403RegistryError::invalid_receive_policy_type().into());
+        }
+
+        let data = self.get_policy_data(policy_id)?;
+        if !data.is_simple() {
+            return Err(TIP403RegistryError::invalid_receive_policy_type().into());
+        }
+        data.policy_type()
+    }
+
     // Internal helper functions
 
     /// Returns policy data for the given policy ID.
@@ -1235,6 +1259,39 @@ mod tests {
             assert_eq!(
                 registry.receive_policies[account].recovery_address.read()?,
                 Address::ZERO
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_receive_policy_pre_t6_reads_types_from_policy_ids() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T2);
+        let account = Address::random();
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = TIP403Registry::new();
+            registry.receive_policies[account]
+                .config
+                .write(ReceivePolicyConfig {
+                    has_receive_policy: true,
+                    sender_policy_id: ALLOW_ALL_POLICY_ID,
+                    sender_policy_type: PolicyType::WHITELIST as u8,
+                    token_filter_id: ALLOW_ALL_POLICY_ID,
+                    token_filter_type: PolicyType::WHITELIST as u8,
+                    recovery_mode: RecoveryMode::Originator,
+                })?;
+
+            let policy = registry.receive_policy(account)?;
+            assert_eq!(policy.senderPolicyId, ALLOW_ALL_POLICY_ID);
+            assert_eq!(
+                policy.senderPolicyType,
+                ITIP403Registry::PolicyType::BLACKLIST
+            );
+            assert_eq!(policy.tokenFilterId, ALLOW_ALL_POLICY_ID);
+            assert_eq!(
+                policy.tokenFilterType,
+                ITIP403Registry::PolicyType::BLACKLIST
             );
 
             Ok(())

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -186,14 +186,8 @@ impl ReceivePolicyConfig {
         }
     }
 
-    fn sender_policy_type(&self) -> Result<PolicyType> {
-        self.sender_policy_type
-            .try_into()
-            .map_err(|_| TIP403RegistryError::invalid_receive_policy_type().into())
-    }
-
-    fn token_filter_type(&self) -> Result<PolicyType> {
-        self.token_filter_type
+    fn receive_policy_type(policy_type: u8) -> Result<PolicyType> {
+        policy_type
             .try_into()
             .map_err(|_| TIP403RegistryError::invalid_receive_policy_type().into())
     }
@@ -301,7 +295,10 @@ impl TIP403Registry {
     pub fn receive_policy(&self, account: Address) -> Result<ITIP403Registry::receivePolicyReturn> {
         let config = self.receive_policies[account].config.read()?;
         let (sender_policy_type, token_filter_type) = if self.storage.spec().is_t6() {
-            (config.sender_policy_type()?, config.token_filter_type()?)
+            (
+                ReceivePolicyConfig::receive_policy_type(config.sender_policy_type)?,
+                ReceivePolicyConfig::receive_policy_type(config.token_filter_type)?,
+            )
         } else {
             (
                 self.receive_policy_type(config.sender_policy_id)?,


### PR DESCRIPTION
## Summary
- use cached receive-policy type bytes only when T6 is active
- preserve pre-T6 getter behavior by resolving policy types from policy IDs
- add a pre-T6 regression test for cached type mismatch

## Tests
- cargo fmt --check
- cargo test -p tempo-precompiles tip403_registry

Prompted by: @0xrusowsky