### PR TITLE
docs(tip1028): update interface to match implementation

### DIFF
--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -391,20 +391,19 @@ Token filters use the existing TIP-403 policy events: `PolicyCreated`, `PolicyAd
 ```solidity
 event TransferBlocked(
     address indexed token,
-    address indexed from,
     address indexed receiver,
-    uint64 blockedNonce,
-    uint8 receiptVersion,
+    uint64 indexed blockedNonce,
     uint256 amount,
+    uint8 receiptVersion,
     bytes receipt
 );
 
 event ReceiptClaimed(
     address indexed token,
     address indexed receiver,
-    uint8 receiptVersion,
     uint64 indexed blockedNonce,
     uint64 blockedAt,
+    uint8 receiptVersion,
     address originator,
     address recipient,
     address recoveryAuthority,
@@ -416,9 +415,9 @@ event ReceiptClaimed(
 event ReceiptBurned(
     address indexed token,
     address indexed receiver,
-    uint8 receiptVersion,
     uint64 indexed blockedNonce,
     uint64 blockedAt,
+    uint8 receiptVersion,
     address originator,
     address recipient,
     address recoveryAuthority,
@@ -506,18 +505,6 @@ interface IReceivePolicyGuard {
     function claim(address to, bytes calldata receipt) external;
 
     function burnBlockedReceipt(bytes calldata receipt) external;
-
-    function storeBlocked(
-        address token,
-        address originator,
-        address receiver,
-        address recipient,
-        address recoveryAuthority,
-        uint256 amount,
-        BlockedReason blockedReason,
-        InboundKind kind,
-        bytes32 memo
-    ) external returns (uint64 blockedNonce, uint64 blockedAt);
 }
 ```
 


### PR DESCRIPTION
This PR updates the interface specified in the TIP-1028 spec to match the latest version of the implementation.

Closes: ZELLIC-217