### PR TITLE
docs(tip-1076): add consensus-managed capacity allocations TIP

### DIFF
--- a/tips/tip-1076.md
+++ b/tips/tip-1076.md
@@ -1,0 +1,299 @@
+---
+id: TIP-1076
+title: Consensus-Managed Capacity Allocations
+description: Adds consensus-managed signer-scoped gas allocations and base fee discounts.
+authors: Tanishk Goyal (@legion2002)
+status: Draft
+related: TIP-1010, TIP-1045, TIP-1059, TIP-1067, Sub-block Specification
+protocolVersion: TBD
+---
+
+# TIP-1076: Consensus-Managed Capacity Allocations
+
+## Abstract
+
+This TIP adds a consensus-managed registry of allocation signers. A transaction authorized by an active allocation signer can receive a negotiated base fee discount and consume signer-scoped allocated gas that does not count against the normal payment or general block gas limits.
+
+Allocated gas is additive blockspace capped at `100,000,000` gas per block, on top of TIP-1010's existing `500,000,000` gas block limit.
+
+The goal is to give selected activity fast, consistent, and cheap execution through one mechanism instead of separately expanding payment lanes, subblocks, and temporary base fee discounts.
+
+This TIP is intended to replace TIP-1067 for onboarding and discount use cases. Instead of lowering fees broadly whenever the chain is underutilized, discounts become explicit, signer-scoped, and bounded by capacity allocations.
+
+## Motivation
+
+Tempo has three recurring execution goals:
+
+1. The chain should be fast.
+2. The chain should be consistent.
+3. The chain should be cheap.
+
+Today these goals are addressed by separate mechanisms. Payment lanes give lane-specific access to payment-shaped transactions. Subblocks reserve blockspace for validators. TIP-1067 proposes a broad dynamic base fee that can make all activity cheaper during low utilization.
+
+These mechanisms solve adjacent problems but leave fragmented policy surfaces. Payment-lane classification has to keep closing shapes that can smuggle non-payment activity into cheap or privileged blockspace. Dynamic base fee discounts are broad and can be consumed by any activity when the chain is idle. Subblocks require applications to run validator infrastructure, and their guarantees weaken as validator participation decentralizes.
+
+Consensus-managed capacity allocations make the policy explicit: some authorized activity is valuable to the network and should receive explicit execution terms. An allocation signer can authorize arbitrary application flows, including onboarding, earn, swap, payments, and other contract interactions, without forcing those flows through payment-lane shape checks or validator-operated subblocks.
+
+## Assumptions
+
+- Capacity allocation entries are maintained by validator consensus. The concrete update path can be feature flags, onchain votes, or hardfork state, but every node MUST derive the same registry for a given block.
+- Registry updates take effect only at deterministic block or epoch boundaries. A block cannot observe a mid-block config change.
+- Each allocation signer is responsible for authorizing only approved activity. If a signer abuses its allocation or its key is compromised, the damage is bounded by its configured per-block gas allocation until the entry is reduced or removed.
+- The aggregate allocated gas cap is `100,000,000` gas per block, increasing the maximum protocol block execution budget from TIP-1010's `500,000,000` gas to `600,000,000` gas when allocated capacity is fully used.
+- Allocation signatures use secp256k1 address recovery. Other signature schemes can be added by a future TIP if applications need them.
+
+## Threat Model
+
+- **Allocation signer**: trusted to authorize only activity covered by its allocation terms. It can spend its configured allocation on arbitrary valid Tempo transactions, so abuse is handled by allocation limits, monitoring, and removal from the registry.
+- **User or fee payer**: controls the underlying transaction and pays the discounted fee. They cannot receive allocation treatment unless an allocation signer authorizes the transaction.
+- **Block proposer or builder**: can choose which valid allocated transactions to include and how to order them, but cannot exceed per-signer gas allocations or apply discounts without a valid allocation signature.
+- **Validators**: enforce the registry, allocation counters, and fee rules during block validation. They must agree on the active config for each block.
+- **Ordinary users**: adversarial users may try to forge signatures, replay allocation authorizations, exhaust signer allocation, or get arbitrary calls treated as allocated. Signature binding, chain-id binding, per-block allocation accounting, and normal transaction validity checks are in scope.
+
+---
+
+# Specification
+
+## Capacity Allocation Registry
+
+At activation, consensus defines a registry:
+
+```text
+mapping(address capacitySigner => CapacityAllocationConfig)
+
+struct CapacityAllocationConfig {
+    bool active;
+    uint64 gasAllocated;
+    uint32 baseFeeDiscountBps;
+}
+```
+
+The global allocated gas cap is:
+
+```text
+CAPACITY_ALLOCATION_GAS_LIMIT = 100,000,000 gas per block
+```
+
+`capacitySigner` is the address recovered from the capacity allocation signature.
+
+`gasAllocated` is the maximum allocated gas the signer can authorize per block. Allocation is charged against the transaction gas limit, not post-execution gas used, so capacity is deterministic before execution.
+
+`baseFeeDiscountBps` is a discount on the block base fee in basis points. It MUST be less than or equal to `10_000`. `0` means no discount. `9_500` means a 95% discount, equivalent to paying one twentieth of the normal base fee. `10_000` means the base fee component is zero.
+
+A missing entry is equivalent to `active == false`, `gasAllocated == 0`, and `baseFeeDiscountBps == 0`.
+
+The registry update mechanism is intentionally abstract in this TIP. Implementations SHOULD reuse Tempo's feature flag or equivalent consensus configuration infrastructure so allocation signers can be added or removed on an operational time scale without coordinating a new hardfork for each entry.
+
+## Transaction Format
+
+Tempo transactions gain an optional capacity allocation signature field:
+
+```text
+capacity_signature: Option<Signature>
+```
+
+RPC and JSON encodings SHOULD expose this as `capacitySig`.
+
+The field is valid only for Tempo transaction type `0x76`. Legacy, EIP-2930, EIP-1559, and EIP-7702 transactions cannot receive allocation treatment directly. An application that needs allocation treatment for multiple calls SHOULD use a Tempo transaction batch.
+
+`capacity_signature` MUST NOT be part of the sender signing hash. This lets an allocation signer authorize the transaction after the user signs it, similar to fee payer signing.
+
+Allocation signatures use a domain-separated authorization hash:
+
+```text
+capacity_authorization_hash =
+    keccak256(0x79 || rlp([
+        chain_id,
+        sender,
+        transaction_hash_without_capacity_signature
+    ]))
+```
+
+`0x79` is the capacity allocation signature magic byte and MUST NOT be reused by other transaction authorization schemes.
+
+`transaction_hash_without_capacity_signature` is the canonical typed transaction hash with `capacity_signature` encoded as empty and all other transaction fields, including fee fields, calls, access lists, key authorization, fee payer signature, and sender signature, preserved. This avoids circular signing while binding the allocation authorization to the exact transaction contents.
+
+An allocation signature is replay-protected by `chain_id`, sender binding, normal transaction nonce rules, and the transaction contents committed by `transaction_hash_without_capacity_signature`.
+
+## Allocated Transaction Classification
+
+During block validation, transactions are processed in block order. For each transaction, the validator determines whether it is allocated:
+
+1. The transaction is a Tempo transaction.
+2. `capacity_signature` is present and recovers a `capacitySigner` from `capacity_authorization_hash`.
+3. `capacitySigner` has an active registry entry for the current block.
+4. `allocatedGasReservedBySigner[capacitySigner] + tx.gas_limit <= gasAllocated`.
+5. `allocatedGasReservedTotal + tx.gas_limit <= CAPACITY_ALLOCATION_GAS_LIMIT`.
+6. The transaction is otherwise valid under Tempo transaction validity rules, using the discounted base fee defined below.
+
+If all conditions hold, the transaction is an allocated transaction. The validator increments:
+
+```text
+allocatedGasReservedBySigner[capacitySigner] += tx.gas_limit
+allocatedGasReservedTotal += tx.gas_limit
+```
+
+If any condition fails, the transaction receives no allocation treatment and is validated through the normal payment-lane or general-lane rules. A transaction that only satisfies fee validity under the allocation discount is invalid if it does not qualify as allocated.
+
+Allocated transaction classification does not depend on payment-lane eligibility. An allocated transaction MAY contain arbitrary valid calls, contract creation, access lists, key authorization, and account authorization data unless another active TIP forbids those fields for all Tempo transactions.
+
+## Block Gas Accounting
+
+Allocated transactions do not count against TIP-1010 payment, general, shared, or non-shared gas limits. They are accounted for under the per-signer allocation described above.
+
+Normal transactions continue to be accounted under the existing TIP-1010 lane rules:
+
+- Payment transactions use payment-lane accounting.
+- Non-payment transactions use general-lane accounting.
+- Validator subblock transactions use shared gas accounting.
+
+Allocated gas is additive blockspace capped by `CAPACITY_ALLOCATION_GAS_LIMIT`. A block is invalid if any signer exceeds its `gasAllocated` value for that block or if total allocated gas exceeds `100,000,000` gas.
+
+Under TIP-1010, the normal block gas limit is `500,000,000` gas. With this TIP active, the maximum execution budget is `600,000,000` gas: up to `500,000,000` gas under the existing TIP-1010 accounting plus up to `100,000,000` allocated gas.
+
+The per-transaction gas cap still applies. Allocation treatment does not let a single transaction exceed the protocol transaction gas cap.
+
+Block validation MUST track normal-lane gas and allocated gas with separate counters derived from the ordered transaction list. Validators MUST NOT use the header `gasUsed` value alone to enforce TIP-1010 lane limits after this TIP activates.
+
+Receipt `cumulativeGasUsed` values and the header `gasUsed` value SHOULD continue to include actual gas consumed by all transactions for EVM compatibility. If so, a post-activation block's header `gasUsed` MAY exceed the TIP-1010 block gas limit by the amount of actual allocated gas consumed, but it MUST NOT exceed `600,000,000` gas. Block validity is determined by the lane counters, per-signer allocation counters, and the global allocated gas counter.
+
+## Fee Calculation
+
+For an allocated transaction, define:
+
+```text
+discounted_base_fee =
+    floor(block_base_fee * (10_000 - baseFeeDiscountBps) / 10_000)
+```
+
+Fee validity and effective gas price are computed using `discounted_base_fee` instead of `block_base_fee`.
+
+The priority fee is not discounted. For allocated transactions:
+
+```text
+effective_priority_fee =
+    min(max_priority_fee_per_gas, max_fee_per_gas - discounted_base_fee)
+
+effective_gas_price =
+    discounted_base_fee + effective_priority_fee
+```
+
+An allocated transaction is invalid if `max_fee_per_gas < discounted_base_fee`.
+
+Fee settlement, fee token conversion, fee payer handling, gas refunds, receipts, and builder payload value MUST use the discounted fee actually charged. An ordinary transaction with a `capacity_signature` field receives no discount.
+
+## Registry Updates
+
+Registry updates MUST be deterministic and auditable. Each update MUST specify:
+
+- `capacitySigner`
+- `active`
+- `gasAllocated`
+- `baseFeeDiscountBps`
+- activation block or epoch
+
+Updating `gasAllocated` changes the signer's per-block allocated capacity starting at the activation boundary. Updating `baseFeeDiscountBps` changes the discount for transactions in blocks at or after the activation boundary.
+
+Removing a signer is represented by setting `active` to `false` or `gasAllocated` to zero. Already finalized blocks remain valid under the registry state that was active for those blocks.
+
+## Relationship to Existing Mechanisms
+
+Payment lanes remain the default high-throughput path for payment-shaped activity. Allocated transactions are a separate path and do not need to satisfy TIP-1045 payment classification.
+
+TIP-1059 remains a narrow discount for pure payment transfers. Capacity allocation discounts are signer-authorized and can apply to broader application flows.
+
+This TIP is intended to replace TIP-1067 as the mechanism for onboarding discounts. If this TIP is adopted, TIP-1067 SHOULD either be withdrawn or scoped strictly to ordinary network-wide fee policy rather than allocation-specific cost relief.
+
+Subblocks remain a validator-operated reserved blockspace mechanism. Capacity allocations provide similar reserved-capacity properties without requiring applications to run validator infrastructure.
+
+## Out of Scope
+
+This TIP does not define:
+
+- The offchain commercial or legal process for admitting allocation signers.
+- The exact governance mechanism for registry updates.
+- Fee sharing.
+- Allocation-specific execution features beyond gas allocation and base fee discounts.
+
+## Alternatives Considered
+
+### Continue expanding payment lanes
+
+Payment lanes are useful for generic payment-shaped traffic, but using them for allocation-specific policy forces consensus to classify business intent from calldata shape. That creates a recurring DoS surface whenever a payment-shaped transaction can be used for non-payment activity.
+
+### Use only dynamic base fees
+
+A broad dynamic base fee makes idle blocks cheaper for everyone, but it does not reserve capacity for onboarding or distinguish valuable allocated activity from spam when the chain becomes busy.
+
+### Require applications to run validators for subblocks
+
+Subblocks provide reserved capacity, but requiring every application to operate validator infrastructure is a high integration burden. In a more decentralized validator set, subblock guarantees also depend on which validators participate and how capacity is allocated.
+
+### Hardfork each allocation into protocol config
+
+Hardfork-gated allocation config is simple to validate but too slow for onboarding and incident response. Feature-flag or governance-backed registry updates keep the same deterministic consensus surface while allowing faster operational changes.
+
+## Future Extensions
+
+A future TIP can add fee sharing by extending the registry with a `feeShareBps` field and a fee recipient. The share SHOULD be capped by registry config rather than chosen freely by each transaction, so fee splits remain consensus-governed and auditable.
+
+Future updates can also allocate signer capacity to stakers or validators according to an algorithm. Equal validator allocation would recreate subblock-like capacity while keeping the allocation signature model.
+
+The same allocation signer registry can be reused as an allow-list for allocation-only features, including trusted privacy setups, compliance-gated DeFi access, or other policy-gated execution paths.
+
+# Observability
+
+If the registry is implemented as an onchain or precompile-backed state transition, it MUST emit:
+
+```text
+CapacityAllocationConfigUpdated(
+    address indexed capacitySigner,
+    bool active,
+    uint64 gasAllocated,
+    uint32 baseFeeDiscountBps,
+    uint64 activationBlock
+)
+```
+
+This answers which allocation config changed, when it becomes active, and what operational limits now apply.
+
+Nodes MUST expose equivalent logs or metrics for feature-flag-backed registry updates.
+
+Nodes SHOULD expose per-block metrics:
+
+- `capacity_allocation_gas_limit{capacitySigner}`: configured per-block allocation.
+- `capacity_allocation_gas_reserved{capacitySigner}`: sum of allocated transaction gas limits included in the block.
+- `capacity_allocation_gas_used{capacitySigner}`: post-execution gas used by allocated transactions.
+- `capacity_allocation_fee_discounted{capacitySigner}`: base fee amount discounted for included allocated transactions.
+- `capacity_allocation_transactions_included{capacitySigner}`: count of included allocated transactions.
+- `capacity_allocation_transactions_rejected{reason}`: count of allocation-signature transactions rejected or treated as ordinary, labeled by reason.
+
+# Invariants
+
+- A transaction MUST receive allocation treatment only if its allocation signature recovers an active `capacitySigner` for that block.
+- For every block and capacity signer, the sum of gas limits for allocated transactions MUST be less than or equal to `gasAllocated`.
+- For every block, the sum of gas limits for all allocated transactions MUST be less than or equal to `100,000,000`.
+- Allocated gas MUST NOT count against the normal payment, general, shared, or non-shared gas limits.
+- Ordinary transactions MUST continue to obey the active payment-lane, general-lane, and subblock gas rules.
+- `baseFeeDiscountBps` MUST be less than or equal to `10_000`.
+- An allocated transaction's base fee component MUST equal `floor(block_base_fee * (10_000 - baseFeeDiscountBps) / 10_000)`.
+- Priority fees MUST NOT be discounted unless a future TIP explicitly changes priority-fee accounting.
+- Registry state MUST be deterministic for every block. Two honest validators validating the same block number and parent state MUST derive the same capacity allocation entries.
+- Removing or reducing an allocation entry MUST NOT affect validity of blocks finalized before the update activation boundary.
+- Adding `capacity_signature` MUST NOT change the sender signing hash.
+
+## Test Cases
+
+The test suite MUST cover:
+
+1. A valid allocated transaction with arbitrary non-payment calls is included outside normal lane gas limits and receives the configured base fee discount.
+2. An allocated transaction with `max_fee_per_gas` below the discounted base fee is rejected.
+3. A transaction with a missing, malformed, or inactive allocation signature receives no allocation treatment.
+4. Multiple allocated transactions from the same signer are accepted until the sum of gas limits reaches `gasAllocated`.
+5. Multiple allocated transactions across signers are accepted until the sum of allocated gas limits reaches `100,000,000`.
+6. A transaction that would exceed the signer's remaining allocation or the global allocated gas cap is validated as ordinary if it satisfies ordinary rules, otherwise rejected.
+7. Allocations are independent across different capacity signers, subject to the global cap.
+8. Allocated transactions still obey the protocol transaction gas cap.
+9. `baseFeeDiscountBps == 0` charges the normal base fee, and `baseFeeDiscountBps == 10_000` charges zero base fee.
+10. Registry updates take effect exactly at their configured activation boundary.
+11. Fee payer, fee token, key authorization, and validity-window behavior are unchanged except for the discounted base fee used by allocation fee accounting.


### PR DESCRIPTION
Adds TIP-1076 for Consensus-Managed Capacity Allocations with signer-scoped gas allocations, a 100M global allocated gas cap, and base fee discounts. It positions capacity allocations as the onboarding-discount replacement for TIP-1067 while avoiding broader network-wide fee discounts.