### PR TITLE
chore: gate evm dependencies

### DIFF
--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -55,7 +55,7 @@ serde = [
     "alloy-primitives/serde",
     "tempo-primitives/serde"
 ]
-evm = ["dep:alloy-evm"]
+evm = ["dep:alloy-evm", "tempo-primitives/evm"]
 reth = [
     "std",
     "evm",

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -19,7 +19,7 @@ reth-chainspec = { workspace = true, optional = true }
 reth-network-peers = { workspace = true, optional = true }
 tempo-dkg-onchain-artifacts = { workspace = true, optional = true }
 
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, optional = true }
 alloy-genesis.workspace = true
 once_cell.workspace = true
 alloy-primitives.workspace = true
@@ -39,7 +39,7 @@ commonware-cryptography = { workspace = true, optional = true }
 default = ["std", "serde", "reth", "cli"]
 std = [
     "alloy-eips/std",
-    "alloy-evm/std",
+    "alloy-evm?/std",
     "alloy-genesis/std",
     "alloy-primitives/std",
     "once_cell/std",
@@ -55,8 +55,10 @@ serde = [
     "alloy-primitives/serde",
     "tempo-primitives/serde"
 ]
+evm = ["dep:alloy-evm"]
 reth = [
     "std",
+    "evm",
     "dep:commonware-codec",
     "dep:commonware-cryptography",
     "dep:eyre",

--- a/crates/chainspec/src/constants.rs
+++ b/crates/chainspec/src/constants.rs
@@ -6,10 +6,10 @@
 pub mod gas {
     //! Gas-accounting constants shared with `spec.rs`.
 
-    use alloy_evm::revm::interpreter::gas::{
-        COLD_SLOAD_COST as COLD_SLOAD, SSTORE_SET, WARM_SSTORE_RESET,
-        WARM_STORAGE_READ_COST as WARM_SLOAD,
-    };
+    const COLD_SLOAD: u64 = 2100;
+    const SSTORE_SET: u64 = 20000;
+    const WARM_SLOAD: u64 = 100;
+    const WARM_SSTORE_RESET: u64 = 2900;
 
     /// T0 base fee: 10 billion attodollars (1×10^10).
     ///

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -25,6 +25,7 @@
 
 use crate::constants::gas;
 use alloy_eips::eip7825::MAX_TX_GAS_LIMIT_OSAKA;
+#[cfg(feature = "evm")]
 use alloy_evm::revm::primitives::hardfork::SpecId;
 use alloy_hardforks::hardfork;
 
@@ -369,18 +370,21 @@ impl TempoHardfork {
     }
 }
 
+#[cfg(feature = "evm")]
 impl From<TempoHardfork> for SpecId {
     fn from(_value: TempoHardfork) -> Self {
         Self::OSAKA
     }
 }
 
+#[cfg(feature = "evm")]
 impl From<&TempoHardfork> for SpecId {
     fn from(value: &TempoHardfork) -> Self {
         Self::from(*value)
     }
 }
 
+#[cfg(feature = "evm")]
 impl From<SpecId> for TempoHardfork {
     fn from(_spec: SpecId) -> Self {
         // All Tempo hardforks map to SpecId::OSAKA, so we cannot derive the hardfork from SpecId.

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -384,22 +384,27 @@ mod tests {
     use crate::hardfork::{TempoHardfork, TempoHardforks};
     use alloy_primitives::hex;
     use commonware_codec::Encode as _;
+    #[cfg(feature = "cli")]
     use reth_chainspec::{ForkCondition, Hardforks};
+    #[cfg(feature = "cli")]
     use reth_cli::chainspec::ChainSpecParser as _;
 
     #[test]
+    #[cfg(feature = "cli")]
     fn can_load_testnet() {
         let _ = super::TempoChainSpecParser::parse("testnet")
             .expect("the testnet chainspec must always be well formed");
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn can_load_dev() {
         let _ = super::TempoChainSpecParser::parse("dev")
             .expect("the dev chainspec must always be well formed");
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn test_tempo_chainspec_has_tempo_hardforks() {
         let chainspec = super::TempoChainSpecParser::parse("mainnet")
             .expect("the mainnet chainspec must always be well formed");
@@ -414,6 +419,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn test_tempo_chainspec_implements_tempo_hardforks_trait() {
         let chainspec = super::TempoChainSpecParser::parse("mainnet")
             .expect("the mainnet chainspec must always be well formed");
@@ -446,6 +452,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn named_network_identities_use_compiled_identities() {
         let moderato = super::TempoChainSpecParser::parse("testnet")
             .expect("the moderato chainspec must always be well formed");
@@ -480,6 +487,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn test_tempo_hardforks_in_inner_hardforks() {
         let chainspec = super::TempoChainSpecParser::parse("mainnet")
             .expect("the mainnet chainspec must always be well formed");
@@ -533,6 +541,7 @@ mod tests {
         assert_eq!(chainspec.tempo_hardfork_at(u64::MAX), latest);
     }
 
+    #[cfg(feature = "cli")]
     mod tempo_hardfork_at {
         use super::*;
 
@@ -680,6 +689,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     #[allow(clippy::expect_fun_call)]
     fn chainspec_from_chain_id_roundtrips_supported_chains() {
         use reth_chainspec::EthChainSpec;

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 tempo-contracts.workspace = true
-tempo-chainspec.workspace = true
+tempo-chainspec = { workspace = true, features = ["evm"] }
 tempo-primitives.workspace = true
 tempo-precompiles-macros.workspace = true
 alloy = { workspace = true, features = ["sol-types", "consensus"] }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -22,7 +22,7 @@ reth-codecs = { workspace = true, optional = true }
 reth-rpc-convert = { workspace = true, optional = true }
 
 # revm
-revm.workspace = true
+revm = { workspace = true, optional = true }
 
 # Alloy
 alloy-consensus = { workspace = true, features = ["k256"] }
@@ -66,7 +66,7 @@ rand.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
-default = ["std", "reth", "serde", "reth-codec", "serde-bincode-compat", "rpc"]
+default = ["std", "evm", "reth", "serde", "reth-codec", "serde-bincode-compat", "rpc"]
 std = [
 	"alloy-consensus/secp256k1",
 	"alloy-consensus/std",
@@ -82,9 +82,9 @@ std = [
 	"p256/std",
 	"reth-ethereum-primitives?/std",
 	"reth-primitives-traits?/std",
-	"revm/std",
-	"revm/blst",
-	"revm/c-kzg",
+	"revm?/std",
+	"revm?/blst",
+	"revm?/c-kzg",
 	"serde/std",
 	"serde_json/std",
 	"sha2/std",
@@ -104,9 +104,10 @@ serde = [
 	"p256/serde",
 	"rand/serde",
 	"tracing-subscriber/serde",
-	"revm/serde",
+	"revm?/serde",
 	"tempo-contracts/serde",
 ]
+evm = ["dep:revm"]
 reth-codec = [
 	"reth",
 	"serde",
@@ -137,7 +138,7 @@ arbitrary = [
 	"reth-primitives-traits?/arbitrary",
 	"alloy-rpc-types-eth?/arbitrary",
 	"reth-db-api?/arbitrary",
-	"revm/arbitrary",
+	"revm?/arbitrary",
 	"alloy-sol-types/arbitrary",
 ]
 rpc = [

--- a/crates/primitives/src/transaction/tt_authorization.rs
+++ b/crates/primitives/src/transaction/tt_authorization.rs
@@ -1,8 +1,11 @@
 use alloc::vec::Vec;
 use alloy_eips::eip7702::{Authorization, RecoveredAuthority, RecoveredAuthorization};
-use alloy_primitives::{Address, B256, U256, keccak256};
+#[cfg(feature = "evm")]
+use alloy_primitives::U256;
+use alloy_primitives::{Address, B256, keccak256};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header, Result as RlpResult, length_of_length};
 use core::ops::Deref;
+#[cfg(feature = "evm")]
 use revm::context::transaction::AuthorizationTr;
 
 #[cfg(not(feature = "std"))]
@@ -286,6 +289,7 @@ impl Deref for RecoveredTempoAuthorization {
     }
 }
 
+#[cfg(feature = "evm")]
 impl AuthorizationTr for RecoveredTempoAuthorization {
     fn chain_id(&self) -> U256 {
         self.chain_id

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 tempo-precompiles.workspace = true
-tempo-primitives = { workspace = true, features = ["reth"] }
+tempo-primitives = { workspace = true, features = ["reth", "evm"] }
 tempo-contracts.workspace = true
 tempo-chainspec.workspace = true
 


### PR DESCRIPTION
Makes the EVM-facing pieces of chainspec and primitives opt-in so lightweight consumers do not pull alloy-evm or revm in no-default builds.

The EVM compatibility remains enabled for default builds and for execution crates through explicit evm features.
