### PR TITLE
Keep T7 inactive by default

### DIFF
--- a/crates/chainspec/src/genesis/dev.json
+++ b/crates/chainspec/src/genesis/dev.json
@@ -30,7 +30,7 @@
     "t4Time": 0,
     "t5Time": 0,
     "t6Time": 0,
-    "t7Time": 0,
+    "t7Time": 9223372036854775807,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/crates/node/tests/assets/test-genesis.json
+++ b/crates/node/tests/assets/test-genesis.json
@@ -30,7 +30,7 @@
     "t4Time": 0,
     "t5Time": 0,
     "t6Time": 0,
-    "t7Time": 0,
+    "t7Time": 9223372036854775807,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/crates/node/tests/it/fork_schedule.rs
+++ b/crates/node/tests/it/fork_schedule.rs
@@ -71,12 +71,18 @@ async fn test_is_hardfork_active() -> eyre::Result<()> {
     let setup = TestNodeBuilder::new().build_http_only().await?;
     let provider = ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(setup.http_url);
 
-    // Devnet activates all forks at t=0, so every known hardfork should be active.
+    // Devnet activates stable forks at t=0, but scaffolded future forks stay inactive until
+    // explicitly scheduled.
     for fork in TempoHardfork::VARIANTS {
-        assert!(
-            provider.is_hardfork_active(*fork).await?,
-            "{fork:?} should be active on devnet",
-        );
+        let active = provider.is_hardfork_active(*fork).await?;
+        if *fork == TempoHardfork::T7 {
+            assert!(
+                !active,
+                "{fork:?} should not be active on devnet by default"
+            );
+        } else {
+            assert!(active, "{fork:?} should be active on devnet");
+        }
     }
 
     Ok(())

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -47,12 +47,12 @@ impl ForkSchedule {
 
     /// Returns whether the given Tempo hardfork is active for this schedule.
     ///
-    /// For [`Devnet`](Self::Devnet) all forks from the dev genesis are active.
+    /// For [`Devnet`](Self::Devnet) stable forks from the dev genesis are active.
     /// For other schedules, a fork is active only if its timestamp in the
     /// reference genesis is in the past.
     pub(crate) fn is_active(&self, fork: TempoHardfork) -> bool {
         let Some(reference_json) = self.reference_genesis() else {
-            return true; // devnet: all forks active
+            return fork != TempoHardfork::T7; // devnet: T7 is scaffolded but not active by default
         };
         let reference: serde_json::Value =
             serde_json::from_str(reference_json).expect("reference genesis must parse");

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -187,7 +187,7 @@ pub(crate) struct GenesisArgs {
     t6_time: u64,
 
     /// T7 hardfork activation time.
-    #[arg(long, default_value = "0")]
+    #[arg(long, default_value = "9223372036854775807")]
     t7_time: u64,
 }
 


### PR DESCRIPTION
## Summary
- set dev/test genesis `t7Time` to the disabled future timestamp
- make `generate-genesis` default T7 activation to the disabled timestamp unless explicitly provided
- update devnet fork-schedule tests/helpers to treat T7 as scaffolded but inactive by default

## Testing
- `cargo check -p tempo-chainspec`
- `cargo test -p tempo-node test_is_hardfork_active --test it -- --nocapture`
- `cargo test -p tempo-chainspec test_from_genesis_with_hardforks_at_zero -- --nocapture`
- `cargo fmt --check`
- `git diff --check`