### PR TITLE
Use maxperf profile for benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,9 +87,10 @@ debug = "line-tables-only"
 strip = "none"
 incremental = true
 
-# Include debug info in benchmarks too.
 [profile.bench]
-inherits = "profiling"
+inherits = "maxperf"
+debug = "line-tables-only"
+strip = "none"
 
 [profile.maxperf]
 inherits = "release"


### PR DESCRIPTION
## Summary
- Make the Cargo bench profile inherit from maxperf so CodSpeed benchmark targets build with the same max performance settings.

## Testing
- cargo metadata --no-deps --format-version 1

Prompted by: @shekhirin