### PR TITLE
feat(pool): add best transaction size hints

### DIFF
--- a/crates/transaction-pool/src/best.rs
+++ b/crates/transaction-pool/src/best.rs
@@ -94,6 +94,23 @@ impl Iterator for MergeBestTransactions {
     fn next(&mut self) -> Option<Self::Item> {
         self.next_best().map(|(tx, _)| tx)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let buffered = usize::from(self.next_protocol_pool.is_some())
+            + usize::from(self.next_aa_2d_pool.is_some());
+        let (protocol_lower, protocol_upper) = self.protocol_pool.size_hint();
+        let (aa_2d_lower, aa_2d_upper) = self.aa_2d_pool.size_hint();
+
+        (
+            buffered
+                .saturating_add(protocol_lower)
+                .saturating_add(aa_2d_lower),
+            protocol_upper
+                .zip(aa_2d_upper)
+                .and_then(|(protocol_upper, aa_2d_upper)| protocol_upper.checked_add(aa_2d_upper))
+                .and_then(|upper| upper.checked_add(buffered)),
+        )
+    }
 }
 
 impl BestTransactions for MergeBestTransactions {
@@ -344,6 +361,36 @@ mod tests {
         assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*tx_c.hash())); // priority 3
         assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*tx_f.hash())); // priority 1
         assert!(merged.next().is_none());
+    }
+
+    #[test]
+    fn test_merge_best_transactions_size_hint() {
+        let protocol_sender = Address::random();
+        let protocol_tx_0 = protocol_tx_for_sender(protocol_sender, 0, 10);
+        let protocol_tx_1 = protocol_tx_for_sender(protocol_sender, 1, 9);
+        let aa_2d_tx = aa_2d_tx(0, 8);
+        let mut merged = merged_best_transactions(
+            vec![protocol_tx_0.clone(), protocol_tx_1.clone()],
+            vec![aa_2d_tx.clone()],
+        );
+        merged.no_updates();
+
+        assert_eq!(merged.size_hint(), (0, Some(3)));
+
+        assert_eq!(
+            merged.next().map(|tx| *tx.hash()),
+            Some(*protocol_tx_0.hash())
+        );
+        assert_eq!(merged.size_hint(), (1, Some(2)));
+
+        assert_eq!(
+            merged.next().map(|tx| *tx.hash()),
+            Some(*protocol_tx_1.hash())
+        );
+        assert_eq!(merged.size_hint(), (1, Some(1)));
+
+        assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*aa_2d_tx.hash()));
+        assert_eq!(merged.size_hint(), (0, Some(0)));
     }
 
     #[test]

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -2076,6 +2076,15 @@ impl Iterator for BestAA2dTransactions {
     fn next(&mut self) -> Option<Self::Item> {
         self.next_tx_and_priority().map(|(tx, _)| tx)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            0,
+            self.by_id
+                .len()
+                .checked_add(self.expiring_nonce_order.len()),
+        )
+    }
 }
 
 impl BestTransactions for BestAA2dTransactions {
@@ -4082,6 +4091,76 @@ mod tests {
 
         let third = best.next();
         assert!(third.is_none());
+    }
+
+    #[test]
+    fn test_best_transactions_size_hint_counts_snapshot() {
+        let mut pool = AA2dPool::default();
+        let sender = Address::random();
+        let expiring_sender = Address::random();
+
+        let tx0 = TxBuilder::aa(sender).nonce_key(U256::ZERO).build();
+        let tx1 = TxBuilder::aa(sender).nonce_key(U256::ZERO).nonce(1).build();
+        let expiring_tx = TxBuilder::aa(expiring_sender).nonce_key(U256::MAX).build();
+
+        pool.add_transaction(
+            Arc::new(wrap_valid_tx(tx0, TransactionOrigin::Local)),
+            0,
+            TempoHardfork::T1,
+        )
+        .unwrap();
+        pool.add_transaction(
+            Arc::new(wrap_valid_tx(tx1, TransactionOrigin::Local)),
+            0,
+            TempoHardfork::T1,
+        )
+        .unwrap();
+        pool.add_transaction(
+            Arc::new(wrap_valid_tx(expiring_tx, TransactionOrigin::Local)),
+            0,
+            TempoHardfork::T1,
+        )
+        .unwrap();
+
+        let mut best = pool.best_transactions();
+
+        assert_eq!(best.size_hint(), (0, Some(3)));
+        assert!(best.next().is_some());
+        assert_eq!(best.size_hint(), (0, Some(2)));
+        assert!(best.next().is_some());
+        assert_eq!(best.size_hint(), (0, Some(1)));
+        assert!(best.next().is_some());
+        assert_eq!(best.size_hint(), (0, Some(0)));
+    }
+
+    #[test]
+    fn test_best_transactions_size_hint_ignores_unread_new_transactions() {
+        let mut pool = AA2dPool::default();
+        let snapshot_sender = Address::random();
+        let incoming_sender = Address::random();
+
+        let snapshot_tx = TxBuilder::aa(snapshot_sender).nonce_key(U256::ZERO).build();
+        let incoming_tx = TxBuilder::aa(incoming_sender)
+            .nonce_key(U256::from(1))
+            .build();
+
+        pool.add_transaction(
+            Arc::new(wrap_valid_tx(snapshot_tx, TransactionOrigin::Local)),
+            0,
+            TempoHardfork::T1,
+        )
+        .unwrap();
+
+        let best = pool.best_transactions();
+
+        pool.add_transaction(
+            Arc::new(wrap_valid_tx(incoming_tx, TransactionOrigin::Local)),
+            0,
+            TempoHardfork::T1,
+        )
+        .unwrap();
+
+        assert_eq!(best.size_hint(), (0, Some(1)));
     }
 
     #[test]


### PR DESCRIPTION
Adds `size_hint` implementations for merged best transaction iteration and AA 2D best transaction snapshots. Merge hints include cached lookahead plus both inner iterators, while AA 2D hints report a finite snapshot upper bound and intentionally ignore unread live update receiver transactions.

This gives downstream block-building code a cheap advisory upper bound without changing transaction selection behavior. Future transaction-hint derivation and remaining-block allocation logic are left for a follow-up PR.