### PR TITLE
feat(protocol): attest feature support with digest

### DIFF
--- a/crates/chainspec/src/features.rs
+++ b/crates/chainspec/src/features.rs
@@ -5,6 +5,8 @@
 
 use core::fmt;
 
+use alloy_primitives::{B256, Keccak256};
+
 /// No protocol feature is active.
 pub const NO_ACTIVE_PROTOCOL_FEATURE_ID: u64 = 0;
 
@@ -17,7 +19,7 @@ pub const HIGHEST_ACTIVE_PROTOCOL_FEATURE_ID_SLOT: alloy_primitives::U256 =
 pub struct ProtocolFeature {
     /// 1-indexed feature ID. This must match the feature's registry position.
     pub id: u64,
-    /// Canonical dotted feature name used in off-chain metadata and operator tooling.
+    /// Canonical dotted feature name used in support reports, off-chain metadata, and operator tooling.
     pub name: &'static str,
     /// Encoded minimum Tempo version that supports this feature.
     pub minimum_supported_version_key: u64,
@@ -55,6 +57,35 @@ pub fn protocol_feature_by_id(id: u64) -> Option<&'static ProtocolFeature> {
     }
     let index = usize::try_from(id.checked_sub(1)?).ok()?;
     PROTOCOL_FEATURE_REGISTRY.get(index)
+}
+
+/// Returns the digest validators must report when supporting every feature through `features_tip`.
+///
+/// Feature tip `0` means no supported protocol feature flags and has the zero digest. Higher tips
+/// commit to the ordered `(feature_id, name)` prefix of [`PROTOCOL_FEATURE_REGISTRY`].
+pub fn protocol_features_digest(features_tip: u64) -> Option<B256> {
+    if features_tip == NO_ACTIVE_PROTOCOL_FEATURE_ID {
+        return Some(B256::ZERO);
+    }
+
+    let features_len = u64::try_from(PROTOCOL_FEATURE_REGISTRY.len()).ok()?;
+    if features_tip > features_len {
+        return None;
+    }
+
+    let mut hasher = Keccak256::new();
+    for feature in PROTOCOL_FEATURE_REGISTRY
+        .iter()
+        .take(usize::try_from(features_tip).ok()?)
+    {
+        let name = feature.name.as_bytes();
+        let name_len = u64::try_from(name.len()).ok()?;
+        hasher.update(feature.id.to_be_bytes());
+        hasher.update(name_len.to_be_bytes());
+        hasher.update(name);
+    }
+
+    Some(hasher.finalize())
 }
 
 /// Error returned when chain history has activated a feature this binary does not support.
@@ -99,6 +130,7 @@ mod tests {
     fn zero_means_no_active_feature() {
         assert_eq!(NO_ACTIVE_PROTOCOL_FEATURE_ID, 0);
         assert_eq!(protocol_feature_by_id(0), None);
+        assert_eq!(protocol_features_digest(0), Some(B256::ZERO));
         assert!(supports_protocol_feature_id(0));
     }
 
@@ -109,6 +141,17 @@ mod tests {
             assert_eq!(feature.id, expected_id);
             assert_eq!(protocol_feature_by_id(feature.id), Some(feature));
         }
+    }
+
+    #[test]
+    fn feature_digest_commits_to_ordered_feature_names() {
+        let mut hasher = Keccak256::new();
+        hasher.update(1u64.to_be_bytes());
+        hasher.update(25u64.to_be_bytes());
+        hasher.update(b"tip-1063.feature-registry");
+
+        assert_eq!(protocol_features_digest(1), Some(hasher.finalize()));
+        assert_eq!(protocol_features_digest(2), None);
     }
 
     #[test]

--- a/crates/contracts/src/precompiles/feature_registry.rs
+++ b/crates/contracts/src/precompiles/feature_registry.rs
@@ -19,6 +19,9 @@ crate::sol! {
         /// @notice Returns the highest active protocol feature ID.
         function featuresTip() external view returns (uint64);
 
+        /// @notice Returns the highest protocol feature tip with observed quorum support.
+        function highestQuorumFeaturesTip() external view returns (uint64 featuresTip);
+
         /// @notice Returns the scheduled feature tip and earliest activation epoch.
         function scheduledFeaturesTip() external view returns (uint64 featuresTip, uint64 activationEpoch);
 
@@ -81,5 +84,8 @@ crate::sol! {
 
         /// @notice Requested activation epoch is not strictly greater than the current epoch.
         error ActivationEpochNotFuture();
+
+        /// @notice Scheduled feature tip does not have quorum support.
+        error FeaturesTipQuorumNotReached();
     }
 }

--- a/crates/contracts/src/precompiles/feature_registry.rs
+++ b/crates/contracts/src/precompiles/feature_registry.rs
@@ -22,8 +22,8 @@ crate::sol! {
         /// @notice Returns the scheduled feature tip and earliest activation epoch.
         function scheduledFeaturesTip() external view returns (uint64 featuresTip, uint64 activationEpoch);
 
-        /// @notice Records the highest protocol feature tip reported by a validator public key. System caller only.
-        function setSupportedFeaturesTip(bytes32 publicKey, uint64 featuresTip) external;
+        /// @notice Records the highest protocol feature tip and registry digest reported by a validator public key. System caller only.
+        function setSupportedFeaturesTip(bytes32 publicKey, uint64 featuresTip, bytes32 featuresDigest) external;
 
         /// @notice Schedules a higher feature tip for activation at the target epoch.
         function scheduleFeaturesTip(uint64 featuresTip, uint64 activationEpoch) external;
@@ -35,7 +35,10 @@ crate::sol! {
         function cancelScheduledFeaturesTip() external;
 
         /// @notice Returns the latest feature tip reported by a validator.
-        function validatorSupportedFeaturesTip(address validator) external view returns (uint64);
+        function validatorSupportedFeaturesTip(address validator) external view returns (uint64 featuresTip);
+
+        /// @notice Returns the registry digest reported by a validator for a feature tip.
+        function validatorSupportedFeaturesDigest(address validator, uint64 featuresTip) external view returns (bytes32 featuresDigest);
 
         /// @notice Returns current active-validator support for a feature tip.
         function featuresTipSupport(uint64 featuresTip) external view returns (uint256 support, uint256 required);
@@ -44,7 +47,7 @@ crate::sol! {
         function hasFeaturesTipQuorum(uint64 featuresTip) external view returns (bool);
 
         /// @notice Emitted when a validator reports support for a feature tip.
-        event SupportedFeaturesTipSet(address indexed validator, uint64 featuresTip, uint256 supportCount);
+        event SupportedFeaturesTipSet(address indexed validator, uint64 featuresTip, bytes32 featuresDigest, uint256 supportCount);
 
         /// @notice Emitted when a higher feature tip is scheduled for activation.
         event FeaturesTipScheduled(uint64 featuresTip, uint64 activationEpoch);

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -1031,7 +1031,8 @@ mod tests {
 
         let input = IFeatureRegistry::setSupportedFeaturesTipCall {
             publicKey: b256_public_key_from_private_key(&proposer_key),
-            featuresTip: 13,
+            featuresTip: 1,
+            featuresDigest: tempo_chainspec::features::protocol_features_digest(1).unwrap(),
         }
         .abi_encode()
         .into();
@@ -1065,7 +1066,8 @@ mod tests {
 
         let input = IFeatureRegistry::setSupportedFeaturesTipCall {
             publicKey: b256_public_key_from_private_key(&other_key),
-            featuresTip: 13,
+            featuresTip: 1,
+            featuresDigest: tempo_chainspec::features::protocol_features_digest(1).unwrap(),
         }
         .abi_encode()
         .into();
@@ -1093,7 +1095,8 @@ mod tests {
             .build(&mut db, &chainspec);
         let input = IFeatureRegistry::setSupportedFeaturesTipCall {
             publicKey: B256::repeat_byte(0x11),
-            featuresTip: 13,
+            featuresTip: 1,
+            featuresDigest: tempo_chainspec::features::protocol_features_digest(1).unwrap(),
         }
         .abi_encode()
         .into();

--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -15,7 +15,10 @@ use commonware_codec::Encode;
 use commonware_cryptography::{Signer as _, ed25519::PrivateKey as Ed25519PrivateKey};
 use reth_node_api::BuiltPayload;
 use std::net::{IpAddr, SocketAddr};
-use tempo_chainspec::{features::highest_supported_protocol_feature_id, spec::TEMPO_T1_BASE_FEE};
+use tempo_chainspec::{
+    features::{highest_supported_protocol_feature_id, protocol_features_digest},
+    spec::TEMPO_T1_BASE_FEE,
+};
 use tempo_contracts::precompiles::{
     IFeatureRegistry, IFeeManager, IRolesAuth, ITIP20, ITIP20ChannelReserve, ITIP20Factory,
     ITIPFeeAMM, IValidatorConfigV2,
@@ -362,13 +365,19 @@ async fn test_block_building_reports_supported_features_tip_once() -> eyre::Resu
 
     let feature_registry = IFeatureRegistry::new(FEATURE_REGISTRY_ADDRESS, provider);
     let expected_features_tip = highest_supported_protocol_feature_id();
+    let expected_features_digest = protocol_features_digest(expected_features_tip).unwrap();
     assert!(expected_features_tip > 0);
+    let initial_report = feature_registry
+        .validatorSupportedFeaturesTip(validator.validatorAddress)
+        .call()
+        .await?;
+    assert_eq!(initial_report, 0);
     assert_eq!(
         feature_registry
-            .validatorSupportedFeaturesTip(validator.validatorAddress)
+            .validatorSupportedFeaturesDigest(validator.validatorAddress, expected_features_tip)
             .call()
             .await?,
-        0
+        B256::ZERO
     );
 
     let first_payload = advance_block_with_proposer(&mut setup.node, validator.publicKey).await?;
@@ -376,12 +385,18 @@ async fn test_block_building_reports_supported_features_tip_once() -> eyre::Resu
     assert_eq!(reports.len(), 1);
     assert_eq!(reports[0].publicKey, validator.publicKey);
     assert_eq!(reports[0].featuresTip, expected_features_tip);
+    assert_eq!(reports[0].featuresDigest, expected_features_digest);
+    let stored_report = feature_registry
+        .validatorSupportedFeaturesTip(validator.validatorAddress)
+        .call()
+        .await?;
+    assert_eq!(stored_report, expected_features_tip);
     assert_eq!(
         feature_registry
-            .validatorSupportedFeaturesTip(validator.validatorAddress)
+            .validatorSupportedFeaturesDigest(validator.validatorAddress, expected_features_tip)
             .call()
             .await?,
-        expected_features_tip
+        expected_features_digest
     );
 
     let second_payload = advance_block_with_proposer(&mut setup.node, validator.publicKey).await?;

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -67,7 +67,7 @@ use std::{
 use tempo_chainspec::{
     TempoChainSpec, features::highest_supported_protocol_feature_id, hardfork::TempoHardforks,
 };
-use tempo_contracts::precompiles::{FEATURE_REGISTRY_ADDRESS, IFeatureRegistry};
+use tempo_contracts::precompiles::FEATURE_REGISTRY_ADDRESS;
 use tempo_evm::{TempoEvmConfig, TempoNextBlockEnvAttributes, TempoStateAccess, evm::TempoEvm};
 use tempo_payload_types::{TempoBuiltPayload, TempoPayloadAttributes, marshal_persist_estimate};
 use tempo_precompiles::{
@@ -246,37 +246,27 @@ impl<Provider: ChainSpecProvider<ChainSpec = TempoChainSpec>> TempoPayloadBuilde
         if supported_features_tip == 0 {
             return None;
         }
-
         let public_key = attributes.proposer_public_key()?;
 
         let spec = evm.cfg.spec;
-        let should_report = match evm
+        let report = match evm
             .ctx_mut()
             .journaled_state
             .database
-            .with_read_only_storage_ctx(spec, || -> Result<bool, PayloadBuilderError> {
-                let reported_features_tip = FeatureRegistry::new()
-                    .validator_supported_features_tip_by_public_key(*public_key)
+            .with_read_only_storage_ctx(spec, || -> Result<_, PayloadBuilderError> {
+                let report = FeatureRegistry::new()
+                    .next_validator_support_update(*public_key, supported_features_tip)
                     .map_err(PayloadBuilderError::other)?;
-                Ok(reported_features_tip < supported_features_tip)
+                Ok(report)
             }) {
-            Ok(should_report) => should_report,
+            Ok(report) => report,
             Err(err) => {
                 debug!(%err, "skipping supported feature tip report");
-                false
+                None
             }
         };
 
-        if !should_report {
-            return None;
-        }
-
-        let input = IFeatureRegistry::setSupportedFeaturesTipCall {
-            publicKey: *public_key,
-            featuresTip: supported_features_tip,
-        }
-        .abi_encode()
-        .into();
+        let input = report?.abi_encode().into();
         Some(Self::system_tx(chain_id, FEATURE_REGISTRY_ADDRESS, input))
     }
 

--- a/crates/precompiles/src/feature_registry/dispatch.rs
+++ b/crates/precompiles/src/feature_registry/dispatch.rs
@@ -904,6 +904,108 @@ mod tests {
     }
 
     #[test]
+    fn features_tip_support_uses_cached_digest_count() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let owner = Address::repeat_byte(0xaa);
+            initialize_validator_config_owner(owner)?;
+            let digest = protocol_features_digest(1).unwrap();
+
+            for seed in 1..=5 {
+                let validator = Address::repeat_byte(seed as u8);
+                let public_key = add_test_validator(owner, validator, seed)?;
+                if seed <= 4 {
+                    registry.set_supported_features_tip(
+                        Address::ZERO,
+                        IFeatureRegistry::setSupportedFeaturesTipCall {
+                            publicKey: public_key,
+                            featuresTip: 1,
+                            featuresDigest: digest,
+                        },
+                    )?;
+                }
+            }
+
+            let support = registry.features_tip_support(1)?;
+            assert_eq!(support.support, U256::from(4));
+            assert_eq!(support.required, U256::from(4));
+            assert!(registry.has_features_tip_quorum(1)?);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn set_supported_features_tip_moves_cached_support_between_digests() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let owner = Address::repeat_byte(0xaa);
+            let validator = Address::repeat_byte(0x01);
+            initialize_validator_config_owner(owner)?;
+            let public_key = add_test_validator(owner, validator, 1)?;
+            let stale_digest = B256::repeat_byte(0xff);
+            let expected_digest = protocol_features_digest(1).unwrap();
+
+            registry.validator_supported_features_tip[validator].write(1)?;
+            registry.validator_supported_features_digest[validator][1].write(stale_digest)?;
+            registry.features_tip_support_count[1][stale_digest].write(1)?;
+
+            registry.set_supported_features_tip(
+                Address::ZERO,
+                IFeatureRegistry::setSupportedFeaturesTipCall {
+                    publicKey: public_key,
+                    featuresTip: 1,
+                    featuresDigest: expected_digest,
+                },
+            )?;
+
+            assert_eq!(
+                registry.features_tip_support_count[1][stale_digest].read()?,
+                0
+            );
+            assert_eq!(
+                registry.features_tip_support_count[1][expected_digest].read()?,
+                1
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn set_supported_features_tip_counts_existing_digest_when_tip_increases() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let owner = Address::repeat_byte(0xaa);
+            let validator = Address::repeat_byte(0x01);
+            initialize_validator_config_owner(owner)?;
+            let public_key = add_test_validator(owner, validator, 1)?;
+            let expected_digest = protocol_features_digest(1).unwrap();
+
+            registry.validator_supported_features_digest[validator][1].write(expected_digest)?;
+
+            registry.set_supported_features_tip(
+                Address::ZERO,
+                IFeatureRegistry::setSupportedFeaturesTipCall {
+                    publicKey: public_key,
+                    featuresTip: 1,
+                    featuresDigest: expected_digest,
+                },
+            )?;
+
+            assert_eq!(
+                registry.features_tip_support_count[1][expected_digest].read()?,
+                1
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn has_features_tip_quorum_rejects_unknown_feature_tip() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {

--- a/crates/precompiles/src/feature_registry/dispatch.rs
+++ b/crates/precompiles/src/feature_registry/dispatch.rs
@@ -1,20 +1,10 @@
 //! ABI dispatch for the [`FeatureRegistry`] precompile.
 
 use super::*;
-use crate::{
-    Precompile, charge_input_cost, dispatch_call, error::TempoPrecompileError, mutate_void,
-    storage::StorageCtx, view,
-};
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
+use crate::{Precompile, charge_input_cost, dispatch_call, mutate_void, view};
+use alloy::{primitives::Address, sol_types::SolInterface};
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::IFeatureRegistry::{self, IFeatureRegistryCalls};
-
-fn unsupported<T: SolCall>() -> PrecompileResult {
-    StorageCtx.error_result(TempoPrecompileError::UnknownFunctionSelector(T::SELECTOR))
-}
+use tempo_contracts::precompiles::IFeatureRegistry::IFeatureRegistryCalls;
 
 impl Precompile for FeatureRegistry {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -58,11 +48,16 @@ impl Precompile for FeatureRegistry {
                 IFeatureRegistryCalls::validatorSupportedFeaturesTip(call) => view(call, |call| {
                     self.validator_supported_features_tip(call.validator)
                 }),
-                IFeatureRegistryCalls::featuresTipSupport(_) => {
-                    unsupported::<IFeatureRegistry::featuresTipSupportCall>()
+                IFeatureRegistryCalls::validatorSupportedFeaturesDigest(call) => {
+                    view(call, |call| {
+                        self.validator_supported_features_digest(call.validator, call.featuresTip)
+                    })
                 }
-                IFeatureRegistryCalls::hasFeaturesTipQuorum(_) => {
-                    unsupported::<IFeatureRegistry::hasFeaturesTipQuorumCall>()
+                IFeatureRegistryCalls::featuresTipSupport(call) => {
+                    view(call, |call| self.features_tip_support(call.featuresTip))
+                }
+                IFeatureRegistryCalls::hasFeaturesTipQuorum(call) => {
+                    view(call, |call| self.has_features_tip_quorum(call.featuresTip))
                 }
             },
         )
@@ -79,16 +74,16 @@ mod tests {
     };
     use alloy::{
         primitives::{B256, Keccak256, U256},
-        sol_types::{SolCall, SolError, SolValue},
+        sol_types::{SolCall, SolValue},
     };
     use commonware_codec::Encode;
     use commonware_cryptography::{Signer, ed25519::PrivateKey};
     use tempo_chainspec::{
-        epoch::EPOCH_LENGTH_BLOCKS, features::HIGHEST_ACTIVE_PROTOCOL_FEATURE_ID_SLOT,
+        epoch::EPOCH_LENGTH_BLOCKS,
+        features::{HIGHEST_ACTIVE_PROTOCOL_FEATURE_ID_SLOT, protocol_features_digest},
     };
     use tempo_contracts::precompiles::{
-        FeatureRegistryError, IValidatorConfigV2, UnknownFunctionSelector,
-        VALIDATOR_CONFIG_V2_ADDRESS,
+        FeatureRegistryError, IValidatorConfigV2, VALIDATOR_CONFIG_V2_ADDRESS,
     };
 
     fn initialize_validator_config_owner(owner: Address) -> eyre::Result<()> {
@@ -549,6 +544,10 @@ mod tests {
             let validator = Address::repeat_byte(0x01);
 
             assert_eq!(registry.validator_supported_features_tip(validator)?, 0);
+            assert_eq!(
+                registry.validator_supported_features_digest(validator, 1)?,
+                B256::ZERO
+            );
 
             Ok(())
         })
@@ -561,9 +560,15 @@ mod tests {
             let mut registry = FeatureRegistry::new();
             let validator = Address::repeat_byte(0x01);
 
-            registry.validator_supported_features_tip[validator].write(13)?;
+            let digest = protocol_features_digest(1).unwrap();
+            registry.validator_supported_features_tip[validator].write(1)?;
+            registry.validator_supported_features_digest[validator][1].write(digest)?;
 
-            assert_eq!(registry.validator_supported_features_tip(validator)?, 13);
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 1);
+            assert_eq!(
+                registry.validator_supported_features_digest(validator, 1)?,
+                digest
+            );
 
             Ok(())
         })
@@ -583,11 +588,89 @@ mod tests {
                 Address::ZERO,
                 IFeatureRegistry::setSupportedFeaturesTipCall {
                     publicKey: public_key,
-                    featuresTip: 13,
+                    featuresTip: 1,
+                    featuresDigest: protocol_features_digest(1).unwrap(),
                 },
             )?;
 
-            assert_eq!(registry.validator_supported_features_tip(validator)?, 13);
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 1);
+            assert_eq!(
+                registry.validator_supported_features_digest(validator, 1)?,
+                protocol_features_digest(1).unwrap()
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn set_supported_features_tip_only_writes_reported_height_digest() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let owner = Address::repeat_byte(0xaa);
+            let validator = Address::repeat_byte(0x01);
+            initialize_validator_config_owner(owner)?;
+            let public_key = add_test_validator(owner, validator, 1)?;
+
+            registry.set_supported_features_tip(
+                Address::ZERO,
+                IFeatureRegistry::setSupportedFeaturesTipCall {
+                    publicKey: public_key,
+                    featuresTip: 1,
+                    featuresDigest: protocol_features_digest(1).unwrap(),
+                },
+            )?;
+
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 1);
+            assert_eq!(
+                registry.validator_supported_features_digest(validator, 1)?,
+                protocol_features_digest(1).unwrap()
+            );
+            assert_eq!(
+                registry.validator_supported_features_digest(validator, 0)?,
+                B256::ZERO
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn next_validator_support_update_returns_missing_or_stale_height() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let owner = Address::repeat_byte(0xaa);
+            let validator = Address::repeat_byte(0x01);
+            initialize_validator_config_owner(owner)?;
+            let public_key = add_test_validator(owner, validator, 1)?;
+
+            let update = registry
+                .next_validator_support_update(public_key, 1)?
+                .expect("missing high-water report should need update");
+            assert_eq!(update.publicKey, public_key);
+            assert_eq!(update.featuresTip, 1);
+            assert_eq!(update.featuresDigest, protocol_features_digest(1).unwrap());
+
+            registry.validator_supported_features_tip[validator].write(1)?;
+            let update = registry
+                .next_validator_support_update(public_key, 1)?
+                .expect("missing digest should need update");
+            assert_eq!(update.featuresTip, 1);
+            assert_eq!(update.featuresDigest, protocol_features_digest(1).unwrap());
+
+            registry.validator_supported_features_digest[validator][1]
+                .write(B256::repeat_byte(0xff))?;
+            let update = registry
+                .next_validator_support_update(public_key, 1)?
+                .expect("stale digest should need update");
+            assert_eq!(update.featuresTip, 1);
+            assert_eq!(update.featuresDigest, protocol_features_digest(1).unwrap());
+
+            registry.validator_supported_features_digest[validator][1]
+                .write(protocol_features_digest(1).unwrap())?;
+            assert_eq!(registry.next_validator_support_update(public_key, 1)?, None);
 
             Ok(())
         })
@@ -602,20 +685,23 @@ mod tests {
             let validator = Address::repeat_byte(0x01);
             initialize_validator_config_owner(owner)?;
             let public_key = add_test_validator(owner, validator, 1)?;
-            registry.validator_supported_features_tip[validator].write(13)?;
+            registry.validator_supported_features_tip[validator].write(1)?;
+            registry.validator_supported_features_digest[validator][1]
+                .write(protocol_features_digest(1).unwrap())?;
 
             let result = registry.set_supported_features_tip(
                 Address::ZERO,
                 IFeatureRegistry::setSupportedFeaturesTipCall {
                     publicKey: public_key,
-                    featuresTip: 12,
+                    featuresTip: 0,
+                    featuresDigest: protocol_features_digest(0).unwrap(),
                 },
             );
             assert_eq!(
                 result,
                 Err(FeatureRegistryError::supported_features_tip_decreased().into())
             );
-            assert_eq!(registry.validator_supported_features_tip(validator)?, 13);
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 1);
 
             Ok(())
         })
@@ -686,7 +772,8 @@ mod tests {
                 Address::repeat_byte(0x02),
                 IFeatureRegistry::setSupportedFeaturesTipCall {
                     publicKey: B256::repeat_byte(0x03),
-                    featuresTip: 13,
+                    featuresTip: 1,
+                    featuresDigest: protocol_features_digest(1).unwrap(),
                 },
             );
             assert_eq!(result, Err(FeatureRegistryError::unauthorized().into()));
@@ -709,11 +796,16 @@ mod tests {
 
             let call = IFeatureRegistry::setSupportedFeaturesTipCall {
                 publicKey: public_key,
-                featuresTip: 34,
+                featuresTip: 1,
+                featuresDigest: protocol_features_digest(1).unwrap(),
             };
             let result = registry.call(&call.abi_encode(), Address::ZERO)?;
             assert!(!result.is_revert());
-            assert_eq!(registry.validator_supported_features_tip(validator)?, 34);
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 1);
+            assert_eq!(
+                registry.validator_supported_features_digest(validator, 1)?,
+                protocol_features_digest(1).unwrap()
+            );
 
             Ok(())
         })
@@ -728,7 +820,8 @@ mod tests {
 
             let call = IFeatureRegistry::setSupportedFeaturesTipCall {
                 publicKey: B256::repeat_byte(0x03),
-                featuresTip: 34,
+                featuresTip: 1,
+                featuresDigest: protocol_features_digest(1).unwrap(),
             };
             let result = registry.call(&call.abi_encode(), Address::repeat_byte(0x02))?;
             assert!(result.is_revert());
@@ -750,11 +843,14 @@ mod tests {
             let validator = Address::repeat_byte(0x01);
             initialize_validator_config_owner(owner)?;
             let public_key = add_test_validator(owner, validator, 1)?;
-            registry.validator_supported_features_tip[validator].write(34)?;
+            registry.validator_supported_features_tip[validator].write(1)?;
+            registry.validator_supported_features_digest[validator][1]
+                .write(protocol_features_digest(1).unwrap())?;
 
             let call = IFeatureRegistry::setSupportedFeaturesTipCall {
                 publicKey: public_key,
-                featuresTip: 33,
+                featuresTip: 0,
+                featuresDigest: protocol_features_digest(0).unwrap(),
             };
             let result = registry.call(&call.abi_encode(), Address::ZERO)?;
             assert!(result.is_revert());
@@ -763,7 +859,7 @@ mod tests {
                 decoded,
                 FeatureRegistryError::supported_features_tip_decreased()
             );
-            assert_eq!(registry.validator_supported_features_tip(validator)?, 34);
+            assert_eq!(registry.validator_supported_features_tip(validator)?, 1);
 
             Ok(())
         })
@@ -775,30 +871,48 @@ mod tests {
         StorageCtx::enter(&mut storage, || {
             let mut registry = FeatureRegistry::new();
             let validator = Address::repeat_byte(0x01);
-            registry.validator_supported_features_tip[validator].write(34)?;
+            registry.validator_supported_features_tip[validator].write(1)?;
 
             let call = IFeatureRegistry::validatorSupportedFeaturesTipCall { validator };
             let result = registry.call(&call.abi_encode(), Address::ZERO)?;
             assert!(!result.is_revert());
-            assert_eq!(u64::abi_decode(&result.bytes)?, 34);
+            assert_eq!(u64::abi_decode(&result.bytes)?, 1);
 
             Ok(())
         })
     }
 
     #[test]
-    fn unimplemented_selectors_remain_unknown() -> eyre::Result<()> {
+    fn validator_supported_features_digest_dispatch_returns_encoded_digest() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut registry = FeatureRegistry::new();
-            let call = IFeatureRegistry::hasFeaturesTipQuorumCall { featuresTip: 1 };
+            let validator = Address::repeat_byte(0x01);
+            let digest = protocol_features_digest(1).unwrap();
+            registry.validator_supported_features_digest[validator][1].write(digest)?;
+
+            let call = IFeatureRegistry::validatorSupportedFeaturesDigestCall {
+                validator,
+                featuresTip: 1,
+            };
+            let result = registry.call(&call.abi_encode(), Address::ZERO)?;
+            assert!(!result.is_revert());
+            assert_eq!(B256::abi_decode(&result.bytes)?, digest);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn has_features_tip_quorum_rejects_unknown_feature_tip() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let call = IFeatureRegistry::hasFeaturesTipQuorumCall { featuresTip: 2 };
             let result = registry.call(&call.abi_encode(), Address::ZERO)?;
             assert!(result.is_revert());
-            let decoded = UnknownFunctionSelector::abi_decode(&result.bytes)?;
-            assert_eq!(
-                decoded.selector.0,
-                IFeatureRegistry::hasFeaturesTipQuorumCall::SELECTOR
-            );
+            let decoded = FeatureRegistryError::abi_decode(&result.bytes)?;
+            assert_eq!(decoded, FeatureRegistryError::invalid_features_tip());
 
             Ok(())
         })

--- a/crates/precompiles/src/feature_registry/dispatch.rs
+++ b/crates/precompiles/src/feature_registry/dispatch.rs
@@ -1018,6 +1018,39 @@ mod tests {
     }
 
     #[test]
+    fn highest_quorum_features_tip_drops_when_prefix_loses_quorum() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            let owner = Address::repeat_byte(0xaa);
+            initialize_validator_config_owner(owner)?;
+            let digest1 = protocol_features_digest(1).unwrap();
+            let stale_digest1 = B256::repeat_byte(0xff);
+
+            for seed in 1..=5 {
+                let validator = Address::repeat_byte(seed as u8);
+                add_test_validator(owner, validator, seed)?;
+                if seed <= 4 {
+                    registry.validator_supported_features_tip[validator].write(1)?;
+                    registry.validator_supported_features_digest[validator][1].write(digest1)?;
+                    registry.features_tip_support_count[1][digest1].write(seed)?;
+                }
+            }
+            registry.highest_quorum_features_tip.write(1)?;
+
+            let validator = Address::repeat_byte(0x01);
+            registry.features_tip_support_count[1][digest1].write(3)?;
+            registry.validator_supported_features_digest[validator][1].write(stale_digest1)?;
+            registry.features_tip_support_count[1][stale_digest1].write(1)?;
+            registry.refresh_highest_quorum_features_tip(1)?;
+
+            assert_eq!(registry.highest_quorum_features_tip()?, 0);
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn set_supported_features_tip_moves_cached_support_between_digests() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {

--- a/crates/precompiles/src/feature_registry/dispatch.rs
+++ b/crates/precompiles/src/feature_registry/dispatch.rs
@@ -18,6 +18,9 @@ impl Precompile for FeatureRegistry {
             IFeatureRegistryCalls::abi_decode,
             |call| match call {
                 IFeatureRegistryCalls::featuresTip(call) => view(call, |_| self.features_tip()),
+                IFeatureRegistryCalls::highestQuorumFeaturesTip(call) => {
+                    view(call, |_| self.highest_quorum_features_tip())
+                }
                 IFeatureRegistryCalls::owner(call) => view(call, |_| self.owner()),
                 IFeatureRegistryCalls::activationQuorum(call) => {
                     view(call, |_| self.activation_quorum())
@@ -128,12 +131,50 @@ mod tests {
         Ok(public_key)
     }
 
+    fn add_test_validator_support(
+        registry: &mut FeatureRegistry,
+        owner: Address,
+        seed: u64,
+        features_tip: u64,
+    ) -> eyre::Result<()> {
+        let validator = Address::repeat_byte(seed as u8);
+        let public_key = add_test_validator(owner, validator, seed)?;
+        registry
+            .set_supported_features_tip(
+                Address::ZERO,
+                IFeatureRegistry::setSupportedFeaturesTipCall {
+                    publicKey: public_key,
+                    featuresTip: features_tip,
+                    featuresDigest: protocol_features_digest(features_tip).unwrap(),
+                },
+            )
+            .map_err(Into::into)
+    }
+
+    fn add_quorum_support(
+        registry: &mut FeatureRegistry,
+        owner: Address,
+        features_tip: u64,
+    ) -> eyre::Result<()> {
+        initialize_validator_config_owner(owner)?;
+        for seed in 1..=5 {
+            if seed <= 4 {
+                add_test_validator_support(registry, owner, seed, features_tip)?;
+            } else {
+                let validator = Address::repeat_byte(seed as u8);
+                add_test_validator(owner, validator, seed)?;
+            }
+        }
+        Ok(())
+    }
+
     #[test]
     fn features_tip_defaults_to_zero() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
             let registry = FeatureRegistry::new();
             assert_eq!(registry.features_tip()?, 0);
+            assert_eq!(registry.highest_quorum_features_tip()?, 0);
             Ok(())
         })
     }
@@ -463,15 +504,15 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut registry = FeatureRegistry::new();
-            registry.features_tip.write(7)?;
-            registry.scheduled_features_tip.write(13)?;
+            registry.scheduled_features_tip.write(1)?;
             registry.scheduled_activation_epoch.write(21)?;
+            add_quorum_support(&mut registry, Address::repeat_byte(0xaa), 1)?;
 
             assert!(!registry.activate_scheduled_features_tip(20)?);
-            assert_eq!(registry.features_tip()?, 7);
+            assert_eq!(registry.features_tip()?, 0);
 
             let scheduled = registry.scheduled_features_tip()?;
-            assert_eq!(scheduled.featuresTip, 13);
+            assert_eq!(scheduled.featuresTip, 1);
             assert_eq!(scheduled.activationEpoch, 21);
 
             Ok(())
@@ -483,16 +524,39 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut registry = FeatureRegistry::new();
-            registry.features_tip.write(7)?;
-            registry.scheduled_features_tip.write(13)?;
+            registry.scheduled_features_tip.write(1)?;
             registry.scheduled_activation_epoch.write(21)?;
+            add_quorum_support(&mut registry, Address::repeat_byte(0xaa), 1)?;
 
             assert!(registry.activate_scheduled_features_tip(21)?);
-            assert_eq!(registry.features_tip()?, 13);
+            assert_eq!(registry.features_tip()?, 1);
 
             let scheduled = registry.scheduled_features_tip()?;
             assert_eq!(scheduled.featuresTip, 0);
             assert_eq!(scheduled.activationEpoch, 0);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn activate_scheduled_features_tip_rejects_missing_quorum() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            registry.scheduled_features_tip.write(1)?;
+            registry.scheduled_activation_epoch.write(21)?;
+
+            let result = registry.activate_scheduled_features_tip(21);
+            assert_eq!(
+                result,
+                Err(FeatureRegistryError::features_tip_quorum_not_reached().into())
+            );
+            assert_eq!(registry.features_tip()?, 0);
+
+            let scheduled = registry.scheduled_features_tip()?;
+            assert_eq!(scheduled.featuresTip, 1);
+            assert_eq!(scheduled.activationEpoch, 21);
 
             Ok(())
         })
@@ -519,15 +583,15 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut registry = FeatureRegistry::new();
-            registry.features_tip.write(7)?;
-            registry.scheduled_features_tip.write(13)?;
+            registry.scheduled_features_tip.write(1)?;
             registry.scheduled_activation_epoch.write(21)?;
+            add_quorum_support(&mut registry, Address::repeat_byte(0xaa), 1)?;
 
             let call = IFeatureRegistry::activateScheduledFeaturesTipCall { currentEpoch: 21 };
             let result = registry.call(&call.abi_encode(), SYSTEM_CALLER_ADDRESS)?;
             assert!(!result.is_revert());
 
-            assert_eq!(registry.features_tip()?, 13);
+            assert_eq!(registry.features_tip()?, 1);
             let scheduled = registry.scheduled_features_tip()?;
             assert_eq!(scheduled.featuresTip, 0);
             assert_eq!(scheduled.activationEpoch, 0);
@@ -718,6 +782,22 @@ mod tests {
             let result = registry.call(&call.abi_encode(), Address::ZERO)?;
             assert!(!result.is_revert());
             assert_eq!(u64::abi_decode(&result.bytes)?, 11);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn highest_quorum_features_tip_dispatch_returns_encoded_cursor() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = FeatureRegistry::new();
+            registry.highest_quorum_features_tip.write(1)?;
+
+            let call = IFeatureRegistry::highestQuorumFeaturesTipCall {};
+            let result = registry.call(&call.abi_encode(), Address::ZERO)?;
+            assert!(!result.is_revert());
+            assert_eq!(u64::abi_decode(&result.bytes)?, 1);
 
             Ok(())
         })
@@ -931,6 +1011,7 @@ mod tests {
             assert_eq!(support.support, U256::from(4));
             assert_eq!(support.required, U256::from(4));
             assert!(registry.has_features_tip_quorum(1)?);
+            assert_eq!(registry.highest_quorum_features_tip()?, 1);
 
             Ok(())
         })

--- a/crates/precompiles/src/feature_registry/mod.rs
+++ b/crates/precompiles/src/feature_registry/mod.rs
@@ -31,6 +31,8 @@ pub struct FeatureRegistry {
     scheduled_features_tip: u64,
     /// Earliest activation epoch for the scheduled feature tip, or zero when none is scheduled.
     scheduled_activation_epoch: u64,
+    /// Highest protocol feature tip that has reached quorum support.
+    highest_quorum_features_tip: u64,
     /// Latest feature tip reported as supported by each validator.
     validator_supported_features_tip: Mapping<Address, u64>,
     /// Digest of each ordered feature registry prefix reported by each validator.
@@ -60,6 +62,11 @@ impl FeatureRegistry {
     /// Returns the highest active protocol feature ID.
     pub fn features_tip(&self) -> Result<u64> {
         self.features_tip.read()
+    }
+
+    /// Returns the highest protocol feature tip with observed quorum support.
+    pub fn highest_quorum_features_tip(&self) -> Result<u64> {
+        self.highest_quorum_features_tip.read()
     }
 
     /// Returns the fixed activation quorum threshold as an exact fraction: 4/5, or 80%.
@@ -174,7 +181,9 @@ impl FeatureRegistry {
             if let Some(old_digest) = old_counted_digest {
                 self.decrement_features_tip_support(call.featuresTip, old_digest)?;
             }
-            self.increment_features_tip_support(call.featuresTip, call.featuresDigest)?;
+            let support =
+                self.increment_features_tip_support(call.featuresTip, call.featuresDigest)?;
+            self.update_highest_quorum_features_tip(call.featuresTip, support)?;
         }
 
         Ok(())
@@ -194,14 +203,39 @@ impl FeatureRegistry {
         Ok((digest != B256::ZERO).then_some(digest))
     }
 
-    fn increment_features_tip_support(&mut self, features_tip: u64, digest: B256) -> Result<()> {
+    fn increment_features_tip_support(&mut self, features_tip: u64, digest: B256) -> Result<u64> {
         let support = self.features_tip_support_count[features_tip][digest].read()?;
-        self.features_tip_support_count[features_tip][digest].write(support + 1)
+        let support = support + 1;
+        self.features_tip_support_count[features_tip][digest].write(support)?;
+        Ok(support)
     }
 
     fn decrement_features_tip_support(&mut self, features_tip: u64, digest: B256) -> Result<()> {
         let support = self.features_tip_support_count[features_tip][digest].read()?;
         self.features_tip_support_count[features_tip][digest].write(support.saturating_sub(1))
+    }
+
+    fn update_highest_quorum_features_tip(
+        &mut self,
+        features_tip: u64,
+        support: u64,
+    ) -> Result<()> {
+        if features_tip <= self.highest_quorum_features_tip.read()? {
+            return Ok(());
+        }
+
+        let required = self.required_support_count()?;
+        if support >= required {
+            self.highest_quorum_features_tip.write(features_tip)?;
+        }
+
+        Ok(())
+    }
+
+    fn required_support_count(&self) -> Result<u64> {
+        Ok(required_support_count(
+            ValidatorConfigV2::new().active_validator_count()?,
+        ))
     }
 
     pub fn features_tip_support(
@@ -210,12 +244,11 @@ impl FeatureRegistry {
     ) -> Result<IFeatureRegistry::featuresTipSupportReturn> {
         let expected_digest = protocol_features_digest(features_tip)
             .ok_or_else(|| FeatureRegistryError::invalid_features_tip())?;
-        let active_validator_count = ValidatorConfigV2::new().active_validator_count()?;
         let support = self.features_tip_support_count[features_tip][expected_digest].read()?;
 
         Ok((
             U256::from(support),
-            U256::from(required_support_count(active_validator_count)),
+            U256::from(self.required_support_count()?),
         )
             .into())
     }
@@ -282,10 +315,7 @@ impl FeatureRegistry {
         Ok(())
     }
 
-    /// Activates the scheduled feature tip if its target epoch has arrived.
-    ///
-    /// Quorum enforcement is intentionally not implemented in this scaffold. The full activation
-    /// path should enforce validator support once TIP-1070 lands.
+    /// Activates the scheduled feature tip if its target epoch has arrived and it has quorum.
     pub fn activate_scheduled_features_tip(&mut self, current_epoch: u64) -> Result<bool> {
         let scheduled_features_tip = self.scheduled_features_tip.read()?;
         let scheduled_activation_epoch = self.scheduled_activation_epoch.read()?;
@@ -295,6 +325,10 @@ impl FeatureRegistry {
             || scheduled_activation_epoch > current_epoch
         {
             return Ok(false);
+        }
+
+        if !self.has_features_tip_quorum(scheduled_features_tip)? {
+            return Err(FeatureRegistryError::features_tip_quorum_not_reached().into());
         }
 
         let active_features_tip = self.features_tip.read()?;
@@ -310,5 +344,9 @@ impl FeatureRegistry {
 }
 
 fn required_support_count(active_validator_count: u64) -> u64 {
+    if active_validator_count == 0 {
+        return 1;
+    }
+
     (ACTIVATION_QUORUM_NUMERATOR * active_validator_count).div_ceil(ACTIVATION_QUORUM_DENOMINATOR)
 }

--- a/crates/precompiles/src/feature_registry/mod.rs
+++ b/crates/precompiles/src/feature_registry/mod.rs
@@ -181,9 +181,8 @@ impl FeatureRegistry {
             if let Some(old_digest) = old_counted_digest {
                 self.decrement_features_tip_support(call.featuresTip, old_digest)?;
             }
-            let support =
-                self.increment_features_tip_support(call.featuresTip, call.featuresDigest)?;
-            self.update_highest_quorum_features_tip(call.featuresTip, support)?;
+            self.increment_features_tip_support(call.featuresTip, call.featuresDigest)?;
+            self.refresh_highest_quorum_features_tip(call.featuresTip)?;
         }
 
         Ok(())
@@ -203,11 +202,9 @@ impl FeatureRegistry {
         Ok((digest != B256::ZERO).then_some(digest))
     }
 
-    fn increment_features_tip_support(&mut self, features_tip: u64, digest: B256) -> Result<u64> {
+    fn increment_features_tip_support(&mut self, features_tip: u64, digest: B256) -> Result<()> {
         let support = self.features_tip_support_count[features_tip][digest].read()?;
-        let support = support + 1;
-        self.features_tip_support_count[features_tip][digest].write(support)?;
-        Ok(support)
+        self.features_tip_support_count[features_tip][digest].write(support + 1)
     }
 
     fn decrement_features_tip_support(&mut self, features_tip: u64, digest: B256) -> Result<()> {
@@ -215,21 +212,28 @@ impl FeatureRegistry {
         self.features_tip_support_count[features_tip][digest].write(support.saturating_sub(1))
     }
 
-    fn update_highest_quorum_features_tip(
-        &mut self,
-        features_tip: u64,
-        support: u64,
-    ) -> Result<()> {
-        if features_tip <= self.highest_quorum_features_tip.read()? {
-            return Ok(());
+    fn refresh_highest_quorum_features_tip(&mut self, changed_features_tip: u64) -> Result<()> {
+        let current = self.highest_quorum_features_tip.read()?;
+        let candidate = current.max(changed_features_tip);
+
+        for features_tip in (1..=candidate).rev() {
+            if self.has_contiguous_quorum(features_tip)? {
+                self.highest_quorum_features_tip.write(features_tip)?;
+                return Ok(());
+            }
         }
 
-        let required = self.required_support_count()?;
-        if support >= required {
-            self.highest_quorum_features_tip.write(features_tip)?;
+        self.highest_quorum_features_tip.write(0)
+    }
+
+    fn has_contiguous_quorum(&self, features_tip: u64) -> Result<bool> {
+        for prefix_tip in 1..=features_tip {
+            if !self.has_features_tip_quorum(prefix_tip)? {
+                return Ok(false);
+            }
         }
 
-        Ok(())
+        Ok(true)
     }
 
     fn required_support_count(&self) -> Result<u64> {

--- a/crates/precompiles/src/feature_registry/mod.rs
+++ b/crates/precompiles/src/feature_registry/mod.rs
@@ -35,6 +35,8 @@ pub struct FeatureRegistry {
     validator_supported_features_tip: Mapping<Address, u64>,
     /// Digest of each ordered feature registry prefix reported by each validator.
     validator_supported_features_digest: Mapping<Address, Mapping<u64, B256>>,
+    /// Number of validators that currently agree with a feature tip digest.
+    features_tip_support_count: Mapping<u64, Mapping<B256, u64>>,
 }
 
 impl FeatureRegistry {
@@ -158,12 +160,32 @@ impl FeatureRegistry {
             return Err(FeatureRegistryError::invalid_features_tip().into());
         }
 
+        let previous_digest =
+            self.validator_supported_features_digest[validator][call.featuresTip].read()?;
+        let was_counted = previous >= call.featuresTip && previous_digest != B256::ZERO;
+
         if call.featuresTip > previous {
             self.validator_supported_features_tip[validator].write(call.featuresTip)?;
         }
 
-        self.validator_supported_features_digest[validator][call.featuresTip]
-            .write(call.featuresDigest)?;
+        if was_counted && previous_digest != call.featuresDigest {
+            let previous_support =
+                self.features_tip_support_count[call.featuresTip][previous_digest].read()?;
+            self.features_tip_support_count[call.featuresTip][previous_digest]
+                .write(previous_support.saturating_sub(1))?;
+        }
+
+        if previous_digest != call.featuresDigest {
+            self.validator_supported_features_digest[validator][call.featuresTip]
+                .write(call.featuresDigest)?;
+        }
+
+        if !was_counted || previous_digest != call.featuresDigest {
+            let support =
+                self.features_tip_support_count[call.featuresTip][call.featuresDigest].read()?;
+            self.features_tip_support_count[call.featuresTip][call.featuresDigest]
+                .write(support + 1)?;
+        }
 
         Ok(())
     }
@@ -174,23 +196,12 @@ impl FeatureRegistry {
     ) -> Result<IFeatureRegistry::featuresTipSupportReturn> {
         let expected_digest = protocol_features_digest(features_tip)
             .ok_or_else(|| FeatureRegistryError::invalid_features_tip())?;
-        let active_validators = ValidatorConfigV2::new().get_active_validators()?;
-        let mut support = 0u64;
-
-        for validator in &active_validators {
-            let reported_tip =
-                self.validator_supported_features_tip[validator.validatorAddress].read()?;
-            let reported_digest = self.validator_supported_features_digest
-                [validator.validatorAddress][features_tip]
-                .read()?;
-            if reported_tip >= features_tip && reported_digest == expected_digest {
-                support += 1;
-            }
-        }
+        let active_validator_count = ValidatorConfigV2::new().active_validator_count()?;
+        let support = self.features_tip_support_count[features_tip][expected_digest].read()?;
 
         Ok((
             U256::from(support),
-            U256::from(required_support_count(active_validators.len() as u64)),
+            U256::from(required_support_count(active_validator_count)),
         )
             .into())
     }

--- a/crates/precompiles/src/feature_registry/mod.rs
+++ b/crates/precompiles/src/feature_registry/mod.rs
@@ -160,34 +160,48 @@ impl FeatureRegistry {
             return Err(FeatureRegistryError::invalid_features_tip().into());
         }
 
-        let previous_digest =
-            self.validator_supported_features_digest[validator][call.featuresTip].read()?;
-        let was_counted = previous >= call.featuresTip && previous_digest != B256::ZERO;
+        let old_counted_digest =
+            self.counted_validator_digest(validator, call.featuresTip, previous)?;
 
         if call.featuresTip > previous {
             self.validator_supported_features_tip[validator].write(call.featuresTip)?;
         }
 
-        if was_counted && previous_digest != call.featuresDigest {
-            let previous_support =
-                self.features_tip_support_count[call.featuresTip][previous_digest].read()?;
-            self.features_tip_support_count[call.featuresTip][previous_digest]
-                .write(previous_support.saturating_sub(1))?;
-        }
+        self.validator_supported_features_digest[validator][call.featuresTip]
+            .write(call.featuresDigest)?;
 
-        if previous_digest != call.featuresDigest {
-            self.validator_supported_features_digest[validator][call.featuresTip]
-                .write(call.featuresDigest)?;
-        }
-
-        if !was_counted || previous_digest != call.featuresDigest {
-            let support =
-                self.features_tip_support_count[call.featuresTip][call.featuresDigest].read()?;
-            self.features_tip_support_count[call.featuresTip][call.featuresDigest]
-                .write(support + 1)?;
+        if old_counted_digest != Some(call.featuresDigest) {
+            if let Some(old_digest) = old_counted_digest {
+                self.decrement_features_tip_support(call.featuresTip, old_digest)?;
+            }
+            self.increment_features_tip_support(call.featuresTip, call.featuresDigest)?;
         }
 
         Ok(())
+    }
+
+    fn counted_validator_digest(
+        &self,
+        validator: Address,
+        features_tip: u64,
+        validator_supported_features_tip: u64,
+    ) -> Result<Option<B256>> {
+        if validator_supported_features_tip < features_tip {
+            return Ok(None);
+        }
+
+        let digest = self.validator_supported_features_digest[validator][features_tip].read()?;
+        Ok((digest != B256::ZERO).then_some(digest))
+    }
+
+    fn increment_features_tip_support(&mut self, features_tip: u64, digest: B256) -> Result<()> {
+        let support = self.features_tip_support_count[features_tip][digest].read()?;
+        self.features_tip_support_count[features_tip][digest].write(support + 1)
+    }
+
+    fn decrement_features_tip_support(&mut self, features_tip: u64, digest: B256) -> Result<()> {
+        let support = self.features_tip_support_count[features_tip][digest].read()?;
+        self.features_tip_support_count[features_tip][digest].write(support.saturating_sub(1))
     }
 
     pub fn features_tip_support(

--- a/crates/precompiles/src/feature_registry/mod.rs
+++ b/crates/precompiles/src/feature_registry/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     validator_config_v2::ValidatorConfigV2,
 };
 use alloy::primitives::{Address, B256, U256};
-use tempo_chainspec::epoch::block_to_epoch;
+use tempo_chainspec::{epoch::block_to_epoch, features::protocol_features_digest};
 use tempo_contracts::precompiles::{
     FeatureRegistryError, FeatureRegistryEvent, IFeatureRegistry, ValidatorConfigV2Error,
 };
@@ -33,6 +33,8 @@ pub struct FeatureRegistry {
     scheduled_activation_epoch: u64,
     /// Latest feature tip reported as supported by each validator.
     validator_supported_features_tip: Mapping<Address, u64>,
+    /// Digest of each ordered feature registry prefix reported by each validator.
+    validator_supported_features_digest: Mapping<Address, Mapping<u64, B256>>,
 }
 
 impl FeatureRegistry {
@@ -81,9 +83,49 @@ impl FeatureRegistry {
         self.validator_supported_features_tip[validator].read()
     }
 
+    /// Returns the feature registry prefix digest reported by `validator` for `features_tip`.
+    pub fn validator_supported_features_digest(
+        &self,
+        validator: Address,
+        features_tip: u64,
+    ) -> Result<B256> {
+        self.validator_supported_features_digest[validator][features_tip].read()
+    }
+
     pub fn validator_supported_features_tip_by_public_key(&self, public_key: B256) -> Result<u64> {
         let validator = self.validator_address_by_public_key(public_key)?;
         self.validator_supported_features_tip(validator)
+    }
+
+    pub fn next_validator_support_update(
+        &self,
+        public_key: B256,
+        supported_features_tip: u64,
+    ) -> Result<Option<IFeatureRegistry::setSupportedFeaturesTipCall>> {
+        let validator = self.validator_address_by_public_key(public_key)?;
+        if self.validator_supported_features_tip(validator)? < supported_features_tip {
+            return Ok(Some(IFeatureRegistry::setSupportedFeaturesTipCall {
+                publicKey: public_key,
+                featuresTip: supported_features_tip,
+                featuresDigest: protocol_features_digest(supported_features_tip)
+                    .ok_or_else(|| FeatureRegistryError::invalid_features_tip())?,
+            }));
+        }
+
+        for features_tip in 1..=supported_features_tip {
+            let expected_digest = protocol_features_digest(features_tip)
+                .ok_or_else(|| FeatureRegistryError::invalid_features_tip())?;
+            if self.validator_supported_features_digest(validator, features_tip)? != expected_digest
+            {
+                return Ok(Some(IFeatureRegistry::setSupportedFeaturesTipCall {
+                    publicKey: public_key,
+                    featuresTip: features_tip,
+                    featuresDigest: expected_digest,
+                }));
+            }
+        }
+
+        Ok(None)
     }
 
     fn validator_address_by_public_key(&self, public_key: B256) -> Result<Address> {
@@ -110,7 +152,52 @@ impl FeatureRegistry {
             return Err(FeatureRegistryError::supported_features_tip_decreased().into());
         }
 
-        self.validator_supported_features_tip[validator].write(call.featuresTip)
+        let expected_digest = protocol_features_digest(call.featuresTip)
+            .ok_or_else(|| FeatureRegistryError::invalid_features_tip())?;
+        if call.featuresDigest != expected_digest {
+            return Err(FeatureRegistryError::invalid_features_tip().into());
+        }
+
+        if call.featuresTip > previous {
+            self.validator_supported_features_tip[validator].write(call.featuresTip)?;
+        }
+
+        self.validator_supported_features_digest[validator][call.featuresTip]
+            .write(call.featuresDigest)?;
+
+        Ok(())
+    }
+
+    pub fn features_tip_support(
+        &self,
+        features_tip: u64,
+    ) -> Result<IFeatureRegistry::featuresTipSupportReturn> {
+        let expected_digest = protocol_features_digest(features_tip)
+            .ok_or_else(|| FeatureRegistryError::invalid_features_tip())?;
+        let active_validators = ValidatorConfigV2::new().get_active_validators()?;
+        let mut support = 0u64;
+
+        for validator in &active_validators {
+            let reported_tip =
+                self.validator_supported_features_tip[validator.validatorAddress].read()?;
+            let reported_digest = self.validator_supported_features_digest
+                [validator.validatorAddress][features_tip]
+                .read()?;
+            if reported_tip >= features_tip && reported_digest == expected_digest {
+                support += 1;
+            }
+        }
+
+        Ok((
+            U256::from(support),
+            U256::from(required_support_count(active_validators.len() as u64)),
+        )
+            .into())
+    }
+
+    pub fn has_features_tip_quorum(&self, features_tip: u64) -> Result<bool> {
+        let support = self.features_tip_support(features_tip)?;
+        Ok(support.support >= support.required)
     }
 
     pub fn schedule_features_tip(
@@ -195,4 +282,8 @@ impl FeatureRegistry {
 
         Ok(scheduled_features_tip > active_features_tip)
     }
+}
+
+fn required_support_count(active_validator_count: u64) -> u64 {
+    (ACTIVATION_QUORUM_NUMERATOR * active_validator_count).div_ceil(ACTIVATION_QUORUM_DENOMINATOR)
 }

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -221,6 +221,11 @@ impl ValidatorConfigV2 {
         Ok(self.validators.len()? as u64)
     }
 
+    /// Returns the number of currently active validators.
+    pub(crate) fn active_validator_count(&self) -> Result<u64> {
+        Ok(self.active_indices.len()? as u64)
+    }
+
     /// Returns the validator at the given global index, or errors if the index
     /// is out of bounds or the validator has been deactivated.
     fn get_active_validator(&self, idx: u64) -> Result<ValidatorRecord> {
@@ -294,7 +299,7 @@ impl ValidatorConfigV2 {
     ///
     /// NOTE: the order of returned validator records is NOT stable and should NOT be relied upon.
     pub fn get_active_validators(&self) -> Result<Vec<IValidatorConfigV2::Validator>> {
-        let count = self.active_indices.len()?;
+        let count = self.active_validator_count()? as usize;
         let mut out = Vec::new();
         for i in 0..count {
             let global_idx1 = self.active_indices[i].read()?;


### PR DESCRIPTION
## Summary

Targets #5213 and addresses the index-based support concern from #4079 review discussion.

This keeps `featuresTip` as the activation cursor, but requires validator reports to include a digest over the ordered feature registry prefix. Feature tip `0` remains the unsupported/no-feature state with a zero digest; feature index `1` uses the existing feature name `tip-1063.feature-registry`.

The registry stores digest support per validator and per feature-tip height, so quorum for target `N` checks the digest reported at height `N`. Builders compute the next missing/stale height once and submit only that `(featuresTip, featuresDigest)` update.

## Changes

- Add `protocol_features_digest(features_tip)` over `(feature_id, name)` for each feature in `1..=features_tip`.
- Extend `setSupportedFeaturesTip` to report `(publicKey, featuresTip, featuresDigest)`.
- Keep `validatorSupportedFeaturesTip` as the validator high-water mark.
- Add `validatorSupportedFeaturesDigest(validator, featuresTip)` for per-height digest reads.
- Add a read-only planning helper that returns the next high-water, missing, or stale digest update for a validator.
- On report, validate the submitted digest for that exact `featuresTip`, update the high-water mark only if it increases, and write only the submitted height's digest.
- Implement `featuresTipSupport` / `hasFeaturesTipQuorum` over active validators using the scalar high-water tip plus the canonical digest at the target height.
- Update payload builder, block validation tests, and integration assertions for the new ABI.

## Validation

- `cargo test -p tempo-chainspec features --lib`
- `cargo test -p tempo-precompiles feature_registry --lib`
- `cargo check -p tempo-evm -p tempo-payload-builder -p tempo-node`
- `cargo check -p tempo-payload-builder`
