### PR TITLE
refactor(primitives): move expiry check onto recovered subblock

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -81,17 +81,6 @@ use tempo_transaction_pool::{
 use tokio::sync::oneshot;
 use tracing::{Level, debug, debug_span, error, info, instrument, trace, warn};
 
-/// Returns true if a subblock has any expired transactions for the given timestamp.
-fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> bool {
-    subblock.transactions.iter().any(|tx| {
-        tx.as_aa().is_some_and(|tx| {
-            tx.tx()
-                .valid_before
-                .is_some_and(|valid| valid.get() <= timestamp)
-        })
-    })
-}
-
 #[derive(Debug, Clone)]
 pub struct TempoPayloadBuilder<Provider> {
     pool: TempoTransactionPool<Provider>,
@@ -432,7 +421,7 @@ where
             // We pre-validate all of the subblocks on top of parent state in subblocks service
             // which leaves the only reason for transactions to get invalidated by expiry of
             // `valid_before` field.
-            if has_expired_transactions(subblock, attributes.timestamp) {
+            if subblock.has_expired_transactions(attributes.timestamp) {
                 self.metrics.inc_subblocks_expired();
                 return false;
             }
@@ -1435,19 +1424,19 @@ mod tests {
     }
 
     #[test]
-    fn test_has_expired_transactions_boundary() {
+    fn test_recovered_subblock_has_expired_transactions_boundary() {
         // valid_before == timestamp → expired
         let subblock = RecoveredSubBlock::with_valid_before(Some(nz(1000)));
-        assert!(has_expired_transactions(&subblock, 1000));
+        assert!(subblock.has_expired_transactions(1000));
 
         // valid_before < timestamp → expired
-        assert!(has_expired_transactions(&subblock, 1001));
+        assert!(subblock.has_expired_transactions(1001));
 
         // valid_before > timestamp → NOT expired
-        assert!(!has_expired_transactions(&subblock, 999));
+        assert!(!subblock.has_expired_transactions(999));
 
         // No valid_before → NOT expired
         let subblock_no_expiry = RecoveredSubBlock::with_valid_before(None);
-        assert!(!has_expired_transactions(&subblock_no_expiry, 1000));
+        assert!(!subblock_no_expiry.has_expired_transactions(1000));
     }
 }

--- a/crates/primitives/src/subblock.rs
+++ b/crates/primitives/src/subblock.rs
@@ -246,6 +246,17 @@ impl RecoveredSubBlock {
             .map(|(sender, tx)| Recovered::new_unchecked(tx, sender))
     }
 
+    /// Returns true if this subblock has any expired transactions for the given timestamp.
+    pub fn has_expired_transactions(&self, timestamp: u64) -> bool {
+        self.transactions.iter().any(|tx| {
+            tx.as_aa().is_some_and(|tx| {
+                tx.tx()
+                    .valid_before
+                    .is_some_and(|valid| valid.get() <= timestamp)
+            })
+        })
+    }
+
     /// Returns the validator that submitted the subblock.
     pub fn validator(&self) -> B256 {
         self.validator

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -2405,7 +2405,7 @@ pub fn validate_time_window(
     }
 
     // Validate validBefore constraint
-    // IMPORTANT: must be aligned with `fn has_expired_transactions` in `tempo-payload-builder`.
+    // IMPORTANT: must be aligned with `RecoveredSubBlock::has_expired_transactions`.
     if let Some(before) = valid_before
         && block_timestamp >= before
     {


### PR DESCRIPTION
Moves subblock `valid_before` expiry scanning onto `RecoveredSubBlock` and has the payload builder call the method when filtering subblocks. Updates the revm validation comment so the block-time boundary reference follows the new API.