### PR TITLE
fix(ci): ignore proc-macro-error2 advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,9 @@ ignore = [
   # moved from hickory-proto to hickory-net in 0.26.0; we use hickory-net 0.26.1 which has
   # the fix, and no patched hickory-proto release exists
   "RUSTSEC-2026-0118",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
+  # and is pulled in transitively by upstream crates with no safe upgrade available.
+  "RUSTSEC-2026-0173",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Allows `RUSTSEC-2026-0173` in `cargo-deny` because `proc-macro-error2` is currently pulled in transitively by upstream crates and the advisory has no safe upgrade.

This restores the deny lint gate on main while keeping the advisory explicit until upstream dependencies remove it.