### PR TITLE
docs(tip-1068): add shielded denomination notes

### DIFF
--- a/tips/tip-1068.md
+++ b/tips/tip-1068.md
@@ -1,0 +1,502 @@
+---
+id: TIP-1068
+title: Issuer-Viewable Shielded Denomination Notes
+description: Adds issuer-auditable shielded TIP-20 notes with common-denomination public entry and exit.
+authors: Tanishk Goyal
+status: Draft
+related: TIP-20, TIP-403, Tempo Zones
+protocolVersion: TBD
+---
+
+# TIP-1068: Issuer-Viewable Shielded Denomination Notes
+
+## Abstract
+
+This TIP introduces shielded TIP-20 notes whose balances are hidden from the public but decryptable by the token issuer. Public entry and exit are limited to a common denomination set so deposits and redemptions do not expose arbitrary exact amounts such as `$29`. Users can privately split, merge, and transfer notes inside the shielded pool while the issuer maintains an audit view of outstanding notes and per-owner balances.
+
+## Motivation
+
+TIP-20 balances are public today. That is useful for transparency and ordinary indexing, but it is a poor fit for regulated payment tokens where the issuer needs balance visibility while unrelated observers should not be able to inspect every holder balance.
+
+An issuer-signed cash-note model gives users bearer-style payment privacy without removing issuer oversight. A holder converts public TIP-20 into shielded notes, privately moves or recombines those notes, and later redeems a note back into public TIP-20.
+
+The main privacy failure to avoid is amount fingerprinting. If a user burns exactly `$29` and later mints exactly `$29`, public observers can correlate those actions even if addresses differ. This TIP therefore only permits public shield and unshield actions in common denominations, with private change kept inside the pool.
+
+## Assumptions
+
+- TIP-20 tokens use 6 decimals, where one token unit is one microdollar.
+- A token issuer that opts into this pool is already trusted to mint and administer the corresponding TIP-20 token.
+- Each participating issuer registers an issuance signing key and an audit encryption key for the shielded pool.
+- The issuer authorizes the pool to mint public TIP-20 only for redemption and pending-deposit cancellation flows.
+- The issuer keeps enough supply-cap headroom for pending and outstanding shielded liabilities. If the issuer fills the public supply cap through unrelated mints, shielded redemptions may fail until cap headroom is restored.
+- Wallets can generate shielded note secrets locally and can receive encrypted note payloads out of band.
+- Users that want transaction-sender privacy use relayers or account-abstraction flows that avoid linking the funding account to shielded operations.
+- The first version only defines issuer-viewable privacy. It does not provide privacy from the issuer.
+
+If an issuer loses the audit decryption key, the public chain can still enforce note validity and double-spend prevention, but the issuer loses the required balance view for newly created notes until the key is rotated and wallets adopt the new key.
+
+## Threat Model
+
+- Public observers can see public TIP-20 burns and mints, pool calls, timestamps, common denominations, note commitments, nullifiers, public recipients, and transaction senders.
+- Token issuers can decrypt issuer audit ciphertexts, reconstruct active shielded notes, compute the nullifiers for notes they have seen, and track issuer-visible balances.
+- Users may try to create notes without backing value, spend the same note twice, omit issuer-readable ciphertext, or create output notes whose ciphertext does not match the committed note.
+- Relayers may observe network metadata and may refuse to submit transactions. They must not be trusted for value correctness.
+- The proof system is trusted to enforce membership, note ownership, value conservation, common-denomination public legs, and issuer-ciphertext consistency.
+
+Out of scope: hiding balances from the issuer, hiding timing metadata from a global passive observer, recovering from issuer key compromise, and enforcing TIP-403 transfer policy inside fully private note-to-note transfers without revealing transfer counterparties publicly.
+
+---
+
+# Specification
+
+This TIP adds a native shielded denomination note pool for TIP-20 tokens that opt in.
+
+## Terms
+
+- `denomination`: a public amount from the token's registered common denomination set.
+- `note`: a private commitment to a TIP-20 token, amount, owner key, and nullifier secret.
+- `commitment`: the public hash inserted into the note tree for an unspent note.
+- `nullifier`: the public one-time spend marker derived from a note secret.
+- `issuerCiphertext`: an encrypted audit payload that lets the token issuer view the note amount, owner audit identifier, and nullifier.
+- `mintReceipt`: an issuer signature authorizing activation of a pending public deposit into a shielded note.
+
+## Common Denomination Set
+
+The default USD-denominated TIP-20 shielded pool uses a `1-2-5` denomination ladder:
+
+| Human amount | TIP-20 units |
+| ---: | ---: |
+| `$1` | `1_000_000` |
+| `$2` | `2_000_000` |
+| `$5` | `5_000_000` |
+| `$10` | `10_000_000` |
+| `$20` | `20_000_000` |
+| `$50` | `50_000_000` |
+| `$100` | `100_000_000` |
+| `$200` | `200_000_000` |
+| `$500` | `500_000_000` |
+| `$1,000` | `1_000_000_000` |
+| `$2,000` | `2_000_000_000` |
+| `$5,000` | `5_000_000_000` |
+| `$10,000` | `10_000_000_000` |
+| `$20,000` | `20_000_000_000` |
+| `$50,000` | `50_000_000_000` |
+| `$100,000` | `100_000_000_000` |
+
+Public deposits and public redemptions MUST use exactly one registered denomination per shielded action. The pool MUST reject any public amount that is not in the active denomination set for that token.
+
+Wallets SHOULD keep exact payment amounts private by transferring notes inside the pool and leaving change shielded. If a user needs to redeem `$29` publicly, the user can redeem `$20`, `$5`, `$2`, and `$2` denominations, but doing all redemptions together to the same public recipient still reveals the aggregate `$29` public amount. This TIP reduces protocol-level arbitrary amount fingerprints; it does not make exact public balance changes private.
+
+Future TIPs MAY add token-specific denomination sets or sub-dollar denominations. Smaller denominations improve UX but reduce anonymity per denomination.
+
+## Pool Registration
+
+A TIP-20 issuer opts into the shielded pool by registering:
+
+- `token`: the TIP-20 token address.
+- `issuerSigningKey`: the key that signs `mintReceipt` values.
+- `issuerAuditKey`: the public encryption key used for `issuerCiphertext`.
+- `denominationSetId`: the common denomination set accepted for public entry and exit.
+- `depositActivationDelay`: an optional minimum delay between deposit request and activation.
+- `depositCancelDelay`: the delay after which an unsigned pending deposit can be cancelled and refunded.
+
+Only the token issuer or an issuer-admin key may update these fields. Updates to `issuerSigningKey`, `issuerAuditKey`, or `denominationSetId` apply only to new notes and new deposit requests after the update block.
+
+## Note Format
+
+A note commits to:
+
+```
+NotePlaintext {
+    token: address,
+    amount: uint128,
+    owner: bytes32,
+    nullifierSecret: bytes32,
+    noteRandomness: bytes32,
+    auditId: bytes32
+}
+```
+
+The note commitment is:
+
+```
+commitment = H(
+    "TEMPO_SHIELDED_NOTE_V1",
+    token,
+    amount,
+    owner,
+    nullifierSecret,
+    noteRandomness,
+    auditId
+)
+```
+
+The note nullifier is:
+
+```
+nullifier = H(
+    "TEMPO_SHIELDED_NULLIFIER_V1",
+    token,
+    nullifierSecret
+)
+```
+
+`owner` is the shielded spend authorization key or a hash of it. `auditId` is issuer-readable owner metadata, such as a customer identifier, wallet audit key, or other issuer-defined balance attribution value. `auditId` is not public.
+
+Every created note MUST include an `issuerCiphertext` whose plaintext contains at least:
+
+```
+IssuerAuditPlaintext {
+    token: address,
+    amount: uint128,
+    auditId: bytes32,
+    nullifier: bytes32,
+    commitment: bytes32
+}
+```
+
+The zero-knowledge proof for every note creation MUST bind the note commitment to the encrypted issuer audit plaintext. A note creation MUST revert if the ciphertext is missing, malformed, encrypted to the wrong issuer audit key, or not proven to match the committed note.
+
+## Deposit Request
+
+To enter the shielded pool, a user requests a deposit for one common denomination:
+
+```
+requestDeposit(
+    token,
+    denomination,
+    commitment,
+    issuerCiphertext,
+    refundAddress,
+    depositProof
+) -> depositId
+```
+
+The pool MUST:
+
+1. Verify that `token` is registered for shielded notes.
+2. Verify that `denomination` is in the token's active denomination set.
+3. Verify that `commitment` has not already been reserved by a pending deposit or inserted into the note tree.
+4. Verify, through the deposit proof, that `issuerCiphertext` encrypts audit plaintext matching the note commitment and denomination.
+5. Atomically move `denomination` TIP-20 units from the depositor to the pool using `transferFrom`, `system_transfer_from`, or an equivalent protocol debit, then burn the same amount from the pool's balance.
+6. Record a pending deposit keyed by `depositId` and reserve `commitment`.
+7. Increase `pendingShielded[token]` by `denomination`.
+8. Emit `ShieldedDepositRequested`.
+
+`depositId` is:
+
+```
+depositId = H(
+    "TEMPO_SHIELDED_DEPOSIT_V1",
+    chainId,
+    poolAddress,
+    token,
+    denomination,
+    commitment,
+    issuerCiphertextHash,
+    msg.sender,
+    depositNonce
+)
+```
+
+The deposit amount is public but restricted to a common denomination. The note commitment and issuer ciphertext do not reveal the future owner or amount to public observers beyond the public denomination.
+
+## Issuer Mint Receipt
+
+After a deposit request is final, the issuer signs a `mintReceipt`:
+
+```
+MintReceipt {
+    chainId: uint256,
+    poolAddress: address,
+    token: address,
+    denomination: uint128,
+    depositId: bytes32,
+    commitment: bytes32,
+    issuerCiphertextHash: bytes32,
+    expiryBlock: uint64
+}
+```
+
+The signature MUST be domain-separated with:
+
+```
+TEMPO_SHIELDED_MINT_RECEIPT_V1
+```
+
+The pool treats the issuer signature as confirmation that the issuer has accepted the burned public funds and the audit ciphertext. A malicious issuer that signs unsupported receipts can inflate shielded liabilities; this is equivalent to the issuer's existing ability to mint public TIP-20.
+
+## Deposit Activation
+
+A user activates a pending deposit by submitting the `mintReceipt` and issuer signature:
+
+```
+activateDeposit(mintReceipt, issuerSignature)
+```
+
+The pool MUST:
+
+1. Verify that the pending `depositId` exists and has not been cancelled or activated.
+2. Verify that the receipt fields match the pending deposit.
+3. Verify that the receipt is not expired.
+4. Verify the issuer signature against the token's active `issuerSigningKey` for the pending deposit's registration epoch.
+5. Verify that `commitment` has not been inserted since the deposit request.
+6. Insert `commitment` into the token's shielded note tree.
+7. Decrease `pendingShielded[token]` by `denomination`.
+8. Increase `outstandingShielded[token]` by `denomination`.
+9. Mark the pending deposit and receipt as used.
+10. Emit `ShieldedDepositActivated`.
+
+If the issuer does not sign before `depositCancelDelay`, the depositor may cancel the pending deposit:
+
+```
+cancelDeposit(depositId)
+```
+
+Cancellation MUST decrease `pendingShielded[token]` by `denomination`, mark the pending deposit as cancelled, and mint exactly `denomination` public TIP-20 units to `refundAddress`. Cancelled deposits cannot later be activated.
+
+## Private Split, Merge, and Transfer
+
+Users split, merge, and transfer shielded value with a join-split operation:
+
+```
+joinSplit(
+    token,
+    root,
+    nullifiers[],
+    outputCommitments[],
+    issuerCiphertexts[],
+    proof
+)
+```
+
+The proof MUST verify:
+
+1. Each input note commitment exists in the note tree identified by `root`.
+2. The proof was generated with the spend secret for each input note.
+3. Each input nullifier is derived correctly.
+4. No input nullifier has already been spent.
+5. Each output commitment is derived from a valid output note.
+6. Each output note includes issuer audit ciphertext matching the committed note.
+7. The sum of input note amounts equals the sum of output note amounts plus any explicitly public redemption amount.
+
+For a pure private `joinSplit`, the public redemption amount is zero and no TIP-20 public mint occurs. This supports:
+
+- Splitting one note into multiple smaller private notes.
+- Aggregating multiple notes into one larger private note.
+- Paying a recipient by creating an output note for the recipient while returning change to the sender.
+
+The public chain sees spent nullifiers and new commitments, but not the private note amounts or owners. The issuer can decrypt output ciphertexts and remove spent input notes from its balance view by matching observed nullifiers.
+
+After proof verification, the pool MUST mark every input nullifier as spent, insert every output commitment into the token's note tree, and emit `ShieldedJoinSplit`.
+
+## Public Redemption
+
+A user exits the shielded pool with:
+
+```
+redeem(
+    token,
+    root,
+    nullifiers[],
+    changeCommitments[],
+    changeIssuerCiphertexts[],
+    denomination,
+    recipient,
+    memo,
+    proof
+)
+```
+
+The proof MUST satisfy all join-split requirements and additionally prove:
+
+```
+sum(inputs) = denomination + sum(changeOutputs)
+```
+
+The pool MUST:
+
+1. Verify that `denomination` is in the token's active denomination set.
+2. Verify that all nullifiers are unused, then mark them spent.
+3. Insert any change commitments into the note tree.
+4. Decrease `outstandingShielded[token]` by `denomination`.
+5. Mint exactly `denomination` public TIP-20 units to `recipient`, using `mintWithMemo` when `memo != 0`.
+6. Emit `ShieldedRedeemed`.
+
+Redemption MUST NOT allow arbitrary public amounts. Any non-denomination remainder must remain in shielded change notes.
+
+## TIP-20 and TIP-403 Interaction
+
+The public deposit leg MUST follow TIP-20 transfer and burn semantics and MUST fail when the token is paused, the caller lacks the required public balance, the pool lacks transfer authority, or TIP-403 blocks the transfer into the pool. The public redemption and cancellation legs MUST follow TIP-20 mint semantics and MUST fail when the token is paused, the recipient is invalid, the mint would exceed supply constraints, or the recipient is blocked by active TIP-403 policy.
+
+Private note-to-note transfers do not expose public sender or recipient addresses to TIP-403. Participating issuers therefore rely on issuer audit visibility for private balance monitoring unless a future TIP adds encrypted policy proofs or issuer-online transfer authorization.
+
+## Supply Accounting
+
+For each token:
+
+```
+effectiveSupply =
+    token.totalSupply()
+    + pendingShielded[token]
+    + outstandingShielded[token]
+```
+
+Deposit requests decrease `token.totalSupply()` and increase `pendingShielded[token]` by the same denomination. Deposit activation decreases `pendingShielded[token]` and increases `outstandingShielded[token]` by the same denomination. Deposit cancellation decreases `pendingShielded[token]` and increases `token.totalSupply()` by the same denomination. Redemptions increase `token.totalSupply()` and decrease `outstandingShielded[token]` by the same denomination. Pure private joinsplits do not change any supply aggregate.
+
+`effectiveSupply` MUST NOT change as a result of deposit request, deposit activation, cancellation, private join-split, or redemption except for ordinary TIP-20 mint and burn authority outside this pool.
+
+# Comparison with Tempo Zones
+
+Tempo Zones provide private execution by moving users into a separate L2 environment anchored to Tempo. A zone portal locks TIP-20 tokens on Tempo, the zone mints equivalent zone-side tokens, users transact privately through the zone sequencer and private RPC layer, and withdrawals burn zone-side tokens before releasing escrowed Tempo tokens. The sequencer is the sole block producer, sees all zone activity, provides data availability, processes deposits and withdrawals, and submits batches with a proof-agnostic verifier.
+
+This TIP is narrower. It does not create a new execution environment. It defines a shielded-note system for TIP-20 value on Tempo, with public entry and exit constrained to common denominations and private split, merge, and transfer performed by proofs over note commitments and nullifiers.
+
+## Properties Zones Provide That This TIP Does Not
+
+Zones preserve an account-style TIP-20 UX inside the private environment. Zone tokens live at the same addresses as their Tempo counterparts, `ZoneInbox` is the sole mint authority for deposits, and `ZoneOutbox` is the sole burn authority for withdrawals. This TIP uses private notes instead of account balances, so wallets must manage note ownership, change, nullifiers, and recipient note delivery.
+
+Zones provide privacy-gated RPC. Every RPC request is authenticated, account-scoped, and redacted: non-sequencer callers cannot inspect other accounts, full transaction lists, raw state, unrestricted logs, or pending transactions. This TIP only hides note contents cryptographically. It does not add a private RPC boundary, so public transactions, proof calls, common denominations, recipients on redemption, nullifiers, and commitment timing remain visible.
+
+Zones enforce privacy at the execution layer. Zone-side `balanceOf` and `allowance` revert unless the caller is authorized, transfer and approval gas is fixed to avoid storage-layout side channels, and contract creation is disabled so user contracts cannot bypass the privacy controls. This TIP does not change ordinary Tempo execution or RPC behavior outside the note pool.
+
+Zones inherit TIP-403 policy enforcement for private-zone transfers. The zone-side TIP-403 proxy resolves policy state from Tempo, and Zone TIP-20 transfers check sender and recipient authorization before executing. This TIP applies TIP-403 only at public deposit and redemption boundaries. Fully private note-to-note transfers are not synchronously checked against TIP-403 unless a future design adds encrypted policy proofs or issuer-online authorization.
+
+Zones support a broader bridge and application lifecycle: encrypted deposits, deposit queues, bounce-back refunds, withdrawals, withdrawal callbacks, authenticated withdrawal sender tags, zone-to-zone flows through Tempo callbacks, token enablement, deposit pausing, sequencer key rotation, and batch proofs. This TIP only covers shielded TIP-20 notes and public redemption mints.
+
+Zones give the account holder and sequencer normal account-level visibility inside the zone. The sequencer has full visibility into balances, transfers, and transaction history, while public observers, other users, and token issuers that are not the sequencer do not. This TIP gives the token issuer an audit view through ciphertexts, but the public chain still sees all pool operations and the issuer's view depends on wallet correctness and proof-enforced ciphertext consistency.
+
+## Advantages of This TIP Relative to Zones
+
+This TIP has a smaller deployment and trust surface. It does not require a new L2 chain, portal, zone sequencer, private RPC service, batch prover, withdrawal processor, or separate data-availability assumption.
+
+This TIP avoids bridge custody. Deposits burn public TIP-20 supply into pending or outstanding shielded liabilities, and redemptions mint public TIP-20 back out. Zones lock tokens in an L1 portal and rely on the zone withdrawal path to release them.
+
+This TIP can be token-scoped. An issuer can enable shielded notes for one TIP-20 asset without launching a general private execution environment or admitting arbitrary enabled tokens.
+
+This TIP gives stronger public amount hygiene at the protocol boundary than ordinary zone deposits. Zone deposits expose token, sender, and amount publicly; encrypted deposits hide recipient and memo but not amount. This TIP requires public entry and exit through common denominations and keeps arbitrary amounts as private note change.
+
+This TIP supports bearer-style private payments. Notes can be split, merged, and transferred without preserving account-style balance slots. That is useful for cash-like flows where the user wants to hand off a claim without exposing an account balance to counterparties.
+
+## Disadvantages of This TIP Relative to Zones
+
+This TIP is less general. It does not run arbitrary private account activity, private contract calls, private swaps, or private app workflows. Zones are a full private execution environment with normal transaction sequencing inside the zone.
+
+This TIP has weaker metadata privacy at the transport and RPC layers. Public observers can still see when a user interacts with the pool, which denomination is deposited or redeemed, which nullifiers are spent, and which public recipient receives redeemed funds. Zones hide transaction history and scoped logs from public RPC users.
+
+This TIP has weaker compliance enforcement inside the private domain. Issuers can audit decrypted notes and react after the fact, but the pool does not natively block a private note transfer at execution time based on current TIP-403 policy. Zones check TIP-403 on zone-side transfer and mint paths.
+
+This TIP shifts complexity into wallet note management and proof generation. Wallets must avoid consolidating or redeeming patterns that undo denomination privacy, maintain note backups, handle change, deliver recipient note payloads, and protect nullifier secrets. Zones preserve a familiar account model for users.
+
+This TIP requires a sound zero-knowledge circuit for note membership, value conservation, nullifier derivation, denomination public legs, and issuer-ciphertext consistency. Zones also need a sound batch verifier, but their user-facing token model can remain ordinary TIP-20 once inside the zone.
+
+This TIP does not solve data or transaction censorship by itself. It avoids the zone-specific sequencer data-availability assumption, but proof submissions and redemptions are still public Tempo transactions and can be linked by timing or blocked by ordinary transaction inclusion dynamics. Zones similarly trust the sequencer for liveness and have no forced inclusion or permissionless exit in the current design.
+
+## Design Guidance
+
+Use zones when the product needs account-style private balances, private transaction history, private RPC, private app execution, synchronous TIP-403 enforcement, withdrawals with callbacks, or zone-to-zone composability.
+
+Use this TIP when the product needs a simpler issuer-viewable private payment instrument for one or a small number of TIP-20 assets, especially where common-denomination public entry and exit plus private note splitting and merging are enough.
+
+The two designs can coexist. A zone can support private account activity, while a shielded denomination pool can provide cash-like bearer notes for users who want denomination-based amount privacy without entering a separate L2.
+
+# Observability
+
+The pool MUST emit:
+
+```
+event ShieldedPoolRegistered(
+    address indexed token,
+    bytes32 issuerSigningKeyHash,
+    bytes32 issuerAuditKeyHash,
+    uint64 denominationSetId
+);
+
+event ShieldedDepositRequested(
+    address indexed token,
+    bytes32 indexed depositId,
+    uint256 denomination,
+    bytes32 commitment,
+    bytes32 issuerCiphertextHash,
+    address indexed refundAddress,
+    uint64 cancelAfterBlock
+);
+
+event ShieldedDepositActivated(
+    address indexed token,
+    bytes32 indexed depositId,
+    bytes32 commitment,
+    uint256 denomination
+);
+
+event ShieldedDepositCancelled(
+    address indexed token,
+    bytes32 indexed depositId,
+    address indexed refundAddress,
+    uint256 denomination
+);
+
+event ShieldedJoinSplit(
+    address indexed token,
+    bytes32 indexed root,
+    bytes32 nullifiersHash,
+    bytes32 outputCommitmentsHash,
+    uint256 inputCount,
+    uint256 outputCount
+);
+
+event ShieldedRedeemed(
+    address indexed token,
+    address indexed recipient,
+    bytes32 indexed root,
+    uint256 denomination,
+    bytes32 nullifiersHash,
+    bytes32 changeCommitmentsHash,
+    bytes32 memo
+);
+```
+
+These events answer:
+
+- Which tokens have enabled shielded notes, and which issuer keys were active.
+- Which public denomination deposits are pending issuer signature.
+- Whether a deposit was activated or cancelled.
+- Which nullifier and commitment batches are associated with a private join-split.
+- How much value exited the shielded pool publicly, and to which public recipient.
+
+The full nullifier and commitment arrays are available in transaction calldata. Events use hashes for compact indexing and dashboarding.
+
+# Invariants
+
+- Public deposits MUST use one active common denomination.
+- Public redemptions MUST use one active common denomination.
+- A commitment MUST be reserved by at most one pending deposit or inserted into a token note tree at most once.
+- A nullifier MUST be spent at most once.
+- A pending deposit MUST end in exactly one of: activated or cancelled.
+- A mint receipt MUST be usable only for the pending deposit it names.
+- Deposit request MUST increase `pendingShielded[token]` by exactly the requested denomination.
+- Deposit activation MUST decrease `pendingShielded[token]` and increase `outstandingShielded[token]` by exactly the pending denomination.
+- Deposit cancellation MUST decrease `pendingShielded[token]`, mint exactly the pending denomination to `refundAddress`, and MUST NOT insert the note commitment.
+- Pure private joinsplits MUST preserve shielded value exactly.
+- Public redemptions MUST decrease `outstandingShielded[token]` by exactly the redeemed denomination.
+- Every output note MUST include issuer-readable ciphertext that is proven to match the note commitment.
+- `token.totalSupply() + pendingShielded[token] + outstandingShielded[token]` MUST be unchanged by deposit request, deposit activation, cancellation, private transfer, and redemption flows except for issuer-authorized TIP-20 mint or burn operations outside this pool.
+- TIP-20 pause, supply cap, invalid recipient, and TIP-403 receive-policy checks MUST continue to apply to public redemption mints.
+
+# Alternatives Considered
+
+## Arbitrary public burn and mint amounts
+
+This is simpler, but it leaks exact amounts. A `$29` public burn followed by a `$29` public mint is strongly linkable even when different addresses are used. Common denominations remove this arbitrary amount fingerprint at the protocol boundary.
+
+## Fixed-denomination notes only
+
+Every private note could be forced to equal one common denomination. That simplifies proofs, but it makes private split and merge operations reveal more structure and creates many small notes for ordinary payments. This TIP instead limits common denominations to public entry and exit while allowing private notes to carry confidential amounts inside the pool.
+
+## Fully confidential TIP-20 balances with an issuer view key
+
+Confidential balances with an issuer view key are a viable alternative if the goal is only to hide account balances from the public. The note model adds bearer-style private payments, split and merge operations, and public redemption through common denominations, at the cost of a larger proof system and more wallet complexity.
+
+## Issuer-online signing for every private transfer
+
+Requiring the issuer to sign every split, merge, and private payment would give stronger real-time issuer control. It would also make private payments depend on issuer availability and would expose more behavioral metadata to the issuer. This TIP requires issuer signatures only for activation of public deposits; issuer visibility for later private transfers comes from mandatory audit ciphertexts.

--- a/tips/tip-1068.md
+++ b/tips/tip-1068.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP introduces shielded TIP-20 notes whose balances are hidden from the public but decryptable by the token issuer. Public entry and exit are limited to a common denomination set so deposits and redemptions do not expose arbitrary exact amounts such as `$29`. Users can privately split, merge, and transfer notes inside the shielded pool while the issuer maintains an audit view of outstanding notes and per-owner balances.
+This TIP introduces shielded TIP-20 notes whose balances are hidden from the public but decryptable by the token issuer. Public entry and exit are limited to a common denomination set so deposits and redemptions do not expose arbitrary exact amounts. Users can privately split, merge, and transfer notes inside the shielded pool while the issuer maintains an audit view of outstanding notes and per-owner balances.
 
 ## Motivation
 
@@ -20,7 +20,7 @@ TIP-20 balances are public today. That is useful for transparency and ordinary i
 
 An issuer-signed cash-note model gives users bearer-style payment privacy without removing issuer oversight. A holder converts public TIP-20 into shielded notes, privately moves or recombines those notes, and later redeems a note back into public TIP-20.
 
-The main privacy failure to avoid is amount fingerprinting. If a user burns exactly `$29` and later mints exactly `$29`, public observers can correlate those actions even if addresses differ. This TIP therefore only permits public shield and unshield actions in common denominations, with private change kept inside the pool.
+The main privacy failure to avoid is amount fingerprinting. This TIP therefore only permits public shield and unshield actions in common denominations, with private change kept inside the pool.
 
 ## Assumptions
 
@@ -85,9 +85,13 @@ The default USD-denominated TIP-20 shielded pool uses a `1-2-5` denomination lad
 
 Public deposits and public redemptions MUST use exactly one registered denomination per shielded action. The pool MUST reject any public amount that is not in the active denomination set for that token.
 
-Wallets SHOULD keep exact payment amounts private by transferring notes inside the pool and leaving change shielded. If a user needs to redeem `$29` publicly, the user can redeem `$20`, `$5`, `$2`, and `$2` denominations, but doing all redemptions together to the same public recipient still reveals the aggregate `$29` public amount. This TIP reduces protocol-level arbitrary amount fingerprints; it does not make exact public balance changes private.
+Wallets SHOULD keep exact payment amounts private by transferring notes inside the pool and leaving change shielded. This TIP reduces protocol-level arbitrary amount fingerprints; it does not make exact public balance changes private.
 
 Future TIPs MAY add token-specific denomination sets or sub-dollar denominations. Smaller denominations improve UX but reduce anonymity per denomination.
+
+## Notes
+
+Common denominations reduce amount fingerprinting at the protocol boundary, but they do not make exact public balance changes private. If a user needs to redeem `$29` publicly, the user can redeem it as `$20`, `$5`, `$2`, and `$2` denominations, but doing all redemptions together to the same public recipient still reveals the aggregate public amount.
 
 ## Pool Registration
 
@@ -400,6 +404,27 @@ Use this TIP when the product needs a simpler issuer-viewable private payment in
 
 The two designs can coexist. A zone can support private account activity, while a shielded denomination pool can provide cash-like bearer notes for users who want denomination-based amount privacy without entering a separate L2.
 
+# Comparison with Standard Privacy Pools
+
+This TIP uses the same core vocabulary as standard privacy pools: users create commitments, later spend them with nullifiers, and proofs prevent double-spends without revealing the private note contents. It differs because it is designed for issuer-viewable regulated TIP-20 money rather than operator-neutral public anonymity.
+
+The closest standard model is a Tornado-style or privacy-pool-style UTXO system. Users deposit value, receive a private note, and withdraw later by revealing a nullifier and proving note ownership. This TIP keeps that spend model but adds issuer audit ciphertexts, issuer-signed deposit activation, TIP-20 mint and burn integration, supply-liability accounting, and TIP-403 checks at public entry and exit.
+
+| Property | Standard privacy pool | This TIP |
+|---|---|---|
+| Privacy target | Hide flows from public observers and usually from the operator | Hide flows from the public while preserving issuer visibility |
+| Asset backing | Contract custody or escrowed pool balance | TIP-20 burn/mint with `pendingShielded` and `outstandingShielded` liabilities |
+| Operator role | Ideally none or minimal after deposit | Issuer signs deposit activation receipts and decrypts audit payloads |
+| Note data | Commitment, nullifier, owner secret, randomness | Standard note data plus issuer-readable audit plaintext bound to the commitment |
+| Compliance model | External screening, allowlists, or proof-of-innocence style constraints | Issuer audit view plus TIP-403 checks at public deposit and redemption boundaries |
+| Public amounts | Often fixed-denomination deposits and withdrawals | Common-denomination public legs with confidential arbitrary private note change |
+| Supply accounting | Pool escrow balance backs withdrawals | `token.totalSupply() + pendingShielded[token] + outstandingShielded[token]` tracks effective supply |
+| Failure handling | Depends on pool implementation | Unsigned deposits can be cancelled and refunded after `depositCancelDelay` |
+
+The advantage over a standard privacy pool is issuer compatibility. The issuer can audit outstanding shielded liabilities and per-owner balances without relying only on public events. The tradeoff is that users do not get privacy from the issuer, and deposit activation depends on issuer liveness unless the deposit is cancelled.
+
+The advantage over simple fixed-denomination mixers is private amount flexibility inside the pool. Public entry and exit are standardized, but users can split, merge, and transfer confidential amounts internally as long as proofs preserve value and output notes include issuer-readable ciphertext.
+
 # Observability
 
 The pool MUST emit:
@@ -487,7 +512,7 @@ The full nullifier and commitment arrays are available in transaction calldata. 
 
 ## Arbitrary public burn and mint amounts
 
-This is simpler, but it leaks exact amounts. A `$29` public burn followed by a `$29` public mint is strongly linkable even when different addresses are used. Common denominations remove this arbitrary amount fingerprint at the protocol boundary.
+This is simpler, but it leaks exact amounts. Common denominations remove this arbitrary amount fingerprint at the protocol boundary.
 
 ## Fixed-denomination notes only
 


### PR DESCRIPTION
Adds TIP-1068 for issuer-viewable shielded denomination notes. The draft specifies common-denomination entry and exit, private note split/merge/transfer, issuer audit ciphertexts, supply accounting, and a comparison with Tempo Zones.

Validated with `git diff --check` and an ASCII scan.