### PR TITLE
feat(evm): report supported feature tip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13164,7 +13164,6 @@ dependencies = [
  "tempo-chainspec",
  "tempo-contracts",
  "tempo-payload-types",
- "tempo-precompiles",
  "tempo-primitives",
  "tempo-revm",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13309,6 +13309,7 @@ dependencies = [
  "reth-transaction-pool",
  "reth-trie-common",
  "tempo-chainspec",
+ "tempo-contracts",
  "tempo-evm",
  "tempo-payload-types",
  "tempo-precompiles",

--- a/crates/contracts/src/precompiles/feature_registry.rs
+++ b/crates/contracts/src/precompiles/feature_registry.rs
@@ -22,8 +22,8 @@ crate::sol! {
         /// @notice Returns the scheduled feature tip and earliest activation epoch.
         function scheduledFeaturesTip() external view returns (uint64 featuresTip, uint64 activationEpoch);
 
-        /// @notice Records the highest protocol feature tip reported for a validator. System caller only.
-        function setSupportedFeaturesTip(address validator, uint64 featuresTip) external;
+        /// @notice Records the highest protocol feature tip reported by a validator public key. System caller only.
+        function setSupportedFeaturesTip(bytes32 publicKey, uint64 featuresTip) external;
 
         /// @notice Schedules a higher feature tip for activation at the target epoch.
         function scheduleFeaturesTip(uint64 featuresTip, uint64 activationEpoch) external;

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 tempo-chainspec = { workspace = true, features = ["reth"] }
 tempo-contracts.workspace = true
 tempo-payload-types = { workspace = true, optional = true }
-tempo-precompiles.workspace = true
 tempo-primitives = { workspace = true, features = ["reth"] }
 tempo-revm.workspace = true
 

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 tempo-chainspec = { workspace = true, features = ["reth"] }
 tempo-contracts.workspace = true
 tempo-payload-types = { workspace = true, optional = true }
+tempo-precompiles.workspace = true
 tempo-primitives = { workspace = true, features = ["reth"] }
 tempo-revm.workspace = true
 
@@ -51,7 +52,6 @@ revm.workspace = true
 reth-execution-cache.workspace = true
 reth-storage-api.workspace = true
 reth-trie.workspace = true
-tempo-precompiles = { workspace = true, features = ["test-utils"] }
 tempo-primitives = { workspace = true, features = ["arbitrary"] }
 
 [features]

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -30,15 +30,18 @@ use tempo_chainspec::{
     TempoChainSpec, features::highest_supported_protocol_feature_id, hardfork::TempoHardforks,
 };
 use tempo_contracts::precompiles::{
-    ADDRESS_REGISTRY_ADDRESS, FEATURE_REGISTRY_ADDRESS, IFeatureRegistry, IValidatorConfigV2,
+    ADDRESS_REGISTRY_ADDRESS, FEATURE_REGISTRY_ADDRESS, IFeatureRegistry,
     RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS, SYSTEM_CALLER_ADDRESS,
     TIP20_CHANNEL_RESERVE_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
+};
+use tempo_precompiles::{
+    feature_registry::FeatureRegistry, validator_config_v2::ValidatorConfigV2,
 };
 use tempo_primitives::{
     SubBlock, SubBlockMetadata, TempoConsensusContext, TempoReceipt, TempoTxEnvelope, TempoTxType,
     subblock::PartialValidatorKey,
 };
-use tempo_revm::{TempoHaltReason, evm::TempoContext};
+use tempo_revm::{TempoHaltReason, TempoStateAccess, evm::TempoContext};
 use tracing::trace;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -220,8 +223,7 @@ where
         contract: Address,
         data: Bytes,
         context: &str,
-        commit: bool,
-    ) -> Result<Bytes, BlockExecutionError> {
+    ) -> Result<(), BlockExecutionError> {
         let result_and_state = self
             .evm_mut()
             .transact_system_call(SYSTEM_CALLER_ADDRESS, contract, data)
@@ -230,11 +232,9 @@ where
             })?;
 
         match result_and_state.result {
-            ExecutionResult::Success { output, .. } => {
-                if commit {
-                    self.evm_mut().db_mut().commit(result_and_state.state);
-                }
-                Ok(output.into_data())
+            ExecutionResult::Success { .. } => {
+                self.evm_mut().db_mut().commit(result_and_state.state);
+                Ok(())
             }
             ExecutionResult::Revert { output, .. } => Err(BlockExecutionError::msg(format!(
                 "{context} system call reverted: {output}"
@@ -249,15 +249,12 @@ where
         &mut self,
         validator: Address,
     ) -> Result<u64, BlockExecutionError> {
-        let call = IFeatureRegistry::validatorSupportedFeaturesTipCall { validator };
-        let output = self.transact_precompile_system_call(
-            FEATURE_REGISTRY_ADDRESS,
-            call.abi_encode().into(),
-            "feature registry support read",
-            false,
-        )?;
-
-        IFeatureRegistry::validatorSupportedFeaturesTipCall::abi_decode_returns(&output)
+        let spec = self.evm().cfg.spec;
+        self.evm_mut()
+            .db_mut()
+            .with_read_only_storage_ctx(spec, || {
+                FeatureRegistry::new().validator_supported_features_tip(validator)
+            })
             .map_err(BlockExecutionError::other)
     }
 
@@ -279,7 +276,6 @@ where
             FEATURE_REGISTRY_ADDRESS,
             call.abi_encode().into(),
             "feature registry support report",
-            true,
         )?;
 
         Ok(())
@@ -290,16 +286,14 @@ where
             return Ok(None);
         };
 
-        let call = IValidatorConfigV2::validatorByPublicKeyCall {
-            publicKey: B256::from(&consensus_context.proposer),
-        };
-        let output = self.transact_precompile_system_call(
-            VALIDATOR_CONFIG_V2_ADDRESS,
-            call.abi_encode().into(),
-            "validator config proposer lookup",
-            false,
-        )?;
-        let validator = IValidatorConfigV2::validatorByPublicKeyCall::abi_decode_returns(&output)
+        let public_key = B256::from(&consensus_context.proposer);
+        let spec = self.evm().cfg.spec;
+        let validator = self
+            .evm_mut()
+            .db_mut()
+            .with_read_only_storage_ctx(spec, || {
+                ValidatorConfigV2::new().validator_by_public_key(public_key)
+            })
             .map_err(BlockExecutionError::other)?;
 
         if validator.deactivatedAtHeight != 0 {
@@ -335,7 +329,6 @@ where
             FEATURE_REGISTRY_ADDRESS,
             call.abi_encode().into(),
             "feature registry activation",
-            true,
         )?;
 
         Ok(())

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -32,9 +32,7 @@ use tempo_contracts::precompiles::{
     RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS, SYSTEM_CALLER_ADDRESS,
     TIP20_CHANNEL_RESERVE_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
-use tempo_precompiles::{
-    feature_registry::FeatureRegistry, validator_config_v2::ValidatorConfigV2,
-};
+use tempo_precompiles::feature_registry::FeatureRegistry;
 use tempo_primitives::{
     SubBlock, SubBlockMetadata, TempoConsensusContext, TempoReceipt, TempoTxEnvelope, TempoTxType,
     subblock::PartialValidatorKey,
@@ -363,25 +361,25 @@ where
             ));
         };
 
-        let public_key = B256::from(&consensus_context.proposer);
+        if call.publicKey != B256::from(&consensus_context.proposer) {
+            return Err(BlockValidationError::msg(
+                "invalid feature registry system transaction",
+            ));
+        }
+
         let spec = self.evm().cfg.spec;
-        let (validator, reported_features_tip) = self
+        let reported_features_tip = self
             .evm_mut()
             .db_mut()
-            .with_read_only_storage_ctx(spec, || -> tempo_precompiles::error::Result<_> {
-                let validator = ValidatorConfigV2::new().validator_by_public_key(public_key)?;
-                let reported_features_tip =
-                    FeatureRegistry::new().validator_supported_features_tip(call.validator)?;
-                Ok((validator, reported_features_tip))
+            .with_read_only_storage_ctx(spec, || {
+                FeatureRegistry::new()
+                    .validator_supported_features_tip_by_public_key(call.publicKey)
             })
             .map_err(|_| {
                 BlockValidationError::msg("invalid feature registry system transaction")
             })?;
 
-        if validator.deactivatedAtHeight != 0
-            || validator.validatorAddress != call.validator
-            || reported_features_tip >= call.featuresTip
-        {
+        if reported_features_tip >= call.featuresTip {
             return Err(BlockValidationError::msg(
                 "invalid feature registry system transaction",
             ));
@@ -833,7 +831,7 @@ mod tests {
     use tempo_contracts::precompiles::PATH_USD_ADDRESS;
     use tempo_precompiles::{
         storage::StorageCtx,
-        validator_config_v2::{IValidatorConfigV2, VALIDATOR_NS_ADD},
+        validator_config_v2::{IValidatorConfigV2, VALIDATOR_NS_ADD, ValidatorConfigV2},
     };
     use tempo_primitives::{
         SubBlockMetadata, TempoSignature, TempoTransaction, TempoTxType,
@@ -919,6 +917,10 @@ mod tests {
             &private_key.public_key().encode(),
         ))
         .unwrap()
+    }
+
+    fn b256_public_key_from_private_key(private_key: &PrivateKey) -> B256 {
+        B256::from_slice(&private_key.public_key().encode())
     }
 
     fn add_validator_signature(
@@ -1149,7 +1151,7 @@ mod tests {
         initialize_validator_config_v2(&mut executor, owner, validator, &proposer_key);
 
         let input = IFeatureRegistry::setSupportedFeaturesTipCall {
-            validator,
+            publicKey: b256_public_key_from_private_key(&proposer_key),
             featuresTip: 13,
         }
         .abi_encode()
@@ -1173,10 +1175,11 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_system_tx_feature_registry_report_rejects_other_validator() {
+    fn test_validate_system_tx_feature_registry_report_rejects_other_public_key() {
         let chainspec = test_chainspec();
         let mut db = State::builder().with_bundle_update().build();
         let proposer_key = PrivateKey::from_seed(0);
+        let other_key = PrivateKey::from_seed(1);
         let validator = Address::repeat_byte(0x11);
         let owner = Address::repeat_byte(0xaa);
         let mut builder = TestExecutorBuilder::default().with_runtime_spec(TempoHardfork::T6);
@@ -1185,7 +1188,7 @@ mod tests {
         initialize_validator_config_v2(&mut executor, owner, validator, &proposer_key);
 
         let input = IFeatureRegistry::setSupportedFeaturesTipCall {
-            validator: Address::repeat_byte(0x22),
+            publicKey: b256_public_key_from_private_key(&other_key),
             featuresTip: 13,
         }
         .abi_encode()
@@ -1219,7 +1222,7 @@ mod tests {
         initialize_validator_config_v2(&mut executor, owner, validator, &proposer_key);
 
         let input = IFeatureRegistry::setSupportedFeaturesTipCall {
-            validator,
+            publicKey: b256_public_key_from_private_key(&proposer_key),
             featuresTip: 13,
         }
         .abi_encode()
@@ -1247,7 +1250,7 @@ mod tests {
             })
             .build(&mut db, &chainspec);
         let input = IFeatureRegistry::setSupportedFeaturesTipCall {
-            validator: Address::repeat_byte(0x11),
+            publicKey: B256::repeat_byte(0x11),
             featuresTip: 13,
         }
         .abi_encode()

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -32,7 +32,9 @@ use tempo_contracts::precompiles::{
     RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS, SYSTEM_CALLER_ADDRESS,
     TIP20_CHANNEL_RESERVE_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
-use tempo_precompiles::validator_config_v2::ValidatorConfigV2;
+use tempo_precompiles::{
+    feature_registry::FeatureRegistry, validator_config_v2::ValidatorConfigV2,
+};
 use tempo_primitives::{
     SubBlock, SubBlockMetadata, TempoConsensusContext, TempoReceipt, TempoTxEnvelope, TempoTxType,
     subblock::PartialValidatorKey,
@@ -363,17 +365,23 @@ where
 
         let public_key = B256::from(&consensus_context.proposer);
         let spec = self.evm().cfg.spec;
-        let validator = self
+        let (validator, reported_features_tip) = self
             .evm_mut()
             .db_mut()
-            .with_read_only_storage_ctx(spec, || {
-                ValidatorConfigV2::new().validator_by_public_key(public_key)
+            .with_read_only_storage_ctx(spec, || -> tempo_precompiles::error::Result<_> {
+                let validator = ValidatorConfigV2::new().validator_by_public_key(public_key)?;
+                let reported_features_tip =
+                    FeatureRegistry::new().validator_supported_features_tip(call.validator)?;
+                Ok((validator, reported_features_tip))
             })
             .map_err(|_| {
                 BlockValidationError::msg("invalid feature registry system transaction")
             })?;
 
-        if validator.deactivatedAtHeight != 0 || validator.validatorAddress != call.validator {
+        if validator.deactivatedAtHeight != 0
+            || validator.validatorAddress != call.validator
+            || reported_features_tip >= call.featuresTip
+        {
             return Err(BlockValidationError::msg(
                 "invalid feature registry system transaction",
             ));
@@ -807,7 +815,7 @@ mod tests {
     use crate::test_utils::{TestExecutorBuilder, test_chainspec, test_evm};
     use alloy_consensus::{Signed, TxLegacy};
     use alloy_evm::{block::BlockExecutor, eth::receipt_builder::ReceiptBuilder};
-    use alloy_primitives::{Keccak256, Log, Signature, TxKind, bytes::BytesMut};
+    use alloy_primitives::{Keccak256, Log, Signature, TxKind, bytes::BytesMut, keccak256};
     use alloy_rlp::Encodable;
     use commonware_codec::Encode;
     use commonware_cryptography::{Signer, ed25519::PrivateKey};
@@ -884,6 +892,22 @@ mod tests {
                 scheduled_features_tip,
                 scheduled_activation_epoch,
             ),
+        );
+        storage
+    }
+
+    fn validator_supported_features_tip_slot(validator: Address) -> U256 {
+        let mut buf = [0u8; 64];
+        buf[12..32].copy_from_slice(validator.as_ref());
+        buf[32..].copy_from_slice(&U256::ONE.to_be_bytes::<32>());
+        U256::from_be_bytes(keccak256(buf).0)
+    }
+
+    fn feature_registry_report_storage(validator: Address, features_tip: u64) -> PlainStorage {
+        let mut storage = PlainStorage::default();
+        storage.insert(
+            validator_supported_features_tip_slot(validator),
+            U256::from(features_tip),
         );
         storage
     }
@@ -1162,6 +1186,40 @@ mod tests {
 
         let input = IFeatureRegistry::setSupportedFeaturesTipCall {
             validator: Address::repeat_byte(0x22),
+            featuresTip: 13,
+        }
+        .abi_encode()
+        .into();
+        let system_tx =
+            create_system_tx_to(chainspec.chain().id(), FEATURE_REGISTRY_ADDRESS, input);
+
+        let result = executor.validate_system_tx(&system_tx);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "invalid feature registry system transaction"
+        );
+    }
+
+    #[test]
+    fn test_validate_system_tx_feature_registry_report_rejects_noop_report() {
+        let chainspec = test_chainspec();
+        let mut db = State::builder().with_bundle_update().build();
+        let proposer_key = PrivateKey::from_seed(0);
+        let validator = Address::repeat_byte(0x11);
+        let owner = Address::repeat_byte(0xaa);
+        db.insert_account_with_storage(
+            FEATURE_REGISTRY_ADDRESS,
+            AccountInfo::default(),
+            feature_registry_report_storage(validator, 13),
+        );
+        let mut builder = TestExecutorBuilder::default().with_runtime_spec(TempoHardfork::T6);
+        builder.consensus_context = Some(consensus_context_from_proposer(&proposer_key));
+        let mut executor = builder.build(&mut db, &chainspec);
+        initialize_validator_config_v2(&mut executor, owner, validator, &proposer_key);
+
+        let input = IFeatureRegistry::setSupportedFeaturesTipCall {
+            validator,
             featuresTip: 13,
         }
         .abi_encode()

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -11,7 +11,7 @@ use alloy_evm::{
         receipt_builder::{ReceiptBuilder, ReceiptBuilderCtx},
     },
 };
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_rlp::Decodable;
 use alloy_sol_types::SolCall;
 use commonware_codec::DecodeExt;
@@ -26,9 +26,11 @@ use reth_revm::{
     state::{Account, Bytecode, EvmState},
 };
 use std::collections::{HashMap, HashSet};
-use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
+use tempo_chainspec::{
+    TempoChainSpec, features::highest_supported_protocol_feature_id, hardfork::TempoHardforks,
+};
 use tempo_contracts::precompiles::{
-    ADDRESS_REGISTRY_ADDRESS, FEATURE_REGISTRY_ADDRESS, IFeatureRegistry,
+    ADDRESS_REGISTRY_ADDRESS, FEATURE_REGISTRY_ADDRESS, IFeatureRegistry, IValidatorConfigV2,
     RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS, SYSTEM_CALLER_ADDRESS,
     TIP20_CHANNEL_RESERVE_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
@@ -213,6 +215,113 @@ where
         Ok(())
     }
 
+    fn transact_precompile_system_call(
+        &mut self,
+        contract: Address,
+        data: Bytes,
+        context: &str,
+        commit: bool,
+    ) -> Result<Bytes, BlockExecutionError> {
+        let result_and_state = self
+            .evm_mut()
+            .transact_system_call(SYSTEM_CALLER_ADDRESS, contract, data)
+            .map_err(|err| {
+                BlockExecutionError::msg(format!("{context} system call failed: {err}"))
+            })?;
+
+        match result_and_state.result {
+            ExecutionResult::Success { output, .. } => {
+                if commit {
+                    self.evm_mut().db_mut().commit(result_and_state.state);
+                }
+                Ok(output.into_data())
+            }
+            ExecutionResult::Revert { output, .. } => Err(BlockExecutionError::msg(format!(
+                "{context} system call reverted: {output}"
+            ))),
+            ExecutionResult::Halt { reason, .. } => Err(BlockExecutionError::msg(format!(
+                "{context} system call halted: {reason:?}"
+            ))),
+        }
+    }
+
+    fn validator_supported_features_tip(
+        &mut self,
+        validator: Address,
+    ) -> Result<u64, BlockExecutionError> {
+        let call = IFeatureRegistry::validatorSupportedFeaturesTipCall { validator };
+        let output = self.transact_precompile_system_call(
+            FEATURE_REGISTRY_ADDRESS,
+            call.abi_encode().into(),
+            "feature registry support read",
+            false,
+        )?;
+
+        IFeatureRegistry::validatorSupportedFeaturesTipCall::abi_decode_returns(&output)
+            .map_err(BlockExecutionError::other)
+    }
+
+    fn report_supported_features_tip(
+        &mut self,
+        validator: Address,
+        supported_features_tip: u64,
+    ) -> Result<(), BlockExecutionError> {
+        let reported_features_tip = self.validator_supported_features_tip(validator)?;
+        if reported_features_tip >= supported_features_tip {
+            return Ok(());
+        }
+
+        let call = IFeatureRegistry::setSupportedFeaturesTipCall {
+            validator,
+            featuresTip: supported_features_tip,
+        };
+        self.transact_precompile_system_call(
+            FEATURE_REGISTRY_ADDRESS,
+            call.abi_encode().into(),
+            "feature registry support report",
+            true,
+        )?;
+
+        Ok(())
+    }
+
+    fn consensus_proposer_validator(&mut self) -> Result<Option<Address>, BlockExecutionError> {
+        let Some(consensus_context) = self.consensus_context else {
+            return Ok(None);
+        };
+
+        let call = IValidatorConfigV2::validatorByPublicKeyCall {
+            publicKey: B256::from(&consensus_context.proposer),
+        };
+        let output = self.transact_precompile_system_call(
+            VALIDATOR_CONFIG_V2_ADDRESS,
+            call.abi_encode().into(),
+            "validator config proposer lookup",
+            false,
+        )?;
+        let validator = IValidatorConfigV2::validatorByPublicKeyCall::abi_decode_returns(&output)
+            .map_err(BlockExecutionError::other)?;
+
+        if validator.deactivatedAtHeight != 0 {
+            return Ok(None);
+        }
+
+        Ok(Some(validator.validatorAddress))
+    }
+
+    fn report_local_supported_features_tip(&mut self) -> Result<(), BlockExecutionError> {
+        let supported_features_tip = highest_supported_protocol_feature_id();
+        if supported_features_tip == 0 {
+            return Ok(());
+        }
+
+        let Some(validator) = self.consensus_proposer_validator()? else {
+            return Ok(());
+        };
+
+        self.report_supported_features_tip(validator, supported_features_tip)
+    }
+
     /// Activates a scheduled feature tip once the consensus epoch reaches the target epoch.
     fn activate_scheduled_features_tip(&mut self) -> Result<(), BlockExecutionError> {
         let Some(consensus_context) = self.consensus_context else {
@@ -222,29 +331,14 @@ where
         let call = IFeatureRegistry::activateScheduledFeaturesTipCall {
             currentEpoch: consensus_context.epoch,
         };
-        let result_and_state = self
-            .evm_mut()
-            .transact_system_call(
-                SYSTEM_CALLER_ADDRESS,
-                FEATURE_REGISTRY_ADDRESS,
-                call.abi_encode().into(),
-            )
-            .map_err(|err| {
-                BlockExecutionError::msg(format!("feature registry activation failed: {err}"))
-            })?;
+        self.transact_precompile_system_call(
+            FEATURE_REGISTRY_ADDRESS,
+            call.abi_encode().into(),
+            "feature registry activation",
+            true,
+        )?;
 
-        match result_and_state.result {
-            ExecutionResult::Success { .. } => {
-                self.evm_mut().db_mut().commit(result_and_state.state);
-                Ok(())
-            }
-            ExecutionResult::Revert { output, .. } => Err(BlockExecutionError::msg(format!(
-                "feature registry activation reverted: {output}"
-            ))),
-            ExecutionResult::Halt { reason, .. } => Err(BlockExecutionError::msg(format!(
-                "feature registry activation halted: {reason:?}"
-            ))),
-        }
+        Ok(())
     }
 
     /// Validates a system transaction.
@@ -533,6 +627,7 @@ where
             self.deploy_precompile_at_boundary(RECEIVE_POLICY_GUARD_ADDRESS)?;
             // TODO(TIP-1063): update this gate to T7 before merging.
             self.deploy_precompile_at_boundary(FEATURE_REGISTRY_ADDRESS)?;
+            self.report_local_supported_features_tip()?;
             self.activate_scheduled_features_tip()?;
         }
 
@@ -732,7 +827,7 @@ mod tests {
     use crate::test_utils::{TestExecutorBuilder, test_chainspec, test_evm};
     use alloy_consensus::{Signed, TxLegacy};
     use alloy_evm::{block::BlockExecutor, eth::receipt_builder::ReceiptBuilder};
-    use alloy_primitives::{Bytes, Log, Signature, TxKind, bytes::BytesMut};
+    use alloy_primitives::{Log, Signature, TxKind, bytes::BytesMut};
     use alloy_rlp::Encodable;
     use commonware_cryptography::{Signer, ed25519::PrivateKey};
     use reth_chainspec::EthChainSpec;
@@ -1817,6 +1912,79 @@ mod tests {
         assert_eq!(
             acc.storage_slot(U256::ZERO).unwrap(),
             packed_feature_registry_tips(7, 13, 21)
+        );
+    }
+
+    #[test]
+    fn test_report_supported_features_tip_updates_validator_report() {
+        let chainspec = Arc::new(TempoChainSpec::from_genesis(DEV.genesis().clone()));
+        let mut db = State::builder().with_bundle_update().build();
+        let mut executor = TestExecutorBuilder::default()
+            .with_parent_beacon_block_root(B256::ZERO)
+            .with_runtime_spec(TempoHardfork::T6)
+            .build(&mut db, &chainspec);
+        let validator = Address::repeat_byte(0x11);
+
+        executor
+            .deploy_precompile_at_boundary(FEATURE_REGISTRY_ADDRESS)
+            .unwrap();
+        executor
+            .report_supported_features_tip(validator, 13)
+            .unwrap();
+
+        assert_eq!(
+            executor
+                .validator_supported_features_tip(validator)
+                .unwrap(),
+            13
+        );
+    }
+
+    #[test]
+    fn test_report_supported_features_tip_does_not_lower_validator_report() {
+        let chainspec = Arc::new(TempoChainSpec::from_genesis(DEV.genesis().clone()));
+        let mut db = State::builder().with_bundle_update().build();
+        let mut executor = TestExecutorBuilder::default()
+            .with_parent_beacon_block_root(B256::ZERO)
+            .with_runtime_spec(TempoHardfork::T6)
+            .build(&mut db, &chainspec);
+        let validator = Address::repeat_byte(0x11);
+
+        executor
+            .deploy_precompile_at_boundary(FEATURE_REGISTRY_ADDRESS)
+            .unwrap();
+        executor
+            .report_supported_features_tip(validator, 13)
+            .unwrap();
+        executor
+            .report_supported_features_tip(validator, 12)
+            .unwrap();
+
+        assert_eq!(
+            executor
+                .validator_supported_features_tip(validator)
+                .unwrap(),
+            13
+        );
+    }
+
+    #[test]
+    fn test_apply_pre_execution_skips_supported_features_tip_report_when_none_supported() {
+        let chainspec = Arc::new(TempoChainSpec::from_genesis(DEV.genesis().clone()));
+        let mut db = State::builder().with_bundle_update().build();
+        let mut executor = TestExecutorBuilder::default()
+            .with_parent_beacon_block_root(B256::ZERO)
+            .with_runtime_spec(TempoHardfork::T6)
+            .with_consensus_epoch(21)
+            .build(&mut db, &chainspec);
+
+        executor.apply_pre_execution_changes().unwrap();
+
+        assert_eq!(
+            executor
+                .validator_supported_features_tip(Address::repeat_byte(0x11))
+                .unwrap(),
+            0
         );
     }
 

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -32,12 +32,11 @@ use tempo_contracts::precompiles::{
     RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS, SYSTEM_CALLER_ADDRESS,
     TIP20_CHANNEL_RESERVE_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
-use tempo_precompiles::feature_registry::FeatureRegistry;
 use tempo_primitives::{
     SubBlock, SubBlockMetadata, TempoConsensusContext, TempoReceipt, TempoTxEnvelope, TempoTxType,
     subblock::PartialValidatorKey,
 };
-use tempo_revm::{TempoHaltReason, TempoStateAccess, evm::TempoContext};
+use tempo_revm::{TempoHaltReason, evm::TempoContext};
 use tracing::trace;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -362,24 +361,6 @@ where
         };
 
         if call.publicKey != B256::from(&consensus_context.proposer) {
-            return Err(BlockValidationError::msg(
-                "invalid feature registry system transaction",
-            ));
-        }
-
-        let spec = self.evm().cfg.spec;
-        let reported_features_tip = self
-            .evm_mut()
-            .db_mut()
-            .with_read_only_storage_ctx(spec, || {
-                FeatureRegistry::new()
-                    .validator_supported_features_tip_by_public_key(call.publicKey)
-            })
-            .map_err(|_| {
-                BlockValidationError::msg("invalid feature registry system transaction")
-            })?;
-
-        if reported_features_tip >= call.featuresTip {
             return Err(BlockValidationError::msg(
                 "invalid feature registry system transaction",
             ));
@@ -813,26 +794,19 @@ mod tests {
     use crate::test_utils::{TestExecutorBuilder, test_chainspec, test_evm};
     use alloy_consensus::{Signed, TxLegacy};
     use alloy_evm::{block::BlockExecutor, eth::receipt_builder::ReceiptBuilder};
-    use alloy_primitives::{Keccak256, Log, Signature, TxKind, bytes::BytesMut, keccak256};
+    use alloy_primitives::{Log, Signature, TxKind, bytes::BytesMut};
     use alloy_rlp::Encodable;
     use commonware_codec::Encode;
     use commonware_cryptography::{Signer, ed25519::PrivateKey};
     use reth_chainspec::EthChainSpec;
     use reth_revm::{State, state::AccountInfo};
     use revm::{
-        context::{
-            JournalTr,
-            result::{ExecutionResult, ResultGas},
-        },
+        context::result::{ExecutionResult, ResultGas},
         database::{EmptyDB, states::plain_account::PlainStorage},
     };
     use std::sync::{Arc, Mutex};
     use tempo_chainspec::{hardfork::TempoHardfork, spec::DEV};
     use tempo_contracts::precompiles::PATH_USD_ADDRESS;
-    use tempo_precompiles::{
-        storage::StorageCtx,
-        validator_config_v2::{IValidatorConfigV2, VALIDATOR_NS_ADD, ValidatorConfigV2},
-    };
     use tempo_primitives::{
         SubBlockMetadata, TempoSignature, TempoTransaction, TempoTxType,
         subblock::{SubBlockVersion, TEMPO_SUBBLOCK_NONCE_KEY_PREFIX},
@@ -894,22 +868,6 @@ mod tests {
         storage
     }
 
-    fn validator_supported_features_tip_slot(validator: Address) -> U256 {
-        let mut buf = [0u8; 64];
-        buf[12..32].copy_from_slice(validator.as_ref());
-        buf[32..].copy_from_slice(&U256::ONE.to_be_bytes::<32>());
-        U256::from_be_bytes(keccak256(buf).0)
-    }
-
-    fn feature_registry_report_storage(validator: Address, features_tip: u64) -> PlainStorage {
-        let mut storage = PlainStorage::default();
-        storage.insert(
-            validator_supported_features_tip_slot(validator),
-            U256::from(features_tip),
-        );
-        storage
-    }
-
     fn public_key_from_private_key(
         private_key: &PrivateKey,
     ) -> tempo_primitives::ed25519::PublicKey {
@@ -923,29 +881,6 @@ mod tests {
         B256::from_slice(&private_key.public_key().encode())
     }
 
-    fn add_validator_signature(
-        chain_id: u64,
-        private_key: &PrivateKey,
-        validator: Address,
-        ingress: &str,
-        egress: &str,
-        fee_recipient: Address,
-    ) -> Vec<u8> {
-        let mut hasher = Keccak256::new();
-        hasher.update(chain_id.to_be_bytes());
-        hasher.update(VALIDATOR_CONFIG_V2_ADDRESS.as_slice());
-        hasher.update(validator.as_slice());
-        hasher.update([u8::try_from(ingress.len()).unwrap()]);
-        hasher.update(ingress.as_bytes());
-        hasher.update([u8::try_from(egress.len()).unwrap()]);
-        hasher.update(egress.as_bytes());
-        hasher.update(fee_recipient.as_slice());
-        private_key
-            .sign(VALIDATOR_NS_ADD, hasher.finalize().as_slice())
-            .encode()
-            .to_vec()
-    }
-
     fn consensus_context_from_proposer(proposer_key: &PrivateKey) -> TempoConsensusContext {
         TempoConsensusContext {
             epoch: 21,
@@ -953,59 +888,6 @@ mod tests {
             parent_view: 0,
             proposer: public_key_from_private_key(proposer_key),
         }
-    }
-
-    fn initialize_validator_config_v2<DB, I>(
-        executor: &mut TempoBlockExecutor<'_, DB, I>,
-        owner: Address,
-        validator: Address,
-        validator_key: &PrivateKey,
-    ) where
-        DB: StateDB,
-        I: Inspector<TempoContext<DB>>,
-    {
-        let chain_id = executor.evm().cfg.chain_id;
-        let public_key = B256::from_slice(&validator_key.public_key().encode());
-        let ingress = "127.0.0.1:9000";
-        let egress = "127.0.0.1";
-        let fee_recipient = Address::repeat_byte(0x44);
-        let signature = add_validator_signature(
-            chain_id,
-            validator_key,
-            validator,
-            ingress,
-            egress,
-            fee_recipient,
-        );
-
-        StorageCtx::enter_ctx(
-            executor.evm_mut().ctx_mut(),
-            || -> tempo_precompiles::error::Result<()> {
-                let mut config = ValidatorConfigV2::new();
-                config.initialize(owner)?;
-                config.add_validator(
-                    owner,
-                    IValidatorConfigV2::addValidatorCall {
-                        validatorAddress: validator,
-                        publicKey: public_key,
-                        ingress: ingress.to_string(),
-                        egress: egress.to_string(),
-                        feeRecipient: fee_recipient,
-                        signature: signature.into(),
-                    },
-                )?;
-                Ok(())
-            },
-        )
-        .unwrap();
-
-        let evm_state = executor
-            .evm_mut()
-            .ctx_mut()
-            .journaled_state
-            .evm_state()
-            .clone();
-        executor.evm_mut().db_mut().commit(evm_state);
     }
 
     #[test]
@@ -1143,12 +1025,9 @@ mod tests {
         let chainspec = test_chainspec();
         let mut db = State::builder().with_bundle_update().build();
         let proposer_key = PrivateKey::from_seed(0);
-        let validator = Address::repeat_byte(0x11);
-        let owner = Address::repeat_byte(0xaa);
         let mut builder = TestExecutorBuilder::default().with_runtime_spec(TempoHardfork::T6);
         builder.consensus_context = Some(consensus_context_from_proposer(&proposer_key));
         let mut executor = builder.build(&mut db, &chainspec);
-        initialize_validator_config_v2(&mut executor, owner, validator, &proposer_key);
 
         let input = IFeatureRegistry::setSupportedFeaturesTipCall {
             publicKey: b256_public_key_from_private_key(&proposer_key),
@@ -1180,49 +1059,12 @@ mod tests {
         let mut db = State::builder().with_bundle_update().build();
         let proposer_key = PrivateKey::from_seed(0);
         let other_key = PrivateKey::from_seed(1);
-        let validator = Address::repeat_byte(0x11);
-        let owner = Address::repeat_byte(0xaa);
         let mut builder = TestExecutorBuilder::default().with_runtime_spec(TempoHardfork::T6);
         builder.consensus_context = Some(consensus_context_from_proposer(&proposer_key));
         let mut executor = builder.build(&mut db, &chainspec);
-        initialize_validator_config_v2(&mut executor, owner, validator, &proposer_key);
 
         let input = IFeatureRegistry::setSupportedFeaturesTipCall {
             publicKey: b256_public_key_from_private_key(&other_key),
-            featuresTip: 13,
-        }
-        .abi_encode()
-        .into();
-        let system_tx =
-            create_system_tx_to(chainspec.chain().id(), FEATURE_REGISTRY_ADDRESS, input);
-
-        let result = executor.validate_system_tx(&system_tx);
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "invalid feature registry system transaction"
-        );
-    }
-
-    #[test]
-    fn test_validate_system_tx_feature_registry_report_rejects_noop_report() {
-        let chainspec = test_chainspec();
-        let mut db = State::builder().with_bundle_update().build();
-        let proposer_key = PrivateKey::from_seed(0);
-        let validator = Address::repeat_byte(0x11);
-        let owner = Address::repeat_byte(0xaa);
-        db.insert_account_with_storage(
-            FEATURE_REGISTRY_ADDRESS,
-            AccountInfo::default(),
-            feature_registry_report_storage(validator, 13),
-        );
-        let mut builder = TestExecutorBuilder::default().with_runtime_spec(TempoHardfork::T6);
-        builder.consensus_context = Some(consensus_context_from_proposer(&proposer_key));
-        let mut executor = builder.build(&mut db, &chainspec);
-        initialize_validator_config_v2(&mut executor, owner, validator, &proposer_key);
-
-        let input = IFeatureRegistry::setSupportedFeaturesTipCall {
-            publicKey: b256_public_key_from_private_key(&proposer_key),
             featuresTip: 13,
         }
         .abi_encode()

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -26,17 +26,13 @@ use reth_revm::{
     state::{Account, Bytecode, EvmState},
 };
 use std::collections::{HashMap, HashSet};
-use tempo_chainspec::{
-    TempoChainSpec, features::highest_supported_protocol_feature_id, hardfork::TempoHardforks,
-};
+use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_contracts::precompiles::{
     ADDRESS_REGISTRY_ADDRESS, FEATURE_REGISTRY_ADDRESS, IFeatureRegistry,
     RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS, SYSTEM_CALLER_ADDRESS,
     TIP20_CHANNEL_RESERVE_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
-use tempo_precompiles::{
-    feature_registry::FeatureRegistry, validator_config_v2::ValidatorConfigV2,
-};
+use tempo_precompiles::validator_config_v2::ValidatorConfigV2;
 use tempo_primitives::{
     SubBlock, SubBlockMetadata, TempoConsensusContext, TempoReceipt, TempoTxEnvelope, TempoTxType,
     subblock::PartialValidatorKey,
@@ -57,7 +53,10 @@ pub(crate) enum BlockSection {
     /// Gas incentive transaction.
     GasIncentive,
     /// End of block system transactions.
-    System { seen_subblocks_signatures: bool },
+    System {
+        seen_subblocks_signatures: bool,
+        seen_features_tip_report: bool,
+    },
 }
 
 /// Builder for [`TempoReceipt`].
@@ -245,77 +244,6 @@ where
         }
     }
 
-    fn validator_supported_features_tip(
-        &mut self,
-        validator: Address,
-    ) -> Result<u64, BlockExecutionError> {
-        let spec = self.evm().cfg.spec;
-        self.evm_mut()
-            .db_mut()
-            .with_read_only_storage_ctx(spec, || {
-                FeatureRegistry::new().validator_supported_features_tip(validator)
-            })
-            .map_err(BlockExecutionError::other)
-    }
-
-    fn report_supported_features_tip(
-        &mut self,
-        validator: Address,
-        supported_features_tip: u64,
-    ) -> Result<(), BlockExecutionError> {
-        let reported_features_tip = self.validator_supported_features_tip(validator)?;
-        if reported_features_tip >= supported_features_tip {
-            return Ok(());
-        }
-
-        let call = IFeatureRegistry::setSupportedFeaturesTipCall {
-            validator,
-            featuresTip: supported_features_tip,
-        };
-        self.transact_precompile_system_call(
-            FEATURE_REGISTRY_ADDRESS,
-            call.abi_encode().into(),
-            "feature registry support report",
-        )?;
-
-        Ok(())
-    }
-
-    fn consensus_proposer_validator(&mut self) -> Result<Option<Address>, BlockExecutionError> {
-        let Some(consensus_context) = self.consensus_context else {
-            return Ok(None);
-        };
-
-        let public_key = B256::from(&consensus_context.proposer);
-        let spec = self.evm().cfg.spec;
-        let validator = self
-            .evm_mut()
-            .db_mut()
-            .with_read_only_storage_ctx(spec, || {
-                ValidatorConfigV2::new().validator_by_public_key(public_key)
-            })
-            .map_err(BlockExecutionError::other)?;
-
-        if validator.deactivatedAtHeight != 0 {
-            return Ok(None);
-        }
-
-        Ok(Some(validator.validatorAddress))
-    }
-
-    fn report_local_supported_features_tip(&mut self) -> Result<(), BlockExecutionError> {
-        let supported_features_tip = highest_supported_protocol_feature_id();
-        if supported_features_tip == 0 {
-            return Ok(());
-        }
-
-        let Some(validator) = self.consensus_proposer_validator()? else {
-            return Ok(());
-        };
-
-        self.report_supported_features_tip(validator, supported_features_tip)
-    }
-
     /// Activates a scheduled feature tip once the consensus epoch reaches the target epoch.
     fn activate_scheduled_features_tip(&mut self) -> Result<(), BlockExecutionError> {
         let Some(consensus_context) = self.consensus_context else {
@@ -336,7 +264,7 @@ where
 
     /// Validates a system transaction.
     pub(crate) fn validate_system_tx(
-        &self,
+        &mut self,
         tx: &TempoTxEnvelope,
     ) -> Result<BlockSection, BlockValidationError> {
         let block = self.evm().block();
@@ -347,7 +275,15 @@ where
         let mut seen_subblocks_signatures = match self.section {
             BlockSection::System {
                 seen_subblocks_signatures,
+                ..
             } => seen_subblocks_signatures,
+            _ => false,
+        };
+        let mut seen_features_tip_report = match self.section {
+            BlockSection::System {
+                seen_features_tip_report,
+                ..
+            } => seen_features_tip_report,
             _ => false,
         };
 
@@ -386,13 +322,64 @@ where
             self.validate_shared_gas(&metadata)?;
 
             seen_subblocks_signatures = true;
+        } else if to == FEATURE_REGISTRY_ADDRESS {
+            if seen_features_tip_report {
+                return Err(BlockValidationError::msg(
+                    "duplicate feature registry system transaction",
+                ));
+            }
+
+            if !self.evm().cfg.spec.is_t6() {
+                return Err(BlockValidationError::msg(
+                    "feature registry system transaction is disabled",
+                ));
+            }
+
+            self.validate_feature_registry_system_tx(tx)?;
+
+            seen_features_tip_report = true;
         } else {
             return Err(BlockValidationError::msg("invalid system transaction"));
         }
 
         Ok(BlockSection::System {
             seen_subblocks_signatures,
+            seen_features_tip_report,
         })
+    }
+
+    fn validate_feature_registry_system_tx(
+        &mut self,
+        tx: &TempoTxEnvelope,
+    ) -> Result<(), BlockValidationError> {
+        let call = IFeatureRegistry::setSupportedFeaturesTipCall::abi_decode(tx.input()).map_err(
+            |_| BlockValidationError::msg("invalid feature registry system transaction"),
+        )?;
+        let Some(consensus_context) = self.consensus_context else {
+            return Err(BlockValidationError::msg(
+                "invalid feature registry system transaction",
+            ));
+        };
+
+        let public_key = B256::from(&consensus_context.proposer);
+        let spec = self.evm().cfg.spec;
+        let validator = self
+            .evm_mut()
+            .db_mut()
+            .with_read_only_storage_ctx(spec, || {
+                ValidatorConfigV2::new().validator_by_public_key(public_key)
+            })
+            .map_err(|_| {
+                BlockValidationError::msg("invalid feature registry system transaction")
+            })?;
+
+        if validator.deactivatedAtHeight != 0 || validator.validatorAddress != call.validator {
+            return Err(BlockValidationError::msg(
+                "invalid feature registry system transaction",
+            ));
+        }
+
+        Ok(())
     }
 
     pub(crate) fn validate_shared_gas(
@@ -493,7 +480,7 @@ where
     /// the regular block gas limit checks and we need to make sure that they
     /// only perform explicitly allowed actions.
     pub(crate) fn validate_tx_pre_execution(
-        &self,
+        &mut self,
         tx: &TempoTxEnvelope,
     ) -> Result<Option<BlockSection>, BlockValidationError> {
         if tx.is_system_tx() {
@@ -519,7 +506,7 @@ where
     }
 
     pub(crate) fn validate_tx(
-        &self,
+        &mut self,
         tx: &TempoTxEnvelope,
         gas_used: u64,
     ) -> Result<BlockSection, BlockValidationError> {
@@ -620,7 +607,6 @@ where
             self.deploy_precompile_at_boundary(RECEIVE_POLICY_GUARD_ADDRESS)?;
             // TODO(TIP-1063): update this gate to T7 before merging.
             self.deploy_precompile_at_boundary(FEATURE_REGISTRY_ADDRESS)?;
-            self.report_local_supported_features_tip()?;
             self.activate_scheduled_features_tip()?;
         }
 
@@ -744,6 +730,7 @@ where
         let seen_subblock_signatures = match self.section {
             BlockSection::System {
                 seen_subblocks_signatures,
+                ..
             } => seen_subblocks_signatures,
             _ => false,
         };
@@ -820,18 +807,26 @@ mod tests {
     use crate::test_utils::{TestExecutorBuilder, test_chainspec, test_evm};
     use alloy_consensus::{Signed, TxLegacy};
     use alloy_evm::{block::BlockExecutor, eth::receipt_builder::ReceiptBuilder};
-    use alloy_primitives::{Log, Signature, TxKind, bytes::BytesMut};
+    use alloy_primitives::{Keccak256, Log, Signature, TxKind, bytes::BytesMut};
     use alloy_rlp::Encodable;
+    use commonware_codec::Encode;
     use commonware_cryptography::{Signer, ed25519::PrivateKey};
     use reth_chainspec::EthChainSpec;
     use reth_revm::{State, state::AccountInfo};
     use revm::{
-        context::result::{ExecutionResult, ResultGas},
+        context::{
+            JournalTr,
+            result::{ExecutionResult, ResultGas},
+        },
         database::{EmptyDB, states::plain_account::PlainStorage},
     };
     use std::sync::{Arc, Mutex};
     use tempo_chainspec::{hardfork::TempoHardfork, spec::DEV};
     use tempo_contracts::precompiles::PATH_USD_ADDRESS;
+    use tempo_precompiles::{
+        storage::StorageCtx,
+        validator_config_v2::{IValidatorConfigV2, VALIDATOR_NS_ADD},
+    };
     use tempo_primitives::{
         SubBlockMetadata, TempoSignature, TempoTransaction, TempoTxType,
         subblock::{SubBlockVersion, TEMPO_SUBBLOCK_NONCE_KEY_PREFIX},
@@ -893,6 +888,100 @@ mod tests {
         storage
     }
 
+    fn public_key_from_private_key(
+        private_key: &PrivateKey,
+    ) -> tempo_primitives::ed25519::PublicKey {
+        tempo_primitives::ed25519::PublicKey::try_from(B256::from_slice(
+            &private_key.public_key().encode(),
+        ))
+        .unwrap()
+    }
+
+    fn add_validator_signature(
+        chain_id: u64,
+        private_key: &PrivateKey,
+        validator: Address,
+        ingress: &str,
+        egress: &str,
+        fee_recipient: Address,
+    ) -> Vec<u8> {
+        let mut hasher = Keccak256::new();
+        hasher.update(chain_id.to_be_bytes());
+        hasher.update(VALIDATOR_CONFIG_V2_ADDRESS.as_slice());
+        hasher.update(validator.as_slice());
+        hasher.update([u8::try_from(ingress.len()).unwrap()]);
+        hasher.update(ingress.as_bytes());
+        hasher.update([u8::try_from(egress.len()).unwrap()]);
+        hasher.update(egress.as_bytes());
+        hasher.update(fee_recipient.as_slice());
+        private_key
+            .sign(VALIDATOR_NS_ADD, hasher.finalize().as_slice())
+            .encode()
+            .to_vec()
+    }
+
+    fn consensus_context_from_proposer(proposer_key: &PrivateKey) -> TempoConsensusContext {
+        TempoConsensusContext {
+            epoch: 21,
+            view: 0,
+            parent_view: 0,
+            proposer: public_key_from_private_key(proposer_key),
+        }
+    }
+
+    fn initialize_validator_config_v2<DB, I>(
+        executor: &mut TempoBlockExecutor<'_, DB, I>,
+        owner: Address,
+        validator: Address,
+        validator_key: &PrivateKey,
+    ) where
+        DB: StateDB,
+        I: Inspector<TempoContext<DB>>,
+    {
+        let chain_id = executor.evm().cfg.chain_id;
+        let public_key = B256::from_slice(&validator_key.public_key().encode());
+        let ingress = "127.0.0.1:9000";
+        let egress = "127.0.0.1";
+        let fee_recipient = Address::repeat_byte(0x44);
+        let signature = add_validator_signature(
+            chain_id,
+            validator_key,
+            validator,
+            ingress,
+            egress,
+            fee_recipient,
+        );
+
+        StorageCtx::enter_ctx(
+            executor.evm_mut().ctx_mut(),
+            || -> tempo_precompiles::error::Result<()> {
+                let mut config = ValidatorConfigV2::new();
+                config.initialize(owner)?;
+                config.add_validator(
+                    owner,
+                    IValidatorConfigV2::addValidatorCall {
+                        validatorAddress: validator,
+                        publicKey: public_key,
+                        ingress: ingress.to_string(),
+                        egress: egress.to_string(),
+                        feeRecipient: fee_recipient,
+                        signature: signature.into(),
+                    },
+                )?;
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        let evm_state = executor
+            .evm_mut()
+            .ctx_mut()
+            .journaled_state
+            .evm_state()
+            .clone();
+        executor.evm_mut().db_mut().commit(evm_state);
+    }
+
     #[test]
     fn test_build_receipt() {
         let builder = TempoReceiptBuilder;
@@ -932,7 +1021,7 @@ mod tests {
     fn test_validate_system_tx() {
         let chainspec = test_chainspec();
         let mut db = State::builder().with_bundle_update().build();
-        let executor = TestExecutorBuilder::default().build(&mut db, &chainspec);
+        let mut executor = TestExecutorBuilder::default().build(&mut db, &chainspec);
 
         let signer = PrivateKey::from_seed(0);
         let metadata = vec![create_valid_subblock_metadata(B256::ZERO, &signer)];
@@ -948,7 +1037,8 @@ mod tests {
         assert_eq!(
             result.unwrap(),
             BlockSection::System {
-                seen_subblocks_signatures: true
+                seen_subblocks_signatures: true,
+                seen_features_tip_report: false,
             }
         );
     }
@@ -961,13 +1051,17 @@ mod tests {
     }
 
     fn create_system_tx(chain_id: u64, input: Bytes) -> TempoTxEnvelope {
+        create_system_tx_to(chain_id, Address::ZERO, input)
+    }
+
+    fn create_system_tx_to(chain_id: u64, to: Address, input: Bytes) -> TempoTxEnvelope {
         TempoTxEnvelope::Legacy(Signed::new_unhashed(
             TxLegacy {
                 chain_id: Some(chain_id),
                 nonce: 0,
                 gas_price: 0,
                 gas_limit: 0,
-                to: TxKind::Call(Address::ZERO),
+                to: TxKind::Call(to),
                 value: U256::ZERO,
                 input,
             },
@@ -998,9 +1092,10 @@ mod tests {
     fn test_validate_system_tx_duplicate_subblocks_system_tx() {
         let chainspec = test_chainspec();
         let mut db = State::builder().with_bundle_update().build();
-        let executor = TestExecutorBuilder::default()
+        let mut executor = TestExecutorBuilder::default()
             .with_section(BlockSection::System {
                 seen_subblocks_signatures: true,
+                seen_features_tip_report: false,
             })
             .build(&mut db, &chainspec);
 
@@ -1018,10 +1113,103 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_system_tx_feature_registry_report() {
+        let chainspec = test_chainspec();
+        let mut db = State::builder().with_bundle_update().build();
+        let proposer_key = PrivateKey::from_seed(0);
+        let validator = Address::repeat_byte(0x11);
+        let owner = Address::repeat_byte(0xaa);
+        let mut builder = TestExecutorBuilder::default().with_runtime_spec(TempoHardfork::T6);
+        builder.consensus_context = Some(consensus_context_from_proposer(&proposer_key));
+        let mut executor = builder.build(&mut db, &chainspec);
+        initialize_validator_config_v2(&mut executor, owner, validator, &proposer_key);
+
+        let input = IFeatureRegistry::setSupportedFeaturesTipCall {
+            validator,
+            featuresTip: 13,
+        }
+        .abi_encode()
+        .into();
+        let system_tx =
+            create_system_tx_to(chainspec.chain().id(), FEATURE_REGISTRY_ADDRESS, input);
+
+        let result = executor.validate_system_tx(&system_tx);
+        assert!(
+            result.is_ok(),
+            "validate_system_tx failed: {:?}",
+            result.err()
+        );
+        assert_eq!(
+            result.unwrap(),
+            BlockSection::System {
+                seen_subblocks_signatures: false,
+                seen_features_tip_report: true,
+            }
+        );
+    }
+
+    #[test]
+    fn test_validate_system_tx_feature_registry_report_rejects_other_validator() {
+        let chainspec = test_chainspec();
+        let mut db = State::builder().with_bundle_update().build();
+        let proposer_key = PrivateKey::from_seed(0);
+        let validator = Address::repeat_byte(0x11);
+        let owner = Address::repeat_byte(0xaa);
+        let mut builder = TestExecutorBuilder::default().with_runtime_spec(TempoHardfork::T6);
+        builder.consensus_context = Some(consensus_context_from_proposer(&proposer_key));
+        let mut executor = builder.build(&mut db, &chainspec);
+        initialize_validator_config_v2(&mut executor, owner, validator, &proposer_key);
+
+        let input = IFeatureRegistry::setSupportedFeaturesTipCall {
+            validator: Address::repeat_byte(0x22),
+            featuresTip: 13,
+        }
+        .abi_encode()
+        .into();
+        let system_tx =
+            create_system_tx_to(chainspec.chain().id(), FEATURE_REGISTRY_ADDRESS, input);
+
+        let result = executor.validate_system_tx(&system_tx);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "invalid feature registry system transaction"
+        );
+    }
+
+    #[test]
+    fn test_validate_system_tx_duplicate_feature_registry_report() {
+        let chainspec = test_chainspec();
+        let mut db = State::builder().with_bundle_update().build();
+        let mut executor = TestExecutorBuilder::default()
+            .with_runtime_spec(TempoHardfork::T6)
+            .with_section(BlockSection::System {
+                seen_subblocks_signatures: false,
+                seen_features_tip_report: true,
+            })
+            .build(&mut db, &chainspec);
+        let input = IFeatureRegistry::setSupportedFeaturesTipCall {
+            validator: Address::repeat_byte(0x11),
+            featuresTip: 13,
+        }
+        .abi_encode()
+        .into();
+        let system_tx =
+            create_system_tx_to(chainspec.chain().id(), FEATURE_REGISTRY_ADDRESS, input);
+
+        let result = executor.validate_system_tx(&system_tx);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "duplicate feature registry system transaction"
+        );
+    }
+
+    #[test]
     fn test_validate_system_tx_invalid_sublocks_metadata() {
         let chainspec = test_chainspec();
         let mut db = State::builder().with_bundle_update().build();
-        let executor = TestExecutorBuilder::default().build(&mut db, &chainspec);
+        let mut executor = TestExecutorBuilder::default().build(&mut db, &chainspec);
 
         let mut input = BytesMut::new();
         input.extend_from_slice(&[0xff, 0xff, 0xff]); // Invalid RLP
@@ -1040,7 +1228,7 @@ mod tests {
     fn test_validate_system_tx_invalid_system_tx() {
         let chainspec = test_chainspec();
         let mut db = State::builder().with_bundle_update().build();
-        let executor = TestExecutorBuilder::default().build(&mut db, &chainspec);
+        let mut executor = TestExecutorBuilder::default().build(&mut db, &chainspec);
 
         // Create system tx with non-zero `to` address
         let system_tx = TempoTxEnvelope::Legacy(Signed::new_unhashed(
@@ -1322,7 +1510,7 @@ mod tests {
     fn test_validate_tx() {
         let chainspec = test_chainspec();
         let mut db = State::builder().with_bundle_update().build();
-        let executor = TestExecutorBuilder::default().build(&mut db, &chainspec);
+        let mut executor = TestExecutorBuilder::default().build(&mut db, &chainspec);
 
         // Test regular transaction in StartOfBlock section goes to NonShared
         let tx = create_legacy_tx();
@@ -1363,7 +1551,7 @@ mod tests {
         let proposer = PartialValidatorKey::from_slice(&validator_key[..15]);
 
         // Test with GasIncentive section
-        let executor = TestExecutorBuilder::default()
+        let mut executor = TestExecutorBuilder::default()
             .with_section(BlockSection::GasIncentive)
             .build(&mut db, &chainspec);
 
@@ -1377,9 +1565,10 @@ mod tests {
 
         // Also test with System section
         let mut db2 = State::builder().with_bundle_update().build();
-        let executor2 = TestExecutorBuilder::default()
+        let mut executor2 = TestExecutorBuilder::default()
             .with_section(BlockSection::System {
                 seen_subblocks_signatures: false,
+                seen_features_tip_report: false,
             })
             .build(&mut db2, &chainspec);
 
@@ -1404,7 +1593,7 @@ mod tests {
         let proposer2 = PartialValidatorKey::from_slice(&validator_key2[..15]);
 
         // Set section to SubBlock with a different proposer, and mark proposer1 as already seen
-        let executor = TestExecutorBuilder::default()
+        let mut executor = TestExecutorBuilder::default()
             .with_section(BlockSection::SubBlock {
                 proposer: proposer2,
             })
@@ -1427,9 +1616,10 @@ mod tests {
         let mut db = State::builder().with_bundle_update().build();
 
         // Set section to System
-        let executor = TestExecutorBuilder::default()
+        let mut executor = TestExecutorBuilder::default()
             .with_section(BlockSection::System {
                 seen_subblocks_signatures: false,
+                seen_features_tip_report: false,
             })
             .build(&mut db, &chainspec);
 
@@ -1905,79 +2095,6 @@ mod tests {
         assert_eq!(
             acc.storage_slot(U256::ZERO).unwrap(),
             packed_feature_registry_tips(7, 13, 21)
-        );
-    }
-
-    #[test]
-    fn test_report_supported_features_tip_updates_validator_report() {
-        let chainspec = Arc::new(TempoChainSpec::from_genesis(DEV.genesis().clone()));
-        let mut db = State::builder().with_bundle_update().build();
-        let mut executor = TestExecutorBuilder::default()
-            .with_parent_beacon_block_root(B256::ZERO)
-            .with_runtime_spec(TempoHardfork::T6)
-            .build(&mut db, &chainspec);
-        let validator = Address::repeat_byte(0x11);
-
-        executor
-            .deploy_precompile_at_boundary(FEATURE_REGISTRY_ADDRESS)
-            .unwrap();
-        executor
-            .report_supported_features_tip(validator, 13)
-            .unwrap();
-
-        assert_eq!(
-            executor
-                .validator_supported_features_tip(validator)
-                .unwrap(),
-            13
-        );
-    }
-
-    #[test]
-    fn test_report_supported_features_tip_does_not_lower_validator_report() {
-        let chainspec = Arc::new(TempoChainSpec::from_genesis(DEV.genesis().clone()));
-        let mut db = State::builder().with_bundle_update().build();
-        let mut executor = TestExecutorBuilder::default()
-            .with_parent_beacon_block_root(B256::ZERO)
-            .with_runtime_spec(TempoHardfork::T6)
-            .build(&mut db, &chainspec);
-        let validator = Address::repeat_byte(0x11);
-
-        executor
-            .deploy_precompile_at_boundary(FEATURE_REGISTRY_ADDRESS)
-            .unwrap();
-        executor
-            .report_supported_features_tip(validator, 13)
-            .unwrap();
-        executor
-            .report_supported_features_tip(validator, 12)
-            .unwrap();
-
-        assert_eq!(
-            executor
-                .validator_supported_features_tip(validator)
-                .unwrap(),
-            13
-        );
-    }
-
-    #[test]
-    fn test_apply_pre_execution_skips_supported_features_tip_report_when_none_supported() {
-        let chainspec = Arc::new(TempoChainSpec::from_genesis(DEV.genesis().clone()));
-        let mut db = State::builder().with_bundle_update().build();
-        let mut executor = TestExecutorBuilder::default()
-            .with_parent_beacon_block_root(B256::ZERO)
-            .with_runtime_spec(TempoHardfork::T6)
-            .with_consensus_epoch(21)
-            .build(&mut db, &chainspec);
-
-        executor.apply_pre_execution_changes().unwrap();
-
-        assert_eq!(
-            executor
-                .validator_supported_features_tip(Address::repeat_byte(0x11))
-                .unwrap(),
-            0
         );
     }
 

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 tempo-chainspec = { workspace = true, features = ["reth"] }
+tempo-contracts.workspace = true
 tempo-evm.workspace = true
 tempo-precompiles.workspace = true
 tempo-primitives = { workspace = true, features = ["reth"] }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -252,49 +252,29 @@ impl<Provider: ChainSpecProvider<ChainSpec = TempoChainSpec>> TempoPayloadBuilde
         };
 
         let spec = evm.cfg.spec;
-        let parent_number = evm.block.number.saturating_to::<u64>().saturating_sub(1);
-        let validator = match evm
+        let should_report = match evm
             .ctx_mut()
             .journaled_state
             .database
-            .with_read_only_storage_ctx(spec, || -> Result<Option<Address>, PayloadBuilderError> {
-                let config = ValidatorConfigV2::new();
-                if !config
-                    .is_initialized()
-                    .map_err(PayloadBuilderError::other)?
-                {
-                    return Ok(None);
-                }
-                if config
-                    .get_initialized_at_height()
-                    .map_err(PayloadBuilderError::other)?
-                    > parent_number
-                {
-                    return Ok(None);
-                }
-
-                let validator = config
-                    .validator_by_public_key(*public_key)
-                    .map_err(PayloadBuilderError::other)?;
-                if validator.deactivatedAtHeight != 0 {
-                    return Ok(None);
-                }
-
+            .with_read_only_storage_ctx(spec, || -> Result<bool, PayloadBuilderError> {
                 let reported_features_tip = FeatureRegistry::new()
-                    .validator_supported_features_tip(validator.validatorAddress)
+                    .validator_supported_features_tip_by_public_key(*public_key)
                     .map_err(PayloadBuilderError::other)?;
-                Ok((reported_features_tip < supported_features_tip)
-                    .then_some(validator.validatorAddress))
+                Ok(reported_features_tip < supported_features_tip)
             }) {
-            Ok(validator) => validator,
+            Ok(should_report) => should_report,
             Err(err) => {
-                warn!(%err, "failed resolving supported feature tip report; skipping");
-                None
+                debug!(%err, "skipping supported feature tip report");
+                false
             }
-        }?;
+        };
+
+        if !should_report {
+            return None;
+        }
 
         let input = IFeatureRegistry::setSupportedFeaturesTipCall {
-            validator,
+            publicKey: *public_key,
             featuresTip: supported_features_tip,
         }
         .abi_encode()

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -24,6 +24,7 @@ use alloy_eip7928::compute_block_access_list_hash;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bloom, Bytes, U256};
 use alloy_rlp::{Decodable, Encodable};
+use alloy_sol_types::SolCall;
 use reth_basic_payload_builder::{
     BuildArguments, BuildOutcome, MissingPayloadBehaviour, PayloadBuilder, PayloadConfig,
     is_better_payload,
@@ -63,10 +64,15 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
+use tempo_chainspec::{
+    TempoChainSpec, features::highest_supported_protocol_feature_id, hardfork::TempoHardforks,
+};
+use tempo_contracts::precompiles::{FEATURE_REGISTRY_ADDRESS, IFeatureRegistry};
 use tempo_evm::{TempoEvmConfig, TempoNextBlockEnvAttributes, TempoStateAccess, evm::TempoEvm};
 use tempo_payload_types::{TempoBuiltPayload, TempoPayloadAttributes, marshal_persist_estimate};
-use tempo_precompiles::validator_config_v2::ValidatorConfigV2;
+use tempo_precompiles::{
+    feature_registry::FeatureRegistry, validator_config_v2::ValidatorConfigV2,
+};
 use tempo_primitives::{
     RecoveredSubBlock, SubBlockMetadata, TempoHeader, TempoReceipt, TempoTxEnvelope,
     subblock::PartialValidatorKey,
@@ -194,22 +200,23 @@ impl<Provider> TempoPayloadBuilder<Provider> {
 }
 
 impl<Provider: ChainSpecProvider<ChainSpec = TempoChainSpec>> TempoPayloadBuilder<Provider> {
-    /// Builds system transactions to seal the block.
-    ///
-    /// Returns a vector of system transactions that must be executed at the end of each block:
-    /// - Subblocks signatures - validates subblock signatures
     fn build_seal_block_txs(
         &self,
-        evm: &TempoEvm<impl Database>,
+        evm: &mut TempoEvm<impl Database>,
+        attributes: &TempoPayloadAttributes,
         subblocks: &[RecoveredSubBlock],
     ) -> Vec<Recovered<TempoTxEnvelope>> {
-        if subblocks.is_empty() && evm.cfg.spec.is_t4() {
-            // Post-T4, omit the subblocks metadata transaction if there are no subblocks
-            return vec![];
-        }
-
         let chain_spec = self.provider.chain_spec();
         let chain_id = Some(chain_spec.chain().id());
+        let mut txs = Vec::new();
+
+        if let Some(tx) = self.build_supported_features_tip_tx(evm, attributes, chain_id) {
+            txs.push(tx);
+        }
+
+        if subblocks.is_empty() && evm.cfg.spec.is_t4() {
+            return txs;
+        }
 
         // Build subblocks signatures system transaction
         let subblocks_metadata = subblocks
@@ -221,23 +228,96 @@ impl<Provider: ChainSpecProvider<ChainSpec = TempoChainSpec>> TempoPayloadBuilde
             .chain(evm.block.number.to_be_bytes_vec())
             .collect();
 
-        let subblocks_signatures_tx = Recovered::new_unchecked(
+        txs.push(Self::system_tx(chain_id, Address::ZERO, subblocks_input));
+        txs
+    }
+
+    fn build_supported_features_tip_tx(
+        &self,
+        evm: &mut TempoEvm<impl Database>,
+        attributes: &TempoPayloadAttributes,
+        chain_id: Option<u64>,
+    ) -> Option<Recovered<TempoTxEnvelope>> {
+        if !evm.cfg.spec.is_t6() {
+            return None;
+        }
+
+        let supported_features_tip = highest_supported_protocol_feature_id();
+        if supported_features_tip == 0 {
+            return None;
+        }
+
+        let Some(public_key) = attributes.proposer_public_key() else {
+            return None;
+        };
+
+        let spec = evm.cfg.spec;
+        let parent_number = evm.block.number.saturating_to::<u64>().saturating_sub(1);
+        let validator = match evm
+            .ctx_mut()
+            .journaled_state
+            .database
+            .with_read_only_storage_ctx(spec, || -> Result<Option<Address>, PayloadBuilderError> {
+                let config = ValidatorConfigV2::new();
+                if !config
+                    .is_initialized()
+                    .map_err(PayloadBuilderError::other)?
+                {
+                    return Ok(None);
+                }
+                if config
+                    .get_initialized_at_height()
+                    .map_err(PayloadBuilderError::other)?
+                    > parent_number
+                {
+                    return Ok(None);
+                }
+
+                let validator = config
+                    .validator_by_public_key(*public_key)
+                    .map_err(PayloadBuilderError::other)?;
+                if validator.deactivatedAtHeight != 0 {
+                    return Ok(None);
+                }
+
+                let reported_features_tip = FeatureRegistry::new()
+                    .validator_supported_features_tip(validator.validatorAddress)
+                    .map_err(PayloadBuilderError::other)?;
+                Ok((reported_features_tip < supported_features_tip)
+                    .then_some(validator.validatorAddress))
+            }) {
+            Ok(validator) => validator,
+            Err(err) => {
+                warn!(%err, "failed resolving supported feature tip report; skipping");
+                None
+            }
+        }?;
+
+        let input = IFeatureRegistry::setSupportedFeaturesTipCall {
+            validator,
+            featuresTip: supported_features_tip,
+        }
+        .abi_encode()
+        .into();
+        Some(Self::system_tx(chain_id, FEATURE_REGISTRY_ADDRESS, input))
+    }
+
+    fn system_tx(chain_id: Option<u64>, to: Address, input: Bytes) -> Recovered<TempoTxEnvelope> {
+        Recovered::new_unchecked(
             TempoTxEnvelope::Legacy(Signed::new_unhashed(
                 TxLegacy {
                     chain_id,
                     nonce: 0,
                     gas_price: 0,
                     gas_limit: 0,
-                    to: Address::ZERO.into(),
+                    to: to.into(),
                     value: U256::ZERO,
-                    input: subblocks_input,
+                    input,
                 },
                 TEMPO_SYSTEM_TX_SIGNATURE,
             )),
             TEMPO_SYSTEM_TX_SENDER,
-        );
-
-        vec![subblocks_signatures_tx]
+        )
     }
 }
 
@@ -507,7 +587,7 @@ where
 
         // Prepare system transactions before actual block building and account for their size.
         let prepare_system_txs_start = Instant::now();
-        let system_txs = self.build_seal_block_txs(executor.evm(), &subblocks);
+        let system_txs = self.build_seal_block_txs(executor.evm_mut(), &attributes, &subblocks);
         for tx in &system_txs {
             block_size_used += tx.inner().length();
         }

--- a/crates/precompiles/src/feature_registry/dispatch.rs
+++ b/crates/precompiles/src/feature_registry/dispatch.rs
@@ -96,7 +96,7 @@ mod tests {
         Ok(())
     }
 
-    fn add_validator(owner: Address, validator: Address, seed: u64) -> eyre::Result<B256> {
+    fn add_test_validator(owner: Address, validator: Address, seed: u64) -> eyre::Result<B256> {
         let private_key = PrivateKey::from_seed(seed);
         let public_key = B256::from_slice(&private_key.public_key().encode());
         let ingress = format!("127.0.0.1:{}", 9000 + seed);
@@ -577,7 +577,7 @@ mod tests {
             let owner = Address::repeat_byte(0xaa);
             let validator = Address::repeat_byte(0x01);
             initialize_validator_config_owner(owner)?;
-            let public_key = add_validator(owner, validator, 1)?;
+            let public_key = add_test_validator(owner, validator, 1)?;
 
             registry.set_supported_features_tip(
                 Address::ZERO,
@@ -601,7 +601,7 @@ mod tests {
             let owner = Address::repeat_byte(0xaa);
             let validator = Address::repeat_byte(0x01);
             initialize_validator_config_owner(owner)?;
-            let public_key = add_validator(owner, validator, 1)?;
+            let public_key = add_test_validator(owner, validator, 1)?;
             registry.validator_supported_features_tip[validator].write(13)?;
 
             let result = registry.set_supported_features_tip(
@@ -705,7 +705,7 @@ mod tests {
             let owner = Address::repeat_byte(0xaa);
             let validator = Address::repeat_byte(0x01);
             initialize_validator_config_owner(owner)?;
-            let public_key = add_validator(owner, validator, 1)?;
+            let public_key = add_test_validator(owner, validator, 1)?;
 
             let call = IFeatureRegistry::setSupportedFeaturesTipCall {
                 publicKey: public_key,
@@ -749,7 +749,7 @@ mod tests {
             let owner = Address::repeat_byte(0xaa);
             let validator = Address::repeat_byte(0x01);
             initialize_validator_config_owner(owner)?;
-            let public_key = add_validator(owner, validator, 1)?;
+            let public_key = add_test_validator(owner, validator, 1)?;
             registry.validator_supported_features_tip[validator].write(34)?;
 
             let call = IFeatureRegistry::setSupportedFeaturesTipCall {

--- a/crates/precompiles/src/feature_registry/dispatch.rs
+++ b/crates/precompiles/src/feature_registry/dispatch.rs
@@ -535,7 +535,7 @@ mod tests {
             let validator = Address::repeat_byte(0x01);
 
             registry.set_supported_features_tip(
-                SYSTEM_CALLER_ADDRESS,
+                Address::ZERO,
                 IFeatureRegistry::setSupportedFeaturesTipCall {
                     validator,
                     featuresTip: 13,
@@ -557,7 +557,7 @@ mod tests {
             registry.validator_supported_features_tip[validator].write(13)?;
 
             let result = registry.set_supported_features_tip(
-                SYSTEM_CALLER_ADDRESS,
+                Address::ZERO,
                 IFeatureRegistry::setSupportedFeaturesTipCall {
                     validator,
                     featuresTip: 12,
@@ -628,7 +628,7 @@ mod tests {
     }
 
     #[test]
-    fn set_supported_features_tip_rejects_non_system_caller() -> eyre::Result<()> {
+    fn set_supported_features_tip_rejects_non_system_tx_sender() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut registry = FeatureRegistry::new();
@@ -649,7 +649,8 @@ mod tests {
     }
 
     #[test]
-    fn set_supported_features_tip_dispatch_sets_validator_report_from_system() -> eyre::Result<()> {
+    fn set_supported_features_tip_dispatch_sets_validator_report_from_system_tx_sender()
+    -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut registry = FeatureRegistry::new();
@@ -659,7 +660,7 @@ mod tests {
                 validator,
                 featuresTip: 34,
             };
-            let result = registry.call(&call.abi_encode(), SYSTEM_CALLER_ADDRESS)?;
+            let result = registry.call(&call.abi_encode(), Address::ZERO)?;
             assert!(!result.is_revert());
             assert_eq!(registry.validator_supported_features_tip(validator)?, 34);
 
@@ -668,7 +669,7 @@ mod tests {
     }
 
     #[test]
-    fn set_supported_features_tip_dispatch_rejects_non_system_caller() -> eyre::Result<()> {
+    fn set_supported_features_tip_dispatch_rejects_non_system_tx_sender() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut registry = FeatureRegistry::new();
@@ -701,7 +702,7 @@ mod tests {
                 validator,
                 featuresTip: 33,
             };
-            let result = registry.call(&call.abi_encode(), SYSTEM_CALLER_ADDRESS)?;
+            let result = registry.call(&call.abi_encode(), Address::ZERO)?;
             assert!(result.is_revert());
             let decoded = FeatureRegistryError::abi_decode(&result.bytes)?;
             assert_eq!(

--- a/crates/precompiles/src/feature_registry/dispatch.rs
+++ b/crates/precompiles/src/feature_registry/dispatch.rs
@@ -75,20 +75,62 @@ mod tests {
     use crate::{
         FEATURE_REGISTRY_ADDRESS, SYSTEM_CALLER_ADDRESS,
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
-        validator_config_v2::ValidatorConfigV2,
+        validator_config_v2::{VALIDATOR_NS_ADD, ValidatorConfigV2},
     };
     use alloy::{
-        primitives::U256,
+        primitives::{B256, Keccak256, U256},
         sol_types::{SolCall, SolError, SolValue},
     };
+    use commonware_codec::Encode;
+    use commonware_cryptography::{Signer, ed25519::PrivateKey};
     use tempo_chainspec::{
         epoch::EPOCH_LENGTH_BLOCKS, features::HIGHEST_ACTIVE_PROTOCOL_FEATURE_ID_SLOT,
     };
-    use tempo_contracts::precompiles::{FeatureRegistryError, UnknownFunctionSelector};
+    use tempo_contracts::precompiles::{
+        FeatureRegistryError, IValidatorConfigV2, UnknownFunctionSelector,
+        VALIDATOR_CONFIG_V2_ADDRESS,
+    };
 
     fn initialize_validator_config_owner(owner: Address) -> eyre::Result<()> {
         ValidatorConfigV2::new().initialize(owner)?;
         Ok(())
+    }
+
+    fn add_validator(owner: Address, validator: Address, seed: u64) -> eyre::Result<B256> {
+        let private_key = PrivateKey::from_seed(seed);
+        let public_key = B256::from_slice(&private_key.public_key().encode());
+        let ingress = format!("127.0.0.1:{}", 9000 + seed);
+        let egress = format!("127.0.0.{}", seed + 1);
+        let fee_recipient = Address::repeat_byte(0x03);
+
+        let mut hasher = Keccak256::new();
+        hasher.update(1u64.to_be_bytes());
+        hasher.update(VALIDATOR_CONFIG_V2_ADDRESS.as_slice());
+        hasher.update(validator.as_slice());
+        hasher.update([u8::try_from(ingress.len())?]);
+        hasher.update(ingress.as_bytes());
+        hasher.update([u8::try_from(egress.len())?]);
+        hasher.update(egress.as_bytes());
+        hasher.update(fee_recipient.as_slice());
+        let message = hasher.finalize();
+        let signature = private_key
+            .sign(VALIDATOR_NS_ADD, message.as_slice())
+            .encode()
+            .to_vec();
+
+        ValidatorConfigV2::new().add_validator(
+            owner,
+            IValidatorConfigV2::addValidatorCall {
+                validatorAddress: validator,
+                publicKey: public_key,
+                ingress,
+                egress,
+                feeRecipient: fee_recipient,
+                signature: signature.into(),
+            },
+        )?;
+
+        Ok(public_key)
     }
 
     #[test]
@@ -532,12 +574,15 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut registry = FeatureRegistry::new();
+            let owner = Address::repeat_byte(0xaa);
             let validator = Address::repeat_byte(0x01);
+            initialize_validator_config_owner(owner)?;
+            let public_key = add_validator(owner, validator, 1)?;
 
             registry.set_supported_features_tip(
                 Address::ZERO,
                 IFeatureRegistry::setSupportedFeaturesTipCall {
-                    validator,
+                    publicKey: public_key,
                     featuresTip: 13,
                 },
             )?;
@@ -553,13 +598,16 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut registry = FeatureRegistry::new();
+            let owner = Address::repeat_byte(0xaa);
             let validator = Address::repeat_byte(0x01);
+            initialize_validator_config_owner(owner)?;
+            let public_key = add_validator(owner, validator, 1)?;
             registry.validator_supported_features_tip[validator].write(13)?;
 
             let result = registry.set_supported_features_tip(
                 Address::ZERO,
                 IFeatureRegistry::setSupportedFeaturesTipCall {
-                    validator,
+                    publicKey: public_key,
                     featuresTip: 12,
                 },
             );
@@ -637,7 +685,7 @@ mod tests {
             let result = registry.set_supported_features_tip(
                 Address::repeat_byte(0x02),
                 IFeatureRegistry::setSupportedFeaturesTipCall {
-                    validator,
+                    publicKey: B256::repeat_byte(0x03),
                     featuresTip: 13,
                 },
             );
@@ -654,10 +702,13 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut registry = FeatureRegistry::new();
+            let owner = Address::repeat_byte(0xaa);
             let validator = Address::repeat_byte(0x01);
+            initialize_validator_config_owner(owner)?;
+            let public_key = add_validator(owner, validator, 1)?;
 
             let call = IFeatureRegistry::setSupportedFeaturesTipCall {
-                validator,
+                publicKey: public_key,
                 featuresTip: 34,
             };
             let result = registry.call(&call.abi_encode(), Address::ZERO)?;
@@ -676,7 +727,7 @@ mod tests {
             let validator = Address::repeat_byte(0x01);
 
             let call = IFeatureRegistry::setSupportedFeaturesTipCall {
-                validator,
+                publicKey: B256::repeat_byte(0x03),
                 featuresTip: 34,
             };
             let result = registry.call(&call.abi_encode(), Address::repeat_byte(0x02))?;
@@ -695,11 +746,14 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut registry = FeatureRegistry::new();
+            let owner = Address::repeat_byte(0xaa);
             let validator = Address::repeat_byte(0x01);
+            initialize_validator_config_owner(owner)?;
+            let public_key = add_validator(owner, validator, 1)?;
             registry.validator_supported_features_tip[validator].write(34)?;
 
             let call = IFeatureRegistry::setSupportedFeaturesTipCall {
-                validator,
+                publicKey: public_key,
                 featuresTip: 33,
             };
             let result = registry.call(&call.abi_encode(), Address::ZERO)?;

--- a/crates/precompiles/src/feature_registry/mod.rs
+++ b/crates/precompiles/src/feature_registry/mod.rs
@@ -84,7 +84,7 @@ impl FeatureRegistry {
         msg_sender: Address,
         call: IFeatureRegistry::setSupportedFeaturesTipCall,
     ) -> Result<()> {
-        if msg_sender != SYSTEM_CALLER_ADDRESS {
+        if !msg_sender.is_zero() {
             return Err(FeatureRegistryError::unauthorized().into());
         }
 

--- a/crates/precompiles/src/feature_registry/mod.rs
+++ b/crates/precompiles/src/feature_registry/mod.rs
@@ -8,9 +8,11 @@ use crate::{
     storage::{Handler, Mapping},
     validator_config_v2::ValidatorConfigV2,
 };
-use alloy::primitives::{Address, U256};
+use alloy::primitives::{Address, B256, U256};
 use tempo_chainspec::epoch::block_to_epoch;
-use tempo_contracts::precompiles::{FeatureRegistryError, FeatureRegistryEvent, IFeatureRegistry};
+use tempo_contracts::precompiles::{
+    FeatureRegistryError, FeatureRegistryEvent, IFeatureRegistry, ValidatorConfigV2Error,
+};
 use tempo_precompiles_macros::contract;
 
 // Activation requires 80% support from the active validator set, represented exactly as 4/5.
@@ -79,6 +81,20 @@ impl FeatureRegistry {
         self.validator_supported_features_tip[validator].read()
     }
 
+    pub fn validator_supported_features_tip_by_public_key(&self, public_key: B256) -> Result<u64> {
+        let validator = self.validator_address_by_public_key(public_key)?;
+        self.validator_supported_features_tip(validator)
+    }
+
+    fn validator_address_by_public_key(&self, public_key: B256) -> Result<Address> {
+        let validator = ValidatorConfigV2::new().validator_by_public_key(public_key)?;
+        if validator.deactivatedAtHeight != 0 {
+            return Err(ValidatorConfigV2Error::validator_already_deactivated().into());
+        }
+
+        Ok(validator.validatorAddress)
+    }
+
     pub fn set_supported_features_tip(
         &mut self,
         msg_sender: Address,
@@ -88,12 +104,13 @@ impl FeatureRegistry {
             return Err(FeatureRegistryError::unauthorized().into());
         }
 
-        let previous = self.validator_supported_features_tip[call.validator].read()?;
+        let validator = self.validator_address_by_public_key(call.publicKey)?;
+        let previous = self.validator_supported_features_tip[validator].read()?;
         if call.featuresTip < previous {
             return Err(FeatureRegistryError::supported_features_tip_decreased().into());
         }
 
-        self.validator_supported_features_tip[call.validator].write(call.featuresTip)
+        self.validator_supported_features_tip[validator].write(call.featuresTip)
     }
 
     pub fn schedule_features_tip(


### PR DESCRIPTION
Adds block execution wiring to report the local node's highest supported protocol feature tip through FeatureRegistry when nonzero. The write is skipped when the validator has already reported that tip or a higher one, and scheduled activation now reuses the same system-call result handling.