### PR TITLE
fix: apply_refunds moved and clear/create flag does not touch origin

### DIFF
--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -147,7 +147,7 @@ pub fn extend_tempo_precompiles(precompiles: &mut PrecompilesMap, cfg: &CfgEnv<T
             Some(SignatureVerifier::create_precompile(&cfg))
         } else if *address == RECEIVE_POLICY_GUARD_ADDRESS && cfg.spec.is_t6() {
             Some(ReceivePolicyGuard::create_precompile(&cfg))
-        } else if *address == STORAGE_CREDITS_ADDRESS {
+        } else if *address == STORAGE_CREDITS_ADDRESS && cfg.spec.is_t6() {
             Some(TIP1060StorageCredits::create_precompile(&cfg))
         } else {
             None

--- a/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
+++ b/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
@@ -83,8 +83,10 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
         skip_refund: true,
     };
 
-    // if new and present value are equal or if both present value are not zero, skip storage credits accounting.
-    if values.is_new_eq_present() || (!values.is_present_zero() && !values.is_new_zero()) {
+    // Only account for storage credits when the slot crosses the zero boundary
+    // (zero -> non-zero or non-zero -> zero). If both values are zero or both are
+    // non-zero, slot occupancy is unchanged, so skip storage credits accounting.
+    if values.is_present_zero() == values.is_new_zero() {
         return Ok(outcome);
     }
 

--- a/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
+++ b/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
@@ -103,16 +103,6 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
         });
     }
 
-    // 0→x: slot create (charged EIP-8037 state gas today).
-    let is_create = values.is_original_eq_present() && values.is_original_zero();
-    // x→0: slot clear (present non-zero set to zero).
-    let is_clear = values.is_new_zero() && !values.is_present_zero();
-
-    // x→y: return from instruction, nothing to be done.
-    if !(is_create || is_clear) {
-        return Ok(outcome);
-    }
-
     // Load token_state for the contract
     let warm_storage_read_cost = backend.gas_params().warm_storage_read_cost();
     backend.charge_gas(warm_storage_read_cost)?;
@@ -131,10 +121,12 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
         AccountState::from_word(storage_credit_state_load.data).map_err(|_| B::fatal_external())?;
 
     let mut was_changed = false;
-    if is_clear {
+    if values.is_new_zero() {
+        // x→0: slot clear (present non-zero set to zero).
         storage_credits.balance = storage_credits.balance.saturating_add(1);
         was_changed = true;
     } else {
+        // 0→x: slot create (charged EIP-8037 state gas today).
         match storage_credits.mode {
             CreditMode::Direct => {
                 // Only if there is a credit available, skip gas

--- a/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
+++ b/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
@@ -83,7 +83,8 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
         skip_refund: true,
     };
 
-    if values.is_new_eq_present() {
+    // if new and present value are equal or if both present value are not zero, skip storage credits accounting.
+    if values.is_new_eq_present() || (!values.is_present_zero() && !values.is_new_zero()) {
         return Ok(outcome);
     }
 

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -822,12 +822,14 @@ where
 
         let (gas_limit, reservoir) = evm.initial_gas_and_reservoir(init_and_floor_gas);
 
-        if let Some(tempo_tx_env) = evm.ctx().tx().tempo_tx_env.as_ref() {
+        let mut frame_result = if let Some(tempo_tx_env) = evm.ctx().tx().tempo_tx_env.as_ref() {
             let calls = tempo_tx_env.aa_calls.clone();
             self.execute_multi_call(evm, gas_limit, reservoir, calls)
         } else {
             self.execute_single_call(evm, gas_limit, reservoir)
-        }
+        }?;
+        tip1060::apply_refund(evm, frame_result.gas_mut())?;
+        Ok(frame_result)
     }
 
     /// Take logs from the Journal if outcome is Halt Or Revert.
@@ -1532,22 +1534,6 @@ where
             }
         }
 
-        Ok(())
-    }
-
-    #[inline]
-    fn last_frame_result(
-        &mut self,
-        evm: &mut Self::Evm,
-        original_reservoir: u64,
-        frame_result: &mut FrameResult,
-    ) -> Result<(), Self::Error> {
-        MainnetHandler::<_, Self::Error, _>::default().last_frame_result(
-            evm,
-            original_reservoir,
-            frame_result,
-        )?;
-        tip1060::apply_refund(evm, frame_result.gas_mut())?;
         Ok(())
     }
 
@@ -2355,12 +2341,14 @@ where
 
         let (gas_limit, reservoir) = evm.initial_gas_and_reservoir(init_and_floor_gas);
 
-        if let Some(tempo_tx_env) = evm.ctx().tx().tempo_tx_env.as_ref() {
+        let mut frame_result = if let Some(tempo_tx_env) = evm.ctx().tx().tempo_tx_env.as_ref() {
             let calls = tempo_tx_env.aa_calls.clone();
             self.inspect_execute_multi_call(evm, gas_limit, reservoir, calls)
         } else {
             self.inspect_execute_single_call(evm, gas_limit, reservoir)
-        }
+        }?;
+        tip1060::apply_refund(evm, frame_result.gas_mut())?;
+        Ok(frame_result)
     }
 }
 


### PR DESCRIPTION
Fixes for found bugs:
- apply_refund moved after exec loop
- is_clear and is_create now take into account only new value and not original value. (Checks for new != present is done few lines before).
- t6 check in precompile activation