### PR TITLE
feat(precompiles): set supported feature tip

### DIFF
--- a/crates/contracts/src/precompiles/feature_registry.rs
+++ b/crates/contracts/src/precompiles/feature_registry.rs
@@ -22,8 +22,8 @@ crate::sol! {
         /// @notice Returns the scheduled feature tip and earliest activation epoch.
         function scheduledFeaturesTip() external view returns (uint64 featuresTip, uint64 activationEpoch);
 
-        /// @notice Reports the highest protocol feature ID a validator supports.
-        function setSupportedFeaturesTip(address validator, uint64 featuresTip) external;
+        /// @notice Reports the highest protocol feature tip the caller supports.
+        function setSupportedFeaturesTip(uint64 featuresTip) external;
 
         /// @notice Schedules a higher feature tip for activation at the target epoch.
         function scheduleFeaturesTip(uint64 featuresTip, uint64 activationEpoch) external;

--- a/crates/contracts/src/precompiles/feature_registry.rs
+++ b/crates/contracts/src/precompiles/feature_registry.rs
@@ -22,8 +22,8 @@ crate::sol! {
         /// @notice Returns the scheduled feature tip and earliest activation epoch.
         function scheduledFeaturesTip() external view returns (uint64 featuresTip, uint64 activationEpoch);
 
-        /// @notice Reports the highest protocol feature tip the caller supports.
-        function setSupportedFeaturesTip(uint64 featuresTip) external;
+        /// @notice Records the highest protocol feature tip reported for a validator. System caller only.
+        function setSupportedFeaturesTip(address validator, uint64 featuresTip) external;
 
         /// @notice Schedules a higher feature tip for activation at the target epoch.
         function scheduleFeaturesTip(uint64 featuresTip, uint64 activationEpoch) external;

--- a/crates/precompiles/src/feature_registry/dispatch.rs
+++ b/crates/precompiles/src/feature_registry/dispatch.rs
@@ -535,8 +535,11 @@ mod tests {
             let validator = Address::repeat_byte(0x01);
 
             registry.set_supported_features_tip(
-                validator,
-                IFeatureRegistry::setSupportedFeaturesTipCall { featuresTip: 13 },
+                SYSTEM_CALLER_ADDRESS,
+                IFeatureRegistry::setSupportedFeaturesTipCall {
+                    validator,
+                    featuresTip: 13,
+                },
             )?;
 
             assert_eq!(registry.validator_supported_features_tip(validator)?, 13);
@@ -554,8 +557,11 @@ mod tests {
             registry.validator_supported_features_tip[validator].write(13)?;
 
             let result = registry.set_supported_features_tip(
-                validator,
-                IFeatureRegistry::setSupportedFeaturesTipCall { featuresTip: 12 },
+                SYSTEM_CALLER_ADDRESS,
+                IFeatureRegistry::setSupportedFeaturesTipCall {
+                    validator,
+                    featuresTip: 12,
+                },
             );
             assert_eq!(
                 result,
@@ -622,14 +628,38 @@ mod tests {
     }
 
     #[test]
-    fn set_supported_features_tip_dispatch_sets_validator_report() -> eyre::Result<()> {
+    fn set_supported_features_tip_rejects_non_system_caller() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut registry = FeatureRegistry::new();
             let validator = Address::repeat_byte(0x01);
 
-            let call = IFeatureRegistry::setSupportedFeaturesTipCall { featuresTip: 34 };
-            let result = registry.call(&call.abi_encode(), validator)?;
+            let result = registry.set_supported_features_tip(
+                Address::repeat_byte(0x02),
+                IFeatureRegistry::setSupportedFeaturesTipCall {
+                    validator,
+                    featuresTip: 13,
+                },
+            );
+            assert_eq!(result, Err(FeatureRegistryError::unauthorized().into()));
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 0);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn set_supported_features_tip_dispatch_sets_validator_report_from_system() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let validator = Address::repeat_byte(0x01);
+
+            let call = IFeatureRegistry::setSupportedFeaturesTipCall {
+                validator,
+                featuresTip: 34,
+            };
+            let result = registry.call(&call.abi_encode(), SYSTEM_CALLER_ADDRESS)?;
             assert!(!result.is_revert());
             assert_eq!(registry.validator_supported_features_tip(validator)?, 34);
 
@@ -638,22 +668,22 @@ mod tests {
     }
 
     #[test]
-    fn set_supported_features_tip_dispatch_uses_msg_sender_as_validator() -> eyre::Result<()> {
+    fn set_supported_features_tip_dispatch_rejects_non_system_caller() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut registry = FeatureRegistry::new();
-            let caller = Address::repeat_byte(0x01);
-            let other_validator = Address::repeat_byte(0x02);
+            let validator = Address::repeat_byte(0x01);
 
-            let call = IFeatureRegistry::setSupportedFeaturesTipCall { featuresTip: 34 };
-            let result = registry.call(&call.abi_encode(), caller)?;
-            assert!(!result.is_revert());
+            let call = IFeatureRegistry::setSupportedFeaturesTipCall {
+                validator,
+                featuresTip: 34,
+            };
+            let result = registry.call(&call.abi_encode(), Address::repeat_byte(0x02))?;
+            assert!(result.is_revert());
+            let decoded = FeatureRegistryError::abi_decode(&result.bytes)?;
+            assert_eq!(decoded, FeatureRegistryError::unauthorized());
 
-            assert_eq!(registry.validator_supported_features_tip(caller)?, 34);
-            assert_eq!(
-                registry.validator_supported_features_tip(other_validator)?,
-                0
-            );
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 0);
 
             Ok(())
         })
@@ -667,8 +697,11 @@ mod tests {
             let validator = Address::repeat_byte(0x01);
             registry.validator_supported_features_tip[validator].write(34)?;
 
-            let call = IFeatureRegistry::setSupportedFeaturesTipCall { featuresTip: 33 };
-            let result = registry.call(&call.abi_encode(), validator)?;
+            let call = IFeatureRegistry::setSupportedFeaturesTipCall {
+                validator,
+                featuresTip: 33,
+            };
+            let result = registry.call(&call.abi_encode(), SYSTEM_CALLER_ADDRESS)?;
             assert!(result.is_revert());
             let decoded = FeatureRegistryError::abi_decode(&result.bytes)?;
             assert_eq!(

--- a/crates/precompiles/src/feature_registry/dispatch.rs
+++ b/crates/precompiles/src/feature_registry/dispatch.rs
@@ -35,8 +35,10 @@ impl Precompile for FeatureRegistry {
                 IFeatureRegistryCalls::scheduledFeaturesTip(call) => {
                     view(call, |_| self.scheduled_features_tip())
                 }
-                IFeatureRegistryCalls::setSupportedFeaturesTip(_) => {
-                    unsupported::<IFeatureRegistry::setSupportedFeaturesTipCall>()
+                IFeatureRegistryCalls::setSupportedFeaturesTip(call) => {
+                    mutate_void(call, msg_sender, |sender, call| {
+                        self.set_supported_features_tip(sender, call)
+                    })
                 }
                 IFeatureRegistryCalls::scheduleFeaturesTip(call) => {
                     mutate_void(call, msg_sender, |sender, call| {
@@ -526,6 +528,46 @@ mod tests {
     }
 
     #[test]
+    fn set_supported_features_tip_sets_validator_report() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let validator = Address::repeat_byte(0x01);
+
+            registry.set_supported_features_tip(
+                validator,
+                IFeatureRegistry::setSupportedFeaturesTipCall { featuresTip: 13 },
+            )?;
+
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 13);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn set_supported_features_tip_rejects_decreased_report() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let validator = Address::repeat_byte(0x01);
+            registry.validator_supported_features_tip[validator].write(13)?;
+
+            let result = registry.set_supported_features_tip(
+                validator,
+                IFeatureRegistry::setSupportedFeaturesTipCall { featuresTip: 12 },
+            );
+            assert_eq!(
+                result,
+                Err(FeatureRegistryError::supported_features_tip_decreased().into())
+            );
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 13);
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn features_tip_dispatch_returns_encoded_cursor() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
@@ -574,6 +616,66 @@ mod tests {
                 IFeatureRegistry::scheduledFeaturesTipCall::abi_decode_returns(&result.bytes)?;
             assert_eq!(decoded.featuresTip, 34);
             assert_eq!(decoded.activationEpoch, 55);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn set_supported_features_tip_dispatch_sets_validator_report() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let validator = Address::repeat_byte(0x01);
+
+            let call = IFeatureRegistry::setSupportedFeaturesTipCall { featuresTip: 34 };
+            let result = registry.call(&call.abi_encode(), validator)?;
+            assert!(!result.is_revert());
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 34);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn set_supported_features_tip_dispatch_uses_msg_sender_as_validator() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let caller = Address::repeat_byte(0x01);
+            let other_validator = Address::repeat_byte(0x02);
+
+            let call = IFeatureRegistry::setSupportedFeaturesTipCall { featuresTip: 34 };
+            let result = registry.call(&call.abi_encode(), caller)?;
+            assert!(!result.is_revert());
+
+            assert_eq!(registry.validator_supported_features_tip(caller)?, 34);
+            assert_eq!(
+                registry.validator_supported_features_tip(other_validator)?,
+                0
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn set_supported_features_tip_dispatch_rejects_decreased_report() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let validator = Address::repeat_byte(0x01);
+            registry.validator_supported_features_tip[validator].write(34)?;
+
+            let call = IFeatureRegistry::setSupportedFeaturesTipCall { featuresTip: 33 };
+            let result = registry.call(&call.abi_encode(), validator)?;
+            assert!(result.is_revert());
+            let decoded = FeatureRegistryError::abi_decode(&result.bytes)?;
+            assert_eq!(
+                decoded,
+                FeatureRegistryError::supported_features_tip_decreased()
+            );
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 34);
 
             Ok(())
         })

--- a/crates/precompiles/src/feature_registry/mod.rs
+++ b/crates/precompiles/src/feature_registry/mod.rs
@@ -84,12 +84,16 @@ impl FeatureRegistry {
         msg_sender: Address,
         call: IFeatureRegistry::setSupportedFeaturesTipCall,
     ) -> Result<()> {
-        let previous = self.validator_supported_features_tip[msg_sender].read()?;
+        if msg_sender != SYSTEM_CALLER_ADDRESS {
+            return Err(FeatureRegistryError::unauthorized().into());
+        }
+
+        let previous = self.validator_supported_features_tip[call.validator].read()?;
         if call.featuresTip < previous {
             return Err(FeatureRegistryError::supported_features_tip_decreased().into());
         }
 
-        self.validator_supported_features_tip[msg_sender].write(call.featuresTip)
+        self.validator_supported_features_tip[call.validator].write(call.featuresTip)
     }
 
     pub fn schedule_features_tip(

--- a/crates/precompiles/src/feature_registry/mod.rs
+++ b/crates/precompiles/src/feature_registry/mod.rs
@@ -79,6 +79,19 @@ impl FeatureRegistry {
         self.validator_supported_features_tip[validator].read()
     }
 
+    pub fn set_supported_features_tip(
+        &mut self,
+        msg_sender: Address,
+        call: IFeatureRegistry::setSupportedFeaturesTipCall,
+    ) -> Result<()> {
+        let previous = self.validator_supported_features_tip[msg_sender].read()?;
+        if call.featuresTip < previous {
+            return Err(FeatureRegistryError::supported_features_tip_decreased().into());
+        }
+
+        self.validator_supported_features_tip[msg_sender].write(call.featuresTip)
+    }
+
     pub fn schedule_features_tip(
         &mut self,
         msg_sender: Address,


### PR DESCRIPTION
Adds `setSupportedFeaturesTip(uint64)` so validators can self-report their supported feature tip under `msg.sender`. Reports are monotonic and reject decreases, while `validatorSupportedFeaturesTip(address)` remains the read path for validator reports.