### PR TITLE
Publish build devnet PR metadata

### DIFF
--- a/.github/workflows/build-devnet.yml
+++ b/.github/workflows/build-devnet.yml
@@ -33,6 +33,7 @@ jobs:
         RUNNER_TEMP: ${{ runner.temp }}
         GH_REPO: ${{ github.repository }}
         PR_NUMBER: ${{ github.event.issue.number }}
+        PR_SHA: ${{ steps.pr.outputs.sha }}
         REQUESTED_BY: ${{ github.event.comment.user.login }}
         PR_BRANCH: ${{ steps.pr.outputs.branch }}
       run: |
@@ -49,8 +50,10 @@ jobs:
             \"repository\": \"${GH_REPO}\",
             \"event\": \"build_devnet\",
             \"data\": {
+              \"pr_number\": \"${PR_NUMBER}\",
               \"name\": \"devnet-pr-${PR_NUMBER}\",
               \"branch\": \"${PR_BRANCH}\",
+              \"sha\": \"${PR_SHA}\",
               \"requested_by\": \"${REQUESTED_BY}\"
             }
           }"


### PR DESCRIPTION
## Summary
- Include `pr_number` in the `build_devnet` event payload.
- Include the PR head `sha` that the workflow already fetches.

## Why
The Argo Events `build-devnet` Sensor and the `devnet-pr` WorkflowTemplate expect `pr_number` for PR comments and `sha` for commit status updates. Without those fields, valid `/build-devnet` requests are published to the event bus but discarded by the Sensor before a Workflow can be submitted.

## Validation
- Parsed `.github/workflows/build-devnet.yml` with Ruby YAML.
- Confirmed `actionlint` is not installed locally, so GitHub Actions lint was not run.