### PR TITLE
feat(bench): add chrome trace option

### DIFF
--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -135,6 +135,40 @@ function fmtBlockCount(baselineBlocks, featureBlocks) {
   return `baseline \`${baselineBlocks}\` | feature \`${featureBlocks}\``;
 }
 
+function loadTracingChromeUrls(workDir) {
+  const urls = {};
+  let runs = [];
+  try {
+    runs = fs.readFileSync(path.join(workDir, 'run-order.txt'), 'utf8')
+      .split(/\r?\n/)
+      .map(run => run.trim())
+      .filter(Boolean);
+  } catch {
+    try {
+      runs = fs.readdirSync(workDir)
+        .filter(name => /^(baseline|feature)-/.test(name))
+        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+    } catch {}
+  }
+  for (const run of runs) {
+    try {
+      const url = fs.readFileSync(path.join(workDir, run, 'tracing-chrome-profile-url.txt'), 'utf8').trim();
+      if (url) urls[run] = url;
+    } catch {}
+  }
+  return urls;
+}
+
+function chromeTraceLinks(tracingChromeUrls, prefix) {
+  return Object.entries(tracingChromeUrls || {})
+    .filter(([run]) => run.startsWith(`${prefix}-`))
+    .sort(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
+    .map(([run, url]) => {
+      const index = run.slice(prefix.length + 1);
+      return `<${url}|Chrome ${index}>`;
+    });
+}
+
 function buildMetricRows(summary) {
   const b = summary.results.baseline;
   const f = summary.results.feature;
@@ -407,7 +441,7 @@ function replayRunLabel() {
   return (process.env.BENCH_RUN_LABEL || 'Replay Bench').trim() || 'Replay Bench';
 }
 
-function buildReplaySuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, repo, chain, blocks, warmup, runLabel }) {
+function buildReplaySuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, repo, chain, blocks, warmup, runLabel, tracingChromeUrls }) {
   const { emoji, label } = verdictFromChanges(summary.changes || {});
   const prUrl = prNumber ? `https://github.com/${repo}/pull/${prNumber}` : '';
   const baseline = summary.baseline || {};
@@ -423,11 +457,16 @@ function buildReplaySuccessBlocks({ summary, prNumber, actor, actorSlackId, jobU
   const blockCount = summary.blocks || blocks || '-';
   const warmupCount = summary.warmup_blocks || warmup || '-';
   const runPairs = summary.run_pairs || process.env.BENCH_RUN_PAIRS || '-';
+  const baselineTraces = chromeTraceLinks(tracingChromeUrls, 'baseline');
+  const featureTraces = chromeTraceLinks(tracingChromeUrls, 'feature');
+  const baselineLine = `*Baseline:* ${baselineLink}${baselineTraces.length ? ` | ${baselineTraces.join(' | ')}` : ''}`;
+  const featureLine = `*Feature:* ${featureLink}${featureTraces.length ? ` | ${featureTraces.join(' | ')}` : ''}`;
+
   const sectionText = [
     metaParts.join(' | '),
     '',
-    `*Baseline:* ${baselineLink}`,
-    `*Feature:* ${featureLink}`,
+    baselineLine,
+    featureLine,
     `*Chain:* \`${chain || '-'}\` | *Warmup:* \`${warmupCount}\` | *Blocks:* \`${blockCount}\` | *Run pairs:* \`${runPairs}\``,
   ].join('\n');
 
@@ -542,6 +581,7 @@ async function replaySuccess({ core, context }) {
   const blocks = process.env.BENCH_BLOCKS || '5000';
   const warmup = process.env.BENCH_WARMUP_BLOCKS || '1000';
   const runLabel = replayRunLabel();
+  const tracingChromeUrls = loadTracingChromeUrls(process.env.BENCH_WORK_DIR);
 
   const slackUsers = loadSlackUsers(process.env.GITHUB_WORKSPACE || '.');
   const actorSlackId = slackUsers[actor];
@@ -556,6 +596,7 @@ async function replaySuccess({ core, context }) {
     blocks,
     warmup,
     runLabel,
+    tracingChromeUrls,
   });
   const text = `Tempo ${runLabel.toLowerCase()}: ${summary.baseline?.name || 'baseline'} vs ${summary.feature?.name || 'feature'} (${chain}, ${summary.run_pairs ?? process.env.BENCH_RUN_PAIRS ?? '-'} run pairs)`;
 

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -16,6 +16,7 @@
 #   BENCH_BASELINE_ARGS           – extra node args for baseline (optional)
 #   BENCH_FEATURE_ARGS            – extra node args for feature (optional)
 #   BENCH_SAMPLY                  – "true" to enable samply profiling (optional)
+#   BENCH_TRACING_CHROME          – "true" to enable Chrome trace recording (optional)
 #   BENCH_REPLAY_RPC_URL          – RPC URL override for replay extraction (optional)
 set -euxo pipefail
 
@@ -280,6 +281,15 @@ run_single() {
   if [ -n "$extra_args" ]; then
     # shellcheck disable=SC2206
     NODE_ARGS+=($extra_args)
+  fi
+
+  if [ "${BENCH_TRACING_CHROME:-false}" = "true" ] && "$binary" node --help 2>&1 | grep -q -- '--log.tracing-chrome'; then
+    NODE_ARGS+=(
+      --log.tracing-chrome
+      --log.tracing-chrome.file "$output_dir/tracing-chrome-profile.json"
+    )
+  elif [ "${BENCH_TRACING_CHROME:-false}" = "true" ]; then
+    echo "::warning::Chrome trace recording requested, but $binary does not support --log.tracing-chrome; skipping $label trace"
   fi
 
   # Memory limit: 95% of available RAM

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -239,6 +239,10 @@ on:
         type: string
         required: false
         default: "false"
+      tracing-chrome:
+        type: string
+        required: false
+        default: "false"
       tracy:
         type: string
         required: false
@@ -377,6 +381,7 @@ jobs:
       BENCH_FEATURE_HARDFORK: ${{ inputs.feature-hardfork }}
       BENCH_TXGEN_REF: ${{ inputs.txgen-ref }}
       BENCH_SAMPLY: ${{ inputs.profiling == 'Samply' || inputs.profiling == 'Both' || inputs.samply == true || inputs.samply == 'true' }}
+      BENCH_TRACING_CHROME: ${{ inputs.tracing-chrome == true || inputs.tracing-chrome == 'true' }}
       BENCH_TRACY: ${{ (inputs.profiling == 'Tracy' || inputs.profiling == 'Both') && 'on' || ((inputs.profiling == 'Off' || inputs.profiling == 'Samply') && 'off' || inputs.tracy) }}
       BENCH_TRACY_SECONDS: ${{ inputs.tracy-seconds || '30' }}
       BENCH_TRACY_OFFSET: ${{ inputs.tracy-offset || '120' }}
@@ -857,6 +862,7 @@ jobs:
           )
           [ -n "$BENCH_TXGEN_REF" ] && derek_cmd+=(txgen-ref="$BENCH_TXGEN_REF")
           [ "$BENCH_SAMPLY" = "true" ] && derek_cmd+=(samply)
+          [ "$BENCH_TRACING_CHROME" = "true" ] && derek_cmd+=(tracing-chrome)
           [ "$BENCH_TRACY" != "off" ] && derek_cmd+=(tracy="$BENCH_TRACY" tracy-seconds="$BENCH_TRACY_SECONDS" tracy-offset="$BENCH_TRACY_OFFSET")
           [ -n "$BENCH_BASELINE_FEATURES" ] && derek_cmd+=(baseline-features="$BENCH_BASELINE_FEATURES")
           [ -n "$BENCH_FEATURE_FEATURES" ] && derek_cmd+=(feature-features="$BENCH_FEATURE_FEATURES")

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -31,6 +31,10 @@ on:
         description: "Enable samply profiling"
         type: string
         default: "false"
+      tracing-chrome:
+        description: "Enable Chrome trace recording"
+        type: string
+        default: "false"
       otlp:
         description: "Export OTLP traces and logs"
         type: boolean
@@ -96,6 +100,10 @@ on:
       samply:
         type: string
         required: true
+      tracing-chrome:
+        type: string
+        required: false
+        default: "false"
       otlp:
         type: string
         required: false
@@ -187,6 +195,7 @@ jobs:
       BENCH_PR: ${{ inputs.pr }}
       BENCH_ACTOR: ${{ inputs.actor }}
       BENCH_SAMPLY: ${{ inputs.samply }}
+      BENCH_TRACING_CHROME: ${{ inputs.tracing-chrome == true || inputs.tracing-chrome == 'true' }}
       BENCH_OTLP: ${{ inputs.otlp != false && inputs.otlp != 'false' }}
       BENCH_FEATURES: ${{ (inputs.otlp != false && inputs.otlp != 'false') && 'jemalloc,asm-keccak,keccak-cache-global,otlp' || 'jemalloc,asm-keccak,keccak-cache-global' }}
       BENCH_BASELINE_FEATURES: ${{ inputs.baseline-features }}
@@ -340,13 +349,15 @@ jobs:
             const feature = '${{ inputs.feature-name }}';
             const samply = process.env.BENCH_SAMPLY === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const tracingChrome = process.env.BENCH_TRACING_CHROME === 'true';
+            const tracingChromeNote = tracingChrome ? ', tracing-chrome: `enabled`' : '';
             const otlp = process.env.BENCH_OTLP === 'true';
             const otlpNote = otlp ? ', otlp: `enabled`' : ', otlp: `disabled`';
             const baselineFeatureFlags = process.env.BENCH_BASELINE_FEATURES || '';
             const featureFeatureFlags = process.env.BENCH_FEATURE_FEATURES || '';
             const featureFlagsNote = `${baselineFeatureFlags ? `, baseline-features: \`${baselineFeatureFlags}\`` : ''}${featureFeatureFlags ? `, feature-features: \`${featureFeatureFlags}\`` : ''}`;
             const chain = process.env.BENCH_CHAIN || 'mainnet';
-            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`replay\`, chain: \`${chain}\`, blocks: \`${blocks}\`, warmup: \`${warmup}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${featureFlagsNote}${samplyNote}${otlpNote}`);
+            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`replay\`, chain: \`${chain}\`, blocks: \`${blocks}\`, warmup: \`${warmup}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${featureFlagsNote}${samplyNote}${tracingChromeNote}${otlpNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -523,7 +534,7 @@ jobs:
           name: tempo-bench-replay-${{ inputs.chain || 'mainnet' }}-results
           path: ${{ env.BENCH_WORK_DIR }}/
 
-      - name: Push charts
+      - name: Push benchmark artifacts
         id: push-charts
         if: success()
         run: |
@@ -545,11 +556,56 @@ jobs:
 
           mkdir -p "${TMP_DIR}/${CHART_DIR}"
           cp "$BENCH_WORK_DIR"/charts/*.png "${TMP_DIR}/${CHART_DIR}/"
+          if [ "${BENCH_TRACING_CHROME:-false}" = "true" ]; then
+            TRACE_DIR="${CHART_DIR}/tracing-chrome"
+            mkdir -p "${TMP_DIR}/${TRACE_DIR}"
+            mapfile -t RUN_DIRS < <(find "$BENCH_WORK_DIR" -mindepth 1 -maxdepth 1 -type d \( -name 'baseline-*' -o -name 'feature-*' \) -printf '%f\n' | sort -V)
+            for run_dir in "${RUN_DIRS[@]}"; do
+              TRACE="$BENCH_WORK_DIR/$run_dir/tracing-chrome-profile.json"
+              if [ ! -f "$TRACE" ]; then continue; fi
+
+              TRACE_SIZE=$(du -h "$TRACE" | cut -f1)
+              echo "Adding $run_dir Chrome trace (${TRACE_SIZE}) to benchmark artifacts..."
+              gzip -c "$TRACE" > "${TMP_DIR}/${TRACE_DIR}/${run_dir}.json.gz"
+            done
+          fi
           git -C "${TMP_DIR}" add "${CHART_DIR}"
-          git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
-            commit -m "bench replay charts for ${BENCH_CHAIN} run ${RUN_ID}"
-          git -C "${TMP_DIR}" push origin HEAD:main
-          echo "sha=$(git -C "${TMP_DIR}" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          if git -C "${TMP_DIR}" diff --cached --quiet; then
+            echo "Artifacts for ${CHART_DIR} are already present, skipping push"
+            PUSH_SHA="$(git -C "${TMP_DIR}" rev-parse HEAD)"
+          else
+            git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
+              commit -m "bench replay artifacts for ${BENCH_CHAIN} run ${RUN_ID}"
+            git -C "${TMP_DIR}" push origin HEAD:main
+            PUSH_SHA="$(git -C "${TMP_DIR}" rev-parse HEAD)"
+          fi
+
+          if [ "${BENCH_TRACING_CHROME:-false}" = "true" ]; then
+            RAW_BASE="https://raw.githubusercontent.com/decofe/tempo-bench-charts/${PUSH_SHA}/${CHART_DIR}/tracing-chrome"
+            mapfile -t RUN_DIRS < <(find "$BENCH_WORK_DIR" -mindepth 1 -maxdepth 1 -type d \( -name 'baseline-*' -o -name 'feature-*' \) -printf '%f\n' | sort -V)
+            for run_dir in "${RUN_DIRS[@]}"; do
+              if [ ! -f "${TMP_DIR}/${CHART_DIR}/tracing-chrome/${run_dir}.json.gz" ]; then continue; fi
+
+              RAW_URL="${RAW_BASE}/${run_dir}.json.gz"
+              PERFETTO_URL="$(uv run python - "$RAW_URL" "${run_dir}.json.gz" <<'PY'
+          import sys
+          from urllib.parse import quote
+
+          raw_url, file_name = sys.argv[1:3]
+          print(
+              "https://ui.perfetto.dev/#!/?url="
+              + quote(raw_url, safe="")
+              + "&fileName="
+              + quote(file_name, safe="")
+          )
+          PY
+          )"
+              echo "$PERFETTO_URL" > "$BENCH_WORK_DIR/$run_dir/tracing-chrome-profile-url.txt"
+              echo "Perfetto URL for $run_dir: $PERFETTO_URL"
+            done
+          fi
+
+          echo "sha=${PUSH_SHA}" >> "$GITHUB_OUTPUT"
           echo "path=${CHART_DIR}" >> "$GITHUB_OUTPUT"
           rm -rf "${TMP_DIR}"
 
@@ -585,6 +641,26 @@ jobs:
                 chartMarkdown += `</details>\n\n`;
               }
               comment += chartMarkdown;
+            }
+
+            if (process.env.BENCH_TRACING_CHROME === 'true') {
+              const links = [];
+              let runs = [];
+              try {
+                runs = fs.readFileSync(`${process.env.BENCH_WORK_DIR}/run-order.txt`, 'utf8')
+                  .split(/\r?\n/)
+                  .map(run => run.trim())
+                  .filter(Boolean);
+              } catch (e) {}
+              for (const run of runs) {
+                try {
+                  const url = fs.readFileSync(`${process.env.BENCH_WORK_DIR}/${run}/tracing-chrome-profile-url.txt`, 'utf8').trim();
+                  if (url) links.push(`- **${run}**: [Perfetto](${url})`);
+                } catch (e) {}
+              }
+              if (links.length > 0) {
+                comment += `\n\n### Chrome Traces\n\n${links.join('\n')}\n`;
+              }
             }
 
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
@@ -640,6 +716,24 @@ jobs:
               echo
               echo "</details>"
             } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ "${BENCH_TRACING_CHROME:-false}" = "true" ]; then
+            mapfile -t RUN_LABELS < "$BENCH_WORK_DIR/run-order.txt"
+            LINKS=()
+            for label in "${RUN_LABELS[@]}"; do
+              [ -z "$label" ] && continue
+              url_file="$BENCH_WORK_DIR/$label/tracing-chrome-profile-url.txt"
+              if [ -f "$url_file" ]; then
+                LINKS+=("- **${label}**: [Perfetto]($(cat "$url_file"))")
+              fi
+            done
+            if [ "${#LINKS[@]}" -gt 0 ]; then
+              {
+                echo
+                echo "### Chrome Traces"
+                printf '%s\n' "${LINKS[@]}"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
           fi
 
       - name: Send Slack notification (success)

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -45,6 +45,7 @@ jobs:
       baseline-name: ${{ steps.args.outputs.baseline-name }}
       feature-name: ${{ steps.args.outputs.feature-name }}
       samply: ${{ steps.args.outputs.samply }}
+      tracing-chrome: ${{ steps.args.outputs.tracing-chrome }}
       tracy: ${{ steps.args.outputs.tracy }}
       tracy-seconds: ${{ steps.args.outputs.tracy-seconds }}
       tracy-offset: ${{ steps.args.outputs.tracy-offset }}
@@ -111,7 +112,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
-            let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, baselineFeatures, featureFeatures, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, valscope, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs;
+            let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, baselineFeatures, featureFeatures, txgenRef, samply, tracingChrome, tracy, tracySeconds, tracyOffset, otlp, valscope, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs;
             let explicitWarmup = false;
             let explicitDuration = false;
             let explicitRunPairs = false;
@@ -123,10 +124,10 @@ jobs:
             const intArgs = new Set(['duration', 'bloat', 'tps', 'accounts', 'max-concurrent-requests', 'gas-limit', 'tracy-seconds', 'tracy-offset', 'blocks', 'warmup', 'run-pairs']);
             const refArgs = new Set(['baseline', 'feature', 'txgen-ref']);
             const stringArgs = new Set(['mode', 'preset', 'tracy', 'baseline-args', 'feature-args', 'baseline-features', 'feature-features', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain', 'baseline-hardfork', 'feature-hardfork']);
-            const boolArgs = new Set(['samply', 'force-bloat', 'no-cache', 'no-slack', 'otlp', 'valscope']);
+            const boolArgs = new Set(['samply', 'tracing-chrome', 'force-bloat', 'no-cache', 'no-slack', 'otlp', 'valscope']);
             const bloatValues = new Set(['1', '10', '100']);
             const hardforkValues = new Set(['T0', 'T1', 'T1A', 'T1B', 'T1C', 'T2', 'T3', 'T4', 'T5', 'T6']);
-            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '50000', accounts: '1000', 'max-concurrent-requests': '500', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'baseline-features': '', 'feature-features': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'true', valscope: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2' };
+            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '50000', accounts: '1000', 'max-concurrent-requests': '500', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'baseline-features': '', 'feature-features': '', 'txgen-ref': '', samply: 'false', 'tracing-chrome': 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'true', valscope: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2' };
             const unknown = [];
             const invalid = [];
             const defaultWarmup = (blockCount) => String(Math.floor(Number(blockCount) / 4));
@@ -208,7 +209,7 @@ jobs:
             if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
             if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
             if (errors.length) {
-              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [otlp] [valscope] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
+              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [tracing-chrome] [otlp] [valscope] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -233,6 +234,7 @@ jobs:
             featureFeatures = defaults['feature-features'];
             txgenRef = defaults['txgen-ref'];
             samply = defaults.samply;
+            tracingChrome = defaults['tracing-chrome'];
             tracy = defaults.tracy;
             tracySeconds = defaults['tracy-seconds'];
             tracyOffset = defaults['tracy-offset'];
@@ -261,7 +263,7 @@ jobs:
               warmup = defaultWarmup(blocks);
             }
 
-            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [otlp] [valscope] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
+            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [tracing-chrome] [otlp] [valscope] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 
             // Validate chain value
             if (!['mainnet', 'testnet'].includes(chain)) {
@@ -393,6 +395,7 @@ jobs:
             core.setOutput('baseline-name', baselineName);
             core.setOutput('feature-name', featureName);
             core.setOutput('samply', samply);
+            core.setOutput('tracing-chrome', tracingChrome);
             core.setOutput('tracy', tracy);
             core.setOutput('tracy-seconds', tracySeconds);
             core.setOutput('tracy-offset', tracyOffset);
@@ -435,6 +438,7 @@ jobs:
           ACK_FEATURE_FEATURES: ${{ steps.args.outputs.feature-features }}
           ACK_TXGEN_REF: ${{ steps.args.outputs.txgen-ref }}
           ACK_SAMPLY: ${{ steps.args.outputs.samply }}
+          ACK_TRACING_CHROME: ${{ steps.args.outputs.tracing-chrome }}
           ACK_TRACY: ${{ steps.args.outputs.tracy }}
           ACK_OTLP: ${{ steps.args.outputs.otlp }}
           ACK_VALSCOPE: ${{ steps.args.outputs.valscope }}
@@ -477,6 +481,8 @@ jobs:
             const txgenRef = process.env.ACK_TXGEN_REF || 'default';
             const samply = process.env.ACK_SAMPLY === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const tracingChrome = process.env.ACK_TRACING_CHROME === 'true';
+            const tracingChromeNote = tracingChrome ? ', tracing-chrome: `enabled`' : '';
             const tracy = process.env.ACK_TRACY;
             const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
             const otlp = process.env.ACK_OTLP === 'true';
@@ -492,7 +498,7 @@ jobs:
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
             const featureFlagsNote = `${baselineFeatureFlags ? `, baseline-features: \`${baselineFeatureFlags}\`` : ''}${featureFeatureFlags ? `, feature-features: \`${featureFeatureFlags}\`` : ''}`;
-            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${naNote}${noCacheNote}`;
+            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracingChromeNote}${tracyNote}${otlpNote}${valscopeNote}${naNote}${noCacheNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -526,6 +532,7 @@ jobs:
       baseline-name: ${{ needs.tempo-bench-ack.outputs.baseline-name }}
       feature-name: ${{ needs.tempo-bench-ack.outputs.feature-name }}
       samply: ${{ needs.tempo-bench-ack.outputs.samply }}
+      tracing-chrome: ${{ needs.tempo-bench-ack.outputs.tracing-chrome }}
       tracy: ${{ needs.tempo-bench-ack.outputs.tracy }}
       tracy-seconds: ${{ needs.tempo-bench-ack.outputs.tracy-seconds }}
       tracy-offset: ${{ needs.tempo-bench-ack.outputs.tracy-offset }}
@@ -572,6 +579,7 @@ jobs:
       baseline-name: ${{ needs.tempo-bench-ack.outputs.baseline-name }}
       feature-name: ${{ needs.tempo-bench-ack.outputs.feature-name }}
       samply: ${{ needs.tempo-bench-ack.outputs.samply }}
+      tracing-chrome: ${{ needs.tempo-bench-ack.outputs.tracing-chrome }}
       otlp: ${{ needs.tempo-bench-ack.outputs.otlp }}
       baseline-features: ${{ needs.tempo-bench-ack.outputs.baseline-features }}
       feature-features: ${{ needs.tempo-bench-ack.outputs.feature-features }}


### PR DESCRIPTION
Ports the applicable benchmark workflow pieces from paradigmxyz/reth#24879 into Tempo.

- Parse and propagate `tracing-chrome` through Derek bench dispatch.
- Capture replay Chrome traces when the built binary supports `--log.tracing-chrome`, gzip and publish them with benchmark artifacts, and expose Perfetto links in PR comments, job summaries, and Slack notifications.
- Leave current pinned Reth behavior safe by warning and skipping trace capture when the CLI flag is unavailable.

Prompted by: @DaniPopes