### PR TITLE
fix(ci): build binaries workflow without just

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,11 +39,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
-        with:
-          tool: just
       - name: Build
-        run: just build ${{ matrix.binary }} "--profile ${{ inputs.profile || 'dev' }}"
+        run: cargo build --bin ${{ matrix.binary }} --profile ${{ inputs.profile || 'dev' }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         id: binary_upload
         with:


### PR DESCRIPTION
## Summary
- build binaries directly with cargo instead of invoking a missing `just build` recipe
- remove the now-unused `just` install step from the workflow

## Testing
- `git diff --check`

Prompted by: @Zygimantass