### PR TITLE
fix(rpc): reject 2D-nonce gas estimation when `from` is missing

### DIFF
--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -356,9 +356,15 @@ impl<N: FullNodeTypes<Types = TempoNode>> Call for TempoEthApi<N> {
             let nonce = if nonce_key == TEMPO_EXPIRING_NONCE_KEY {
                 0 // expiring nonce must be 0
             } else {
-                // 2D nonce: fetch from storage
-                let slot =
-                    NonceManager::new().nonces[request.from.unwrap_or_default()][nonce_key].slot();
+                // 2D nonce: fetch from storage. Mirror `next_available_nonce_for` and reject when
+                // `from` is missing rather than reading the zero-address nonce slot, which yields a
+                // wrong nonce (and therefore wrong gas estimates / simulation results).
+                let from = if let Some(from) = request.from {
+                    from
+                } else {
+                    return Err(SignError::NoAccount.into_eth_err());
+                };
+                let slot = NonceManager::new().nonces[from][nonce_key].slot();
                 db.storage(NONCE_PRECOMPILE_ADDRESS, slot)
                     .map_err(Into::into)?
                     .saturating_to()

--- a/crates/node/tests/it/eth_call.rs
+++ b/crates/node/tests/it/eth_call.rs
@@ -758,3 +758,50 @@ async fn test_tip20_name_state_override_no_oom() -> eyre::Result<()> {
     provider.get_block_number().await?;
     Ok(())
 }
+
+/// Regression test for 2D-nonce gas estimation: an `eth_estimateGas` request that sets a
+/// non-zero `nonceKey` but omits `from` must be rejected with `SignError::NoAccount`
+/// ("unknown account"). Previously `create_txn_env` defaulted the missing sender to the
+/// zero address and read its nonce slot, silently returning a bogus estimate.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_estimate_gas_2d_nonce_without_from_is_rejected() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let provider = ProviderBuilder::new().connect_http(setup.http_url);
+
+    let recipient = Address::random();
+
+    // 2D nonce key (non-zero, not the expiring-nonce sentinel) without a `from` address.
+    let params_without_from = serde_json::json!({
+        "to": recipient,
+        "nonceKey": "0x1",
+    });
+    let err = provider
+        .raw_request::<_, String>("eth_estimateGas".into(), [params_without_from])
+        .await
+        .expect_err("estimateGas with nonceKey but no from must be rejected");
+    assert!(
+        err.to_string().to_lowercase().contains("unknown account"),
+        "expected NoAccount (\"unknown account\") error, got: {err}"
+    );
+
+    // Control: the same request with `from` set must not be rejected as NoAccount.
+    let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
+    let params_with_from = serde_json::json!({
+        "from": wallet.address(),
+        "to": recipient,
+        "nonceKey": "0x1",
+    });
+    if let Err(err) = provider
+        .raw_request::<_, String>("eth_estimateGas".into(), [params_with_from])
+        .await
+    {
+        assert!(
+            !err.to_string().to_lowercase().contains("unknown account"),
+            "request with from must not be rejected as NoAccount, got: {err}"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
`create_txn_env` defaulted a missing `from` to the zero address when a request
set a non-zero `nonceKey` without an explicit `nonce`, then read the zero-address
nonce slot and returned a bogus gas estimate / simulation result.

Now it returns `SignError::NoAccount` ("unknown account") when `from` is absent,
mirroring the existing handling in `next_available_nonce_for`.

Adds an integration test: `eth_estimateGas` with `nonceKey` but no `from` is
rejected as "unknown account".