### PR TITLE
docs(tip-1067): preserve TIP-1059 discount

### DIFF
--- a/tips/tip-1067.md
+++ b/tips/tip-1067.md
@@ -4,7 +4,7 @@ title: Dynamic Base Fee
 description: Replaces Tempo's fixed base fee with an EIP-1559-style controller that lowers the base fee toward one twentieth of the current cost when the chain is underutilized and rises back to the current cost under load, with a 5,000,000 gas target.
 authors: Dankrad Feist @dankrad
 status: Draft
-related: TIP-1010, TIP-1000
+related: TIP-1010, TIP-1000, TIP-1059
 protocolVersion: TBD
 ---
 
@@ -15,6 +15,8 @@ protocolVersion: TBD
 This TIP replaces Tempo's fixed base fee (TIP-1010: `2 × 10^10` attodollars per gas) with an EIP-1559-style per-block controller. The base fee adjusts each block toward a gas target of 5,000,000 gas: it falls when blocks use less than the target and rises when they use more. The base fee is clamped to the range `[1 × 10^9, 2 × 10^10]` attodollars per gas, i.e. between one twentieth of the current fixed cost (the floor) and the current fixed cost (the cap).
 
 The effect is that when the chain is used very little, the base fee decays toward the floor and transactions become up to 20× cheaper than today; when the chain is busy, the base fee rises back to the current cost and never exceeds it. Because the cap equals today's fixed base fee, any caller that budgets for the current price is never surprised by a higher fee, while underutilized periods are made ultracheap.
+
+TIP-1059 eligible transactions continue to receive a discount. Instead of TIP-1059's fixed discounted payment gas price, they settle at 60% of the current block base fee, clamped so the charged gas price is never below `BASE_FEE_FLOOR`.
 
 ## Motivation
 
@@ -91,7 +93,19 @@ For every post-activation block:
 
 1. The block's `baseFeePerGas` header field MUST equal the `base_fee` value computed by the update rule from the parent block's base fee and gas used (or `BASE_FEE_CAP` for the activation block).
 2. A block whose `baseFeePerGas` does not equal the computed value MUST be rejected as invalid.
-3. Transaction validity against the base fee is unchanged: a transaction is includable only if its `maxFeePerGas` is at least the block's `base_fee`, and the effective gas price is computed from `base_fee` exactly as today.
+3. Transaction validity against the base fee is unchanged: a transaction is includable only if its `maxFeePerGas` is at least the block's `base_fee`. The transaction-derived effective gas price is computed from `base_fee` exactly as today, before any TIP-1059 settlement discount.
+
+## TIP-1059 Discount Interaction
+
+TIP-1059 remains in effect after activation of this TIP. For a TIP-1059 eligible transaction in a block with base fee `base_fee`, the discounted payment gas price is:
+
+```text
+discounted_payment_gas_price = max(BASE_FEE_FLOOR, (base_fee * 3) / 5)
+```
+
+This replaces TIP-1059's fixed `12 × 10^9` attodollars/gas discounted payment gas price. At `BASE_FEE_CAP`, the discounted price remains `12 × 10^9` attodollars/gas, preserving the existing TIP-1059 discount. At lower prevailing base fees, eligible transactions receive the same 60% discount until that would fall below `BASE_FEE_FLOOR`; below that point, they pay `BASE_FEE_FLOOR`.
+
+TIP-1059 eligibility rules, gas-used threshold, fee-cap authorization requirement, refund path, and priority-fee treatment are unchanged, except that references to the normal base fee use the current block's `base_fee`.
 
 ## Out of Scope
 
@@ -106,13 +120,20 @@ This TIP does not change:
 
 This TIP supersedes the "fixed base fee" property of TIP-1010. TIP-1010's value `2 × 10^10` attodollars/gas becomes `BASE_FEE_CAP`, the upper bound of the dynamic range, and `BASE_FEE_FLOOR` is derived as `BASE_FEE_CAP / 20`. All other TIP-1010 parameters (block gas limits, lane budgets, transaction gas cap) are unchanged.
 
+## Relationship to TIP-1059
+
+This TIP updates TIP-1059's discounted payment gas price from a fixed value to a value derived from the current block's `base_fee`, as specified above. TIP-1059 eligible transactions therefore continue to pay 60% of the prevailing base fee, subject to the same `BASE_FEE_FLOOR` as all other transactions.
+
 ## Dynamics (informative)
 
 The following illustrate the controller with `BASE_FEE_MAX_CHANGE_DENOMINATOR = 8` and ~500 ms (2 blocks/second) block time. All values are approximate.
 
-- **Floor vs cap pricing of a TIP-20 transfer (50,000 gas):**
+- **Floor vs cap pricing of a non-discounted 50,000-gas transaction:**
   - At `BASE_FEE_CAP` (`2 × 10^10`): `50,000 × 2 × 10^10 = 10^15` attodollars = `1,000` microdollars = `$0.001` (0.1 cent) — same as today.
   - At `BASE_FEE_FLOOR` (`1 × 10^9`): `50,000 × 1 × 10^9 = 5 × 10^13` attodollars = `50` microdollars = `$0.00005` (0.005 cent) — 20× cheaper.
+- **Floor vs cap pricing of a TIP-1059 eligible TIP-20 transfer (50,000 gas):**
+  - At `BASE_FEE_CAP`, the discounted payment gas price is `12 × 10^9`, so the transfer costs `600` microdollars = `$0.0006`.
+  - At `BASE_FEE_FLOOR`, the 60% discount would fall below the floor, so the transfer pays `BASE_FEE_FLOOR` and costs `50` microdollars = `$0.00005`.
 - **Decay when idle:** an empty block (`gas_used = 0`) multiplies the base fee by `7/8` (a 12.5% drop). Starting from the cap, the base fee reaches the floor (a 20× decrease) after about 23 consecutive empty blocks (~12 seconds); the decay half-life is about 5 blocks (~2.6 seconds).
 - **Rise under load:** a block at the 30,000,000 gas general cap multiplies the base fee by about `1.625` (`gas_delta = 25M`, `25M / 5M / 8 = 0.625`), so the base fee climbs from the floor back to the cap in roughly 7 such blocks (~3.5 seconds); fuller blocks saturate to the cap faster.
 
@@ -131,6 +152,7 @@ These time constants are a consequence of the chosen denominator and may be retu
 7. **Header consistency:** A block is valid only if its `baseFeePerGas` header field equals the computed `base_fee`.
 8. **Activation seed:** The base fee of the activation block equals `BASE_FEE_CAP`.
 9. **No fee increase relative to status quo:** For identical block contents, the effective gas price under this TIP is always less than or equal to the effective gas price under TIP-1010's fixed base fee.
+10. **TIP-1059 discount preservation:** A TIP-1059 eligible transaction settles at `max(BASE_FEE_FLOOR, (base_fee * 3) / 5)`, so it keeps the 60% discount when possible and never pays less than the floor.
 
 ## Test Cases
 
@@ -143,5 +165,6 @@ The test suite MUST cover:
 5. **Minimum increase:** when `parent_gas_used` exceeds `GAS_TARGET` by a tiny amount and the parent base fee is at the floor, the base fee increases by at least 1 attodollar/gas.
 6. **Activation:** the activation block uses `BASE_FEE_CAP`; the next block adjusts from it using the activation block's `gas_used`.
 7. **Header rejection:** a block whose `baseFeePerGas` differs from the computed value is rejected.
-8. **Transfer pricing:** a 50,000-gas TIP-20 transfer costs ~0.1 cent at the cap and ~0.005 cent at the floor.
+8. **Transfer pricing:** a non-discounted 50,000-gas transaction costs ~0.1 cent at the cap and ~0.005 cent at the floor.
 9. **Lane aggregation:** payment-lane gas counts toward `gas_used` for the controller, so a block filled with payment-lane transfers raises the base fee.
+10. **TIP-1059 discount:** a TIP-1059 eligible transfer pays 60% of the prevailing base fee when that is above `BASE_FEE_FLOOR`, and pays exactly `BASE_FEE_FLOOR` when the 60% value would be lower.


### PR DESCRIPTION
Updates TIP-1067 so TIP-1059 eligible transactions keep paying 60% of the prevailing base fee, clamped at the dynamic fee floor.

Also clarifies pricing examples and test coverage for discounted transfers.