### PR TITLE
fix(tips): allow T2 tests without address registry

### DIFF
--- a/tips/verify/test/TempoTest.t.sol
+++ b/tips/verify/test/TempoTest.t.sol
@@ -52,7 +52,6 @@ contract TempoTest is Tempo, Test {
     function setUp() public virtual {
         _requirePrecompile("AccountKeychain", KEYCHAIN);
         _requirePrecompile("TIP403Registry", TIP403_REGISTRY);
-        _requirePrecompile("AddressRegistry", ADDRESS_REGISTRY);
         _requirePrecompile("TIP20Factory", TIP20_FACTORY);
         _requirePrecompile("pathUSD", PATH_USD);
         _requirePrecompile("StablecoinDEX", STABLE_DEX);


### PR DESCRIPTION
Fixes the invariant workflow failure where `test/TIP1015.t.sol:TIP1015Test` runs under its declared `tempo:T2` hardfork but inherits `TempoTest.setUp()`, which unconditionally required the T3 `AddressRegistry` precompile.

`AddressRegistry` is not active at T2, so the base fixture should not require it for all TIP verification tests. T3+ coverage still exercises the precompile through the tests that use it directly.

Validation:
- `/home/agent/branches/foundry-rs/foundry/target/debug/forge test --match-path test/TIP1015.t.sol --mt 'test_invariant' -vvvv`\n\nPrompted by: @grandizzy