### PR TITLE
docs: add Rust formatting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ Tempo is a blockchain node built on [Reth SDK](https://github.com/paradigmxyz/re
 
 ## Pull Requests
 
+- Format Rust code with `cargo +nightly fmt`.
+
 ## TIPs (Tempo Improvement Proposals)
 
 When creating a new TIP:


### PR DESCRIPTION
Adds the Rust formatting command to `AGENTS.md` so agent-authored Rust changes use nightly rustfmt.

Prompted by: @SuperFluffy