### PR TITLE
Add chrome trace uploads for Derek benches

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -239,6 +239,10 @@ on:
         type: string
         required: false
         default: "false"
+      tracing-chrome:
+        type: string
+        required: false
+        default: "false"
       tracy:
         type: string
         required: false
@@ -377,6 +381,7 @@ jobs:
       BENCH_FEATURE_HARDFORK: ${{ inputs.feature-hardfork }}
       BENCH_TXGEN_REF: ${{ inputs.txgen-ref }}
       BENCH_SAMPLY: ${{ inputs.profiling == 'Samply' || inputs.profiling == 'Both' || inputs.samply == true || inputs.samply == 'true' }}
+      BENCH_TRACING_CHROME: ${{ inputs.tracing-chrome == true || inputs.tracing-chrome == 'true' }}
       BENCH_TRACY: ${{ (inputs.profiling == 'Tracy' || inputs.profiling == 'Both') && 'on' || ((inputs.profiling == 'Off' || inputs.profiling == 'Samply') && 'off' || inputs.tracy) }}
       BENCH_TRACY_SECONDS: ${{ inputs.tracy-seconds || '30' }}
       BENCH_TRACY_OFFSET: ${{ inputs.tracy-offset || '120' }}
@@ -788,6 +793,7 @@ jobs:
           [ "$BENCH_FORCE_BLOAT" = "true" ] && cmd+=(--force-bloat)
           [ "$BENCH_NO_CACHE" = "true" ] && cmd+=(--no-cache)
           [ "$BENCH_SAMPLY" = "true" ] && cmd+=(--samply)
+          [ "$BENCH_TRACING_CHROME" = "true" ] && cmd+=(--tracing-chrome)
           [ "$BENCH_TRACY" != "off" ] && cmd+=(--tracy "$BENCH_TRACY" --tracy-seconds "$BENCH_TRACY_SECONDS" --tracy-offset "$BENCH_TRACY_OFFSET")
           [ -n "$BENCH_BASELINE_HARDFORK" ] && cmd+=(--baseline-hardfork="$BENCH_BASELINE_HARDFORK")
           [ -n "$BENCH_FEATURE_HARDFORK" ] && cmd+=(--feature-hardfork="$BENCH_FEATURE_HARDFORK")
@@ -857,6 +863,7 @@ jobs:
           )
           [ -n "$BENCH_TXGEN_REF" ] && derek_cmd+=(txgen-ref="$BENCH_TXGEN_REF")
           [ "$BENCH_SAMPLY" = "true" ] && derek_cmd+=(samply)
+          [ "$BENCH_TRACING_CHROME" = "true" ] && derek_cmd+=(tracing-chrome)
           [ "$BENCH_TRACY" != "off" ] && derek_cmd+=(tracy="$BENCH_TRACY" tracy-seconds="$BENCH_TRACY_SECONDS" tracy-offset="$BENCH_TRACY_OFFSET")
           [ -n "$BENCH_BASELINE_FEATURES" ] && derek_cmd+=(baseline-features="$BENCH_BASELINE_FEATURES")
           [ -n "$BENCH_FEATURE_FEATURES" ] && derek_cmd+=(feature-features="$BENCH_FEATURE_FEATURES")
@@ -1052,8 +1059,22 @@ jobs:
               }
             }
 
+            let chromeTraceSection = '';
+            if (process.env.BENCH_TRACING_CHROME === 'true') {
+              const links = [];
+              for (const run of runs) {
+                try {
+                  const url = fs.readFileSync(`${resultsDir}/chrome-trace-${run}-url.txt`, 'utf8').trim();
+                  if (url) links.push(`- **${run}**: [Perfetto](${url})`);
+                } catch (e) {}
+              }
+              if (links.length > 0) {
+                chromeTraceSection = `\n\n### Chrome Traces\n\n${links.join('\n')}\n`;
+              }
+            }
+
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = `cc @${process.env.BENCH_ACTOR}\n\n${resultHeadline} [View job](${jobUrl})\n\n${summary}${grafanaSection}${samplySection}${tracySection}`;
+            const body = `cc @${process.env.BENCH_ACTOR}\n\n${resultHeadline} [View job](${jobUrl})\n\n${summary}${grafanaSection}${samplySection}${tracySection}${chromeTraceSection}`;
             const ackCommentId = process.env.BENCH_COMMENT_ID;
 
             if (ackCommentId) {

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -45,6 +45,7 @@ jobs:
       baseline-name: ${{ steps.args.outputs.baseline-name }}
       feature-name: ${{ steps.args.outputs.feature-name }}
       samply: ${{ steps.args.outputs.samply }}
+      tracing-chrome: ${{ steps.args.outputs.tracing-chrome }}
       tracy: ${{ steps.args.outputs.tracy }}
       tracy-seconds: ${{ steps.args.outputs.tracy-seconds }}
       tracy-offset: ${{ steps.args.outputs.tracy-offset }}
@@ -111,7 +112,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
-            let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, baselineFeatures, featureFeatures, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, valscope, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs;
+            let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, baselineFeatures, featureFeatures, txgenRef, samply, tracingChrome, tracy, tracySeconds, tracyOffset, otlp, valscope, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs;
             let explicitWarmup = false;
             let explicitDuration = false;
             let explicitRunPairs = false;
@@ -123,10 +124,10 @@ jobs:
             const intArgs = new Set(['duration', 'bloat', 'tps', 'accounts', 'max-concurrent-requests', 'gas-limit', 'tracy-seconds', 'tracy-offset', 'blocks', 'warmup', 'run-pairs']);
             const refArgs = new Set(['baseline', 'feature', 'txgen-ref']);
             const stringArgs = new Set(['mode', 'preset', 'tracy', 'baseline-args', 'feature-args', 'baseline-features', 'feature-features', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain', 'baseline-hardfork', 'feature-hardfork']);
-            const boolArgs = new Set(['samply', 'force-bloat', 'no-cache', 'no-slack', 'otlp', 'valscope']);
+            const boolArgs = new Set(['samply', 'tracing-chrome', 'force-bloat', 'no-cache', 'no-slack', 'otlp', 'valscope']);
             const bloatValues = new Set(['1', '10', '100']);
             const hardforkValues = new Set(['T0', 'T1', 'T1A', 'T1B', 'T1C', 'T2', 'T3', 'T4', 'T5', 'T6']);
-            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '50000', accounts: '1000', 'max-concurrent-requests': '500', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'baseline-features': '', 'feature-features': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'true', valscope: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2' };
+            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '50000', accounts: '1000', 'max-concurrent-requests': '500', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'baseline-features': '', 'feature-features': '', 'txgen-ref': '', samply: 'false', 'tracing-chrome': 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'true', valscope: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2' };
             const unknown = [];
             const invalid = [];
             const defaultWarmup = (blockCount) => String(Math.floor(Number(blockCount) / 4));
@@ -233,6 +234,7 @@ jobs:
             featureFeatures = defaults['feature-features'];
             txgenRef = defaults['txgen-ref'];
             samply = defaults.samply;
+            tracingChrome = defaults['tracing-chrome'];
             tracy = defaults.tracy;
             tracySeconds = defaults['tracy-seconds'];
             tracyOffset = defaults['tracy-offset'];
@@ -261,7 +263,7 @@ jobs:
               warmup = defaultWarmup(blocks);
             }
 
-            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [otlp] [valscope] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
+            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [tracing-chrome] [otlp] [valscope] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 
             // Validate chain value
             if (!['mainnet', 'testnet'].includes(chain)) {
@@ -346,6 +348,9 @@ jobs:
               core.setFailed(msg);
               return;
             }
+            if (tracingChrome === 'true') {
+              otlp = 'true';
+            }
             if (Number(runPairs) < 1) {
               const msg = `❌ **Invalid bench command**\n\n\`run-pairs=${runPairs}\` is not valid. Must be a positive integer.\n\n${usageStr}`;
               await github.rest.issues.createComment({
@@ -393,6 +398,7 @@ jobs:
             core.setOutput('baseline-name', baselineName);
             core.setOutput('feature-name', featureName);
             core.setOutput('samply', samply);
+            core.setOutput('tracing-chrome', tracingChrome);
             core.setOutput('tracy', tracy);
             core.setOutput('tracy-seconds', tracySeconds);
             core.setOutput('tracy-offset', tracyOffset);
@@ -435,6 +441,7 @@ jobs:
           ACK_FEATURE_FEATURES: ${{ steps.args.outputs.feature-features }}
           ACK_TXGEN_REF: ${{ steps.args.outputs.txgen-ref }}
           ACK_SAMPLY: ${{ steps.args.outputs.samply }}
+          ACK_TRACING_CHROME: ${{ steps.args.outputs.tracing-chrome }}
           ACK_TRACY: ${{ steps.args.outputs.tracy }}
           ACK_OTLP: ${{ steps.args.outputs.otlp }}
           ACK_VALSCOPE: ${{ steps.args.outputs.valscope }}
@@ -477,6 +484,8 @@ jobs:
             const txgenRef = process.env.ACK_TXGEN_REF || 'default';
             const samply = process.env.ACK_SAMPLY === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const tracingChrome = process.env.ACK_TRACING_CHROME === 'true';
+            const chromeTraceNote = tracingChrome ? ', tracing-chrome: `enabled`' : '';
             const tracy = process.env.ACK_TRACY;
             const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
             const otlp = process.env.ACK_OTLP === 'true';
@@ -492,7 +501,7 @@ jobs:
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
             const featureFlagsNote = `${baselineFeatureFlags ? `, baseline-features: \`${baselineFeatureFlags}\`` : ''}${featureFeatureFlags ? `, feature-features: \`${featureFeatureFlags}\`` : ''}`;
-            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${naNote}${noCacheNote}`;
+            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${chromeTraceNote}${tracyNote}${otlpNote}${valscopeNote}${naNote}${noCacheNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -526,6 +535,7 @@ jobs:
       baseline-name: ${{ needs.tempo-bench-ack.outputs.baseline-name }}
       feature-name: ${{ needs.tempo-bench-ack.outputs.feature-name }}
       samply: ${{ needs.tempo-bench-ack.outputs.samply }}
+      tracing-chrome: ${{ needs.tempo-bench-ack.outputs.tracing-chrome }}
       tracy: ${{ needs.tempo-bench-ack.outputs.tracy }}
       tracy-seconds: ${{ needs.tempo-bench-ack.outputs.tracy-seconds }}
       tracy-offset: ${{ needs.tempo-bench-ack.outputs.tracy-offset }}

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1182,6 +1182,7 @@ def "main e2e" [
     --tracy-seconds: int = 30                           # Tracy capture duration limit in seconds
     --tracy-offset: int = 120                           # Seconds to wait before starting tracy capture
     --tracing-otlp: string = ""                         # OTLP endpoint for tracing (auto-derived from GRAFANA_TEMPO/TEMPO_TELEMETRY_URL)
+    --tracing-chrome                                    # Export Tempo spans as Chrome trace JSON and upload Perfetto links
     --victoriametrics-url: string = ""                  # VictoriaMetrics base URL for txgen metric sample import
     --clickhouse-url: string = ""                       # ClickHouse HTTP endpoint for txgen result upload
     --clickhouse-run: string = "feature-1"              # Run label allowed to use the ClickHouse reporter; empty = every run
@@ -1486,6 +1487,8 @@ def "main e2e" [
         tracy_filter: $tracy_filter
         tracy_seconds: $tracy_seconds
         tracy_offset: $tracy_offset
+        tracing_chrome: $tracing_chrome
+        tracing_otlp: $tracing_otlp
         baseline_args: $baseline_args
         feature_args: $feature_args
         bench_args: $bench_args
@@ -1575,6 +1578,19 @@ def "main e2e" [
             let viewer_url = (upload-tracy-profile $profile $run.phase $run.ref)
             if $viewer_url != null {
                 $viewer_url | save -f $"($results_dir)/tracy-($run.phase)-url.txt"
+            }
+        }
+    }
+    if $e2e_exit == 0 and $tracing_chrome {
+        print "\nExporting local e2e chrome traces for Perfetto..."
+        let end_epoch = ((date now | into int) / 1_000_000_000 | into int)
+        for run in $runs {
+            let trace = $"($results_dir)/chrome-trace-($run.phase).json"
+            if (export-chrome-trace $tracing_otlp $benchmark_id $run.phase $reference_epoch $end_epoch $trace) {
+                let viewer_url = (upload-chrome-trace $trace $run.phase $run.ref)
+                if $viewer_url != null {
+                    $viewer_url | save -f $"($results_dir)/chrome-trace-($run.phase)-url.txt"
+                }
             }
         }
     }

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -58,6 +58,7 @@ def run-txgen-bench-single [
     --tracy-seconds: int = 0
     --tracy-offset: int = 0
     --tracing-otlp: string = ""
+    --tracing-chrome
 ] {
     print $"=== Starting txgen run: ($run_label) ==="
 
@@ -89,7 +90,7 @@ def run-txgen-bench-single [
     } else { [] }
     let node_cmd = wrap-samply [$tempo_bin ...$args] $samply $full_samply_args
     let node_cmd_str = ($node_cmd | str join " ")
-    let profiling_label = if $samply { " (samply)" } else if $tracy != "off" { $" \(tracy=($tracy)\)" } else { "" }
+    let profiling_label = if $samply { " (samply)" } else if $tracy != "off" { $" \(tracy=($tracy)\)" } else if $tracing_chrome { " (tracing-chrome)" } else { "" }
     let env_prefix = if $extra_env != "" { $"($extra_env) " } else { "" }
     print $"  Starting node: ($tempo_bin | path basename)($profiling_label)"
     job spawn { sh -c $"($env_prefix)($otel_attrs)($tracy_env_prefix)($node_cmd_str) 2>&1" | lines | each { |line| print $"[($run_label)] ($line)" } }
@@ -209,6 +210,7 @@ def "main run" [
     --max-concurrent-requests: int = 100
     --samply
     --samply-args: string = ""
+    --tracing-chrome
     --loud
     --profile: string = $DEFAULT_PROFILE
     --features: string = $DEFAULT_FEATURES
@@ -270,6 +272,9 @@ def "main run" [
     let tracy = (normalize-tracy-mode $tracy)
     if $samply and $tracy != "off" {
         error make { msg: "--samply and --tracy are mutually exclusive" }
+    }
+    if $tracing_chrome and $tracing_otlp == "" {
+        error make { msg: "--tracing-chrome requires --tracing-otlp or TEMPO_TELEMETRY_URL/GRAFANA_TEMPO" }
     }
     if $tracy != "off" and ((which tracy-capture | length) == 0) {
         error make { msg: "tracy-capture not found in PATH" }
@@ -573,6 +578,7 @@ def "main run" [
             --tracy-seconds $tracy_seconds
             --tracy-offset $tracy_offset
             --tracing-otlp $tracing_otlp
+            --tracing-chrome=$tracing_chrome
             --platform $platform
             --scenario $resolved_scenario)
     }
@@ -604,6 +610,20 @@ def "main run" [
             let viewer_url = (upload-tracy-profile $profile $run.label $run.git_ref)
             if $viewer_url != null {
                 $viewer_url | save -f $"($results_dir)/tracy-($run.label)-url.txt"
+            }
+        }
+    }
+
+    if $tracing_chrome {
+        print "\nExporting chrome traces for Perfetto..."
+        let end_epoch = ((date now | into int) / 1_000_000_000 | into int)
+        for run in $runs {
+            let trace = $"($results_dir)/chrome-trace-($run.label).json"
+            if (export-chrome-trace $tracing_otlp $benchmark_id $run.label $reference_epoch $end_epoch $trace) {
+                let url = (upload-chrome-trace $trace $run.label $run.git_ref)
+                if $url != null {
+                    $url | save -f $"($results_dir)/chrome-trace-($run.label)-url.txt"
+                }
             }
         }
     }

--- a/contrib/bench/export-chrome-trace.py
+++ b/contrib/bench/export-chrome-trace.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Export Tempo OTLP spans as Chrome trace JSON for Perfetto."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.parse
+import urllib.request
+
+
+def get_json(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=60) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def normalize_tempo_base(url: str) -> str:
+    url = url.rstrip("/")
+    for suffix in ("/opentelemetry/v1/traces", "/v1/traces"):
+        if url.endswith(suffix):
+            return url[: -len(suffix)]
+    return url
+
+
+def tempo_url(base: str, path: str, params: dict[str, str]) -> str:
+    base = base.rstrip("/")
+    if params:
+        return f"{base}{path}?{urllib.parse.urlencode(params)}"
+    return f"{base}{path}"
+
+
+def attr_map(attrs: list[dict]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for attr in attrs:
+        key = attr.get("key")
+        value = attr.get("value", {})
+        if not key:
+            continue
+        if "stringValue" in value:
+            out[key] = value["stringValue"]
+        elif "intValue" in value:
+            out[key] = str(value["intValue"])
+        elif "boolValue" in value:
+            out[key] = str(value["boolValue"])
+    return out
+
+
+def value_for_attr(value: dict) -> object:
+    for key in ("stringValue", "intValue", "doubleValue", "boolValue"):
+        if key in value:
+            return value[key]
+    if "arrayValue" in value:
+        return value["arrayValue"]
+    if "kvlistValue" in value:
+        return value["kvlistValue"]
+    return value
+
+
+def span_events(trace: dict) -> list[dict]:
+    events: list[dict] = []
+    process_names: dict[int, str] = {}
+    thread_names: set[tuple[int, int, str]] = set()
+
+    for resource_span in trace.get("resourceSpans", []):
+        resource_attrs = attr_map(resource_span.get("resource", {}).get("attributes", []))
+        service = resource_attrs.get("service.name", "tempo")
+        run = resource_attrs.get("benchmark_run", resource_attrs.get("benchmark_id", "bench"))
+        pid = abs(hash(service)) % 100000
+        tid = abs(hash(run)) % 100000
+        process_names[pid] = service
+        thread_names.add((pid, tid, run))
+
+        for scope_span in resource_span.get("scopeSpans", []):
+            for span in scope_span.get("spans", []):
+                start = int(span.get("startTimeUnixNano", "0"))
+                end = int(span.get("endTimeUnixNano", "0"))
+                if start <= 0 or end <= start:
+                    continue
+                args = resource_attrs.copy()
+                args.update(
+                    {
+                        attr["key"]: value_for_attr(attr.get("value", {}))
+                        for attr in span.get("attributes", [])
+                        if "key" in attr
+                    }
+                )
+                events.append(
+                    {
+                        "name": span.get("name", "span"),
+                        "cat": scope_span.get("scope", {}).get("name", "tracing"),
+                        "ph": "X",
+                        "ts": start / 1000,
+                        "dur": (end - start) / 1000,
+                        "pid": pid,
+                        "tid": tid,
+                        "args": args,
+                    }
+                )
+
+    for pid, name in process_names.items():
+        events.append({"name": "process_name", "ph": "M", "pid": pid, "args": {"name": name}})
+    for pid, tid, name in thread_names:
+        events.append({"name": "thread_name", "ph": "M", "pid": pid, "tid": tid, "args": {"name": name}})
+
+    return events
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tempo-url", required=True)
+    parser.add_argument("--benchmark-id", required=True)
+    parser.add_argument("--run-label", required=True)
+    parser.add_argument("--start", type=int, required=True, help="Unix seconds")
+    parser.add_argument("--end", type=int, required=True, help="Unix seconds")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    query = f'{{resource.benchmark_id="{args.benchmark_id}" && resource.benchmark_run="{args.run_label}"}}'
+    tempo_base = normalize_tempo_base(args.tempo_url)
+    search_url = tempo_url(
+        tempo_base,
+        "/api/search",
+        {"q": query, "start": str(args.start), "end": str(args.end), "limit": "100"},
+    )
+    search = get_json(search_url)
+    traces = search.get("traces", [])
+    if not traces:
+        print(f"no traces found for {args.benchmark_id}/{args.run_label}", file=sys.stderr)
+        return 2
+
+    events: list[dict] = []
+    for trace in traces:
+        trace_id = trace.get("traceID") or trace.get("traceId")
+        if not trace_id:
+            continue
+        trace_url = tempo_url(tempo_base, f"/api/traces/{trace_id}", {})
+        events.extend(span_events(get_json(trace_url)))
+
+    if not events:
+        print(f"no span events found for {args.benchmark_id}/{args.run_label}", file=sys.stderr)
+        return 3
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump({"traceEvents": events, "displayTimeUnit": "ns"}, f)
+    print(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tempo.nu
+++ b/tempo.nu
@@ -860,6 +860,52 @@ def upload-tracy-profile [profile_path: string, label: string, commit_sha: strin
     }
 }
 
+# Upload a Chrome trace JSON file to R2 and return a Perfetto UI URL.
+def upload-chrome-trace [trace_path: string, label: string, commit_sha: string] {
+    if not ($trace_path | path exists) {
+        print $"  Warning: chrome trace not found: ($trace_path)"
+        return null
+    }
+    if not (has-mc) {
+        print "  Warning: mc not available, skipping chrome trace upload"
+        return null
+    }
+
+    let trace_size = (ls $trace_path | get size | first)
+    print $"  Uploading ($trace_path | path basename) \(($trace_size)\) to R2..."
+
+    let timestamp = (date now | format date "%Y%m%d-%H%M%S")
+    let short_sha = ($commit_sha | str substring 0..7)
+    let remote_name = $"($label)-($short_sha)-($timestamp).json"
+    let mc_alias = "r2"
+    let public_url = $"https://tracy.tempoxyz.dev/chrome-traces/($remote_name)"
+    let perfetto_url = $"https://ui.perfetto.dev/#!/?url=($public_url | url encode)"
+
+    try {
+        mc cp $trace_path $"($mc_alias)/tracy/chrome-traces/($remote_name)"
+        print $"  ($label): ($perfetto_url)"
+        $perfetto_url
+    } catch {
+        print "  Warning: failed to upload chrome trace"
+        null
+    }
+}
+
+def export-chrome-trace [tempo_url: string, benchmark_id: string, run_label: string, start_epoch: int, end_epoch: int, output_path: string] {
+    if $tempo_url == "" {
+        print "  Warning: tracing chrome requested but no Tempo query URL is configured"
+        return false
+    }
+    let script = $"($BENCH_DIR)/export-chrome-trace.py"
+    let result = (python3 $script --tempo-url $tempo_url --benchmark-id $benchmark_id --run-label $run_label --start $start_epoch --end $end_epoch --output $output_path | complete)
+    if $result.exit_code != 0 {
+        print $"  Warning: failed to export chrome trace for ($run_label)"
+        if $result.stderr != "" { print $result.stderr }
+        return false
+    }
+    true
+}
+
 # Generate summary.md from multiple report files
 # Compute percentile from a sorted list (0-100)
 def percentile [sorted_vals: list<any>, pct: int] {


### PR DESCRIPTION
## Summary
- add a `tracing-chrome` Derek bench flag and pass it into e2e runs
- export Tempo spans as Chrome trace JSON and upload R2-hosted Perfetto links
- include Perfetto links in the final Derek bench status comment

## Testing
- `nu --commands 'source tempo.nu; source bench-e2e.nu; source contrib/bench/bench-txgen.nu'`
- `uv run python -m py_compile contrib/bench/export-chrome-trace.py`
- `git diff --check`

Prompted by: @DaniPopes