### PR TITLE
bench: reduce tip20 txgen valid window

### DIFF
--- a/contrib/bench/txgen/presets/tip20.yml
+++ b/contrib/bench/txgen/presets/tip20.yml
@@ -25,7 +25,7 @@ templates:
     max_priority_fee_per_gas: 100000000000
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
-    valid_for_secs: 10
+    valid_for_secs: 5
     call:
       to: "0x20c0000000000000000000000000000000000000"
       abi: ERC20

--- a/contrib/bench/txgen/presets/tip20_existing_recipients.yml
+++ b/contrib/bench/txgen/presets/tip20_existing_recipients.yml
@@ -33,7 +33,7 @@ templates:
     max_priority_fee_per_gas: 100000000000
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
-    valid_for_secs: 10
+    valid_for_secs: 5
     call:
       to: "0x20c0000000000000000000000000000000000000"
       abi: ERC20

--- a/contrib/bench/txgen/presets/tip20_random_recipients.yml
+++ b/contrib/bench/txgen/presets/tip20_random_recipients.yml
@@ -25,7 +25,7 @@ templates:
     max_priority_fee_per_gas: 100000000000
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
-    valid_for_secs: 10
+    valid_for_secs: 5
     call:
       to: "0x20c0000000000000000000000000000000000000"
       abi: ERC20


### PR DESCRIPTION
Summary:
- Change TIP-20 txgen bench presets from valid_for_secs: 10 to 5.

Validation:
- git diff --check
- rg -n "valid_for_secs: (10|5)" contrib/bench/txgen/presets

Prompted by: @shekhirin