### PR TITLE
[DO NOT MERGE] fix(precompiles): gate receive policy cache behind t6

### DIFF
--- a/crates/chainspec/src/features.rs
+++ b/crates/chainspec/src/features.rs
@@ -12,6 +12,9 @@ pub const NO_ACTIVE_PROTOCOL_FEATURE_ID: u64 = 0;
 pub const HIGHEST_ACTIVE_PROTOCOL_FEATURE_ID_SLOT: alloy_primitives::U256 =
     alloy_primitives::U256::ZERO;
 
+pub const FEATURE_REGISTRY_FEATURE_ID: u64 = 1;
+pub const RECEIVE_POLICY_TYPE_CACHE_FEATURE_ID: u64 = 2;
+
 /// A protocol feature supported by this binary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProtocolFeature {
@@ -24,12 +27,20 @@ pub struct ProtocolFeature {
 }
 
 /// Protocol features supported by this binary, in activation-cursor order.
-pub const PROTOCOL_FEATURE_REGISTRY: &[ProtocolFeature] = &[ProtocolFeature {
-    id: 1,
-    name: "tip-1063.feature-registry",
-    // TODO: update before merge if this feature does not ship in 1.8.1.
-    minimum_supported_version_key: version_key(1, 8, 1),
-}];
+pub const PROTOCOL_FEATURE_REGISTRY: &[ProtocolFeature] = &[
+    ProtocolFeature {
+        id: FEATURE_REGISTRY_FEATURE_ID,
+        name: "tip-1063.feature-registry",
+        // TODO: update before merge if this feature does not ship in 1.8.1.
+        minimum_supported_version_key: version_key(1, 8, 1),
+    },
+    ProtocolFeature {
+        id: RECEIVE_POLICY_TYPE_CACHE_FEATURE_ID,
+        name: "tip-403.receive-policy-type-cache",
+        // TODO: update before merge if this feature does not ship in 1.8.1.
+        minimum_supported_version_key: version_key(1, 8, 1),
+    },
+];
 
 /// Encodes a semver version as `(major << 32) | (minor << 16) | patch`.
 #[allow(clippy::cast_lossless)]

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -187,6 +187,12 @@ impl ReceivePolicyConfig {
     }
 }
 
+fn policy_type(policy_type: u8) -> Result<PolicyType> {
+    policy_type
+        .try_into()
+        .map_err(|_| TIP403RegistryError::invalid_receive_policy_type().into())
+}
+
 impl TIP403Registry {
     /// Initializes the TIP-403 registry precompile.
     pub fn initialize(&mut self) -> Result<()> {
@@ -288,12 +294,24 @@ impl TIP403Registry {
     /// Returns `account`'s receive-policy configuration.
     pub fn receive_policy(&self, account: Address) -> Result<ITIP403Registry::receivePolicyReturn> {
         let config = self.receive_policies[account].config.read()?;
+        let (sender_policy_type, token_filter_type) = if self.storage.spec().is_t6() {
+            (
+                policy_type(config.sender_policy_type)?,
+                policy_type(config.token_filter_type)?,
+            )
+        } else {
+            (
+                self.receive_policy_type(config.sender_policy_id)?,
+                self.receive_policy_type(config.token_filter_id)?,
+            )
+        };
+
         Ok(ITIP403Registry::receivePolicyReturn {
             hasReceivePolicy: config.has_receive_policy,
             senderPolicyId: config.sender_policy_id,
-            senderPolicyType: self.receive_policy_type(config.sender_policy_id)?,
+            senderPolicyType: sender_policy_type,
             tokenFilterId: config.token_filter_id,
-            tokenFilterType: self.receive_policy_type(config.token_filter_id)?,
+            tokenFilterType: token_filter_type,
             recoveryAuthority: self.receive_policy_recovery(account, config.recovery_mode)?,
         })
     }
@@ -832,9 +850,7 @@ impl TIP403Registry {
     /// Returns the [`PolicyType`] of a receive-policy slot.
     fn receive_policy_type(&self, policy_id: u64) -> Result<PolicyType> {
         if self.builtin_authorization(policy_id).is_some() {
-            return (policy_id as u8)
-                .try_into()
-                .map_err(|_| TIP403RegistryError::invalid_receive_policy_type().into());
+            return policy_type(policy_id as u8);
         }
 
         let data = self.get_policy_data(policy_id)?;
@@ -1242,6 +1258,74 @@ mod tests {
 
             Ok(())
         })
+    }
+
+    #[test]
+    fn test_receive_policy_type_cache_t5_t6_boundary() -> eyre::Result<()> {
+        for (hardfork, expected_sloads) in [(TempoHardfork::T5, 3), (TempoHardfork::T6, 1)] {
+            let mut storage = HashMapStorageProvider::new_with_spec(1, hardfork);
+            let account = Address::random();
+            let admin = Address::random();
+            let (sender_policy_id, token_filter_id) = StorageCtx::enter(&mut storage, || {
+                let mut registry = TIP403Registry::new();
+                let sender_policy_id = registry.create_policy(
+                    admin,
+                    ITIP403Registry::createPolicyCall {
+                        admin,
+                        policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                    },
+                )?;
+                let token_filter_id = registry.create_policy(
+                    admin,
+                    ITIP403Registry::createPolicyCall {
+                        admin,
+                        policyType: ITIP403Registry::PolicyType::WHITELIST,
+                    },
+                )?;
+                registry.receive_policies[account]
+                    .config
+                    .write(ReceivePolicyConfig {
+                        has_receive_policy: true,
+                        sender_policy_id,
+                        sender_policy_type: PolicyType::WHITELIST as u8,
+                        token_filter_id,
+                        token_filter_type: PolicyType::BLACKLIST as u8,
+                        recovery_mode: RecoveryMode::Originator,
+                    })?;
+
+                Ok::<_, TempoPrecompileError>((sender_policy_id, token_filter_id))
+            })?;
+
+            storage.reset_counters();
+            StorageCtx::enter(&mut storage, || {
+                let registry = TIP403Registry::new();
+                let policy = registry.receive_policy(account)?;
+                let (expected_sender_type, expected_token_type) = if hardfork.is_t6() {
+                    (
+                        ITIP403Registry::PolicyType::WHITELIST,
+                        ITIP403Registry::PolicyType::BLACKLIST,
+                    )
+                } else {
+                    (
+                        ITIP403Registry::PolicyType::BLACKLIST,
+                        ITIP403Registry::PolicyType::WHITELIST,
+                    )
+                };
+                assert_eq!(policy.senderPolicyId, sender_policy_id);
+                assert_eq!(policy.senderPolicyType, expected_sender_type);
+                assert_eq!(policy.tokenFilterId, token_filter_id);
+                assert_eq!(policy.tokenFilterType, expected_token_type);
+
+                Ok::<_, TempoPrecompileError>(())
+            })?;
+            assert_eq!(
+                storage.counter_sload(),
+                expected_sloads,
+                "{hardfork:?} receive_policy SLOAD count"
+            );
+        }
+
+        Ok(())
     }
 
     #[test]

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -12,6 +12,7 @@ pub use slots as tip403_registry_slots;
 
 use crate::{
     StorageCtx,
+    feature_registry::FeatureRegistry,
     receive_policy_guard::{RECOVERY_ORIGINATOR, RecoveryMode},
 };
 pub use tempo_contracts::precompiles::{
@@ -26,7 +27,7 @@ use crate::{
     storage::{Handler, Mapping},
 };
 use alloy::primitives::Address;
-use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_chainspec::{features::RECEIVE_POLICY_TYPE_CACHE_FEATURE_ID, hardfork::TempoHardfork};
 use tempo_primitives::TempoAddressExt;
 
 /// Built-in policy ID that always rejects authorization.
@@ -294,7 +295,7 @@ impl TIP403Registry {
     /// Returns `account`'s receive-policy configuration.
     pub fn receive_policy(&self, account: Address) -> Result<ITIP403Registry::receivePolicyReturn> {
         let config = self.receive_policies[account].config.read()?;
-        let (sender_policy_type, token_filter_type) = if self.storage.spec().is_t6() {
+        let (sender_policy_type, token_filter_type) = if self.receive_policy_type_cache_enabled()? {
             (
                 policy_type(config.sender_policy_type)?,
                 policy_type(config.token_filter_type)?,
@@ -314,6 +315,14 @@ impl TIP403Registry {
             tokenFilterType: token_filter_type,
             recoveryAuthority: self.receive_policy_recovery(account, config.recovery_mode)?,
         })
+    }
+
+    fn receive_policy_type_cache_enabled(&self) -> Result<bool> {
+        if !self.storage.spec().is_t6() {
+            return Ok(false);
+        }
+
+        Ok(FeatureRegistry::new().features_tip()? >= RECEIVE_POLICY_TYPE_CACHE_FEATURE_ID)
     }
 
     /// Checks `receiver`'s receive policy for an inbound transfer. Returns the blocking
@@ -969,11 +978,14 @@ mod tests {
         storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
     };
     use alloy::{
-        primitives::{Address, Log},
+        primitives::{Address, Log, U256},
         sol_types::SolEvent,
     };
     use rand_08::Rng;
-    use tempo_contracts::precompiles::{PATH_USD_ADDRESS, TIP403_REGISTRY_ADDRESS};
+    use tempo_chainspec::features::HIGHEST_ACTIVE_PROTOCOL_FEATURE_ID_SLOT;
+    use tempo_contracts::precompiles::{
+        FEATURE_REGISTRY_ADDRESS, PATH_USD_ADDRESS, TIP403_REGISTRY_ADDRESS,
+    };
     use tempo_primitives::{MasterId, TempoAddressExt, UserTag};
 
     #[test]
@@ -1261,12 +1273,47 @@ mod tests {
     }
 
     #[test]
-    fn test_receive_policy_type_cache_t5_t6_boundary() -> eyre::Result<()> {
-        for (hardfork, expected_sloads) in [(TempoHardfork::T5, 3), (TempoHardfork::T6, 1)] {
+    fn test_receive_policy_type_cache_requires_feature_tip() -> eyre::Result<()> {
+        for (
+            hardfork,
+            active_features_tip,
+            expected_sender_type,
+            expected_token_type,
+            expected_sloads,
+        ) in [
+            (
+                TempoHardfork::T5,
+                RECEIVE_POLICY_TYPE_CACHE_FEATURE_ID,
+                ITIP403Registry::PolicyType::BLACKLIST,
+                ITIP403Registry::PolicyType::WHITELIST,
+                3,
+            ),
+            (
+                TempoHardfork::T6,
+                RECEIVE_POLICY_TYPE_CACHE_FEATURE_ID - 1,
+                ITIP403Registry::PolicyType::BLACKLIST,
+                ITIP403Registry::PolicyType::WHITELIST,
+                4,
+            ),
+            (
+                TempoHardfork::T6,
+                RECEIVE_POLICY_TYPE_CACHE_FEATURE_ID,
+                ITIP403Registry::PolicyType::WHITELIST,
+                ITIP403Registry::PolicyType::BLACKLIST,
+                2,
+            ),
+        ] {
             let mut storage = HashMapStorageProvider::new_with_spec(1, hardfork);
             let account = Address::random();
             let admin = Address::random();
             let (sender_policy_id, token_filter_id) = StorageCtx::enter(&mut storage, || {
+                let mut storage = StorageCtx;
+                storage.sstore(
+                    FEATURE_REGISTRY_ADDRESS,
+                    HIGHEST_ACTIVE_PROTOCOL_FEATURE_ID_SLOT,
+                    U256::from(active_features_tip),
+                )?;
+
                 let mut registry = TIP403Registry::new();
                 let sender_policy_id = registry.create_policy(
                     admin,
@@ -1300,17 +1347,6 @@ mod tests {
             StorageCtx::enter(&mut storage, || {
                 let registry = TIP403Registry::new();
                 let policy = registry.receive_policy(account)?;
-                let (expected_sender_type, expected_token_type) = if hardfork.is_t6() {
-                    (
-                        ITIP403Registry::PolicyType::WHITELIST,
-                        ITIP403Registry::PolicyType::BLACKLIST,
-                    )
-                } else {
-                    (
-                        ITIP403Registry::PolicyType::BLACKLIST,
-                        ITIP403Registry::PolicyType::WHITELIST,
-                    )
-                };
                 assert_eq!(policy.senderPolicyId, sender_policy_id);
                 assert_eq!(policy.senderPolicyType, expected_sender_type);
                 assert_eq!(policy.tokenFilterId, token_filter_id);


### PR DESCRIPTION
Stacks on #5213 to gate receive-policy type cache usage behind T6.\n\nThis mirrors #5262 as a small activation-boundary candidate for testing feature enablement.