### PR TITLE
fix(ci): update stale Foundry Tempo locks first

### DIFF
--- a/scripts/foundry-patch.sh
+++ b/scripts/foundry-patch.sh
@@ -109,6 +109,47 @@ done <<< "$PATCHES"
 echo "Updated Cargo.toml patch sections:"
 sed -n '/^\[patch\./,$p' "$FOUNDRY_CARGO"
 
+update_stale_tempo_git_packages() {
+  local stale_tempo_pkgs
+  stale_tempo_pkgs="$(
+    awk '
+      /^\[\[package\]\]/ {
+        name = ""
+        version = ""
+        next
+      }
+      /^name = / {
+        name = $3
+        gsub(/"/, "", name)
+        next
+      }
+      /^version = / {
+        version = $3
+        gsub(/"/, "", version)
+        next
+      }
+      /^source = "git\+https:\/\/github.com\/tempoxyz\/tempo\?rev=/ {
+        if (name != "" && version != "") {
+          print name "@" version
+        }
+      }
+    ' Cargo.lock | sort -u
+  )"
+
+  if [[ -z "$stale_tempo_pkgs" ]]; then
+    return 0
+  fi
+
+  local update_args=()
+  while IFS= read -r pkg; do
+    [[ -n "$pkg" ]] || continue
+    update_args+=("-p" "$pkg")
+  done <<< "$stale_tempo_pkgs"
+
+  echo "Cargo.lock still contains stale Tempo git packages; running 'cargo update ${update_args[*]}'"
+  cargo update "${update_args[@]}" >/dev/null
+}
+
 # ── 4. Re-resolve the lockfile without upgrading unrelated crates ──────────
 # `cargo update` can pull newer upstream deps from Foundry's workspace, which is non-deterministic.
 # A normal resolver pass is enough to rewrite the lockfile entries for the tempo path overrides.
@@ -125,6 +166,7 @@ sed -n '/^\[patch\./,$p' "$FOUNDRY_CARGO"
 # without falling back to a blanket `cargo update`. Bail out if the same crate
 # conflicts twice in a row (i.e. `cargo update` made no progress).
 pushd "$FOUNDRY_ROOT" >/dev/null
+update_stale_tempo_git_packages
 prev_conflict_pkg=""
 while true; do
   err="$(cargo metadata --format-version=1 --no-default-features 2>&1 >/dev/null)" && break
@@ -144,40 +186,8 @@ while true; do
   prev_conflict_pkg="$conflict_pkg"
 done
 
-stale_tempo_pkgs="$(
-  awk '
-    /^\[\[package\]\]/ {
-      name = ""
-      version = ""
-      next
-    }
-    /^name = / {
-      name = $3
-      gsub(/"/, "", name)
-      next
-    }
-    /^version = / {
-      version = $3
-      gsub(/"/, "", version)
-      next
-    }
-    /^source = "git\+https:\/\/github.com\/tempoxyz\/tempo\?rev=/ {
-      if (name != "" && version != "") {
-        print name "@" version
-      }
-    }
-  ' Cargo.lock | sort -u
-)"
-if [[ -n "$stale_tempo_pkgs" ]]; then
-  update_args=()
-  while IFS= read -r pkg; do
-    [[ -n "$pkg" ]] || continue
-    update_args+=("-p" "$pkg")
-  done <<< "$stale_tempo_pkgs"
-  echo "Cargo.lock still contains stale Tempo git packages; running 'cargo update ${update_args[*]}'"
-  cargo update "${update_args[@]}" >/dev/null
-  cargo metadata --format-version=1 --no-default-features >/dev/null
-fi
+update_stale_tempo_git_packages
+cargo metadata --format-version=1 --no-default-features >/dev/null
 popd >/dev/null
 
 if grep -q '^source = "git+https://github.com/tempoxyz/tempo?rev=' "$FOUNDRY_ROOT/Cargo.lock"; then

--- a/scripts/foundry-patch.sh
+++ b/scripts/foundry-patch.sh
@@ -109,6 +109,12 @@ done <<< "$PATCHES"
 echo "Updated Cargo.toml patch sections:"
 sed -n '/^\[patch\./,$p' "$FOUNDRY_CARGO"
 
+# Foundry's lockfile can still contain packages sourced from old
+# tempoxyz/tempo git revisions after the Cargo.toml patches above are written.
+# `cargo metadata` may fail before it can rewrite those entries if an old Tempo
+# revision carries incompatible transitive constraints, so refresh only those
+# stale Tempo packages first. The name@version form keeps the update targeted
+# and unambiguous when the lockfile contains multiple versions of a crate.
 update_stale_tempo_git_packages() {
   local stale_tempo_pkgs
   stale_tempo_pkgs="$(


### PR DESCRIPTION
Fixes Foundry resolver smoke failures caused by stale Tempo git entries in Foundry's lockfile.

`scripts/foundry-patch.sh` now updates locked `tempoxyz/tempo` packages before the first `cargo metadata` retry loop. That lets Cargo replace stale Tempo git packages with the local patched paths before resolving stricter transitive constraints from newer dependency graphs.