### PR TITLE
test(payload): cover validation budget seams

### DIFF
--- a/crates/payload/builder/src/budget.rs
+++ b/crates/payload/builder/src/budget.rs
@@ -222,6 +222,45 @@ mod tests {
     }
 
     #[test]
+    fn payload_budget_feedback_changes_cutoff_threshold() {
+        let workload = ValidationLatencyWorkload::new(100, 1);
+        let validation_latency = validation_latency_estimate(workload, Duration::from_millis(40));
+        let decision = |validation_latency| {
+            payload_budget_decision(
+                Duration::from_millis(100),
+                Duration::from_millis(10),
+                1_350_000,
+                MarshalPersistEstimator::from_ns_per_byte(1_000),
+                10_000,
+                validation_latency,
+                workload,
+            )
+        };
+
+        let conservative = decision(None);
+        let feedback = decision(validation_latency);
+
+        assert_eq!(
+            conservative.predicted_builder_work,
+            Duration::from_micros(121_500)
+        );
+        assert_eq!(
+            conservative.predicted_validator_work,
+            Duration::from_micros(121_500)
+        );
+        assert_eq!(conservative.marshal_persist, Duration::from_millis(10));
+        assert_eq!(conservative.total_reserved, Duration::from_millis(273));
+
+        assert_eq!(
+            feedback.predicted_builder_work,
+            Duration::from_micros(121_500)
+        );
+        assert_eq!(feedback.predicted_validator_work, Duration::from_millis(40));
+        assert_eq!(feedback.marshal_persist, Duration::from_millis(10));
+        assert_eq!(feedback.total_reserved, Duration::from_micros(191_500));
+    }
+
+    #[test]
     fn payload_budget_caps_scaled_validator_feedback_at_builder_projection() {
         let validation_latency = validation_latency_estimate(
             ValidationLatencyWorkload::new(100, 10),

--- a/crates/payload/types/src/attrs.rs
+++ b/crates/payload/types/src/attrs.rs
@@ -419,6 +419,40 @@ mod tests {
     }
 
     #[test]
+    fn payload_budget_and_validation_latency_are_explicitly_carried() {
+        use crate::{ValidationLatencyEstimator, ValidationLatencyWorkload};
+        use std::time::Duration;
+
+        let mut estimator = ValidationLatencyEstimator::default();
+        let workload = ValidationLatencyWorkload::new(123, 4);
+        estimator.observe(1, workload, Duration::from_millis(7));
+        let estimate = estimator.estimate();
+
+        let attrs = TempoPayloadAttributes::random()
+            .with_payload_build_budget(Duration::from_millis(25))
+            .with_validation_latency_estimate(estimate);
+
+        assert_eq!(
+            attrs.payload_build_budget(),
+            Some(Duration::from_millis(25))
+        );
+        assert_eq!(attrs.validation_latency_estimate(), estimate);
+        assert_eq!(
+            attrs
+                .validation_latency_estimate()
+                .and_then(|estimate| estimate.estimate(workload)),
+            Some(Duration::from_millis(7))
+        );
+
+        let attrs = attrs.with_validation_latency_estimate(None);
+        assert_eq!(
+            attrs.payload_build_budget(),
+            Some(Duration::from_millis(25))
+        );
+        assert_eq!(attrs.validation_latency_estimate(), None);
+    }
+
+    #[test]
     fn test_tempo_payload_attributes_serde() {
         let timestamp = 1234567890;
         let timestamp_millis_part = 999;

--- a/crates/payload/types/src/budget.rs
+++ b/crates/payload/types/src/budget.rs
@@ -399,6 +399,33 @@ mod tests {
     }
 
     #[test]
+    fn validation_latency_estimate_ignores_zero_elapsed_samples() {
+        let mut estimator = ValidationLatencyEstimator::default();
+        estimator.observe(1, ValidationLatencyWorkload::new(100, 1), Duration::ZERO);
+
+        assert_eq!(estimator.estimate(), None);
+    }
+
+    #[test]
+    fn validation_latency_estimate_evicts_oldest_sample_ids() {
+        let mut estimator = ValidationLatencyEstimator::default();
+        let workload = ValidationLatencyWorkload::new(100, 1);
+
+        for sample_id in 1..=VALIDATION_LATENCY_SAMPLE_WINDOW as u64 {
+            estimator.observe(sample_id, workload, Duration::from_nanos(sample_id));
+        }
+
+        estimator.observe(0, workload, Duration::from_nanos(10_000));
+
+        assert_eq!(
+            estimator
+                .estimate()
+                .and_then(|estimate| estimate.estimate(workload)),
+            Some(Duration::from_nanos(58))
+        );
+    }
+
+    #[test]
     fn validation_latency_estimate_does_not_scale_down() {
         assert_eq!(
             estimate_with_sample(


### PR DESCRIPTION
## Summary
- add coverage for payload attributes carrying consensus budget and validation latency estimates
- cover validation latency estimator zero-duration ignores and sample-window eviction
- cover payload budget cutoff behavior when validator feedback changes the reserved budget

## Tests
- cargo test -p tempo-payload-types --lib
- cargo test -p tempo-payload-builder --lib budget

Prompted by: @grandizzy
