### PR TITLE
docs(tip-1028): update 1028 docs to clarify that allowance is spent

### DIFF
--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -81,7 +81,7 @@ TIP-1028 applies to the following TIP-20 operations: `transfer`, `transferFrom`,
 
 For each of these operations, TIP-20 first conducts token-level checks controlled by the issuer as before and continues to revert on failure. It then also checks the receiver's policy configuration before crediting them. It verifies whether the token is allowed by the receiver's token filter and whether the sender is allowed by the receiver's policy. For `transfer`, `transferFrom`, `transferWithMemo`, `transferFromWithMemo`, and `systemTransferFrom`, the policy checks the `from` parameter as the sender. For `mint` and `mintWithMemo`, the policy checks `msg.sender` as the sender.
 
-If both checks pass, the transfer or mint proceeds as normal. If either check fails, the call still succeeds but delivery is redirected to `ReceivePolicyGuard` instead.
+If both checks pass, the transfer or mint proceeds as normal. If either check fails, the call still succeeds but delivery is redirected to `ReceivePolicyGuard` instead. Note that `transferFrom` calls always consume the spender's allowance, regardless of whether the receiver's policy blocks the transfer since the funds are still transferred from the spender's account.
 
 Note that TIP-1028 only applies to the TIP-20 operations listed above. It does not apply to `approve`, `permit`, or `burn` and does not affect fee deposits or refunds via `transfer_fee_pre_tx` or `transfer_fee_post_tx`. Additionally, TIP-1028 does not interact with TIP-20 rewards or internal balances.
 
@@ -202,7 +202,7 @@ enum BlockedReason {
 
 ## ReceivePolicyGuard Precompile
 
-`ReceivePolicyGuard` tracks blocked inbound TIP-20 transfers and mints. Every blocked amount remains directly attributable and only claimable by the designated recovery authority, even though all blocked balances are recorded at the shared `RECEIVE_POLICY_GUARD_ADDRESS` until claimed. 
+`ReceivePolicyGuard` tracks blocked inbound TIP-20 transfers and mints. Every blocked amount remains directly attributable and only claimable by the designated recovery authority, even though all blocked balances are recorded at the shared `RECEIVE_POLICY_GUARD_ADDRESS` until claimed.
 
 ### ReceivePolicyGuard Address
 
@@ -285,16 +285,16 @@ When `validateReceivePolicy(...)` returns blocked, the TIP-20 path credits `RECE
 
 ### Claiming
 
-A claim consumes one full receipt and releases the funds to one destination, partial claims are not supported. 
+A claim consumes one full receipt and releases the funds to one destination, partial claims are not supported.
 
 `claim(...)` takes an encoded receipt and a destination `to`. For `receipt.version == 1`, it decodes the witness as `ClaimReceiptV1`, derives the canonical receiver as `tip1022.resolve(receipt.recipient)`, recomputes `receiptKey`, requires `blockedReceiptAmount[receiptKey] > 0`, zeroes the slot to free its storage, and releases the stored amount from `receipt.token`.
 
-Once consumed, a receipt is permanently retired: its `receiptKey` slot is empty and any later claim against the same witness MUST revert with `InvalidReceipt()`. 
+Once consumed, a receipt is permanently retired: its `receiptKey` slot is empty and any later claim against the same witness MUST revert with `InvalidReceipt()`.
 
 The release path inside the TIP-20 token debits `balances[RECEIVE_POLICY_GUARD_ADDRESS]`, credits the destination, emits `Transfer(RECEIVE_POLICY_GUARD_ADDRESS, to, amount)` followed by `ReceiptClaimed(...)`, and treats `ReceivePolicyGuard` as a reward-exempt always-opted-out source. `RECEIVE_POLICY_GUARD_ADDRESS` is not the real TIP-403 policy subject for a claim. The claim-time checks below determine whose TIP-403 status is used.
 Releasing a previously blocked mint does not emit a fresh `Mint` event because the claim is a transfer out of `ReceivePolicyGuard`, not a new mint.
 
-The sequence diagram below shows the high level flow for a claim. The details are described below. 
+The sequence diagram below shows the high level flow for a claim. The details are described below.
 
 ```mermaid
 sequenceDiagram
@@ -320,9 +320,9 @@ Each receipt is governed by the `recoveryAuthority` captured for that receipt at
 - if `recoveryAuthority == address(0)`, only `receipt.originator` may call `claim(...)`;
 - otherwise, only `recoveryAuthority` may call `claim(...)`.
 
-For transfer-like receipts, `originator` is `from`, including for `transferFrom` where `from` may differ from `msg.sender`. For mint receipts, `originator` is the mint caller. 
+For transfer-like receipts, `originator` is `from`, including for `transferFrom` where `from` may differ from `msg.sender`. For mint receipts, `originator` is the mint caller.
 
-Changing `addressRecoveryAuthority[receiver]` affects future receipts only. Existing receipts remain governed by the recovery authority captured in their key. If a receiver configures originator recovery and the originator is a system or protocol address that cannot call `ReceivePolicyGuard`, the receipt may be unclaimable; this is a receiver configuration risk. 
+Changing `addressRecoveryAuthority[receiver]` affects future receipts only. Existing receipts remain governed by the recovery authority captured in their key. If a receiver configures originator recovery and the originator is a system or protocol address that cannot call `ReceivePolicyGuard`, the receipt may be unclaimable; this is a receiver configuration risk.
 
 #### Policy subject
 
@@ -366,8 +366,6 @@ If the receiver is the authorized claimer and a reroute is initiated through an 
 `burnBlockedReceipt(...)` is not a claim. It consumes one full receipt and burns the stored amount from `receipt.token` at `RECEIVE_POLICY_GUARD_ADDRESS`.
 
 This path exists because `burnBlocked(RECEIVE_POLICY_GUARD_ADDRESS, amount)` cannot safely burn the aggregate guard balance. The caller MUST hold `BURN_BLOCKED_ROLE` for `receipt.token`. A receipt is burnable only when its policy subject, as defined above, is currently unauthorized as a sender under the token's TIP-403 policy.
-
-
 
 <br>
 


### PR DESCRIPTION
This PR updates the TIP-1028 spec to specify that a `transferFrom` call always consumes the spender's allowance regardless of whether the receiver's policy blocks the transfer, since token-level checks run before the receive policy check and a blocked transfer still succeeds.