### PR TITLE
feat(bench): add chrome trace profiles

### DIFF
--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -8,6 +8,7 @@
 //   BENCH_ACTOR            – GitHub user who triggered the bench
 //   BENCH_JOB_URL          – URL to the Actions job page
 //   BENCH_RUN_LABEL        – Replay Slack title label (for example, Replay Bench)
+//   BENCH_TRACING_CHROME   – 'true' if Chrome trace recording was enabled
 //
 // Usage from actions/github-script:
 //   const notify = require('./.github/scripts/bench-slack-notify.js');
@@ -39,6 +40,28 @@ function loadSlackUsers(repoRoot) {
   } catch {
     return {};
   }
+}
+
+function loadRunProfileUrls(workDir, fileName) {
+  const urls = {};
+  try {
+    for (const run of fs.readdirSync(workDir)) {
+      if (!run.startsWith('baseline-') && !run.startsWith('feature-')) continue;
+      const file = path.join(workDir, run, fileName);
+      if (!fs.existsSync(file)) continue;
+      const url = fs.readFileSync(file, 'utf8').trim();
+      if (url) urls[run] = url;
+    }
+  } catch {
+    return {};
+  }
+  return urls;
+}
+
+function chromeTraceLinks(tracingChromeUrls) {
+  return Object.entries(tracingChromeUrls)
+    .sort(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
+    .map(([run, url]) => `<${url}|${run}>`);
 }
 
 async function postToSlack(token, channel, blocks, text, core, threadTs) {
@@ -481,6 +504,17 @@ function buildReplaySuccessBlocks({ summary, prNumber, actor, actorSlackId, jobU
         ...waitRows.map(row => [cell(row.title), cell(row.baseline), cell(row.feature)]),
       ],
     });
+  }
+
+  if (process.env.BENCH_TRACING_CHROME === 'true') {
+    const tracingChromeUrls = loadRunProfileUrls(process.env.BENCH_WORK_DIR, 'tracing-chrome-profile-url.txt');
+    const links = chromeTraceLinks(tracingChromeUrls);
+    if (links.length > 0) {
+      threadBlocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: `*Chrome Traces*\n${links.join(' | ')}` },
+      });
+    }
   }
 
   return { blocks: blocksPayload, threadBlocks };

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -16,6 +16,7 @@
 #   BENCH_BASELINE_ARGS           – extra node args for baseline (optional)
 #   BENCH_FEATURE_ARGS            – extra node args for feature (optional)
 #   BENCH_SAMPLY                  – "true" to enable samply profiling (optional)
+#   BENCH_TRACING_CHROME          – "true" to enable Chrome trace profiling (optional)
 #   BENCH_REPLAY_RPC_URL          – RPC URL override for replay extraction (optional)
 set -euxo pipefail
 
@@ -280,6 +281,17 @@ run_single() {
   if [ -n "$extra_args" ]; then
     # shellcheck disable=SC2206
     NODE_ARGS+=($extra_args)
+  fi
+
+  if [ "${BENCH_TRACING_CHROME:-false}" = "true" ]; then
+    if "$binary" node --log.tracing-chrome --log.tracing-chrome.file "$output_dir/tracing-chrome-profile.json" --help >/dev/null 2>&1; then
+      NODE_ARGS+=(
+        --log.tracing-chrome
+        --log.tracing-chrome.file "$output_dir/tracing-chrome-profile.json"
+      )
+    else
+      echo "Chrome trace recording requested, but ${label} binary rejected --log.tracing-chrome; skipping"
+    fi
   fi
 
   # Memory limit: 95% of available RAM

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -239,6 +239,10 @@ on:
         type: string
         required: false
         default: "false"
+      tracing-chrome:
+        type: string
+        required: false
+        default: "false"
       tracy:
         type: string
         required: false

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -31,6 +31,10 @@ on:
         description: "Enable samply profiling"
         type: string
         default: "false"
+      tracing-chrome:
+        description: "Enable Chrome trace profiling"
+        type: string
+        default: "false"
       otlp:
         description: "Export OTLP traces and logs"
         type: boolean
@@ -96,6 +100,10 @@ on:
       samply:
         type: string
         required: true
+      tracing-chrome:
+        type: string
+        required: false
+        default: "false"
       otlp:
         type: string
         required: false
@@ -187,6 +195,7 @@ jobs:
       BENCH_PR: ${{ inputs.pr }}
       BENCH_ACTOR: ${{ inputs.actor }}
       BENCH_SAMPLY: ${{ inputs.samply }}
+      BENCH_TRACING_CHROME: ${{ inputs.tracing-chrome }}
       BENCH_OTLP: ${{ inputs.otlp != false && inputs.otlp != 'false' }}
       BENCH_FEATURES: ${{ (inputs.otlp != false && inputs.otlp != 'false') && 'jemalloc,asm-keccak,keccak-cache-global,otlp' || 'jemalloc,asm-keccak,keccak-cache-global' }}
       BENCH_BASELINE_FEATURES: ${{ inputs.baseline-features }}
@@ -340,13 +349,15 @@ jobs:
             const feature = '${{ inputs.feature-name }}';
             const samply = process.env.BENCH_SAMPLY === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const tracingChrome = process.env.BENCH_TRACING_CHROME === 'true';
+            const tracingChromeNote = tracingChrome ? ', tracing-chrome: `enabled`' : '';
             const otlp = process.env.BENCH_OTLP === 'true';
             const otlpNote = otlp ? ', otlp: `enabled`' : ', otlp: `disabled`';
             const baselineFeatureFlags = process.env.BENCH_BASELINE_FEATURES || '';
             const featureFeatureFlags = process.env.BENCH_FEATURE_FEATURES || '';
             const featureFlagsNote = `${baselineFeatureFlags ? `, baseline-features: \`${baselineFeatureFlags}\`` : ''}${featureFeatureFlags ? `, feature-features: \`${featureFeatureFlags}\`` : ''}`;
             const chain = process.env.BENCH_CHAIN || 'mainnet';
-            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`replay\`, chain: \`${chain}\`, blocks: \`${blocks}\`, warmup: \`${warmup}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${featureFlagsNote}${samplyNote}${otlpNote}`);
+            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`replay\`, chain: \`${chain}\`, blocks: \`${blocks}\`, warmup: \`${warmup}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${featureFlagsNote}${samplyNote}${tracingChromeNote}${otlpNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -545,12 +556,42 @@ jobs:
 
           mkdir -p "${TMP_DIR}/${CHART_DIR}"
           cp "$BENCH_WORK_DIR"/charts/*.png "${TMP_DIR}/${CHART_DIR}/"
+          if [ "${BENCH_TRACING_CHROME:-false}" = "true" ]; then
+            TRACE_DIR="${CHART_DIR}/tracing-chrome"
+            mkdir -p "${TMP_DIR}/${TRACE_DIR}"
+            mapfile -t RUN_DIRS < <(find "$BENCH_WORK_DIR" -mindepth 1 -maxdepth 1 -type d \( -name 'baseline-*' -o -name 'feature-*' \) -printf '%f\n' | sort -V)
+            for run_dir in "${RUN_DIRS[@]}"; do
+              TRACE="$BENCH_WORK_DIR/$run_dir/tracing-chrome-profile.json"
+              if [ ! -f "$TRACE" ]; then
+                continue
+              fi
+
+              TRACE_SIZE=$(du -h "$TRACE" | cut -f1)
+              echo "Compressing Chrome trace for $run_dir ($TRACE_SIZE)"
+              gzip -c "$TRACE" > "${TMP_DIR}/${TRACE_DIR}/${run_dir}.json.gz"
+            done
+          fi
           git -C "${TMP_DIR}" add "${CHART_DIR}"
           git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
             commit -m "bench replay charts for ${BENCH_CHAIN} run ${RUN_ID}"
           git -C "${TMP_DIR}" push origin HEAD:main
-          echo "sha=$(git -C "${TMP_DIR}" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          PUSH_SHA="$(git -C "${TMP_DIR}" rev-parse HEAD)"
+          echo "sha=${PUSH_SHA}" >> "$GITHUB_OUTPUT"
           echo "path=${CHART_DIR}" >> "$GITHUB_OUTPUT"
+          if [ "${BENCH_TRACING_CHROME:-false}" = "true" ]; then
+            RAW_BASE="https://raw.githubusercontent.com/decofe/tempo-bench-charts/${PUSH_SHA}/${CHART_DIR}/tracing-chrome"
+            mapfile -t RUN_DIRS < <(find "$BENCH_WORK_DIR" -mindepth 1 -maxdepth 1 -type d \( -name 'baseline-*' -o -name 'feature-*' \) -printf '%f\n' | sort -V)
+            for run_dir in "${RUN_DIRS[@]}"; do
+              if [ ! -f "${TMP_DIR}/${CHART_DIR}/tracing-chrome/${run_dir}.json.gz" ]; then
+                continue
+              fi
+
+              RAW_URL="${RAW_BASE}/${run_dir}.json.gz"
+              PERFETTO_URL="$(uv run python -c 'import sys; from urllib.parse import quote; raw_url, file_name = sys.argv[1:3]; print("https://ui.perfetto.dev/#!/?url=" + quote(raw_url, safe="") + "&fileName=" + quote(file_name, safe=""))' "$RAW_URL" "${run_dir}.json.gz")"
+              echo "$PERFETTO_URL" > "$BENCH_WORK_DIR/$run_dir/tracing-chrome-profile-url.txt"
+              echo "Perfetto URL for $run_dir: $PERFETTO_URL"
+            done
+          fi
           rm -rf "${TMP_DIR}"
 
       - name: Compare & comment
@@ -585,6 +626,19 @@ jobs:
                 chartMarkdown += `</details>\n\n`;
               }
               comment += chartMarkdown;
+            }
+
+            if (process.env.BENCH_TRACING_CHROME === 'true') {
+              const links = [];
+              for (const run of fs.readdirSync(process.env.BENCH_WORK_DIR).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))) {
+                const file = `${process.env.BENCH_WORK_DIR}/${run}/tracing-chrome-profile-url.txt`;
+                if (!fs.existsSync(file)) continue;
+                const url = fs.readFileSync(file, 'utf8').trim();
+                if (url) links.push(`- **${run}**: [Perfetto](${url})`);
+              }
+              if (links.length > 0) {
+                comment += `\n\n### Chrome Traces\n\n${links.join('\n')}\n`;
+              }
             }
 
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
@@ -640,6 +694,22 @@ jobs:
               echo
               echo "</details>"
             } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ "${BENCH_TRACING_CHROME:-false}" = "true" ]; then
+            TRACE_LINKS=""
+            while IFS= read -r -d '' url_file; do
+              run_dir="$(basename "$(dirname "$url_file")")"
+              url="$(cat "$url_file")"
+              TRACE_LINKS="${TRACE_LINKS}- **${run_dir}**: [Perfetto](${url})"$'\n'
+            done < <(find "$BENCH_WORK_DIR" -path '*/tracing-chrome-profile-url.txt' -print0 | sort -z)
+            if [ -n "$TRACE_LINKS" ]; then
+              {
+                echo
+                echo "### Chrome Traces"
+                echo
+                printf '%s' "$TRACE_LINKS"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
           fi
 
       - name: Send Slack notification (success)

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -45,6 +45,7 @@ jobs:
       baseline-name: ${{ steps.args.outputs.baseline-name }}
       feature-name: ${{ steps.args.outputs.feature-name }}
       samply: ${{ steps.args.outputs.samply }}
+      tracing-chrome: ${{ steps.args.outputs.tracing-chrome }}
       tracy: ${{ steps.args.outputs.tracy }}
       tracy-seconds: ${{ steps.args.outputs.tracy-seconds }}
       tracy-offset: ${{ steps.args.outputs.tracy-offset }}
@@ -111,7 +112,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
-            let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, baselineFeatures, featureFeatures, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, valscope, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs;
+            let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, baselineFeatures, featureFeatures, txgenRef, samply, tracingChrome, tracy, tracySeconds, tracyOffset, otlp, valscope, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs;
             let explicitWarmup = false;
             let explicitDuration = false;
             let explicitRunPairs = false;
@@ -123,10 +124,10 @@ jobs:
             const intArgs = new Set(['duration', 'bloat', 'tps', 'accounts', 'max-concurrent-requests', 'gas-limit', 'tracy-seconds', 'tracy-offset', 'blocks', 'warmup', 'run-pairs']);
             const refArgs = new Set(['baseline', 'feature', 'txgen-ref']);
             const stringArgs = new Set(['mode', 'preset', 'tracy', 'baseline-args', 'feature-args', 'baseline-features', 'feature-features', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain', 'baseline-hardfork', 'feature-hardfork']);
-            const boolArgs = new Set(['samply', 'force-bloat', 'no-cache', 'no-slack', 'otlp', 'valscope']);
+            const boolArgs = new Set(['samply', 'tracing-chrome', 'force-bloat', 'no-cache', 'no-slack', 'otlp', 'valscope']);
             const bloatValues = new Set(['1', '10', '100']);
             const hardforkValues = new Set(['T0', 'T1', 'T1A', 'T1B', 'T1C', 'T2', 'T3', 'T4', 'T5', 'T6']);
-            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '50000', accounts: '1000', 'max-concurrent-requests': '500', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'baseline-features': '', 'feature-features': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'true', valscope: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2' };
+            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '50000', accounts: '1000', 'max-concurrent-requests': '500', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'baseline-features': '', 'feature-features': '', 'txgen-ref': '', samply: 'false', 'tracing-chrome': 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'true', valscope: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2' };
             const unknown = [];
             const invalid = [];
             const defaultWarmup = (blockCount) => String(Math.floor(Number(blockCount) / 4));
@@ -233,6 +234,7 @@ jobs:
             featureFeatures = defaults['feature-features'];
             txgenRef = defaults['txgen-ref'];
             samply = defaults.samply;
+            tracingChrome = defaults['tracing-chrome'];
             tracy = defaults.tracy;
             tracySeconds = defaults['tracy-seconds'];
             tracyOffset = defaults['tracy-offset'];
@@ -393,6 +395,7 @@ jobs:
             core.setOutput('baseline-name', baselineName);
             core.setOutput('feature-name', featureName);
             core.setOutput('samply', samply);
+            core.setOutput('tracing-chrome', tracingChrome);
             core.setOutput('tracy', tracy);
             core.setOutput('tracy-seconds', tracySeconds);
             core.setOutput('tracy-offset', tracyOffset);
@@ -435,6 +438,7 @@ jobs:
           ACK_FEATURE_FEATURES: ${{ steps.args.outputs.feature-features }}
           ACK_TXGEN_REF: ${{ steps.args.outputs.txgen-ref }}
           ACK_SAMPLY: ${{ steps.args.outputs.samply }}
+          ACK_TRACING_CHROME: ${{ steps.args.outputs.tracing-chrome }}
           ACK_TRACY: ${{ steps.args.outputs.tracy }}
           ACK_OTLP: ${{ steps.args.outputs.otlp }}
           ACK_VALSCOPE: ${{ steps.args.outputs.valscope }}
@@ -477,6 +481,8 @@ jobs:
             const txgenRef = process.env.ACK_TXGEN_REF || 'default';
             const samply = process.env.ACK_SAMPLY === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const tracingChrome = process.env.ACK_TRACING_CHROME === 'true';
+            const tracingChromeNote = tracingChrome ? ', tracing-chrome: `enabled`' : '';
             const tracy = process.env.ACK_TRACY;
             const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
             const otlp = process.env.ACK_OTLP === 'true';
@@ -492,7 +498,7 @@ jobs:
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
             const featureFlagsNote = `${baselineFeatureFlags ? `, baseline-features: \`${baselineFeatureFlags}\`` : ''}${featureFeatureFlags ? `, feature-features: \`${featureFeatureFlags}\`` : ''}`;
-            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${naNote}${noCacheNote}`;
+            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracingChromeNote}${tracyNote}${otlpNote}${valscopeNote}${naNote}${noCacheNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -526,6 +532,7 @@ jobs:
       baseline-name: ${{ needs.tempo-bench-ack.outputs.baseline-name }}
       feature-name: ${{ needs.tempo-bench-ack.outputs.feature-name }}
       samply: ${{ needs.tempo-bench-ack.outputs.samply }}
+      tracing-chrome: ${{ needs.tempo-bench-ack.outputs.tracing-chrome }}
       tracy: ${{ needs.tempo-bench-ack.outputs.tracy }}
       tracy-seconds: ${{ needs.tempo-bench-ack.outputs.tracy-seconds }}
       tracy-offset: ${{ needs.tempo-bench-ack.outputs.tracy-offset }}
@@ -572,6 +579,7 @@ jobs:
       baseline-name: ${{ needs.tempo-bench-ack.outputs.baseline-name }}
       feature-name: ${{ needs.tempo-bench-ack.outputs.feature-name }}
       samply: ${{ needs.tempo-bench-ack.outputs.samply }}
+      tracing-chrome: ${{ needs.tempo-bench-ack.outputs.tracing-chrome }}
       otlp: ${{ needs.tempo-bench-ack.outputs.otlp }}
       baseline-features: ${{ needs.tempo-bench-ack.outputs.baseline-features }}
       feature-features: ${{ needs.tempo-bench-ack.outputs.feature-features }}


### PR DESCRIPTION
Copies the applicable benchmark Chrome trace pieces from paradigmxyz/reth#24879 into Tempo's benchmark workflows.

This adapts the upstream behavior to Tempo replay benches by:
- adding the hidden `tracing-chrome` bench flag and passing it through replay jobs
- recording `tracing-chrome-profile.json` when the benchmarked binary accepts the hidden node flags
- publishing gzipped traces beside chart artifacts and surfacing Perfetto links in PR comments, job summaries, and Slack notifications

The upstream Rust tracing crate/CLI changes do not directly apply here because this Tempo repo does not have the matching `crates/tracing` or `crates/ethereum/cli` layout.

Prompted by: @DaniPopes