### PR TITLE
perf(node): disable redundant payload state precache

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -158,7 +158,11 @@ impl TempoNode {
             .node_types::<Node>()
             .pool(pool_builder)
             .executor(TempoExecutorBuilder::default())
-            .payload(BasicPayloadServiceBuilder::new(payload_builder_builder))
+            .payload(
+                BasicPayloadServiceBuilder::new(payload_builder_builder)
+                    // we can disable basic parent state caching because tempo builder always uses execution cache
+                    .with_pre_cache_state(false),
+            )
             .network(EthereumNetworkBuilder::default())
             .consensus(TempoConsensusBuilder::default())
     }


### PR DESCRIPTION
Disables the basic payload service's parent-state pre-cache for Tempo nodes. The Tempo payload builder always uses the execution cache, so the basic pre-cache work is redundant.