### PR TITLE
feat(account-keychain): add temporary access key pruning

### DIFF
--- a/crates/contracts/src/precompiles/account_keychain.rs
+++ b/crates/contracts/src/precompiles/account_keychain.rs
@@ -5,7 +5,7 @@ pub use IAccountKeychain::{
     authorizeAdminKeyCall, authorizeKey_0Call as legacyAuthorizeKeyCall,
     authorizeKey_1Call as authorizeKeyCall, authorizeKey_2Call as authorizeKeyWithWitnessCall,
     getAllowedCallsReturn, getRemainingLimitWithPeriodCall,
-    getRemainingLimitWithPeriodReturn as getRemainingLimitReturn,
+    getRemainingLimitWithPeriodReturn as getRemainingLimitReturn, pruneExpiryCall,
 };
 
 crate::sol! {
@@ -168,6 +168,9 @@ crate::sol! {
 
         /// Remove any configured call scope for a key+target pair.
         function removeAllowedCalls(address keyId, address target) external;
+
+        /// Permissionlessly prune an expired temporary key and its temporary restriction rows.
+        function pruneExpiry(address account, address keyId) external returns (bool pruned);
 
         /// Get key information
         /// @param account The account address

--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -1,7 +1,9 @@
 //! ABI dispatch for the [`AccountKeychain`] precompile.
 
 use super::{AccountKeychain, KeyRestrictions, TokenLimit, authorizeKeyCall};
-use crate::{Precompile, SelectorSchedule, charge_input_cost, dispatch_call, mutate_void, view};
+use crate::{
+    Precompile, SelectorSchedule, charge_input_cost, dispatch_call, mutate, mutate_void, view,
+};
 use alloy::{
     primitives::Address,
     sol_types::{SolCall, SolInterface},
@@ -17,6 +19,7 @@ const T3_ADDED: &[[u8; 4]] = &[
     authorizeKeyCall::SELECTOR,
     IAccountKeychain::setAllowedCallsCall::SELECTOR,
     IAccountKeychain::removeAllowedCallsCall::SELECTOR,
+    IAccountKeychain::pruneExpiryCall::SELECTOR,
     IAccountKeychain::getRemainingLimitWithPeriodCall::SELECTOR,
     IAccountKeychain::getAllowedCallsCall::SELECTOR,
 ];
@@ -124,6 +127,9 @@ impl Precompile for AccountKeychain {
                     mutate_void(call, msg_sender, |sender, c| {
                         self.remove_allowed_calls(sender, c)
                     })
+                }
+                IAccountKeychainCalls::pruneExpiry(call) => {
+                    mutate(call, msg_sender, |sender, c| self.prune_expiry(sender, c))
                 }
                 IAccountKeychainCalls::getKey(call) => view(call, |c| self.get_key(c)),
                 IAccountKeychainCalls::getRemainingLimit(call) => {

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -18,8 +18,8 @@ pub use tempo_contracts::precompiles::{
         CallScope, KeyInfo, KeyRestrictions, SelectorRule, SignatureType, TokenLimit,
         burnKeyAuthorizationWitnessCall, getAllowedCallsCall, getKeyCall, getRemainingLimitCall,
         getRemainingLimitWithPeriodCall, getTransactionKeyCall,
-        isKeyAuthorizationWitnessBurnedCall, removeAllowedCallsCall, revokeKeyCall,
-        setAllowedCallsCall, updateSpendingLimitCall,
+        isKeyAuthorizationWitnessBurnedCall, pruneExpiryCall, removeAllowedCallsCall,
+        revokeKeyCall, setAllowedCallsCall, updateSpendingLimitCall,
     },
     authorizeKeyCall, authorizeKeyWithWitnessCall, getAllowedCallsReturn, getRemainingLimitReturn,
 };
@@ -38,6 +38,7 @@ use tempo_precompiles_macros::{Storable, contract};
 const TIP20_TRANSFER_SELECTOR: [u8; 4] = ITIP20::transferCall::SELECTOR;
 const TIP20_APPROVE_SELECTOR: [u8; 4] = ITIP20::approveCall::SELECTOR;
 const TIP20_TRANSFER_WITH_MEMO_SELECTOR: [u8; 4] = ITIP20::transferWithMemoCall::SELECTOR;
+const MAX_TEMPORARY_TTL_SECS: u64 = 30 * 24 * 60 * 60;
 
 #[inline]
 pub fn is_constrained_tip20_selector(selector: [u8; 4]) -> bool {
@@ -55,6 +56,7 @@ pub fn is_constrained_tip20_selector(selector: [u8; 4]) -> bool {
 /// - byte 9: enforce_limits (bool)
 /// - byte 10: is_revoked (bool)
 /// - byte 11: is_admin (bool)
+/// - byte 12: is_temporary (bool)
 #[derive(Debug, Clone, Default, PartialEq, Eq, Storable)]
 pub struct AuthorizedKey {
     /// Signature type used by this key.
@@ -68,6 +70,8 @@ pub struct AuthorizedKey {
     pub is_revoked: bool,
     /// Whether this key has admin privileges for keychain management.
     pub is_admin: bool,
+    /// Whether this key uses temporary-state pricing and is pruneable after expiry.
+    pub is_temporary: bool,
 }
 
 #[repr(u8)]
@@ -119,6 +123,9 @@ pub struct AccountKeychain {
 
     // key_authorization_witnesses[account][witness] -> true once manually burned.
     key_authorization_witnesses: Mapping<Address, Mapping<B256, bool>>,
+
+    // spending_limit_tokens[(account, keyId)] -> tokens with temporary spending-limit rows.
+    spending_limit_tokens: Mapping<B256, Set<Address>>,
 
     // WARNING(rusowsky): transient storage slots must always be placed at the very end until the `contract`
     // macro is refactored and has 2 independent layouts (persistent and transient).
@@ -259,6 +266,7 @@ impl AccountKeychain {
         let config = &config;
         self.ensure_admin_caller(msg_sender)?;
         let is_t3 = self.storage.spec().is_t3();
+        let current_timestamp = self.storage.timestamp().saturating_to::<u64>();
 
         // Validate inputs
         if key_id == Address::ZERO {
@@ -271,7 +279,6 @@ impl AccountKeychain {
 
         // T0+: Expiry must be in the future (also catches expiry == 0 which means "key doesn't exist")
         if self.storage.spec().is_t0() {
-            let current_timestamp = self.storage.timestamp().saturating_to::<u64>();
             if config.expiry <= current_timestamp {
                 return Err(AccountKeychainError::expiry_in_past().into());
             }
@@ -289,6 +296,8 @@ impl AccountKeychain {
         }
 
         let signature_type = StoredSignatureType::try_from(signature_type)?;
+        let is_temporary =
+            !is_admin && is_t3 && Self::is_temporary_expiry(config.expiry, current_timestamp);
 
         // TIP-1011 fields are hardfork-gated at T3, so reject them before mutating state.
         let allowed_call_configs = if is_t3 {
@@ -334,6 +343,7 @@ impl AccountKeychain {
             enforce_limits: config.enforceLimits,
             is_revoked: false,
             is_admin,
+            is_temporary,
         };
 
         self.keys[msg_sender][key_id].write(new_key)?;
@@ -350,6 +360,7 @@ impl AccountKeychain {
                 key_id,
                 limits,
                 allowed_call_configs,
+                is_temporary,
             )?;
         }
 
@@ -428,6 +439,12 @@ impl AccountKeychain {
             return Err(AccountKeychainError::key_not_found().into());
         }
 
+        if key.is_temporary {
+            let account_key = Self::spending_limit_key(msg_sender, call.keyId);
+            self.clear_spending_limit_rows(account_key)?;
+            self.clear_key_scope(account_key)?;
+        }
+
         // Mark the key as revoked - this prevents replay attacks by ensuring
         // the same key_id can never be re-authorized for this account.
         // We keep is_revoked=true but clear other fields.
@@ -463,6 +480,9 @@ impl AccountKeychain {
         let current_timestamp = self.storage.timestamp().saturating_to::<u64>();
         let mut key = self.load_active_key(msg_sender, call.keyId, current_timestamp)?;
         if key.is_admin {
+            return Err(AccountKeychainError::invalid_key_id().into());
+        }
+        if key.is_temporary {
             return Err(AccountKeychainError::invalid_key_id().into());
         }
 
@@ -575,6 +595,9 @@ impl AccountKeychain {
         if key.is_admin {
             return Err(AccountKeychainError::invalid_key_id().into());
         }
+        if key.is_temporary {
+            return Err(AccountKeychainError::invalid_key_id().into());
+        }
 
         let key_hash = Self::spending_limit_key(msg_sender, call.keyId);
         let scopes = call.scopes;
@@ -605,6 +628,9 @@ impl AccountKeychain {
         if key.is_admin {
             return Err(AccountKeychainError::invalid_key_id().into());
         }
+        if key.is_temporary {
+            return Err(AccountKeychainError::invalid_key_id().into());
+        }
 
         let key_hash = Self::spending_limit_key(msg_sender, call.keyId);
         let current_mode = self.key_scopes[key_hash].is_scoped.read()?;
@@ -615,6 +641,35 @@ impl AccountKeychain {
         self.remove_target_scope(key_hash, call.target)?;
 
         Ok(())
+    }
+
+    /// Permissionlessly prune an expired temporary key and its temporary restriction rows.
+    ///
+    /// Returns `false` without changing state when the key is missing, revoked, permanent,
+    /// or not yet expired. Permanent finite-expiry keys are intentionally not pruned because they
+    /// did not prepay temporary cleanup and must keep the existing replay behavior.
+    pub fn prune_expiry(&mut self, _msg_sender: Address, call: pruneExpiryCall) -> Result<bool> {
+        if call.keyId.is_zero() {
+            return Ok(false);
+        }
+
+        let key = self.keys[call.account][call.keyId].read()?;
+        if key.expiry == 0 || key.is_revoked || !key.is_temporary {
+            return Ok(false);
+        }
+
+        let current_timestamp = self.storage.timestamp().saturating_to::<u64>();
+        if current_timestamp < key.expiry {
+            return Ok(false);
+        }
+
+        let account_key = Self::spending_limit_key(call.account, call.keyId);
+
+        self.keys[call.account][call.keyId].delete()?;
+        self.clear_spending_limit_rows(account_key)?;
+        self.clear_key_scope(account_key)?;
+
+        Ok(true)
     }
 
     /// Returns whether an account key is call-scoped together with its configured call scopes.
@@ -742,6 +797,7 @@ impl AccountKeychain {
         key_id: Address,
         limits: impl IntoIterator<Item = &'a TokenLimit>,
         allowed_calls: Option<&[CallScope]>,
+        is_temporary: bool,
     ) -> Result<()> {
         let limit_key = Self::spending_limit_key(account, key_id);
 
@@ -767,6 +823,10 @@ impl AccountKeychain {
                 self.spending_limits[limit_key][limit.token]
                     .remaining
                     .write(limit.amount)?;
+            }
+
+            if is_temporary {
+                self.spending_limit_tokens[limit_key].insert(limit.token)?;
             }
         }
 
@@ -909,6 +969,10 @@ impl AccountKeychain {
     /// Deletes every persisted target scope under an account key.
     fn clear_all_target_scopes(&mut self, account_key: B256) -> Result<()> {
         let targets = self.key_scopes[account_key].targets.read()?;
+        if targets.is_empty() {
+            return Ok(());
+        }
+
         for target in targets {
             self.clear_target_selectors(account_key, target)?;
         }
@@ -930,15 +994,47 @@ impl AccountKeychain {
         let selectors = self.key_scopes[account_key].target_scopes[target]
             .selectors
             .read()?;
+        if selectors.is_empty() {
+            return Ok(());
+        }
+
         for selector in selectors {
-            self.key_scopes[account_key].target_scopes[target].selector_scopes[selector]
-                .recipients
-                .delete()?;
+            let recipients = &mut self.key_scopes[account_key].target_scopes[target]
+                .selector_scopes[selector]
+                .recipients;
+            if !recipients.is_empty()? {
+                recipients.delete()?;
+            }
         }
 
         self.key_scopes[account_key].target_scopes[target]
             .selectors
             .delete()
+    }
+
+    /// Deletes all temporary spending-limit rows and the token index for an account key.
+    fn clear_spending_limit_rows(&mut self, account_key: B256) -> Result<()> {
+        let tokens: Vec<Address> = self.spending_limit_tokens[account_key].read()?.into();
+        if tokens.is_empty() {
+            return Ok(());
+        }
+
+        for token in &tokens {
+            self.spending_limits[account_key][*token].delete()?;
+        }
+
+        self.spending_limit_tokens[account_key].delete()
+    }
+
+    /// Deletes the key-level call scope flag and all nested target/selector/recipient rows.
+    fn clear_key_scope(&mut self, account_key: B256) -> Result<()> {
+        self.clear_all_target_scopes(account_key)?;
+
+        if self.key_scopes[account_key].is_scoped.read()? {
+            self.key_scopes[account_key].is_scoped.delete()?;
+        }
+
+        Ok(())
     }
 
     /// Creates or replaces one target scope, including all nested selector rules.
@@ -1062,6 +1158,13 @@ impl AccountKeychain {
         }
 
         Ok(())
+    }
+
+    #[inline]
+    fn is_temporary_expiry(expiry: u64, current_timestamp: u64) -> bool {
+        expiry != u64::MAX
+            && expiry > current_timestamp
+            && expiry <= current_timestamp.saturating_add(MAX_TEMPORARY_TTL_SECS)
     }
 
     /// Ensures admin operations are authorized for this caller.
@@ -1515,6 +1618,28 @@ mod tests {
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, IAccountKeychain::SignatureType};
 
+    const COLD_SLOAD_GAS: u64 = 2_100;
+    const WARM_STORAGE_READ_GAS: u64 = 100;
+    const COLD_SSTORE_CLEAR_GAS: u64 = 7_100;
+    const WARM_SSTORE_CLEAR_GAS: u64 = 5_000;
+    const TIP1000_STORAGE_CREATE_GAS: u64 = 250_000;
+    const ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS: u64 = 15_000;
+    const ACCESS_KEY_CREATION_BUFFER_GAS: u64 = 20_000;
+    const ACCESS_KEY_EXPIRY_PREMIUM_PER_SLOT_DAY_GAS: u64 = 1_000;
+    const BENCHMARK_TIMESTAMP: u64 = 1_000;
+    const BENCHMARK_TTL_DAYS: u64 = 7;
+    const SECONDS_PER_DAY: u64 = 24 * 60 * 60;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Tip1073BenchmarkRow {
+        label: &'static str,
+        temporary_slots: u64,
+        create_without_tip_gas: u64,
+        create_with_tip_gas: u64,
+        prune_execution_gas: u64,
+        prune_refund_gas: u64,
+    }
+
     fn authorize_key(
         keychain: &mut AccountKeychain,
         msg_sender: Address,
@@ -1610,6 +1735,91 @@ mod tests {
         tempo_alloy::provider::keychain::KeyRestrictions::default().into()
     }
 
+    fn estimated_storage_gas(storage: &HashMapStorageProvider) -> u64 {
+        storage.counter_cold_sload() * COLD_SLOAD_GAS
+            + storage.counter_warm_sload() * WARM_STORAGE_READ_GAS
+            + storage.counter_cold_sstore() * COLD_SSTORE_CLEAR_GAS
+            + storage.counter_warm_sstore() * WARM_SSTORE_CLEAR_GAS
+    }
+
+    fn tip1073_create_cost(temporary_slots: u64, ttl_days: u64) -> u64 {
+        temporary_slots * ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS
+            + ACCESS_KEY_CREATION_BUFFER_GAS
+            + temporary_slots * ttl_days * ACCESS_KEY_EXPIRY_PREMIUM_PER_SLOT_DAY_GAS
+    }
+
+    fn run_tip1073_access_key_benchmark(
+        label: &'static str,
+        config: impl FnOnce(u64) -> KeyRestrictions,
+    ) -> eyre::Result<Tip1073BenchmarkRow> {
+        let account = Address::random();
+        let key_id = Address::random();
+        let expiry = BENCHMARK_TIMESTAMP + BENCHMARK_TTL_DAYS * SECONDS_PER_DAY;
+
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(BENCHMARK_TIMESTAMP));
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            TIP20Setup::path_usd(account).apply()?;
+            Ok::<_, eyre::Report>(())
+        })?;
+
+        storage.reset_counters();
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            authorize_key(
+                &mut keychain,
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: config(expiry),
+                },
+            )
+        })?;
+        let temporary_slots = storage.counter_zero_to_nonzero_sstore();
+        assert_ne!(temporary_slots, 0, "{label} must create temporary slots");
+
+        storage.set_timestamp(U256::from(expiry));
+        storage.reset_counters();
+        StorageCtx::enter(&mut storage, || {
+            let pruned = AccountKeychain::new().prune_expiry(
+                Address::random(),
+                pruneExpiryCall {
+                    account,
+                    keyId: key_id,
+                },
+            )?;
+            assert!(pruned, "{label} must prune after expiry");
+            Ok::<_, eyre::Report>(())
+        })?;
+
+        let prune_execution_gas = estimated_storage_gas(&storage);
+        let prune_refund_gas =
+            storage.counter_nonzero_to_zero_sstore() * ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS;
+        assert_eq!(
+            prune_refund_gas,
+            temporary_slots * ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS,
+            "{label} must refund exactly the measured temporary slots"
+        );
+        assert!(
+            prune_refund_gas > prune_execution_gas,
+            "{label}: refund {prune_refund_gas} must exceed prune cost {prune_execution_gas}"
+        );
+
+        Ok(Tip1073BenchmarkRow {
+            label,
+            temporary_slots,
+            create_without_tip_gas: temporary_slots * TIP1000_STORAGE_CREATE_GAS,
+            create_with_tip_gas: tip1073_create_cost(temporary_slots, BENCHMARK_TTL_DAYS),
+            prune_execution_gas,
+            prune_refund_gas,
+        })
+    }
+
     #[test]
     fn test_t6_root_authorizes_admin_key() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
@@ -1657,6 +1867,7 @@ mod tests {
                 enforce_limits: false,
                 is_revoked: false,
                 is_admin: true,
+                is_temporary: false,
             })?;
             keychain.keys[account][non_admin_key].write(AuthorizedKey {
                 signature_type: StoredSignatureType::Secp256k1,
@@ -1664,6 +1875,7 @@ mod tests {
                 enforce_limits: false,
                 is_revoked: false,
                 is_admin: false,
+                is_temporary: false,
             })?;
             keychain.keys[account][revoked_admin_key].write(AuthorizedKey {
                 signature_type: StoredSignatureType::Secp256k1,
@@ -1671,6 +1883,7 @@ mod tests {
                 enforce_limits: false,
                 is_revoked: true,
                 is_admin: true,
+                is_temporary: false,
             })?;
             keychain.keys[account][expired_admin_key].write(AuthorizedKey {
                 signature_type: StoredSignatureType::Secp256k1,
@@ -1678,6 +1891,7 @@ mod tests {
                 enforce_limits: false,
                 is_revoked: false,
                 is_admin: true,
+                is_temporary: false,
             })?;
 
             assert!(keychain.is_admin_key(account, account)?);
@@ -1902,6 +2116,7 @@ mod tests {
                 enforce_limits: false,
                 is_revoked: false,
                 is_admin: false,
+                is_temporary: false,
             })?;
 
             keychain.update_spending_limit(
@@ -4051,6 +4266,7 @@ mod tests {
                 enforce_limits: true,
                 is_revoked: false,
                 is_admin: false,
+                is_temporary: false,
             })?;
             keychain.spending_limits[limit_key][token].write(SpendingLimitState {
                 remaining: U256::from(90),
@@ -4400,6 +4616,569 @@ mod tests {
     }
 
     #[test]
+    fn test_t3_prune_expiry_clears_bare_temporary_key_and_allows_reuse() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(1_000u64));
+
+        let account = Address::random();
+        let key_id = Address::random();
+        let expiry = 1_060u64;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+
+            authorize_key(
+                &mut keychain,
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry,
+                        enforceLimits: false,
+                        limits: vec![],
+                        allowAnyCalls: true,
+                        allowedCalls: vec![],
+                    },
+                },
+            )?;
+
+            let stored = keychain.keys[account][key_id].read()?;
+            assert!(stored.is_temporary);
+
+            let pruned = keychain.prune_expiry(
+                Address::random(),
+                pruneExpiryCall {
+                    account,
+                    keyId: key_id,
+                },
+            )?;
+            assert!(!pruned, "unexpired temporary keys must not prune");
+
+            Ok::<_, eyre::Report>(())
+        })?;
+
+        storage.set_timestamp(U256::from(expiry));
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+
+            let pruned = keychain.prune_expiry(
+                Address::random(),
+                pruneExpiryCall {
+                    account,
+                    keyId: key_id,
+                },
+            )?;
+            assert!(pruned);
+            assert_eq!(
+                keychain.keys[account][key_id].read()?,
+                AuthorizedKey::default()
+            );
+
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            authorize_key(
+                &mut keychain,
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::P256,
+                    config: KeyRestrictions {
+                        expiry: expiry + 60,
+                        enforceLimits: false,
+                        limits: vec![],
+                        allowAnyCalls: true,
+                        allowedCalls: vec![],
+                    },
+                },
+            )?;
+
+            let reused = keychain.keys[account][key_id].read()?;
+            assert_eq!(reused.signature_type, StoredSignatureType::P256);
+            assert!(reused.is_temporary);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t3_prune_expiry_clears_spending_limits_and_token_index() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(1_000u64));
+
+        let account = Address::random();
+        let key_id = Address::random();
+        let token_a = Address::repeat_byte(0x11);
+        let token_b = Address::repeat_byte(0x22);
+        let expiry = 1_060u64;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+
+            authorize_key(
+                &mut keychain,
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry,
+                        enforceLimits: true,
+                        limits: vec![
+                            TokenLimit {
+                                token: token_a,
+                                amount: U256::from(100),
+                                period: 0,
+                            },
+                            TokenLimit {
+                                token: token_b,
+                                amount: U256::from(200),
+                                period: 30,
+                            },
+                        ],
+                        allowAnyCalls: true,
+                        allowedCalls: vec![],
+                    },
+                },
+            )?;
+
+            let account_key = AccountKeychain::spending_limit_key(account, key_id);
+            let indexed_tokens: Vec<Address> =
+                keychain.spending_limit_tokens[account_key].read()?.into();
+            assert_eq!(indexed_tokens.len(), 2);
+
+            Ok::<_, eyre::Report>(())
+        })?;
+
+        storage.set_timestamp(U256::from(expiry));
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            let account_key = AccountKeychain::spending_limit_key(account, key_id);
+
+            assert!(keychain.prune_expiry(
+                Address::random(),
+                pruneExpiryCall {
+                    account,
+                    keyId: key_id,
+                },
+            )?);
+
+            assert_eq!(
+                keychain.keys[account][key_id].read()?,
+                AuthorizedKey::default()
+            );
+            assert_eq!(
+                keychain.spending_limits[account_key][token_a].read()?,
+                SpendingLimitState::default()
+            );
+            assert_eq!(
+                keychain.spending_limits[account_key][token_b].read()?,
+                SpendingLimitState::default()
+            );
+            assert!(
+                keychain.spending_limit_tokens[account_key]
+                    .read()?
+                    .is_empty()
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t3_prune_expiry_clears_call_scopes() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(1_000u64));
+
+        let account = Address::random();
+        let key_id = Address::random();
+        let recipient = Address::repeat_byte(0x44);
+        let expiry = 1_060u64;
+        let target = DEFAULT_FEE_TOKEN;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            TIP20Setup::path_usd(account).apply()?;
+
+            authorize_key(
+                &mut keychain,
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry,
+                        enforceLimits: false,
+                        limits: vec![],
+                        allowAnyCalls: false,
+                        allowedCalls: vec![CallScope {
+                            target,
+                            selectorRules: vec![SelectorRule {
+                                selector: TIP20_TRANSFER_SELECTOR.into(),
+                                recipients: vec![recipient],
+                            }],
+                        }],
+                    },
+                },
+            )?;
+
+            let scopes = keychain.get_allowed_calls(getAllowedCallsCall {
+                account,
+                keyId: key_id,
+            })?;
+            assert!(scopes.isScoped);
+            assert_eq!(scopes.scopes.len(), 1);
+
+            Ok::<_, eyre::Report>(())
+        })?;
+
+        storage.set_timestamp(U256::from(expiry));
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            let account_key = AccountKeychain::spending_limit_key(account, key_id);
+
+            assert!(keychain.prune_expiry(
+                Address::random(),
+                pruneExpiryCall {
+                    account,
+                    keyId: key_id,
+                },
+            )?);
+
+            assert!(!keychain.key_scopes[account_key].is_scoped.read()?);
+            assert!(keychain.key_scopes[account_key].targets.read()?.is_empty());
+            assert!(
+                keychain.key_scopes[account_key].target_scopes[target]
+                    .selectors
+                    .read()?
+                    .is_empty()
+            );
+            assert!(
+                keychain.key_scopes[account_key].target_scopes[target].selector_scopes
+                    [TIP20_TRANSFER_SELECTOR.into()]
+                .recipients
+                .read()?
+                .is_empty()
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t3_temporary_key_rejects_post_authorization_mutators() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(1_000u64));
+
+        let account = Address::random();
+        let key_id = Address::random();
+        let token = Address::repeat_byte(0x11);
+        let target = DEFAULT_FEE_TOKEN;
+        let recipient = Address::repeat_byte(0x44);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            TIP20Setup::path_usd(account).apply()?;
+
+            authorize_key(
+                &mut keychain,
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry: 1_060,
+                        enforceLimits: true,
+                        limits: vec![TokenLimit {
+                            token,
+                            amount: U256::from(100),
+                            period: 30,
+                        }],
+                        allowAnyCalls: false,
+                        allowedCalls: vec![CallScope {
+                            target,
+                            selectorRules: vec![SelectorRule {
+                                selector: TIP20_TRANSFER_SELECTOR.into(),
+                                recipients: vec![recipient],
+                            }],
+                        }],
+                    },
+                },
+            )?;
+
+            assert!(keychain.keys[account][key_id].read()?.is_temporary);
+
+            let update_err = keychain
+                .update_spending_limit(
+                    account,
+                    updateSpendingLimitCall {
+                        keyId: key_id,
+                        token: Address::repeat_byte(0x22),
+                        newLimit: U256::from(200),
+                    },
+                )
+                .expect_err("temporary key spending-limit mutation must be rejected");
+            assert_invalid_key_id(update_err);
+
+            let set_err = keychain
+                .set_allowed_calls(
+                    account,
+                    setAllowedCallsCall {
+                        keyId: key_id,
+                        scopes: vec![CallScope {
+                            target,
+                            selectorRules: Vec::new(),
+                        }],
+                    },
+                )
+                .expect_err("temporary key call-scope mutation must be rejected");
+            assert_invalid_key_id(set_err);
+
+            let remove_err = keychain
+                .remove_allowed_calls(
+                    account,
+                    removeAllowedCallsCall {
+                        keyId: key_id,
+                        target,
+                    },
+                )
+                .expect_err("temporary key call-scope removal must be rejected");
+            assert_invalid_key_id(remove_err);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t3_access_key_tip_1073_benchmark_table() -> eyre::Result<()> {
+        let scoped_recipient = Address::repeat_byte(0x44);
+
+        let rows = vec![
+            run_tip1073_access_key_benchmark("bare key", |expiry| KeyRestrictions {
+                expiry,
+                enforceLimits: false,
+                limits: vec![],
+                allowAnyCalls: true,
+                allowedCalls: vec![],
+            })?,
+            run_tip1073_access_key_benchmark("one spending limit", |expiry| KeyRestrictions {
+                expiry,
+                enforceLimits: true,
+                limits: vec![TokenLimit {
+                    token: Address::repeat_byte(0x11),
+                    amount: U256::from(100),
+                    period: 0,
+                }],
+                allowAnyCalls: true,
+                allowedCalls: vec![],
+            })?,
+            run_tip1073_access_key_benchmark("three spending limits", |expiry| KeyRestrictions {
+                expiry,
+                enforceLimits: true,
+                limits: vec![
+                    TokenLimit {
+                        token: Address::repeat_byte(0x11),
+                        amount: U256::from(100),
+                        period: 0,
+                    },
+                    TokenLimit {
+                        token: Address::repeat_byte(0x22),
+                        amount: U256::from(200),
+                        period: 30,
+                    },
+                    TokenLimit {
+                        token: Address::repeat_byte(0x33),
+                        amount: U256::from(300),
+                        period: 60,
+                    },
+                ],
+                allowAnyCalls: true,
+                allowedCalls: vec![],
+            })?,
+            run_tip1073_access_key_benchmark("one scoped call", |expiry| KeyRestrictions {
+                expiry,
+                enforceLimits: false,
+                limits: vec![],
+                allowAnyCalls: false,
+                allowedCalls: vec![CallScope {
+                    target: DEFAULT_FEE_TOKEN,
+                    selectorRules: vec![SelectorRule {
+                        selector: TIP20_TRANSFER_SELECTOR.into(),
+                        recipients: vec![scoped_recipient],
+                    }],
+                }],
+            })?,
+            run_tip1073_access_key_benchmark("one limit and one scoped call", |expiry| {
+                KeyRestrictions {
+                    expiry,
+                    enforceLimits: true,
+                    limits: vec![TokenLimit {
+                        token: Address::repeat_byte(0x11),
+                        amount: U256::from(100),
+                        period: 0,
+                    }],
+                    allowAnyCalls: false,
+                    allowedCalls: vec![CallScope {
+                        target: DEFAULT_FEE_TOKEN,
+                        selectorRules: vec![SelectorRule {
+                            selector: TIP20_TRANSFER_SELECTOR.into(),
+                            recipients: vec![scoped_recipient],
+                        }],
+                    }],
+                }
+            })?,
+        ];
+
+        eprintln!(
+            "| config | slots | create without TIP | create after TIP | prune execution | prune refund |"
+        );
+        eprintln!("| --- | ---: | ---: | ---: | ---: | ---: |");
+        for row in &rows {
+            eprintln!(
+                "| {} | {} | {} | {} | {} | {} |",
+                row.label,
+                row.temporary_slots,
+                row.create_without_tip_gas,
+                row.create_with_tip_gas,
+                row.prune_execution_gas,
+                row.prune_refund_gas
+            );
+        }
+
+        assert_eq!(
+            rows,
+            vec![
+                Tip1073BenchmarkRow {
+                    label: "bare key",
+                    temporary_slots: 1,
+                    create_without_tip_gas: 250_000,
+                    create_with_tip_gas: 42_000,
+                    prune_execution_gas: 13_400,
+                    prune_refund_gas: 15_000,
+                },
+                Tip1073BenchmarkRow {
+                    label: "one spending limit",
+                    temporary_slots: 6,
+                    create_without_tip_gas: 1_500_000,
+                    create_with_tip_gas: 152_000,
+                    prune_execution_gas: 47_100,
+                    prune_refund_gas: 90_000,
+                },
+                Tip1073BenchmarkRow {
+                    label: "three spending limits",
+                    temporary_slots: 14,
+                    create_without_tip_gas: 3_500_000,
+                    create_with_tip_gas: 328_000,
+                    prune_execution_gas: 104_100,
+                    prune_refund_gas: 210_000,
+                },
+                Tip1073BenchmarkRow {
+                    label: "one scoped call",
+                    temporary_slots: 11,
+                    create_without_tip_gas: 2_750_000,
+                    create_with_tip_gas: 262_000,
+                    prune_execution_gas: 81_000,
+                    prune_refund_gas: 165_000,
+                },
+                Tip1073BenchmarkRow {
+                    label: "one limit and one scoped call",
+                    temporary_slots: 16,
+                    create_without_tip_gas: 4_000_000,
+                    create_with_tip_gas: 372_000,
+                    prune_execution_gas: 114_700,
+                    prune_refund_gas: 240_000,
+                },
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_t3_revoke_temporary_key_clears_temporary_restriction_rows() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(1_000u64));
+
+        let account = Address::random();
+        let key_id = Address::random();
+        let token = Address::repeat_byte(0x55);
+        let recipient = Address::repeat_byte(0x66);
+        let target = DEFAULT_FEE_TOKEN;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            TIP20Setup::path_usd(account).apply()?;
+
+            authorize_key(
+                &mut keychain,
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry: 1_060,
+                        enforceLimits: true,
+                        limits: vec![TokenLimit {
+                            token,
+                            amount: U256::from(100),
+                            period: 30,
+                        }],
+                        allowAnyCalls: false,
+                        allowedCalls: vec![CallScope {
+                            target,
+                            selectorRules: vec![SelectorRule {
+                                selector: TIP20_TRANSFER_SELECTOR.into(),
+                                recipients: vec![recipient],
+                            }],
+                        }],
+                    },
+                },
+            )?;
+
+            keychain.revoke_key(account, revokeKeyCall { keyId: key_id })?;
+
+            let account_key = AccountKeychain::spending_limit_key(account, key_id);
+            let revoked = keychain.keys[account][key_id].read()?;
+            assert!(revoked.is_revoked);
+            assert!(!revoked.is_temporary);
+            assert_eq!(
+                keychain.spending_limits[account_key][token].read()?,
+                SpendingLimitState::default()
+            );
+            assert!(
+                keychain.spending_limit_tokens[account_key]
+                    .read()?
+                    .is_empty()
+            );
+            assert!(!keychain.key_scopes[account_key].is_scoped.read()?);
+            assert!(keychain.key_scopes[account_key].targets.read()?.is_empty());
+            assert!(
+                keychain.key_scopes[account_key].target_scopes[target]
+                    .selectors
+                    .read()?
+                    .is_empty()
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_t3_rejects_recipient_constrained_scope_for_undeployed_tip20() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
         let account = Address::random();
@@ -4445,6 +5224,7 @@ mod tests {
                             recipients: vec![recipient],
                         }],
                     }]),
+                    false,
                 )
                 .expect_err("unexpected success for undeployed TIP-20 target");
 
@@ -4504,6 +5284,7 @@ mod tests {
                     period: 60,
                 }],
                 None,
+                false,
             )?;
 
             keychain.set_transaction_key(key_id)?;
@@ -4572,7 +5353,13 @@ mod tests {
             assert!(!scopes.isScoped);
             assert!(scopes.scopes.is_empty());
 
-            keychain.apply_key_authorization_restrictions(account, key_id, &[], Some(&[]))?;
+            keychain.apply_key_authorization_restrictions(
+                account,
+                key_id,
+                &[],
+                Some(&[]),
+                false,
+            )?;
 
             let deny_all = keychain.get_allowed_calls(getAllowedCallsCall {
                 account,
@@ -5207,6 +5994,7 @@ mod tests {
                         recipients: vec![allowed_recipient],
                     }],
                 }]),
+                false,
             )?;
 
             let make_calldata = |selector: [u8; 4], recipient: Address| {

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -3,7 +3,7 @@ use revm::{
     context::journaled_state::JournalCheckpoint,
     state::{AccountInfo, Bytecode},
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tempo_chainspec::hardfork::TempoHardfork;
 
 use crate::{error::TempoPrecompileError, storage::PrecompileStorageProvider};
@@ -23,8 +23,15 @@ pub struct HashMapStorageProvider {
     spec: TempoHardfork,
     amsterdam_eip8037_enabled: bool,
     is_static: bool,
+    accessed_storage: HashSet<(Address, U256)>,
     counter_sload: u64,
+    counter_cold_sload: u64,
+    counter_warm_sload: u64,
     counter_sstore: u64,
+    counter_cold_sstore: u64,
+    counter_warm_sstore: u64,
+    counter_zero_to_nonzero_sstore: u64,
+    counter_nonzero_to_zero_sstore: u64,
     snapshots: Vec<Snapshot>,
 
     /// Emitted events keyed by contract address.
@@ -67,8 +74,15 @@ impl HashMapStorageProvider {
             spec,
             amsterdam_eip8037_enabled: false,
             is_static: false,
+            accessed_storage: HashSet::new(),
             counter_sload: 0,
+            counter_cold_sload: 0,
+            counter_warm_sload: 0,
             counter_sstore: 0,
+            counter_cold_sstore: 0,
+            counter_warm_sstore: 0,
+            counter_zero_to_nonzero_sstore: 0,
+            counter_nonzero_to_zero_sstore: 0,
         }
     }
 
@@ -125,6 +139,23 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         key: U256,
         value: U256,
     ) -> Result<(), TempoPrecompileError> {
+        if self.accessed_storage.insert((address, key)) {
+            self.counter_cold_sstore += 1;
+        } else {
+            self.counter_warm_sstore += 1;
+        }
+
+        let previous = self
+            .internals
+            .get(&(address, key))
+            .copied()
+            .unwrap_or(U256::ZERO);
+        if previous.is_zero() && !value.is_zero() {
+            self.counter_zero_to_nonzero_sstore += 1;
+        } else if !previous.is_zero() && value.is_zero() {
+            self.counter_nonzero_to_zero_sstore += 1;
+        }
+
         self.counter_sstore += 1;
         self.internals.insert((address, key), value);
         Ok(())
@@ -151,6 +182,12 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         }
 
         self.counter_sload += 1;
+        if self.accessed_storage.insert((address, key)) {
+            self.counter_cold_sload += 1;
+        } else {
+            self.counter_warm_sload += 1;
+        }
+
         Ok(self
             .internals
             .get(&(address, key))
@@ -303,15 +340,52 @@ impl HashMapStorageProvider {
         self.counter_sload
     }
 
+    /// Returns the amount of counted cold SLOADs.
+    pub fn counter_cold_sload(&self) -> u64 {
+        self.counter_cold_sload
+    }
+
+    /// Returns the amount of counted warm SLOADs.
+    pub fn counter_warm_sload(&self) -> u64 {
+        self.counter_warm_sload
+    }
+
     /// Returns the amount of counted SSTOREs.
     pub fn counter_sstore(&self) -> u64 {
         self.counter_sstore
     }
 
+    /// Returns the amount of counted cold SSTOREs.
+    pub fn counter_cold_sstore(&self) -> u64 {
+        self.counter_cold_sstore
+    }
+
+    /// Returns the amount of counted warm SSTOREs.
+    pub fn counter_warm_sstore(&self) -> u64 {
+        self.counter_warm_sstore
+    }
+
+    /// Returns the amount of counted zero-to-nonzero SSTOREs.
+    pub fn counter_zero_to_nonzero_sstore(&self) -> u64 {
+        self.counter_zero_to_nonzero_sstore
+    }
+
+    /// Returns the amount of counted nonzero-to-zero SSTOREs.
+    pub fn counter_nonzero_to_zero_sstore(&self) -> u64 {
+        self.counter_nonzero_to_zero_sstore
+    }
+
     /// Resets the SLOAD and SSTORE counters.
     pub fn reset_counters(&mut self) {
+        self.accessed_storage.clear();
         self.counter_sload = 0;
+        self.counter_cold_sload = 0;
+        self.counter_warm_sload = 0;
         self.counter_sstore = 0;
+        self.counter_cold_sstore = 0;
+        self.counter_warm_sstore = 0;
+        self.counter_zero_to_nonzero_sstore = 0;
+        self.counter_nonzero_to_zero_sstore = 0;
     }
 
     /// Returns all storage entries as `(address, slot, value)`.

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -1417,6 +1417,7 @@ mod tests {
                     enforce_limits: true,
                     is_revoked: false,
                     is_admin: false,
+                    is_temporary: false,
                 })?;
                 let limit_key = AccountKeychain::spending_limit_key(account, key_id);
                 keychain.spending_limits[limit_key][fee_token].write(limit_state)?;
@@ -1488,6 +1489,7 @@ mod tests {
                     enforce_limits: true,
                     is_revoked: false,
                     is_admin: false,
+                    is_temporary: false,
                 })?;
                 let limit_key = AccountKeychain::spending_limit_key(account, key_id);
                 keychain.spending_limits[limit_key][fee_token].write(SpendingLimitState {
@@ -2582,6 +2584,7 @@ mod tests {
                     enforce_limits: true,
                     is_revoked: false,
                     is_admin: false,
+                    is_temporary: false,
                 })
             })
             .unwrap();
@@ -2618,6 +2621,7 @@ mod tests {
                     enforce_limits: false,
                     is_revoked: false,
                     is_admin: false,
+                    is_temporary: false,
                 })
             })
             .unwrap();

--- a/crates/transaction-pool/src/test_utils.rs
+++ b/crates/transaction-pool/src/test_utils.rs
@@ -376,6 +376,8 @@ pub(crate) fn create_mock_provider() -> MockEthProvider<TempoPrimitives, TempoCh
 ///         expiry: u64::MAX,
 ///         enforce_limits: false,
 ///         is_revoked: false,
+///         is_admin: false,
+///         is_temporary: false,
 ///     })
 /// });
 /// ```

--- a/tips/tip-1073.md
+++ b/tips/tip-1073.md
@@ -1,0 +1,175 @@
+---
+id: TIP-1073
+title: Temporary Access Key State
+description: Reduces upfront state-creation cost for bounded-lifetime AccountKeychain access-key rows, with prepaid generic gas refunds for expiry pruning.
+authors: TBD
+status: Draft
+related: TIP-1000, TIP-1011, TIP-1060
+protocolVersion: TBD
+---
+
+# TIP-1073: Temporary Access Key State
+
+## Abstract
+
+This TIP gives bounded-lifetime AccountKeychain access keys temporary state pricing and a
+permissionless expiry cleanup path.
+
+The access-key creator prepays a cleanup budget that scales with the number of temporary storage
+slots created by the key's limits and call scopes. Any caller can later prune the expired key and
+receive a generic gas refund based on the temporary slots actually deleted, capped by the remaining
+prepaid cleanup budget.
+
+## Motivation
+
+Short-lived access keys make wallet sessions cheaper and safer, but their storage can outlive the
+session. Charging full permanent-state pricing for a key with a bounded expiry makes session UX
+expensive. Expiry alone is not sufficient either: stale key rows, spending limits, and call scopes
+still need to be removed by the precompile that understands their semantics.
+
+## Constants
+
+```text
+ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS         = 15_000
+ACCESS_KEY_CREATION_BUFFER_GAS             = 20_000
+ACCESS_KEY_EXPIRY_PREMIUM_PER_SLOT_DAY_GAS = 1_000
+MAX_TEMPORARY_TTL                          = 30 days
+```
+
+For an eligible access key:
+
+```text
+temporary_slot_count(config) =
+    physical nonzero storage slots created for the key and reachable by pruneExpiry
+
+initial_cleanup_budget(config) =
+    ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS * temporary_slot_count(config)
+
+actual_cleanup_refund(key) =
+    ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS
+    * actual_temporary_slots_deleted_by_pruneExpiry(key)
+
+expiry_premium(config, expiry) =
+    ACCESS_KEY_EXPIRY_PREMIUM_PER_SLOT_DAY_GAS
+    * temporary_slot_count(config)
+    * ceil((expiry - block.timestamp) / 1 day)
+
+temporary_access_key_creation_gas(config, expiry) =
+    initial_cleanup_budget(config)
+    + ACCESS_KEY_CREATION_BUFFER_GAS
+    + expiry_premium(config, expiry)
+```
+
+The `20,000` gas buffer and expiry premium are nonrefundable. The transaction that prunes the
+expired key receives `actual_cleanup_refund(key)`, capped by the key's remaining prepaid cleanup
+budget. If fewer temporary slots are deleted than were prepaid, the unused cleanup budget is not
+paid out.
+
+## Benchmarks
+
+The benchmark command is:
+
+```text
+cargo test -p tempo-precompiles test_t3_access_key_tip_1073_benchmark_table -- --nocapture
+```
+
+The benchmark runs Rust `authorize_key` to count temporary slots and Rust `prune_expiry` to measure
+cleanup execution. The table uses a seven-day key lifetime. Creation values are state-creation gas:
+`250,000 * measured slots` for the TIP-1000 column, and the formula above for the TIP-1073 column.
+Prune execution is storage execution inside the AccountKeychain precompile. The arb refund column
+assumes all temporary slots created by the benchmark remain nonzero until prune.
+
+| Access key config | Slots | Create without TIP | Create after TIP | Arb prune execution | Arb refund |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Bare key | 1 | 250,000 | 42,000 | 13,400 | 15,000 |
+| One spending limit | 6 | 1,500,000 | 152,000 | 47,100 | 90,000 |
+| Three spending limits | 14 | 3,500,000 | 328,000 | 104,100 | 210,000 |
+| One scoped call | 11 | 2,750,000 | 262,000 | 81,000 | 165,000 |
+| One spending limit and one scoped call | 16 | 4,000,000 | 372,000 | 114,700 | 240,000 |
+
+These measurements justify `ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS = 15,000`: the tightest case is a
+bare key, where pruning costs `13,400` gas and refunds `15,000` gas. Larger configurations have
+larger margins because the fixed key lookup cost is amortized across more slots.
+
+`ACCESS_KEY_CREATION_BUFFER_GAS = 20,000` makes every temporary key pay a nonrefundable per-key
+cost even when it is pruned. `ACCESS_KEY_EXPIRY_PREMIUM_PER_SLOT_DAY_GAS = 1,000` makes larger and
+longer-lived keys pay more upfront. `MAX_TEMPORARY_TTL = 30 days` bounds the lifetime of discounted
+state.
+
+## Eligibility
+
+Temporary pricing applies only when all of the following are true:
+
+1. The key is not an admin key.
+2. The key expiry is finite.
+3. `block.timestamp < expiry <= block.timestamp + MAX_TEMPORARY_TTL`.
+4. The key has not been revoked.
+
+All temporary slots created for an eligible key MUST be reachable by `pruneExpiry`.
+
+## Mutation Rules
+
+Temporary access keys are immutable after authorization in this TIP. AccountKeychain MUST reject
+post-create changes to a temporary key's spending limits or call scopes, including
+`updateSpendingLimit`, `setAllowedCalls`, and `removeAllowedCalls`.
+
+Revocation remains allowed. If the account needs different limits or scopes, it creates a new
+temporary key and revokes or lets the old key expire.
+
+This keeps cleanup-budget accounting small. A future mutation path MAY create additional temporary
+slots only if it charges cleanup budget and expiry premium for the newly created slots before they
+are written. If a mutation path deletes temporary slots before expiry, those slots MUST reduce the
+future `actual_cleanup_refund(key)`; any unused prepaid cleanup budget is burned.
+
+## Pruning
+
+The AccountKeychain precompile MUST expose:
+
+```solidity
+function pruneExpiry(address account, address keyId) external returns (bool pruned);
+```
+
+`pruneExpiry` MUST return `false` and MUST NOT modify state when:
+
+- the key does not exist,
+- the key is revoked,
+- the key is not temporary,
+- the key has not expired.
+
+When the key exists, is temporary, and `block.timestamp >= key.expiry`, `pruneExpiry` MUST:
+
+1. delete the primary key row,
+2. delete all temporary spending-limit rows associated with the key,
+3. delete all temporary call-scope rows associated with the key,
+4. credit `ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS` for each temporary slot actually deleted, capped by
+   the key's remaining prepaid cleanup budget,
+5. return `true`.
+
+After pruning, a new authorization for the same `keyId` MAY succeed if it carries a new future
+expiry and passes AccountKeychain validation. Revoked keys are not pruneable.
+
+## Refund Rules
+
+TIP-1073 cleanup refunds are generic transaction gas refunds. They are credited to the same
+transaction refund counter as ordinary EVM storage refunds and follow the same transaction-level
+refund cap, success/revert, and settlement semantics. They can offset gas spent by the same
+transaction, but they MUST NOT produce a negative gas charge, token payout, or transferable credit.
+
+Implementations MUST enforce:
+
+- TIP-1073 cleanup refunds MUST be included in the normal transaction refund counter, not paid
+  through a separate bounty or balance transfer.
+- `pruneExpiry` refunds are based on actual temporary slots deleted, not the original slot count at
+  key creation.
+- Total TIP-1073 cleanup refund credited in a transaction MUST NOT exceed remaining prepaid cleanup
+  budgets consumed by that transaction.
+- Unused prepaid cleanup budget is burned and MUST NOT be paid to the key owner or prune caller.
+- A temporary slot deleted before `pruneExpiry` MUST NOT be included in a later `pruneExpiry`
+  refund.
+- Any mutation that creates additional temporary slots MUST charge cleanup budget for those slots
+  before writing them.
+- A temporary slot deletion MUST NOT also receive an ordinary storage-clearing refund for the same
+  slot.
+- A temporary slot deletion MUST NOT mint or consume TIP-1060 storage credits.
+- Temporary-slot creation, cleanup-budget consumption, cleanup refunds, and access-key pruning MUST
+  revert with their EVM execution scope.


### PR DESCRIPTION
Adds TIP-1073 for temporary AccountKeychain access-key state and implements permissionless `pruneExpiry` cleanup with measured Rust benchmark coverage.

Temporary keys now mark eligible finite-expiry rows, index spending-limit tokens for cleanup, and clear key, spending-limit, and call-scope storage on prune or revoke. The TIP includes measured slot counts, creation-cost formula, prune execution cost, and refund sizing.

Checks:
- `cargo test -p tempo-precompiles test_t3_access_key_tip_1073_benchmark_table -- --nocapture`
- `cargo test -p tempo-precompiles account_keychain:: -- --nocapture`
- `cargo check -p tempo-contracts -p tempo-precompiles`
- `cargo check -p tempo-transaction-pool`
- `git diff --check`