### PR TITLE
docs(tip1028): clarify receipt claim checks

### DIFF
--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -359,6 +359,8 @@ A reroute is treated as a new movement by the policy subject. It MUST:
 
 If any of these checks fails, the claim MUST revert. The `ReceiptClaimed` event preserves the literal `to` supplied by the caller for attribution and includes the consumed receipt bytes.
 
+The mint-recipient role is checked only on the original mint. Claiming a blocked `MINT` receipt is a transfer of already-minted funds, so it is authorized as a transfer rather than as a mint.
+
 If the receiver is the authorized claimer and a reroute is initiated through an access key, the claim MUST meter the claimed amount against the receiver's AccountKeychain spending limit as an ordinary TIP-20 spend by the receiver. If an originator-authorized reroute is initiated through an access key, it MUST meter against the originator. If the receiver uses a recovery authority other than itself, any equivalent delegation, timelock, multisig, or key-policy enforcement is the responsibility of that authority.
 
 #### Burning receipts


### PR DESCRIPTION
This PR updates the TIP-1028 spec to clarify that the auth roles checked during mints. 

Closes: ZELLIC-218