### PR TITLE
Update TIP-1067 gas target to 10M

### DIFF
--- a/tips/tip-1067.md
+++ b/tips/tip-1067.md
@@ -120,6 +120,30 @@ These time constants are a consequence of the chosen denominator and may be retu
 
 ---
 
+# Observability
+
+No new protocol event is required. The base fee is committed in each block header and the controller input is the existing block `gasUsed`, so existing block/header telemetry is sufficient for protocol-level debugging. Production deployments MUST expose the metrics below so operators can tell whether this TIP is producing the intended discount under low load and whether the lower fee floor is enabling unsafe state growth.
+
+| Metric | Fields / labels | Operational question |
+|---|---|---|
+| `block_base_fee_attodollars_per_gas` | `chain`, `network`, `validator`, `block_number` | What base fee did the controller produce for each block? |
+| `block_gas_used` | `chain`, `network`, `validator`, `block_number` | Is block gas usage below, near, or above `GAS_TARGET`? |
+| `base_fee_controller_state` | `chain`, `network`, `validator`, `state` (`floor`, `between`, `cap`) | Is the base fee pinned at the floor, pinned at the cap, or moving within the dynamic range? |
+| `state_size_bytes` | `chain`, `network`, `validator`, `component` (`hashed_accounts`, `hashed_storages`, `bytecodes`, `accounts_trie`, `storages_trie`, `total`) | How large is total state, split between flat state (`hashed_accounts`, `hashed_storages`, `bytecodes`) and trie state (`accounts_trie`, `storages_trie`)? |
+| `state_growth_bytes` | `chain`, `network`, `validator`, `component`, `window` (`1d`, `7d`, `30d`) | How quickly is state growing over day, week, and month windows? |
+| `projected_state_size_bytes` | `chain`, `network`, `validator`, `component`, `horizon` (`7d`, `14d`, `30d`) | If recent growth continues, how large will state be in one week, two weeks, and one month? |
+| `state_disk_free_bytes` | `chain`, `network`, `validator`, `volume` | How much capacity remains before state growth threatens node operation? |
+
+Alerts SHOULD cover:
+
+1. **Sustained underpriced load:** `block_base_fee_attodollars_per_gas == BASE_FEE_FLOOR` while gas usage is at or above `GAS_TARGET` for a sustained window.
+2. **State growth anomaly:** 1-day, 7-day, or 30-day `state_growth_bytes{component="total"}` exceeds the expected operating envelope.
+3. **State growth projection:** `projected_state_size_bytes{component="total", horizon="30d"}` exceeds the operator-defined capacity budget.
+4. **Disk exhaustion risk:** projected state growth plus current usage leaves less than the operator-defined free-space buffer.
+5. **Metric freshness:** state-size and block/base-fee metrics are missing or stale for any production validator.
+
+For reth-based nodes, the state-size metrics SHOULD be derived from `reth_db_table_size` with flat state tracked as `HashedAccounts`, `HashedStorages`, and `Bytecodes`, and trie state tracked as `AccountsTrie` and `StoragesTrie`.
+
 # Invariants
 
 1. **Range clamp:** For every post-activation block, `BASE_FEE_FLOOR ≤ base_fee ≤ BASE_FEE_CAP`.

--- a/tips/tip-1067.md
+++ b/tips/tip-1067.md
@@ -1,7 +1,7 @@
 ---
 id: TIP-1067
 title: Dynamic Base Fee
-description: Replaces Tempo's fixed base fee with an EIP-1559-style controller that lowers the base fee toward one twentieth of the current cost when the chain is underutilized and rises back to the current cost under load, with a 5,000,000 gas target.
+description: Replaces Tempo's fixed base fee with an EIP-1559-style controller that lowers the base fee toward one twentieth of the current cost when the chain is underutilized and rises back to the current cost under load, with a 10,000,000 gas target.
 authors: Dankrad Feist @dankrad
 status: Draft
 related: TIP-1010, TIP-1000
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP replaces Tempo's fixed base fee (TIP-1010: `2 × 10^10` attodollars per gas) with an EIP-1559-style per-block controller. The base fee adjusts each block toward a gas target of 5,000,000 gas: it falls when blocks use less than the target and rises when they use more. The base fee is clamped to the range `[1 × 10^9, 2 × 10^10]` attodollars per gas, i.e. between one twentieth of the current fixed cost (the floor) and the current fixed cost (the cap).
+This TIP replaces Tempo's fixed base fee (TIP-1010: `2 × 10^10` attodollars per gas) with an EIP-1559-style per-block controller. The base fee adjusts each block toward a gas target of 10,000,000 gas: it falls when blocks use less than the target and rises when they use more. The base fee is clamped to the range `[1 × 10^9, 2 × 10^10]` attodollars per gas, i.e. between one twentieth of the current fixed cost (the floor) and the current fixed cost (the cap).
 
 The effect is that when the chain is used very little, the base fee decays toward the floor and transactions become up to 20× cheaper than today; when the chain is busy, the base fee rises back to the current cost and never exceeds it. Because the cap equals today's fixed base fee, any caller that budgets for the current price is never surprised by a higher fee, while underutilized periods are made ultracheap.
 
@@ -29,7 +29,7 @@ The design is deliberately a *one-sided discount* relative to the status quo: th
 - The current fixed base fee from TIP-1010 is `2 × 10^10` attodollars per gas. This TIP treats that value as the base fee cap. If TIP-1010's value changes by hardfork, the cap (and the derived floor) MUST be updated to match.
 - The base fee is denominated in attodollars (`10^-18` USD) per gas, as defined by TIP-1000 and TIP-1010. This TIP changes only how the per-gas base fee value is computed each block; it does not change the unit, the conversion to fee tokens, or how collected fees are distributed.
 - The block header carries the per-gas base fee (the `baseFeePerGas` field of the Ethereum-derived Tempo header) so that the value computed by this controller is committed to and validated by every node.
-- The controller input is the total gas used by all transactions included in a block (the header `gasUsed`), across all lanes (payment and general). The 5,000,000 gas target is compared against this total, so heavy payment-lane usage raises the base fee just as general usage does.
+- The controller input is the total gas used by all transactions included in a block (the header `gasUsed`), across all lanes (payment and general). The 10,000,000 gas target is compared against this total, so heavy payment-lane usage raises the base fee just as general usage does.
 - If an assumption is violated (for example, a header carrying a base fee that does not equal the value this TIP computes), the affected block MUST be rejected as invalid.
 
 ---
@@ -42,7 +42,7 @@ The design is deliberately a *one-sided discount* relative to the status quo: th
 |---|---|---|
 | `BASE_FEE_CAP` | `2 × 10^10` attodollars/gas | Maximum base fee; equals TIP-1010's current fixed base fee. |
 | `BASE_FEE_FLOOR` | `1 × 10^9` attodollars/gas | Minimum base fee; `BASE_FEE_CAP / 20` (one twentieth of the current fixed cost). |
-| `GAS_TARGET` | `5,000,000` gas | Per-block gas usage the controller steers toward. |
+| `GAS_TARGET` | `10,000,000` gas | Per-block gas usage the controller steers toward. |
 | `BASE_FEE_MAX_CHANGE_DENOMINATOR` | `8` | Determines the rate of change of the basefee at `1 / 8` (12.5%) of the difference to gas target. |
 
 `BASE_FEE_FLOOR`, `BASE_FEE_CAP`, `GAS_TARGET`, and `BASE_FEE_MAX_CHANGE_DENOMINATOR` are protocol parameters configured at the chainspec level and changeable only by hardfork.
@@ -77,7 +77,7 @@ The clamp is applied last, so:
 - The base fee can never exceed `BASE_FEE_CAP` (today's fixed cost) regardless of how full blocks are.
 - The base fee can never fall below `BASE_FEE_FLOOR` (one twentieth of today's cost) regardless of how empty blocks are.
 
-Because `GAS_TARGET` (5,000,000) is far below the block gas limit (500,000,000 under TIP-1010), a moderately full block produces a large raw upward adjustment that saturates at `BASE_FEE_CAP` within a few blocks. This is intended: under sustained load the base fee returns to today's price quickly, and the dynamic range exists to *discount* the fee during low utilization rather than to surcharge it during congestion.
+Because `GAS_TARGET` (10,000,000) is far below the block gas limit (500,000,000 under TIP-1010), a moderately full block produces a large raw upward adjustment that saturates at `BASE_FEE_CAP` within a few blocks. This is intended: under sustained load the base fee returns to today's price quickly, and the dynamic range exists to *discount* the fee during low utilization rather than to surcharge it during congestion.
 
 ## Activation
 
@@ -114,7 +114,7 @@ The following illustrate the controller with `BASE_FEE_MAX_CHANGE_DENOMINATOR = 
   - At `BASE_FEE_CAP` (`2 × 10^10`): `50,000 × 2 × 10^10 = 10^15` attodollars = `1,000` microdollars = `$0.001` (0.1 cent) — same as today.
   - At `BASE_FEE_FLOOR` (`1 × 10^9`): `50,000 × 1 × 10^9 = 5 × 10^13` attodollars = `50` microdollars = `$0.00005` (0.005 cent) — 20× cheaper.
 - **Decay when idle:** an empty block (`gas_used = 0`) multiplies the base fee by `7/8` (a 12.5% drop). Starting from the cap, the base fee reaches the floor (a 20× decrease) after about 23 consecutive empty blocks (~12 seconds); the decay half-life is about 5 blocks (~2.6 seconds).
-- **Rise under load:** a block at the 30,000,000 gas general cap multiplies the base fee by about `1.625` (`gas_delta = 25M`, `25M / 5M / 8 = 0.625`), so the base fee climbs from the floor back to the cap in roughly 7 such blocks (~3.5 seconds); fuller blocks saturate to the cap faster.
+- **Rise under load:** a block at the 30,000,000 gas general cap multiplies the base fee by about `1.25` (`gas_delta = 20M`, `20M / 10M / 8 = 0.25`), so the base fee climbs from the floor back to the cap in roughly 14 such blocks (~7 seconds); fuller blocks saturate to the cap faster.
 
 These time constants are a consequence of the chosen denominator and may be retuned by hardfork without changing the rest of the mechanism.
 


### PR DESCRIPTION
## Summary
- update TIP-1067 gas target from 5,000,000 to 10,000,000 gas
- adjust the derived under-load example for the 30M general cap

## Testing
- not run; documentation-only change