### PR TITLE
Add execution-time block bound TIP-1074

### DIFF
--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -1,0 +1,121 @@
+---
+id: TIP-1066
+title: Execution-Time Block Bound
+description: Bounds block production and validator voting by measured execution time instead of gas alone.
+authors: Tempo contributors
+status: Draft
+related: RETH-867, TIP-1010
+protocolVersion: TBD
+---
+
+# TIP-1066: Execution-Time Block Bound
+
+## Abstract
+
+This TIP defines local block-building and validator-voting limits that bound block execution time directly. Block builders SHOULD stop adding transactions after 150 ms of block execution work. Validators SHOULD withhold their vote from a block if local execution takes more than 300 ms.
+
+These limits are intentionally not consensus validity rules. A validator that withholds its vote because a block exceeded the local execution-time threshold MUST still accept the block if enough other validators vote to confirm it.
+
+## Motivation
+
+Tempo targets stable sub-second block times. Using only the block gas limit to hit a 500-600 ms block time is too imprecise because gas does not tightly model wall-clock execution time across transaction mixes, state access patterns, implementation details, and hardware. Gas remains useful for fee accounting, state-growth pricing, and coarse block sizing, but it is not a precise enough control loop for benchmark or peak-load block duration.
+
+The immediate goal is to prevent builders from producing blocks that are valid by gas but too slow for validators to execute within the block-time budget. This matters in benchmarking today and can also matter under adversarial load.
+
+This TIP therefore introduces a direct execution-time budget for block construction and a separate validator voting policy for blocks that exceed the expected execution envelope.
+
+## Assumptions
+
+- Validator hardware is reasonably standardized for the target network. If hardware varies widely, a wall-clock voting threshold can cause slower validators to withhold votes from blocks that faster validators consider acceptable.
+- Block execution time measured by a builder is a useful proxy for validator execution time. If builder hardware is materially faster than validator hardware, the builder limit MUST be lowered or calibrated against validator measurements.
+- Network propagation and certificate propagation remain inside the broader block-time budget. This TIP only bounds execution-related time.
+- The limits in this TIP are operational policy parameters and can be adjusted as execution performance changes, including after BAL makes validation faster.
+
+## Threat Model
+
+- Builders may try to maximize throughput by constructing gas-valid blocks that take too long to execute. The builder-side limit reduces this risk for honest builders.
+- A malicious builder may intentionally propose a slow block. The validator voting rule lets validators avoid voting for blocks that exceed their local execution budget.
+- Validators may run slower hardware or overloaded nodes. Those validators may withhold votes from blocks that are accepted by the rest of the network, but they must still accept confirmed blocks.
+- This TIP does not protect against every execution-time denial of service. It adds a local policy guardrail while preserving consensus compatibility.
+
+---
+
+# Specification
+
+## Parameters
+
+Introduce the following policy parameters:
+
+| Parameter | Initial value | Meaning |
+| --- | ---: | --- |
+| Target block interval | 500 ms | Desired steady-state block cadence |
+| Builder execution budget | 150 ms | Maximum execution time a builder should spend constructing a block |
+| Validator voting threshold | 300 ms | Maximum local execution time for a validator to vote for a block |
+
+The parameters are local node policy unless a future TIP promotes them to consensus rules.
+
+## Block Builder Policy
+
+A block builder SHOULD measure elapsed execution time while constructing each candidate block. Once the builder execution budget is reached, the builder SHOULD stop adding transactions and produce the block with the transactions already included, even if the gas limit has remaining capacity.
+
+The builder execution budget applies to transaction execution during block construction. It does not replace existing gas limits, lane limits, transaction validity checks, fee rules, or payload validity rules.
+
+If the mempool does not contain enough eligible transactions to use the full builder execution budget, the builder MUST NOT intentionally delay block production only to fill time. Empty and low-load blocks can complete below the builder budget.
+
+Builders MAY use conservative internal estimates, sampling, or early-stop logic to avoid crossing the budget. If a transaction causes the builder to cross the budget after execution, the builder SHOULD either exclude that transaction from the candidate block or finish the candidate and stop adding further transactions. The implementation MUST choose one behavior and apply it deterministically within the builder process.
+
+## Validator Voting Policy
+
+A validator SHOULD measure local execution time for a proposed block before voting. If local execution time exceeds the validator voting threshold, the validator SHOULD withhold its vote for that block.
+
+This is a voting rule, not a consensus validity rule. A validator MUST NOT reject, slash, quarantine, or refuse to import a block solely because local execution exceeded the validator voting threshold. If the block receives enough votes to be confirmed, the validator MUST accept and import it as long as it otherwise satisfies consensus validity.
+
+Validators MAY expose a configuration override for the voting threshold, but the default SHOULD match this TIP for the target network. Operators who change the threshold risk voting behavior that differs from the rest of the validator set.
+
+## Gas Limits
+
+Existing block gas limits and lane gas limits remain in force. A block remains invalid if it exceeds any consensus gas limit.
+
+Gas limits do not imply an execution-time guarantee. Builders SHOULD treat gas limits as fee and capacity constraints, and SHOULD treat the builder execution budget as the primary control for stable peak-load block construction time.
+
+## Calibration
+
+The initial 150 ms builder budget and 300 ms validator threshold reserve time for network propagation, certificate work, and variance between builder and validator execution. These values SHOULD be recalibrated against benchmark and testnet measurements before mainnet activation.
+
+At minimum, calibration SHOULD record:
+
+- builder execution time per block,
+- validator execution time per block,
+- transaction count and gas used per block,
+- block propagation time,
+- certificate propagation time,
+- hardware profile for builders and validators.
+
+If validation becomes materially faster, the validator voting threshold MAY be lowered or the builder execution budget MAY be raised, depending on the target block interval and observed propagation costs.
+
+# Observability
+
+Nodes MUST expose enough telemetry to determine whether the execution-time policy is working.
+
+Builders SHOULD emit or record:
+
+- `payload_builder_execution_ms`: execution time spent building the block.
+- `payload_builder_stopped_by_time_budget`: whether block construction stopped because the builder budget was reached.
+- `payload_builder_gas_used`: gas used by the produced block.
+- `payload_builder_transaction_count`: number of transactions included in the produced block.
+
+Validators SHOULD emit or record:
+
+- `block_validation_execution_ms`: local execution time for the proposed block.
+- `block_vote_withheld_execution_time`: whether the validator withheld its vote because execution exceeded the threshold.
+- `block_vote_execution_threshold_ms`: threshold used for the voting decision.
+
+These events answer whether blocks are bounded by time instead of gas, whether validators are withholding votes because blocks are too slow, and whether gas usage still correlates poorly with execution duration for observed workloads.
+
+# Invariants
+
+- A block that satisfies consensus validity MUST NOT become invalid solely because it exceeded the builder execution budget or validator voting threshold.
+- A validator that withholds a vote because of local execution time MUST still accept the block if it is otherwise valid and confirmed.
+- Builders MUST continue enforcing all consensus gas limits and transaction validity checks.
+- Under low transaction load, builders MUST NOT delay blocks merely to consume the full builder execution budget.
+- The builder execution budget and validator voting threshold MUST be observable in logs or metrics for benchmark and testnet analysis.

--- a/tips/tip-1074.md
+++ b/tips/tip-1074.md
@@ -1,5 +1,5 @@
 ---
-id: TIP-1066
+id: TIP-1074
 title: Execution-Time Block Bound
 description: Bounds block production and validator voting by measured execution time instead of gas alone.
 authors: Tempo contributors
@@ -8,7 +8,7 @@ related: RETH-867, TIP-1010
 protocolVersion: TBD
 ---
 
-# TIP-1066: Execution-Time Block Bound
+# TIP-1074: Execution-Time Block Bound
 
 ## Abstract
 


### PR DESCRIPTION
## Summary
- add TIP-1074 for execution-time bounded block building and validator voting
- specify 150 ms builder execution budget and 300 ms validator voting threshold
- clarify that slow execution affects voting policy, not consensus validity

## Testing
- not run; documentation-only change

