### PR TITLE
fix(node): set tempo pruning and static-file defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12590,6 +12590,7 @@ dependencies = [
  "reth-node-builder",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-prune-types",
  "reth-rpc-server-types",
  "reth-storage-api",
  "reth-trie",

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -85,6 +85,7 @@ reth-network-peers.workspace = true
 reth-node-builder.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
+reth-prune-types.workspace = true
 reth-rpc-server-types.workspace = true
 secp256k1.workspace = true
 reth-storage-api.workspace = true

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -14,7 +14,7 @@ use url::Url;
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/4217";
 const SNAPSHOT_API_URL: &str = "https://snapshots.tempoxyz.dev/api/snapshots";
 const MINIMAL_PRUNING_DISTANCE: u64 = 86_401;
-const MINIMAL_BLOCKS_PER_STATIC_FILE: u64 = 50_000;
+const DEFAULT_BLOCKS_PER_STATIC_FILE: u64 = 50_000;
 
 /// Default OTLP logs filter level for telemetry.
 const DEFAULT_LOGS_OTLP_FILTER: &str = "debug";
@@ -220,25 +220,25 @@ fn init_pruning_defaults() {
         .expect("failed to initialize pruning defaults");
 }
 
-pub(crate) fn apply_minimal_static_file_defaults(static_files: &mut StaticFilesArgs) {
+pub(crate) fn apply_static_file_defaults(static_files: &mut StaticFilesArgs) {
     static_files
         .blocks_per_file_headers
-        .get_or_insert(MINIMAL_BLOCKS_PER_STATIC_FILE);
+        .get_or_insert(DEFAULT_BLOCKS_PER_STATIC_FILE);
     static_files
         .blocks_per_file_transactions
-        .get_or_insert(MINIMAL_BLOCKS_PER_STATIC_FILE);
+        .get_or_insert(DEFAULT_BLOCKS_PER_STATIC_FILE);
     static_files
         .blocks_per_file_receipts
-        .get_or_insert(MINIMAL_BLOCKS_PER_STATIC_FILE);
+        .get_or_insert(DEFAULT_BLOCKS_PER_STATIC_FILE);
     static_files
         .blocks_per_file_transaction_senders
-        .get_or_insert(MINIMAL_BLOCKS_PER_STATIC_FILE);
+        .get_or_insert(DEFAULT_BLOCKS_PER_STATIC_FILE);
     static_files
         .blocks_per_file_account_change_sets
-        .get_or_insert(MINIMAL_BLOCKS_PER_STATIC_FILE);
+        .get_or_insert(DEFAULT_BLOCKS_PER_STATIC_FILE);
     static_files
         .blocks_per_file_storage_change_sets
-        .get_or_insert(MINIMAL_BLOCKS_PER_STATIC_FILE);
+        .get_or_insert(DEFAULT_BLOCKS_PER_STATIC_FILE);
 }
 
 fn init_engine_defaults() {

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -13,6 +13,7 @@ use url::Url;
 
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/4217";
 const SNAPSHOT_API_URL: &str = "https://snapshots.tempoxyz.dev/api/snapshots";
+/// One Tempo epoch length plus one block.
 const MINIMAL_PRUNING_DISTANCE: u64 = 86_401;
 const DEFAULT_BLOCKS_PER_STATIC_FILE: u64 = 50_000;
 

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -4,14 +4,17 @@ use jiff::SignedDuration;
 use reth_cli_commands::download::DownloadDefaults;
 use reth_ethereum::node::core::args::{
     DefaultDiscoveryArgs, DefaultEngineValues, DefaultNetworkArgs, DefaultPayloadBuilderValues,
-    DefaultTraceValues, DefaultTxPoolValues,
+    DefaultPruningValues, DefaultTraceValues, DefaultTxPoolValues, StaticFilesArgs,
 };
+use reth_prune_types::{MINIMUM_DISTANCE, PruneMode, PruneModes};
 use std::{borrow::Cow, str::FromStr, time::Duration};
 use tempo_chainspec::hardfork::TempoHardfork;
 use url::Url;
 
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/4217";
 const SNAPSHOT_API_URL: &str = "https://snapshots.tempoxyz.dev/api/snapshots";
+const MINIMAL_PRUNING_DISTANCE: u64 = 86_401;
+const MINIMAL_BLOCKS_PER_STATIC_FILE: u64 = 50_000;
 
 /// Default OTLP logs filter level for telemetry.
 const DEFAULT_LOGS_OTLP_FILTER: &str = "debug";
@@ -198,6 +201,46 @@ fn init_txpool_defaults() {
         .expect("failed to initialize txpool defaults");
 }
 
+fn minimal_prune_modes() -> PruneModes {
+    PruneModes {
+        sender_recovery: Some(PruneMode::Full),
+        transaction_lookup: Some(PruneMode::Full),
+        receipts: Some(PruneMode::Distance(MINIMUM_DISTANCE)),
+        account_history: Some(PruneMode::Distance(MINIMAL_PRUNING_DISTANCE)),
+        storage_history: Some(PruneMode::Distance(MINIMAL_PRUNING_DISTANCE)),
+        bodies_history: Some(PruneMode::Distance(MINIMAL_PRUNING_DISTANCE)),
+        receipts_log_filter: Default::default(),
+    }
+}
+
+fn init_pruning_defaults() {
+    DefaultPruningValues::default()
+        .with_minimal_prune_modes(minimal_prune_modes())
+        .try_init()
+        .expect("failed to initialize pruning defaults");
+}
+
+pub(crate) fn apply_minimal_static_file_defaults(static_files: &mut StaticFilesArgs) {
+    static_files
+        .blocks_per_file_headers
+        .get_or_insert(MINIMAL_BLOCKS_PER_STATIC_FILE);
+    static_files
+        .blocks_per_file_transactions
+        .get_or_insert(MINIMAL_BLOCKS_PER_STATIC_FILE);
+    static_files
+        .blocks_per_file_receipts
+        .get_or_insert(MINIMAL_BLOCKS_PER_STATIC_FILE);
+    static_files
+        .blocks_per_file_transaction_senders
+        .get_or_insert(MINIMAL_BLOCKS_PER_STATIC_FILE);
+    static_files
+        .blocks_per_file_account_change_sets
+        .get_or_insert(MINIMAL_BLOCKS_PER_STATIC_FILE);
+    static_files
+        .blocks_per_file_storage_change_sets
+        .get_or_insert(MINIMAL_BLOCKS_PER_STATIC_FILE);
+}
+
 fn init_engine_defaults() {
     DefaultEngineValues::default()
         // In Commonware consensus, it might happen that a head is notarized (causing it to become a canonical tip for reth),
@@ -260,6 +303,7 @@ pub(crate) fn init_defaults() {
     init_download_urls();
     init_payload_builder_defaults();
     init_txpool_defaults();
+    init_pruning_defaults();
     init_engine_defaults();
     init_trace_defaults();
     init_otlp_defaults();

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -347,6 +347,12 @@ fn main() -> eyre::Result<()> {
         }
     };
 
+    if let Commands::Node(node_cmd) = &mut cli.command
+        && node_cmd.pruning.minimal
+    {
+        defaults::apply_minimal_static_file_defaults(&mut node_cmd.static_files);
+    }
+
     if let Commands::Node(node_cmd) = &cli.command
         && node_cmd.engine.share_sparse_trie_with_payload_builder
         && node_cmd.builder.max_payload_tasks != 1

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -347,10 +347,8 @@ fn main() -> eyre::Result<()> {
         }
     };
 
-    if let Commands::Node(node_cmd) = &mut cli.command
-        && node_cmd.pruning.minimal
-    {
-        defaults::apply_minimal_static_file_defaults(&mut node_cmd.static_files);
+    if let Commands::Node(node_cmd) = &mut cli.command {
+        defaults::apply_static_file_defaults(&mut node_cmd.static_files);
     }
 
     if let Commands::Node(node_cmd) = &cli.command


### PR DESCRIPTION
Updates Tempo's `--minimal` preset to keep 86,401 blocks for account history, storage history, and bodies while preserving Reth's receipt safety distance. Tempo now defaults every static-file segment to 50,000 blocks for node runs unless a per-segment CLI value is provided.

Validated with `cargo fmt --all` and `LC_ALL=C LANG=C LC_CTYPE=C cargo check -p tempo`.