### PR TITLE
DNM: chore: add marshal broadcast instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,7 +2976,7 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -2992,7 +2992,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3006,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "commonware-coding"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3057,7 +3057,7 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -3091,7 +3091,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -3100,7 +3100,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros-impl"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "commonware-math"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3125,7 +3125,7 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -3151,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "commonware-parallel"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3181,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "axum",
  "bytes",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3241,7 +3241,7 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
@@ -3260,7 +3260,7 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,7 +2976,7 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -2992,7 +2992,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3006,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "commonware-coding"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3057,7 +3057,7 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -3091,7 +3091,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -3100,7 +3100,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros-impl"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "commonware-math"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3125,7 +3125,7 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -3151,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "commonware-parallel"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3181,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "axum",
  "bytes",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3241,7 +3241,7 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
@@ -3260,7 +3260,7 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#d95049880f822216df8acb7aeca04914c638f2d3"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,7 +2976,7 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -2992,7 +2992,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3006,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "commonware-coding"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3057,7 +3057,7 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -3091,7 +3091,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -3100,7 +3100,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros-impl"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "commonware-math"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3125,7 +3125,7 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -3151,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "commonware-parallel"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3181,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "axum",
  "bytes",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3241,7 +3241,7 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
@@ -3260,7 +3260,7 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "2026.4.0"
-source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#9653d45575589955aa516bd9e9ad4fd78dfb5b0a"
+source = "git+https://github.com/mattsse/monorepo?branch=mattsse%2Fmarshal-broadcast-instrumentation#fe87e731c4c9bb0095a6e33e1886031dfa59e0e4"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -395,16 +395,16 @@ vergen-git2 = "9.1.0"
 # reth-trie-sparse = { path = "../reth/crates/trie/sparse" }
 
 [patch.crates-io]
-# Commonware at HEAD after PR #3588 was merged
-commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
+# Commonware at HEAD after PR #3588 was merged, with marshal/broadcast trace instrumentation.
+commonware-broadcast = { git = "https://github.com/mattsse/monorepo", branch = "mattsse/marshal-broadcast-instrumentation" }
+commonware-codec = { git = "https://github.com/mattsse/monorepo", branch = "mattsse/marshal-broadcast-instrumentation" }
+commonware-consensus = { git = "https://github.com/mattsse/monorepo", branch = "mattsse/marshal-broadcast-instrumentation" }
+commonware-cryptography = { git = "https://github.com/mattsse/monorepo", branch = "mattsse/marshal-broadcast-instrumentation" }
+commonware-macros = { git = "https://github.com/mattsse/monorepo", branch = "mattsse/marshal-broadcast-instrumentation" }
+commonware-math = { git = "https://github.com/mattsse/monorepo", branch = "mattsse/marshal-broadcast-instrumentation" }
+commonware-p2p = { git = "https://github.com/mattsse/monorepo", branch = "mattsse/marshal-broadcast-instrumentation" }
+commonware-parallel = { git = "https://github.com/mattsse/monorepo", branch = "mattsse/marshal-broadcast-instrumentation" }
+commonware-resolver = { git = "https://github.com/mattsse/monorepo", branch = "mattsse/marshal-broadcast-instrumentation" }
+commonware-runtime = { git = "https://github.com/mattsse/monorepo", branch = "mattsse/marshal-broadcast-instrumentation" }
+commonware-storage = { git = "https://github.com/mattsse/monorepo", branch = "mattsse/marshal-broadcast-instrumentation" }
+commonware-utils = { git = "https://github.com/mattsse/monorepo", branch = "mattsse/marshal-broadcast-instrumentation" }

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -35,7 +35,7 @@ use prometheus_client::metrics::counter::Counter;
 use commonware_utils::SystemTimeExt;
 use eyre::{OptionExt as _, WrapErr as _, bail, ensure, eyre};
 use futures::{
-    StreamExt as _, TryFutureExt as _,
+    StreamExt as _,
     channel::{mpsc, oneshot},
     future::try_join,
 };
@@ -245,7 +245,22 @@ impl Inner<Init> {
             Plan::Propose { round } => (round, Recipients::All),
             Plan::Forward { round, recipients } => (round, recipients),
         };
+        info!(
+            target: "tempo_marshal_path",
+            ?round,
+            ?digest,
+            ?recipients,
+            "tempo_application_broadcast_start"
+        );
+        let start = Instant::now();
         self.marshal.forward(round, digest, recipients).await;
+        info!(
+            target: "tempo_marshal_path",
+            ?round,
+            ?digest,
+            elapsed = ?start.elapsed(),
+            "tempo_application_broadcast_done"
+        );
     }
 
     #[instrument(
@@ -397,18 +412,53 @@ impl Inner<Init> {
                 };
 
                 let digest = block.digest();
+                let height = block.height();
+                info!(
+                    target: "tempo_marshal_path",
+                    ?round,
+                    ?digest,
+                    %height,
+                    has_new_block = proposal_return.is_some(),
+                    "tempo_propose_block_ready"
+                );
                 if let Some(proposal_return) = proposal_return {
                     let persist_start = Instant::now();
+                    info!(
+                        target: "tempo_marshal_path",
+                        ?round,
+                        ?digest,
+                        %height,
+                        "tempo_propose_marshal_proposed_start"
+                    );
                     if !self.marshal.proposed(round, block).await {
                         bail!("marshal actor rejected persisting proposal");
                     }
-                    observe_marshal_persist(
-                        proposal_return.block_size_bytes,
-                        persist_start.elapsed(),
+                    let persist_elapsed = persist_start.elapsed();
+                    info!(
+                        target: "tempo_marshal_path",
+                        ?round,
+                        ?digest,
+                        %height,
+                        elapsed = ?persist_elapsed,
+                        "tempo_propose_marshal_proposed_done"
                     );
+                    observe_marshal_persist(proposal_return.block_size_bytes, persist_elapsed);
 
                     // Keep waiting for the remaining return time, if there's anything left after building the block.
+                    info!(
+                        target: "tempo_marshal_path",
+                        ?round,
+                        ?digest,
+                        return_time = ?proposal_return.time,
+                        "tempo_propose_return_delay_start"
+                    );
                     context.sleep_until(proposal_return.time).await;
+                    info!(
+                        target: "tempo_marshal_path",
+                        ?round,
+                        ?digest,
+                        "tempo_propose_return_delay_done"
+                    );
                 }
 
                 eyre::Ok(digest)
@@ -435,6 +485,12 @@ impl Inner<Init> {
             proposal.digest = %proposal_digest,
             "constructed proposal",
         );
+        info!(
+            target: "tempo_marshal_path",
+            ?round,
+            proposal.digest = %proposal_digest,
+            "tempo_propose_digest_returning_to_simplex"
+        );
 
         response.send(proposal_digest).map_err(|_| {
             eyre!(
@@ -442,6 +498,12 @@ impl Inner<Init> {
                 channel was already closed"
             )
         })?;
+        info!(
+            target: "tempo_marshal_path",
+            ?round,
+            proposal.digest = %proposal_digest,
+            "tempo_propose_digest_returned_to_simplex"
+        );
 
         Ok(())
     }
@@ -813,13 +875,44 @@ impl Inner<Init> {
         proposer: PublicKey,
         round: Round,
     ) -> eyre::Result<bool> {
-        let block_request = self
-            .marshal
-            .subscribe_by_digest(None, payload)
-            .await
-            .map_err(|_| {
+        let verify_start = Instant::now();
+        info!(
+            target: "tempo_marshal_path",
+            ?round,
+            ?payload,
+            ?parent_view,
+            ?parent_digest,
+            ?proposer,
+            "tempo_verify_start"
+        );
+
+        let subscribe_start = Instant::now();
+        let block_rx = self.marshal.subscribe_by_digest(None, payload).await;
+        info!(
+            target: "tempo_marshal_path",
+            ?round,
+            ?payload,
+            elapsed = ?subscribe_start.elapsed(),
+            "tempo_verify_block_subscription_registered"
+        );
+
+        let block_wait_start = Instant::now();
+        let payload_for_wait = payload;
+        let block_request = async move {
+            let block = block_rx.await.map_err(|_| {
                 eyre!("marshal actor dropped channel before the block-to-verified was sent")
-            });
+            })?;
+            info!(
+                target: "tempo_marshal_path",
+                ?round,
+                ?payload_for_wait,
+                block.height = %block.height(),
+                block.digest = %block.digest(),
+                elapsed = ?block_wait_start.elapsed(),
+                "tempo_verify_block_subscription_resolved"
+            );
+            Ok::<_, eyre::Report>(block)
+        };
 
         let (block, parent) = try_join(
             block_request,
@@ -833,6 +926,15 @@ impl Inner<Init> {
         )
         .await
         .wrap_err("failed getting required blocks")?;
+        info!(
+            target: "tempo_marshal_path",
+            ?round,
+            ?payload,
+            block.height = %block.height(),
+            parent.height = %parent.height(),
+            elapsed = ?verify_start.elapsed(),
+            "tempo_verify_required_blocks_ready"
+        );
 
         // Can only repropose at the end of an epoch.
         //
@@ -841,16 +943,44 @@ impl Inner<Init> {
         // immediately, and happen very rarely. It's better to optimize for the
         // general case.
         if payload == parent_digest {
+            info!(
+                target: "tempo_marshal_path",
+                ?round,
+                ?payload,
+                "tempo_verify_reproposal_detected"
+            );
             let epoch_info = self
                 .epoch_strategy
                 .containing(block.height())
                 .expect("epoch strategy is for all heights");
             if epoch_info.last() == block.height() && epoch_info.epoch() == round.epoch() {
+                let verified_persist_start = Instant::now();
+                info!(
+                    target: "tempo_marshal_path",
+                    ?round,
+                    ?payload,
+                    block.height = %block.height(),
+                    "tempo_verify_reproposal_marshal_verified_start"
+                );
                 if !self.marshal.verified(round, block).await {
                     bail!("marshal actor refused to persist verified re-proposed block");
                 }
+                info!(
+                    target: "tempo_marshal_path",
+                    ?round,
+                    ?payload,
+                    elapsed = ?verified_persist_start.elapsed(),
+                    total_elapsed = ?verify_start.elapsed(),
+                    "tempo_verify_reproposal_done"
+                );
                 return Ok(true);
             } else {
+                info!(
+                    target: "tempo_marshal_path",
+                    ?round,
+                    ?payload,
+                    "tempo_verify_reproposal_rejected"
+                );
                 return Ok(false);
             }
         }
@@ -865,6 +995,13 @@ impl Inner<Init> {
         )
         .await
         {
+            info!(
+                target: "tempo_marshal_path",
+                ?round,
+                ?payload,
+                %reason,
+                "tempo_verify_header_failed"
+            );
             warn!(%reason, "header could not be verified; failing block");
             return Ok(false);
         }
@@ -883,6 +1020,15 @@ impl Inner<Init> {
             );
         }
 
+        let execution_verify_start = Instant::now();
+        info!(
+            target: "tempo_marshal_path",
+            ?round,
+            ?payload,
+            block.height = %block.height(),
+            parent.digest = %parent_digest,
+            "tempo_verify_execution_start"
+        );
         let validation_duration = verify_block(
             context,
             round.epoch(),
@@ -897,6 +1043,15 @@ impl Inner<Init> {
         )
         .await
         .wrap_err("failed verifying block against execution layer")?;
+        info!(
+            target: "tempo_marshal_path",
+            ?round,
+            ?payload,
+            is_valid = validation_duration.is_some(),
+            validation_duration = ?validation_duration,
+            elapsed = ?execution_verify_start.elapsed(),
+            "tempo_verify_execution_done"
+        );
         if let Some(duration) = validation_duration
             && let Ok(mut estimator) = self.validation_latency_estimator.lock()
         {
@@ -916,17 +1071,50 @@ impl Inner<Init> {
 
         if is_good {
             // Persist the block in the marshal actor and execution layer.
+            let verified_persist_start = Instant::now();
+            info!(
+                target: "tempo_marshal_path",
+                ?round,
+                ?block_digest,
+                %block_height,
+                "tempo_verify_marshal_verified_start"
+            );
             if !self.marshal.verified(round, block).await {
                 bail!("marshal actor refused to persist verified block");
             }
+            info!(
+                target: "tempo_marshal_path",
+                ?round,
+                ?block_digest,
+                %block_height,
+                elapsed = ?verified_persist_start.elapsed(),
+                "tempo_verify_marshal_verified_done"
+            );
 
             // FIXME: move this into the certification step?
+            let canonicalize_start = Instant::now();
             self.state
                 .executor
                 .canonicalize_head(block_height, block_digest)
                 .await
                 .wrap_err("failed making the verified proposal the head of the canonical chain")?;
+            info!(
+                target: "tempo_marshal_path",
+                ?round,
+                ?block_digest,
+                %block_height,
+                elapsed = ?canonicalize_start.elapsed(),
+                "tempo_verify_canonicalize_verified_head_done"
+            );
         }
+        info!(
+            target: "tempo_marshal_path",
+            ?round,
+            ?payload,
+            is_good,
+            elapsed = ?verify_start.elapsed(),
+            "tempo_verify_done"
+        );
         Ok(is_good)
     }
 }
@@ -1166,6 +1354,14 @@ async fn get_parent(
     parent_view: View,
     marshal: &crate::alias::marshal::Mailbox,
 ) -> eyre::Result<Block> {
+    let start = Instant::now();
+    info!(
+        target: "tempo_marshal_path",
+        ?round,
+        ?parent_digest,
+        ?parent_view,
+        "tempo_get_parent_start"
+    );
     if let Some(parent) = execution_node
         .provider
         .find_block_by_hash(parent_digest.0, BlockSource::Any)
@@ -1174,13 +1370,53 @@ async fn get_parent(
         })?
     {
         // EL database reads do not include commonware sidecars.
-        Ok(Block::from_execution_block_unchecked(parent.seal(), None))
+        let parent = Block::from_execution_block_unchecked(parent.seal(), None);
+        info!(
+            target: "tempo_marshal_path",
+            ?round,
+            ?parent_digest,
+            ?parent_view,
+            parent.height = %parent.height(),
+            elapsed = ?start.elapsed(),
+            "tempo_get_parent_el_hit"
+        );
+        Ok(parent)
     } else {
-        marshal
-            .subscribe_by_digest(Some(Round::new(round.epoch(), parent_view)), parent_digest)
+        let parent_round = Round::new(round.epoch(), parent_view);
+        info!(
+            target: "tempo_marshal_path",
+            ?round,
+            ?parent_round,
+            ?parent_digest,
+            "tempo_get_parent_marshal_subscribe_start"
+        );
+        let subscribe_start = Instant::now();
+        let parent_rx = marshal
+            .subscribe_by_digest(Some(parent_round), parent_digest)
+            .await;
+        info!(
+            target: "tempo_marshal_path",
+            ?round,
+            ?parent_round,
+            ?parent_digest,
+            elapsed = ?subscribe_start.elapsed(),
+            "tempo_get_parent_marshal_subscribe_registered"
+        );
+        let wait_start = Instant::now();
+        let parent = parent_rx
             .await
-            .await
-            .map_err(|_| eyre!("syncer dropped channel before the parent block was sent"))
+            .map_err(|_| eyre!("syncer dropped channel before the parent block was sent"))?;
+        info!(
+            target: "tempo_marshal_path",
+            ?round,
+            ?parent_round,
+            ?parent_digest,
+            parent.height = %parent.height(),
+            elapsed = ?wait_start.elapsed(),
+            total_elapsed = ?start.elapsed(),
+            "tempo_get_parent_marshal_subscribe_resolved"
+        );
+        Ok(parent)
     }
 }
 

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -413,11 +413,16 @@ impl Inner<Init> {
 
                 let digest = block.digest();
                 let height = block.height();
+                let block_size_bytes = proposal_return
+                    .as_ref()
+                    .map(|proposal_return| proposal_return.block_size_bytes)
+                    .unwrap_or_else(|| block.encode_size());
                 info!(
                     target: "tempo_marshal_path",
                     ?round,
                     ?digest,
                     %height,
+                    block_size_bytes,
                     has_new_block = proposal_return.is_some(),
                     "tempo_propose_block_ready"
                 );
@@ -428,6 +433,7 @@ impl Inner<Init> {
                         ?round,
                         ?digest,
                         %height,
+                        block_size_bytes = proposal_return.block_size_bytes,
                         "tempo_propose_marshal_proposed_start"
                     );
                     if !self.marshal.proposed(round, block).await {
@@ -439,6 +445,7 @@ impl Inner<Init> {
                         ?round,
                         ?digest,
                         %height,
+                        block_size_bytes = proposal_return.block_size_bytes,
                         elapsed = ?persist_elapsed,
                         "tempo_propose_marshal_proposed_done"
                     );
@@ -449,6 +456,7 @@ impl Inner<Init> {
                         target: "tempo_marshal_path",
                         ?round,
                         ?digest,
+                        block_size_bytes = proposal_return.block_size_bytes,
                         return_time = ?proposal_return.time,
                         "tempo_propose_return_delay_start"
                     );
@@ -457,6 +465,7 @@ impl Inner<Init> {
                         target: "tempo_marshal_path",
                         ?round,
                         ?digest,
+                        block_size_bytes = proposal_return.block_size_bytes,
                         "tempo_propose_return_delay_done"
                     );
                 }
@@ -902,12 +911,14 @@ impl Inner<Init> {
             let block = block_rx.await.map_err(|_| {
                 eyre!("marshal actor dropped channel before the block-to-verified was sent")
             })?;
+            let block_size_bytes = block.encode_size();
             info!(
                 target: "tempo_marshal_path",
                 ?round,
                 ?payload_for_wait,
                 block.height = %block.height(),
                 block.digest = %block.digest(),
+                block_size_bytes,
                 elapsed = ?block_wait_start.elapsed(),
                 "tempo_verify_block_subscription_resolved"
             );
@@ -926,12 +937,14 @@ impl Inner<Init> {
         )
         .await
         .wrap_err("failed getting required blocks")?;
+        let block_size_bytes = block.encode_size();
         info!(
             target: "tempo_marshal_path",
             ?round,
             ?payload,
             block.height = %block.height(),
             parent.height = %parent.height(),
+            block_size_bytes,
             elapsed = ?verify_start.elapsed(),
             "tempo_verify_required_blocks_ready"
         );
@@ -960,6 +973,7 @@ impl Inner<Init> {
                     ?round,
                     ?payload,
                     block.height = %block.height(),
+                    block_size_bytes,
                     "tempo_verify_reproposal_marshal_verified_start"
                 );
                 if !self.marshal.verified(round, block).await {
@@ -969,6 +983,7 @@ impl Inner<Init> {
                     target: "tempo_marshal_path",
                     ?round,
                     ?payload,
+                    block_size_bytes,
                     elapsed = ?verified_persist_start.elapsed(),
                     total_elapsed = ?verify_start.elapsed(),
                     "tempo_verify_reproposal_done"
@@ -1027,6 +1042,7 @@ impl Inner<Init> {
             ?payload,
             block.height = %block.height(),
             parent.digest = %parent_digest,
+            block_size_bytes,
             "tempo_verify_execution_start"
         );
         let validation_duration = verify_block(
@@ -1049,6 +1065,7 @@ impl Inner<Init> {
             ?payload,
             is_valid = validation_duration.is_some(),
             validation_duration = ?validation_duration,
+            block_size_bytes,
             elapsed = ?execution_verify_start.elapsed(),
             "tempo_verify_execution_done"
         );
@@ -1077,6 +1094,7 @@ impl Inner<Init> {
                 ?round,
                 ?block_digest,
                 %block_height,
+                block_size_bytes,
                 "tempo_verify_marshal_verified_start"
             );
             if !self.marshal.verified(round, block).await {
@@ -1087,6 +1105,7 @@ impl Inner<Init> {
                 ?round,
                 ?block_digest,
                 %block_height,
+                block_size_bytes,
                 elapsed = ?verified_persist_start.elapsed(),
                 "tempo_verify_marshal_verified_done"
             );


### PR DESCRIPTION
Adds targeted `tempo_marshal_path` info logs across Tempo's proposal/verify path and the patched Commonware marshal/broadcast branch so benchmark logs can reconstruct Node A broadcast -> Node B subscription timing.

The dependency patch points Commonware crates at `mattsse/marshal-broadcast-instrumentation` commit `9653d455`, which instruments marshal subscription/forwarding and buffered broadcast send/receive/waiter events.