### PR TITLE
Include builder latency scatter in bench comments

### DIFF
--- a/.github/scripts/bench-e2e-charts.py
+++ b/.github/scripts/bench-e2e-charts.py
@@ -63,7 +63,8 @@ CHARTS = [
         "sample_key": "serialized_block_size_bytes",
         "label": "Serialized Block Size Scatter",
         "title": "Serialized block size samples",
-        "ylabel": "Serialized block size (bytes)",
+        "ylabel": "Serialized block size (MiB)",
+        "scale": 1 / (1024 * 1024),
     },
     {
         "file": "builder_fill_idle_scatter.png",
@@ -91,12 +92,12 @@ def number(value: Any) -> float | None:
         return None
 
 
-def values(run: dict[str, Any], key: str) -> list[float]:
+def values(run: dict[str, Any], key: str, scale: float = 1.0) -> list[float]:
     raw = run.get(key) or []
     if not isinstance(raw, list):
         return []
     parsed = [number(value) for value in raw]
-    return [value for value in parsed if value is not None]
+    return [value * scale for value in parsed if value is not None]
 
 
 def group_name(label: str) -> str:
@@ -107,12 +108,14 @@ def group_name(label: str) -> str:
     return "other"
 
 
-def group_values(per_run: list[dict[str, Any]], sample_key: str, group: str) -> list[float]:
+def group_values(
+    per_run: list[dict[str, Any]], sample_key: str, group: str, scale: float = 1.0
+) -> list[float]:
     samples: list[float] = []
     for run in per_run:
         label = str(run.get("label") or "")
         if group_name(label) == group:
-            samples.extend(values(run, sample_key))
+            samples.extend(values(run, sample_key, scale))
     return samples
 
 
@@ -125,6 +128,7 @@ def scatter_samples(
     sample_key: str,
     title: str,
     ylabel: str,
+    scale: float = 1.0,
 ) -> None:
     rng = random.Random(1337)
     colors = {
@@ -145,7 +149,7 @@ def scatter_samples(
 
     for idx, run in enumerate(per_run, start=1):
         label = str(run.get("label") or f"run-{idx}")
-        samples = values(run, sample_key)
+        samples = values(run, sample_key, scale)
         if not samples:
             continue
 
@@ -180,8 +184,9 @@ def distribution_samples(
     group: str,
     title: str,
     xlabel: str,
+    scale: float = 1.0,
 ) -> None:
-    samples = group_values(per_run, sample_key, group)
+    samples = group_values(per_run, sample_key, group, scale)
     if not samples:
         raise ValueError(f"summary.json has no {group} {sample_key} samples")
 
@@ -206,6 +211,7 @@ def maybe_scatter_samples(
     sample_key: str,
     title: str,
     ylabel: str,
+    scale: float = 1.0,
 ) -> bool:
     try:
         scatter_samples(
@@ -216,6 +222,7 @@ def maybe_scatter_samples(
             sample_key=sample_key,
             title=title,
             ylabel=ylabel,
+            scale=scale,
         )
     except ValueError as error:
         print(f"Skipping {output.name}: {error}")
@@ -232,6 +239,7 @@ def maybe_distribution_samples(
     group: str,
     title: str,
     xlabel: str,
+    scale: float = 1.0,
 ) -> bool:
     try:
         distribution_samples(
@@ -242,6 +250,7 @@ def maybe_distribution_samples(
             group=group,
             title=title,
             xlabel=xlabel,
+            scale=scale,
         )
     except ValueError as error:
         print(f"Skipping {output.name}: {error}")
@@ -278,6 +287,7 @@ def main() -> None:
             sample_key=chart["sample_key"],
             title=chart["title"],
             ylabel=chart["ylabel"],
+            scale=chart.get("scale", 1.0),
         ):
             written.append({"file": chart["file"], "label": chart["label"]})
 
@@ -296,6 +306,7 @@ def main() -> None:
                 group=group,
                 title=chart["title"],
                 xlabel=chart["ylabel"],
+                scale=chart.get("scale", 1.0),
             ):
                 written.append({"file": file_name, "label": label})
 

--- a/.github/scripts/bench-e2e-charts.py
+++ b/.github/scripts/bench-e2e-charts.py
@@ -186,7 +186,7 @@ def distribution_samples(
         raise ValueError(f"summary.json has no {group} {sample_key} samples")
 
     color = "#4c78a8" if group == "baseline" else "#f58518"
-    bins = min(60, max(10, int(len(samples) ** 0.5)))
+    bins = min(90, max(16, int((len(samples) ** 0.5) * 1.6)))
     fig, ax = plt.subplots(figsize=(10, 6), constrained_layout=True)
     ax.hist(samples, bins=bins, density=True, alpha=0.72, color=color, edgecolor="white")
     ax.set_title(f"{display_name}: {title}")

--- a/.github/scripts/bench-e2e-charts.py
+++ b/.github/scripts/bench-e2e-charts.py
@@ -19,6 +19,7 @@ CHARTS = [
     {
         "file": "block_time_scatter.png",
         "sample_key": "block_time_ms",
+        "metric": "Block Time",
         "label": "Block Time Scatter",
         "title": "Block time samples",
         "ylabel": "Block time (ms)",
@@ -26,6 +27,7 @@ CHARTS = [
     {
         "file": "serialized_block_size_per_tx_scatter.png",
         "sample_key": "serialized_block_size_per_tx_bytes",
+        "metric": "Serialized Block Size per Transaction",
         "label": "Serialized Block Size per Transaction Scatter",
         "title": "Serialized block size per transaction samples",
         "ylabel": "Serialized bytes per transaction",
@@ -33,6 +35,7 @@ CHARTS = [
     {
         "file": "block_tx_count_scatter.png",
         "sample_key": "serialized_block_tx_count",
+        "metric": "Transactions per Block",
         "label": "Transactions per Block Scatter",
         "title": "Transactions per block samples",
         "ylabel": "Transactions per block",
@@ -40,6 +43,7 @@ CHARTS = [
     {
         "file": "builder_latency_scatter.png",
         "sample_key": "builder_latency_ms",
+        "metric": "Builder Latency",
         "label": "Builder Latency Scatter",
         "title": "Builder latency samples",
         "ylabel": "Builder latency (ms)",
@@ -47,6 +51,7 @@ CHARTS = [
     {
         "file": "builder_finish_scatter.png",
         "sample_key": "builder_finish_ms",
+        "metric": "Builder Finish",
         "label": "Builder Finish Scatter",
         "title": "Builder finish samples",
         "ylabel": "Builder finish (ms)",
@@ -54,6 +59,7 @@ CHARTS = [
     {
         "file": "builder_pool_fetch_scatter.png",
         "sample_key": "builder_pool_fetch_ms",
+        "metric": "Builder Pool Fetch",
         "label": "Builder Pool Fetch Scatter",
         "title": "Builder pool fetch samples",
         "ylabel": "Builder pool fetch (ms)",
@@ -61,6 +67,7 @@ CHARTS = [
     {
         "file": "builder_invalid_tx_execution_attempts_scatter.png",
         "sample_key": "builder_invalid_tx_execution_attempts",
+        "metric": "Builder Invalid Tx Attempts",
         "label": "Builder Invalid Tx Attempts Scatter",
         "title": "Builder invalid transaction attempts samples",
         "ylabel": "Invalid transaction attempts",
@@ -68,6 +75,7 @@ CHARTS = [
     {
         "file": "serialized_block_size_scatter.png",
         "sample_key": "serialized_block_size_bytes",
+        "metric": "Serialized Block Size",
         "label": "Serialized Block Size Scatter",
         "title": "Serialized block size samples",
         "ylabel": "Serialized block size (MiB)",
@@ -76,6 +84,7 @@ CHARTS = [
     {
         "file": "builder_fill_idle_scatter.png",
         "sample_key": "builder_fill_idle_ms",
+        "metric": "Builder Fill Idle",
         "label": "Builder Fill Idle Scatter",
         "title": "Builder fill idle samples",
         "ylabel": "Builder fill idle (ms)",
@@ -83,6 +92,7 @@ CHARTS = [
     {
         "file": "validation_latency_scatter.png",
         "sample_key": "validation_latency_ms",
+        "metric": "Validation Latency",
         "label": "Validation Latency Scatter",
         "title": "Validation latency samples",
         "ylabel": "Validation latency (ms)",
@@ -296,7 +306,14 @@ def main() -> None:
             ylabel=chart["ylabel"],
             scale=chart.get("scale", 1.0),
         ):
-            written.append({"file": chart["file"], "label": chart["label"]})
+            written.append(
+                {
+                    "file": chart["file"],
+                    "label": chart["label"],
+                    "metric": chart["metric"],
+                    "kind": "scatter",
+                }
+            )
 
         stem = chart["file"].removesuffix("_scatter.png")
         for group, display_name in [
@@ -315,7 +332,14 @@ def main() -> None:
                 xlabel=chart["ylabel"],
                 scale=chart.get("scale", 1.0),
             ):
-                written.append({"file": file_name, "label": label})
+                written.append(
+                    {
+                        "file": file_name,
+                        "label": label,
+                        "metric": chart["metric"],
+                        "kind": f"{group}_distribution",
+                    }
+                )
 
     if not written:
         raise SystemExit("summary.json has no chartable samples")

--- a/.github/scripts/bench-e2e-charts.py
+++ b/.github/scripts/bench-e2e-charts.py
@@ -15,6 +15,73 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 
+CHARTS = [
+    {
+        "file": "block_time_scatter.png",
+        "sample_key": "block_time_ms",
+        "label": "Block Time Scatter",
+        "title": "Block time samples",
+        "ylabel": "Block time (ms)",
+    },
+    {
+        "file": "serialized_block_size_per_tx_scatter.png",
+        "sample_key": "serialized_block_size_per_tx_bytes",
+        "label": "Serialized Block Size per Transaction Scatter",
+        "title": "Serialized block size per transaction samples",
+        "ylabel": "Serialized bytes per transaction",
+    },
+    {
+        "file": "builder_latency_scatter.png",
+        "sample_key": "builder_latency_ms",
+        "label": "Builder Latency Scatter",
+        "title": "Builder latency samples",
+        "ylabel": "Builder latency (ms)",
+    },
+    {
+        "file": "builder_finish_scatter.png",
+        "sample_key": "builder_finish_ms",
+        "label": "Builder Finish Scatter",
+        "title": "Builder finish samples",
+        "ylabel": "Builder finish (ms)",
+    },
+    {
+        "file": "builder_pool_fetch_scatter.png",
+        "sample_key": "builder_pool_fetch_ms",
+        "label": "Builder Pool Fetch Scatter",
+        "title": "Builder pool fetch samples",
+        "ylabel": "Builder pool fetch (ms)",
+    },
+    {
+        "file": "builder_invalid_tx_execution_attempts_scatter.png",
+        "sample_key": "builder_invalid_tx_execution_attempts",
+        "label": "Builder Invalid Tx Attempts Scatter",
+        "title": "Builder invalid transaction attempts samples",
+        "ylabel": "Invalid transaction attempts",
+    },
+    {
+        "file": "serialized_block_size_scatter.png",
+        "sample_key": "serialized_block_size_bytes",
+        "label": "Serialized Block Size Scatter",
+        "title": "Serialized block size samples",
+        "ylabel": "Serialized block size (bytes)",
+    },
+    {
+        "file": "builder_fill_idle_scatter.png",
+        "sample_key": "builder_fill_idle_ms",
+        "label": "Builder Fill Idle Scatter",
+        "title": "Builder fill idle samples",
+        "ylabel": "Builder fill idle (ms)",
+    },
+    {
+        "file": "validation_latency_scatter.png",
+        "sample_key": "validation_latency_ms",
+        "label": "Validation Latency Scatter",
+        "title": "Validation latency samples",
+        "ylabel": "Validation latency (ms)",
+    },
+]
+
+
 def number(value: Any) -> float | None:
     if value is None:
         return None
@@ -140,35 +207,9 @@ def main() -> None:
     if not per_run:
         raise SystemExit("summary.json has no per_run data")
 
-    charts = [
-        {
-            "file": "builder_latency_scatter.png",
-            "sample_key": "builder_latency_ms",
-            "title": "Builder latency samples",
-            "ylabel": "Builder latency (ms)",
-        },
-        {
-            "file": "block_size_scatter.png",
-            "sample_key": "serialized_block_size_bytes",
-            "title": "Serialized block size samples",
-            "ylabel": "Serialized block size (bytes)",
-        },
-        {
-            "file": "block_tx_count_scatter.png",
-            "sample_key": "serialized_block_tx_count",
-            "title": "Block transaction count samples",
-            "ylabel": "Transactions per block",
-        },
-        {
-            "file": "block_bytes_per_tx_scatter.png",
-            "sample_key": "serialized_block_size_per_tx_bytes",
-            "title": "Serialized bytes per transaction samples",
-            "ylabel": "Serialized bytes per transaction",
-        },
-    ]
     written = [
-        chart["file"]
-        for chart in charts
+        {"file": chart["file"], "label": chart["label"]}
+        for chart in CHARTS
         if maybe_scatter_samples(
             per_run,
             output_dir / chart["file"],
@@ -181,6 +222,8 @@ def main() -> None:
     ]
     if not written:
         raise SystemExit("summary.json has no chartable samples")
+    with (output_dir / "charts.json").open("w") as f:
+        json.dump(written, f, indent=2)
     print(f"Charts written to {output_dir}")
 
 

--- a/.github/scripts/bench-e2e-charts.py
+++ b/.github/scripts/bench-e2e-charts.py
@@ -40,11 +40,15 @@ def group_name(label: str) -> str:
     return "other"
 
 
-def scatter_builder_latency(
+def scatter_samples(
     per_run: list[dict[str, Any]],
     output: Path,
     baseline_name: str,
     feature_name: str,
+    *,
+    sample_key: str,
+    title: str,
+    ylabel: str,
 ) -> None:
     rng = random.Random(1337)
     colors = {
@@ -65,7 +69,7 @@ def scatter_builder_latency(
 
     for idx, run in enumerate(per_run, start=1):
         label = str(run.get("label") or f"run-{idx}")
-        samples = values(run, "builder_latency_ms")
+        samples = values(run, sample_key)
         if not samples:
             continue
 
@@ -78,17 +82,43 @@ def scatter_builder_latency(
         tick_labels.append(label)
 
     if not tick_positions:
-        raise SystemExit("summary.json has no builder_latency_ms samples")
+        raise ValueError(f"summary.json has no {sample_key} samples")
 
-    ax.set_title("Builder latency samples")
+    ax.set_title(title)
     ax.set_xlabel("Run")
-    ax.set_ylabel("Builder latency (ms)")
+    ax.set_ylabel(ylabel)
     ax.set_xticks(tick_positions)
     ax.set_xticklabels(tick_labels, rotation=30, ha="right")
     ax.grid(True, axis="y", alpha=0.25)
     ax.legend()
     fig.savefig(output, dpi=160)
     plt.close(fig)
+
+
+def maybe_scatter_samples(
+    per_run: list[dict[str, Any]],
+    output: Path,
+    baseline_name: str,
+    feature_name: str,
+    *,
+    sample_key: str,
+    title: str,
+    ylabel: str,
+) -> bool:
+    try:
+        scatter_samples(
+            per_run,
+            output,
+            baseline_name,
+            feature_name,
+            sample_key=sample_key,
+            title=title,
+            ylabel=ylabel,
+        )
+    except ValueError as error:
+        print(f"Skipping {output.name}: {error}")
+        return False
+    return True
 
 
 def main() -> None:
@@ -110,12 +140,47 @@ def main() -> None:
     if not per_run:
         raise SystemExit("summary.json has no per_run data")
 
-    scatter_builder_latency(
-        per_run,
-        output_dir / "builder_latency_scatter.png",
-        args.baseline_name,
-        args.feature_name,
-    )
+    charts = [
+        {
+            "file": "builder_latency_scatter.png",
+            "sample_key": "builder_latency_ms",
+            "title": "Builder latency samples",
+            "ylabel": "Builder latency (ms)",
+        },
+        {
+            "file": "block_size_scatter.png",
+            "sample_key": "serialized_block_size_bytes",
+            "title": "Serialized block size samples",
+            "ylabel": "Serialized block size (bytes)",
+        },
+        {
+            "file": "block_tx_count_scatter.png",
+            "sample_key": "serialized_block_tx_count",
+            "title": "Block transaction count samples",
+            "ylabel": "Transactions per block",
+        },
+        {
+            "file": "block_bytes_per_tx_scatter.png",
+            "sample_key": "serialized_block_size_per_tx_bytes",
+            "title": "Serialized bytes per transaction samples",
+            "ylabel": "Serialized bytes per transaction",
+        },
+    ]
+    written = [
+        chart["file"]
+        for chart in charts
+        if maybe_scatter_samples(
+            per_run,
+            output_dir / chart["file"],
+            args.baseline_name,
+            args.feature_name,
+            sample_key=chart["sample_key"],
+            title=chart["title"],
+            ylabel=chart["ylabel"],
+        )
+    ]
+    if not written:
+        raise SystemExit("summary.json has no chartable samples")
     print(f"Charts written to {output_dir}")
 
 

--- a/.github/scripts/bench-e2e-charts.py
+++ b/.github/scripts/bench-e2e-charts.py
@@ -31,6 +31,13 @@ CHARTS = [
         "ylabel": "Serialized bytes per transaction",
     },
     {
+        "file": "block_tx_count_scatter.png",
+        "sample_key": "serialized_block_tx_count",
+        "label": "Transactions per Block Scatter",
+        "title": "Transactions per block samples",
+        "ylabel": "Transactions per block",
+    },
+    {
         "file": "builder_latency_scatter.png",
         "sample_key": "builder_latency_ms",
         "label": "Builder Latency Scatter",

--- a/.github/scripts/bench-e2e-charts.py
+++ b/.github/scripts/bench-e2e-charts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Generate scatter plots for tempo e2e benchmark sample distributions."""
+"""Generate plots for tempo e2e benchmark sample distributions."""
 
 from __future__ import annotations
 
@@ -107,6 +107,15 @@ def group_name(label: str) -> str:
     return "other"
 
 
+def group_values(per_run: list[dict[str, Any]], sample_key: str, group: str) -> list[float]:
+    samples: list[float] = []
+    for run in per_run:
+        label = str(run.get("label") or "")
+        if group_name(label) == group:
+            samples.extend(values(run, sample_key))
+    return samples
+
+
 def scatter_samples(
     per_run: list[dict[str, Any]],
     output: Path,
@@ -162,6 +171,32 @@ def scatter_samples(
     plt.close(fig)
 
 
+def distribution_samples(
+    per_run: list[dict[str, Any]],
+    output: Path,
+    display_name: str,
+    *,
+    sample_key: str,
+    group: str,
+    title: str,
+    xlabel: str,
+) -> None:
+    samples = group_values(per_run, sample_key, group)
+    if not samples:
+        raise ValueError(f"summary.json has no {group} {sample_key} samples")
+
+    color = "#4c78a8" if group == "baseline" else "#f58518"
+    bins = min(60, max(10, int(len(samples) ** 0.5)))
+    fig, ax = plt.subplots(figsize=(10, 6), constrained_layout=True)
+    ax.hist(samples, bins=bins, density=True, alpha=0.72, color=color, edgecolor="white")
+    ax.set_title(f"{display_name}: {title}")
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel("Density")
+    ax.grid(True, axis="y", alpha=0.25)
+    fig.savefig(output, dpi=160)
+    plt.close(fig)
+
+
 def maybe_scatter_samples(
     per_run: list[dict[str, Any]],
     output: Path,
@@ -188,6 +223,32 @@ def maybe_scatter_samples(
     return True
 
 
+def maybe_distribution_samples(
+    per_run: list[dict[str, Any]],
+    output: Path,
+    display_name: str,
+    *,
+    sample_key: str,
+    group: str,
+    title: str,
+    xlabel: str,
+) -> bool:
+    try:
+        distribution_samples(
+            per_run,
+            output,
+            display_name,
+            sample_key=sample_key,
+            group=group,
+            title=title,
+            xlabel=xlabel,
+        )
+    except ValueError as error:
+        print(f"Skipping {output.name}: {error}")
+        return False
+    return True
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--results-dir", required=True)
@@ -207,9 +268,8 @@ def main() -> None:
     if not per_run:
         raise SystemExit("summary.json has no per_run data")
 
-    written = [
-        {"file": chart["file"], "label": chart["label"]}
-        for chart in CHARTS
+    written: list[dict[str, str]] = []
+    for chart in CHARTS:
         if maybe_scatter_samples(
             per_run,
             output_dir / chart["file"],
@@ -218,8 +278,27 @@ def main() -> None:
             sample_key=chart["sample_key"],
             title=chart["title"],
             ylabel=chart["ylabel"],
-        )
-    ]
+        ):
+            written.append({"file": chart["file"], "label": chart["label"]})
+
+        stem = chart["file"].removesuffix("_scatter.png")
+        for group, display_name in [
+            ("baseline", args.baseline_name or "baseline"),
+            ("feature", args.feature_name or "feature"),
+        ]:
+            file_name = f"{stem}_{group}_distribution.png"
+            label = f"{chart['label'].removesuffix(' Scatter')} {group.title()} Distribution"
+            if maybe_distribution_samples(
+                per_run,
+                output_dir / file_name,
+                display_name,
+                sample_key=chart["sample_key"],
+                group=group,
+                title=chart["title"],
+                xlabel=chart["ylabel"],
+            ):
+                written.append({"file": file_name, "label": label})
+
     if not written:
         raise SystemExit("summary.json has no chartable samples")
     with (output_dir / "charts.json").open("w") as f:

--- a/.github/scripts/bench-e2e-charts.py
+++ b/.github/scripts/bench-e2e-charts.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+"""Generate scatter plots for tempo e2e benchmark sample distributions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def number(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def values(run: dict[str, Any], key: str) -> list[float]:
+    raw = run.get(key) or []
+    if not isinstance(raw, list):
+        return []
+    parsed = [number(value) for value in raw]
+    return [value for value in parsed if value is not None]
+
+
+def group_name(label: str) -> str:
+    if label.startswith("baseline"):
+        return "baseline"
+    if label.startswith("feature"):
+        return "feature"
+    return "other"
+
+
+def scatter_builder_latency(
+    per_run: list[dict[str, Any]],
+    output: Path,
+    baseline_name: str,
+    feature_name: str,
+) -> None:
+    rng = random.Random(1337)
+    colors = {
+        "baseline": "#4c78a8",
+        "feature": "#f58518",
+        "other": "#777777",
+    }
+    display_names = {
+        "baseline": baseline_name or "baseline",
+        "feature": feature_name or "feature",
+        "other": "other",
+    }
+
+    fig, ax = plt.subplots(figsize=(14, 7), constrained_layout=True)
+    seen_groups: set[str] = set()
+    tick_positions: list[int] = []
+    tick_labels: list[str] = []
+
+    for idx, run in enumerate(per_run, start=1):
+        label = str(run.get("label") or f"run-{idx}")
+        samples = values(run, "builder_latency_ms")
+        if not samples:
+            continue
+
+        group = group_name(label)
+        xs = [idx + rng.uniform(-0.18, 0.18) for _ in samples]
+        plot_label = display_names[group] if group not in seen_groups else None
+        ax.scatter(xs, samples, s=13, alpha=0.42, color=colors[group], label=plot_label)
+        seen_groups.add(group)
+        tick_positions.append(idx)
+        tick_labels.append(label)
+
+    if not tick_positions:
+        raise SystemExit("summary.json has no builder_latency_ms samples")
+
+    ax.set_title("Builder latency samples")
+    ax.set_xlabel("Run")
+    ax.set_ylabel("Builder latency (ms)")
+    ax.set_xticks(tick_positions)
+    ax.set_xticklabels(tick_labels, rotation=30, ha="right")
+    ax.grid(True, axis="y", alpha=0.25)
+    ax.legend()
+    fig.savefig(output, dpi=160)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results-dir", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--baseline-name", default="baseline")
+    parser.add_argument("--feature-name", default="feature")
+    args = parser.parse_args()
+
+    results_dir = Path(args.results_dir)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with (results_dir / "summary.json").open() as f:
+        summary = json.load(f)
+
+    per_run = summary.get("per_run") or []
+    if not per_run:
+        raise SystemExit("summary.json has no per_run data")
+
+    scatter_builder_latency(
+        per_run,
+        output_dir / "builder_latency_scatter.png",
+        args.baseline_name,
+        args.feature_name,
+    )
+    print(f"Charts written to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -310,6 +310,8 @@ on:
     secrets:
       DEREK_BENCH_TOKEN:
         required: false
+      DEREK_TOKEN:
+        required: false
       TEMPO_TELEMETRY_URL:
         required: false
       GRAFANA_TEMPO:
@@ -889,12 +891,56 @@ jobs:
             echo "url=${VALSCOPE_REPORTS_BASE_URL%/}/${BENCHMARK_ID}/" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Generate metric scatter plots
+        id: charts
+        if: success()
+        env:
+          BENCH_RESULTS_DIR: ${{ steps.results-dir.outputs.path }}
+          BENCH_BASELINE_NAME: ${{ steps.refs.outputs.baseline-name }}
+          BENCH_FEATURE_NAME: ${{ steps.refs.outputs.feature-name }}
+        run: |
+          uv run --with matplotlib python .github/scripts/bench-e2e-charts.py \
+            --results-dir "$BENCH_RESULTS_DIR" \
+            --output-dir "$BENCH_RESULTS_DIR/charts" \
+            --baseline-name "$BENCH_BASELINE_NAME" \
+            --feature-name "$BENCH_FEATURE_NAME"
+
       - name: Upload results
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tempo-bench-results
           path: bench-results/
+
+      - name: Push charts
+        id: push-charts
+        if: success() && hashFiles('bench-results/*/charts/*.png') != ''
+        run: |
+          RUN_ID=${{ github.run_id }}
+          if [ -n "${BENCH_PR:-}" ]; then
+            CHART_DIR="pr/${BENCH_PR}/${RUN_ID}/e2e"
+          else
+            CHART_DIR="e2e/${RUN_ID}"
+          fi
+          CHARTS_REPO="https://x-access-token:${{ secrets.DEREK_TOKEN }}@github.com/decofe/tempo-bench-charts.git"
+
+          TMP_DIR=$(mktemp -d)
+          if git clone --depth 1 "${CHARTS_REPO}" "${TMP_DIR}" 2>/dev/null; then
+            true
+          else
+            git init "${TMP_DIR}"
+            git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
+          fi
+
+          mkdir -p "${TMP_DIR}/${CHART_DIR}"
+          cp "${{ steps.results-dir.outputs.path }}"/charts/*.png "${TMP_DIR}/${CHART_DIR}/"
+          git -C "${TMP_DIR}" add "${CHART_DIR}"
+          git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
+            commit -m "bench e2e charts for run ${RUN_ID}"
+          git -C "${TMP_DIR}" push origin HEAD:main
+          echo "sha=$(git -C "${TMP_DIR}" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "path=${CHART_DIR}" >> "$GITHUB_OUTPUT"
+          rm -rf "${TMP_DIR}"
 
       - name: Post results to PR
         if: success()
@@ -1037,8 +1083,24 @@ jobs:
               }
             }
 
+            let chartsSection = '';
+            const chartSha = '${{ steps.push-charts.outputs.sha }}';
+            const chartPath = '${{ steps.push-charts.outputs.path }}';
+            if (chartSha && chartPath) {
+              const baseUrl = `https://raw.githubusercontent.com/decofe/tempo-bench-charts/${chartSha}/${chartPath}`;
+              const charts = [
+                { file: 'builder_latency_scatter.png', label: 'Builder Latency Scatter' },
+              ];
+              chartsSection = '\n\n### Builder Latency Scatter Plot\n\n';
+              for (const chart of charts) {
+                chartsSection += `<details><summary>${chart.label}</summary>\n\n`;
+                chartsSection += `![${chart.label}](${baseUrl}/${chart.file})\n\n`;
+                chartsSection += `</details>\n\n`;
+              }
+            }
+
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = `cc @${process.env.BENCH_ACTOR}\n\n${resultHeadline} [View job](${jobUrl})\n\n${summary}${grafanaSection}${samplySection}${tracySection}`;
+            const body = `cc @${process.env.BENCH_ACTOR}\n\n${resultHeadline} [View job](${jobUrl})\n\n${summary}${grafanaSection}${chartsSection}${samplySection}${tracySection}`;
             const ackCommentId = process.env.BENCH_COMMENT_ID;
 
             if (ackCommentId) {

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -1088,12 +1088,12 @@ jobs:
             const chartPath = '${{ steps.push-charts.outputs.path }}';
             if (chartSha && chartPath) {
               const baseUrl = `https://raw.githubusercontent.com/decofe/tempo-bench-charts/${chartSha}/${chartPath}`;
-              const charts = [
-                { file: 'builder_latency_scatter.png', label: 'Builder Latency Scatter' },
-                { file: 'block_size_scatter.png', label: 'Serialized Block Size Scatter' },
-                { file: 'block_tx_count_scatter.png', label: 'Block Transaction Count Scatter' },
-                { file: 'block_bytes_per_tx_scatter.png', label: 'Serialized Bytes per Transaction Scatter' },
-              ];
+              let charts = [];
+              try {
+                charts = JSON.parse(fs.readFileSync(`${process.env.BENCH_RESULTS_DIR}/charts/charts.json`, 'utf8'));
+              } catch (error) {
+                core.info(`No chart manifest found: ${error.message}`);
+              }
               chartsSection = '\n\n### Scatter Plots\n\n';
               for (const chart of charts) {
                 chartsSection += `<details><summary>${chart.label}</summary>\n\n`;

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -1090,8 +1090,11 @@ jobs:
               const baseUrl = `https://raw.githubusercontent.com/decofe/tempo-bench-charts/${chartSha}/${chartPath}`;
               const charts = [
                 { file: 'builder_latency_scatter.png', label: 'Builder Latency Scatter' },
+                { file: 'block_size_scatter.png', label: 'Serialized Block Size Scatter' },
+                { file: 'block_tx_count_scatter.png', label: 'Block Transaction Count Scatter' },
+                { file: 'block_bytes_per_tx_scatter.png', label: 'Serialized Bytes per Transaction Scatter' },
               ];
-              chartsSection = '\n\n### Builder Latency Scatter Plot\n\n';
+              chartsSection = '\n\n### Scatter Plots\n\n';
               for (const chart of charts) {
                 chartsSection += `<details><summary>${chart.label}</summary>\n\n`;
                 chartsSection += `![${chart.label}](${baseUrl}/${chart.file})\n\n`;

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -1094,10 +1094,23 @@ jobs:
               } catch (error) {
                 core.info(`No chart manifest found: ${error.message}`);
               }
-              chartsSection = '\n\n### Scatter Plots\n\n';
+              const groupedCharts = new Map();
               for (const chart of charts) {
-                chartsSection += `<details><summary>${chart.label}</summary>\n\n`;
-                chartsSection += `![${chart.label}](${baseUrl}/${chart.file})\n\n`;
+                const metric = chart.metric || chart.label;
+                if (!groupedCharts.has(metric)) groupedCharts.set(metric, []);
+                groupedCharts.get(metric).push(chart);
+              }
+
+              const chartOrder = ['scatter', 'baseline_distribution', 'feature_distribution'];
+              chartsSection = '\n\n### Metric Distribution Plots\n\n';
+              for (const [metric, metricCharts] of groupedCharts) {
+                metricCharts.sort((a, b) => chartOrder.indexOf(a.kind) - chartOrder.indexOf(b.kind));
+                chartsSection += `<details><summary>${metric}</summary>\n\n`;
+                for (const chart of metricCharts) {
+                  const heading = chart.kind === 'scatter' ? 'Scatter' : chart.kind === 'baseline_distribution' ? 'Baseline distribution' : chart.kind === 'feature_distribution' ? 'Feature distribution' : chart.label;
+                  chartsSection += `#### ${heading}\n\n`;
+                  chartsSection += `![${chart.label}](${baseUrl}/${chart.file})\n\n`;
+                }
                 chartsSection += `</details>\n\n`;
               }
             }

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -1102,7 +1102,7 @@ jobs:
               }
 
               const chartOrder = ['scatter', 'baseline_distribution', 'feature_distribution'];
-              chartsSection = '\n\n### Metric Distribution Plots\n\n';
+              chartsSection = '\n\n<details><summary>Metric distribution plots</summary>\n\n';
               for (const [metric, metricCharts] of groupedCharts) {
                 metricCharts.sort((a, b) => chartOrder.indexOf(a.kind) - chartOrder.indexOf(b.kind));
                 chartsSection += `<details><summary>${metric}</summary>\n\n`;
@@ -1113,6 +1113,7 @@ jobs:
                 }
                 chartsSection += `</details>\n\n`;
               }
+              chartsSection += '</details>\n';
             }
 
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -552,6 +552,7 @@ jobs:
       pr-head-ref: ${{ needs.tempo-bench-ack.outputs.pr-head-ref }}
     secrets:
       DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
+      DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
       GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}
       CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}

--- a/tempo.nu
+++ b/tempo.nu
@@ -1305,7 +1305,13 @@ def generate-summary [
             err: $total_err
             total_gas: $total_gas
             block_time_mean: $block_time_mean
+            block_time_ms: $block_intervals
             builder_latency_ms: $builder_latency_values
+            builder_finish_ms: $builder_finish_samples
+            builder_pool_fetch_ms: $builder_pool_fetch_samples
+            builder_invalid_tx_execution_attempts: $builder_invalid_tx_execution_attempts_samples
+            builder_fill_idle_ms: $builder_fill_idle_samples
+            validation_latency_ms: $validation_latency_values
             serialized_block_size_bytes: $serialized_block_size_values
             serialized_block_tx_count: $serialized_block_tx_count_values
             serialized_block_size_per_tx_bytes: $serialized_block_size_per_tx_values

--- a/tempo.nu
+++ b/tempo.nu
@@ -1306,6 +1306,9 @@ def generate-summary [
             total_gas: $total_gas
             block_time_mean: $block_time_mean
             builder_latency_ms: $builder_latency_values
+            serialized_block_size_bytes: $serialized_block_size_values
+            serialized_block_tx_count: $serialized_block_tx_count_values
+            serialized_block_size_per_tx_bytes: $serialized_block_size_per_tx_values
             builder_latency_p50: $run_builder.p50
             builder_latency_p90: $run_builder.p90
             builder_latency_p99: $run_builder.p99

--- a/tempo.nu
+++ b/tempo.nu
@@ -1305,6 +1305,7 @@ def generate-summary [
             err: $total_err
             total_gas: $total_gas
             block_time_mean: $block_time_mean
+            builder_latency_ms: $builder_latency_values
             builder_latency_p50: $run_builder.p50
             builder_latency_p90: $run_builder.p90
             builder_latency_p99: $run_builder.p99


### PR DESCRIPTION
Adds a builder latency scatter plot to the derek bench e2e result comment. The summary now carries per-run builder latency samples, the workflow renders a single builder_latency_scatter.png chart from those samples, uploads it with the bench artifact, publishes it to the charts repo, and embeds it in the GitHub comment.

Validation:
- Rendered synthetic builder_latency_scatter.png with uv run --with matplotlib python .github/scripts/bench-e2e-charts.py
- Parsed .github/workflows/bench.yml and .github/workflows/bench-e2e.yml with PyYAML

Prompted by: @Rjected