### PR TITLE
Bump reth async tx ingress optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10225,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10273,7 +10273,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "bytes",
  "eyre",
@@ -10302,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10314,7 +10314,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10338,7 +10338,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10350,7 +10350,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10373,7 +10373,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10416,7 +10416,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10465,7 +10465,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10493,7 +10493,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10600,7 +10600,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10673,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10693,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10724,7 +10724,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10771,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10822,7 +10822,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10867,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10918,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10960,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10980,7 +10980,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10995,7 +10995,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11021,7 +11021,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11039,7 +11039,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11060,7 +11060,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11086,7 +11086,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "clap",
  "eyre",
@@ -11106,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11125,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11170,7 +11170,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11196,7 +11196,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11223,7 +11223,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11243,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11272,7 +11272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8b902fe#8b902fe0b3af1bde8efc25dca12b4baee8ed2175"
+source = "git+https://github.com/paradigmxyz/reth?rev=74ccbce50d9d272f10eb78fd2a65d4f87891d442#74ccbce50d9d272f10eb78fd2a65d4f87891d442"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,66 +141,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
 reth-codecs = { version = "0.4.1", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
 reth-primitives-traits = { version = "0.4.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8b902fe", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "74ccbce50d9d272f10eb78fd2a65d4f87891d442", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
## Summary
- Bumps the workspace reth pin from `8b902fe` to `74ccbce50d9d272f10eb78fd2a65d4f87891d442`.
- The reth branch is based on Tempo's current pinned reth commit and reduces async state-machine overhead in RPC transaction ingress and the no-op pool implementation.
- Targets `eth_sendRawTransaction`/txpool async wrapper overhead called out by the async state-machine optimization work.

## Reth Changes
- `reth-rpc-eth-api`: rewrites `EthTransactions::send_raw_transaction` from an `async move` wrapper into a composed future using `future::ready(...).and_then(...)`.
- `reth-transaction-pool`: rewrites `NoopTransactionPool` no-await async methods to return `ready(...)` futures.

## Verification
- reth: `cargo test -p reth-transaction-pool noop --lib`
- reth: `cargo check -p reth-rpc-eth-api`
- tempo: `cargo check -p tempo`
- Derek bench: pending PR comment trigger.

Prompted by: @shekhirin
