### PR TITLE
chore(consensus): provide round to fetch proposal and log success

### DIFF
--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -35,7 +35,7 @@ use prometheus_client::metrics::counter::Counter;
 use commonware_utils::SystemTimeExt;
 use eyre::{OptionExt as _, WrapErr as _, bail, ensure, eyre};
 use futures::{
-    StreamExt as _, TryFutureExt as _,
+    StreamExt as _,
     channel::{mpsc, oneshot},
     future::try_join,
 };
@@ -549,11 +549,10 @@ impl Inner<Init> {
             leader,
         } = args;
 
-        let parent = get_parent(
+        let parent = fetch_block_from_el_or_subscribe(
             &self.execution_node,
-            round,
+            Round::new(round.epoch(), parent_view),
             parent_digest,
-            parent_view,
             &self.marshal,
         )
         .await?;
@@ -813,21 +812,12 @@ impl Inner<Init> {
         proposer: PublicKey,
         round: Round,
     ) -> eyre::Result<bool> {
-        let block_request = self
-            .marshal
-            .subscribe_by_digest(None, payload)
-            .await
-            .map_err(|_| {
-                eyre!("marshal actor dropped channel before the block-to-verified was sent")
-            });
-
         let (block, parent) = try_join(
-            block_request,
-            get_parent(
+            fetch_block_from_el_or_subscribe(&self.execution_node, round, payload, &self.marshal),
+            fetch_block_from_el_or_subscribe(
                 &self.execution_node,
-                round,
+                Round::new(round.epoch(), parent_view),
                 parent_digest,
-                parent_view,
                 &self.marshal,
             ),
         )
@@ -1159,29 +1149,31 @@ async fn verify_header(
     Ok(())
 }
 
-async fn get_parent(
+/// Attempts to read a block from the execution layer or fetch it from consensus
+/// p2p.
+#[instrument(skip_all, fields(%round, %digest), err)]
+async fn fetch_block_from_el_or_subscribe(
     execution_node: &TempoFullNode,
     round: Round,
-    parent_digest: Digest,
-    parent_view: View,
+    digest: Digest,
     marshal: &crate::alias::marshal::Mailbox,
 ) -> eyre::Result<Block> {
-    if let Some(parent) = execution_node
+    let block = if let Some(parent) = execution_node
         .provider
-        .find_block_by_hash(parent_digest.0, BlockSource::Any)
-        .wrap_err_with(|| {
-            format!("failed querying execution layer for parent block `{parent_digest}`")
-        })?
+        .find_block_by_hash(digest.0, BlockSource::Any)
+        .wrap_err_with(|| format!("failed querying execution layer for parent block `{digest}`"))?
     {
         // EL database reads do not include commonware sidecars.
-        Ok(Block::from_execution_block_unchecked(parent.seal(), None))
+        Block::from_execution_block_unchecked(parent.seal(), None)
     } else {
         marshal
-            .subscribe_by_digest(Some(Round::new(round.epoch(), parent_view)), parent_digest)
+            .subscribe_by_digest(Some(round), digest)
             .await
             .await
-            .map_err(|_| eyre!("syncer dropped channel before the parent block was sent"))
-    }
+            .map_err(|_| eyre!("syncer dropped channel before the parent block was sent"))?
+    };
+    debug!("retrieved block");
+    Ok(block)
 }
 
 #[derive(Clone)]

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -549,7 +549,7 @@ impl Inner<Init> {
             leader,
         } = args;
 
-        let parent = fetch_block_from_el_or_subscribe(
+        let parent = subscribe(
             &self.execution_node,
             Round::new(round.epoch(), parent_view),
             parent_digest,
@@ -813,8 +813,8 @@ impl Inner<Init> {
         round: Round,
     ) -> eyre::Result<bool> {
         let (block, parent) = try_join(
-            fetch_block_from_el_or_subscribe(&self.execution_node, round, payload, &self.marshal),
-            fetch_block_from_el_or_subscribe(
+            subscribe(&self.execution_node, round, payload, &self.marshal),
+            subscribe(
                 &self.execution_node,
                 Round::new(round.epoch(), parent_view),
                 parent_digest,
@@ -1150,8 +1150,8 @@ async fn verify_header(
 }
 
 /// Read a block from the execution layer or fetches it from consensus p2p.
-#[instrument(skip_all, fields(%round, %digest), err)]
-async fn fetch_block_from_el_or_subscribe(
+#[instrument(skip_all, fields(%round, %digest), err, ret(Display))]
+async fn subscribe(
     execution_node: &TempoFullNode,
     round: Round,
     digest: Digest,
@@ -1171,7 +1171,6 @@ async fn fetch_block_from_el_or_subscribe(
             .await
             .map_err(|_| eyre!("syncer dropped channel before the parent block was sent"))?
     };
-    debug!("retrieved block");
     Ok(block)
 }
 

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -1149,8 +1149,7 @@ async fn verify_header(
     Ok(())
 }
 
-/// Attempts to read a block from the execution layer or fetch it from consensus
-/// p2p.
+/// Read a block from the execution layer or fetches it from consensus p2p.
 #[instrument(skip_all, fields(%round, %digest), err)]
 async fn fetch_block_from_el_or_subscribe(
     execution_node: &TempoFullNode,
@@ -1158,7 +1157,7 @@ async fn fetch_block_from_el_or_subscribe(
     digest: Digest,
     marshal: &crate::alias::marshal::Mailbox,
 ) -> eyre::Result<Block> {
-    let block = if let Some(parent) = execution_node
+    let block = if let Some(block) = execution_node
         .provider
         .find_block_by_hash(digest.0, BlockSource::Any)
         .wrap_err_with(|| format!("failed querying execution layer for parent block `{digest}`"))?

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -1163,7 +1163,7 @@ async fn fetch_block_from_el_or_subscribe(
         .wrap_err_with(|| format!("failed querying execution layer for parent block `{digest}`"))?
     {
         // EL database reads do not include commonware sidecars.
-        Block::from_execution_block_unchecked(parent.seal(), None)
+        Block::from_execution_block_unchecked(block.seal(), None)
     } else {
         marshal
             .subscribe_by_digest(Some(round), digest)

--- a/crates/commonware-node/src/consensus/block.rs
+++ b/crates/commonware-node/src/consensus/block.rs
@@ -20,7 +20,10 @@ use commonware_cryptography::{
     ed25519::{PrivateKey, PublicKey},
 };
 use reth_node_core::primitives::SealedBlock;
-use std::sync::{Arc, OnceLock};
+use std::{
+    fmt::Display,
+    sync::{Arc, OnceLock},
+};
 use tracing::warn;
 
 use crate::consensus::Digest;
@@ -174,6 +177,16 @@ impl Block {
         {
             None
         }
+    }
+}
+
+impl Display for Block {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "digest: {}, height: {}",
+            self.digest(),
+            self.height()
+        ))
     }
 }
 


### PR DESCRIPTION
The application actor was not using round information to fetch the proposed block - but it should, since it indeed has that information.

Also, this patch logs if a block was received, using the same EL-then-marshal logic as was used for fetching parents.