### PR TITLE
docs: add TIP-1075 rewards rollout plan

### DIFF
--- a/tips/tip-1075.md
+++ b/tips/tip-1075.md
@@ -1,18 +1,18 @@
 ---
 id: TIP-1075
 title: Deprecate TIP-20 Rewards
-description: Deprecate TIP-20 rewards at T6 while preserving legacy reward claims.
+description: Progressively disable TIP-20 rewards across T7 and T8 while preserving settled reward claims.
 authors: TBD
 status: Draft
 related: TIP-20, TIP-1065
-protocolVersion: T7
+protocolVersion: T7/T8
 ---
 
 # TIP-1075: Deprecate TIP-20 Rewards
 
 ## Abstract
 
-This TIP deprecates TIP-20 rewards at T6.
+This TIP progressively deprecates TIP-20 rewards across T7 and T8.
 
 After activation, TIP-20 tokens no longer support new reward opt-ins or new reward distributions. Existing rewards-related state remains in storage, and already-accrued rewards remain claimable indefinitely through the existing `claimRewards()` API.
 
@@ -33,15 +33,15 @@ If the first assumption is wrong, deprecated opt-in and distribution calls still
 
 ## Threat Model
 
-This TIP relies on TIP-20 callers tolerating successful no-op behavior for deprecated reward opt-in and distribution calls. Callers that require new rewards to accrue after T6 are out of scope because new reward accrual is intentionally disabled.
+This TIP relies on TIP-20 callers tolerating successful no-op behavior for deprecated reward opt-in and distribution calls. Callers that require new rewards to accrue after T7 are out of scope because new reward accrual is intentionally disabled.
 
-The protocol must continue to protect already-accrued reward balances. Implementations must not remove, overwrite, or migrate legacy rewards-related storage in a way that prevents holders from claiming rewards accrued before T6.
+The protocol must continue to protect already-accrued reward balances. Implementations must not remove, overwrite, or migrate legacy rewards-related storage in a way that prevents holders from claiming settled rewards accrued before T7 or checkpointed before T8.
 
 ---
 
 # Specification
 
-At T6 activation, TIP-20 rewards are deprecated.
+At T7 activation, TIP-20 rewards are deprecated.
 
 ## Deprecated Functions
 
@@ -53,15 +53,15 @@ function setRewardRecipient(address recipient) external;
 function claimRewards() external returns (uint256);
 ```
 
-After T6 activation:
+After T7 activation:
 
 - `setRewardRecipient(address recipient)` MUST be a no-op.
 - `distributeReward(uint256 amount)` MUST be a no-op.
 - `claimRewards()` MUST continue to use the existing claim API and accounting for already-accrued rewards.
 
-No new reward opt-in, opt-out, delegation, or reward-distribution state transitions occur after T6.
+No new reward opt-in, opt-out, delegation, or reward-distribution state transitions occur after T7.
 
-Existing opted-in status and reward-recipient state MUST be ignored for all post-T6 reward accrual and balance-changing behavior.
+Existing opted-in status and reward-recipient state MUST be ignored for all post-T7 reward accrual and balance-changing behavior, except temporary checkpointing needed to settle pre-T7 lazy rewards before T8.
 
 The protocol MUST NOT treat existing opted-in status as causing any remaining participation in rewards. Existing state may remain readable through existing view methods, but it has no effect on new reward accrual because new rewards cannot be distributed and ordinary balance-changing paths no longer update reward participation.
 
@@ -71,7 +71,7 @@ Already-accrued rewards remain claimable indefinitely.
 
 This TIP does not introduce a sunset period for claims.
 
-After T6 activation, TIP-20 transfer, `transferFrom`, mint, burn, fee-refund, and other internal balance-changing paths MUST NOT run reward update checks for ordinary balance movement.
+After T8 activation, TIP-20 transfer, `transferFrom`, mint, burn, fee-refund, and other internal balance-changing paths MUST NOT run reward update checks for ordinary balance movement.
 
 This replaces the reward-accounting optimization proposed in TIP-1065. The reward-specific balance-bit optimization MUST NOT be activated if rewards are deprecated under this TIP.
 
@@ -81,7 +81,25 @@ Existing rewards-related storage, including reward recipient, reward balance, gl
 
 This TIP does not reserve any special pending or in-flight reward distributions before activation.
 
-Any rewards accrued before T6 remain claimable. New distributions after T6 are no-ops.
+Settled rewards accrued before T7, plus lazy rewards checkpointed before T8, remain claimable. New distributions after T7 are no-ops.
+
+# Rollout Plan
+
+TIP-20 rewards should be disabled through a progressive rollout across T7 and T8. The T7 implementation removes `UserState` because the TIP-1065 optimization will not be enabled in production.
+
+At T7 activation:
+
+- `distributeReward(uint256 amount)` and `setRewardRecipient(address recipient)` become non-reverting no-ops.
+- `UserState` is removed.
+- Existing reward update logic remains available only as needed to settle pre-T7 lazy rewards.
+- No new reward distributions or reward-recipient changes are accepted.
+
+Between T7 and T8, operators should checkpoint any opted-in holders that may have unclaimed lazy rewards. A zero-value or dust transfer to each affected holder can force lazy rewards to accrue into settled reward balances. This window covers rewards distributed before T7 and any additional reward distributions that may occur before the T7 activation block.
+
+At T8 activation:
+
+- The temporary reward tracking needed for T7-to-T8 checkpointing is removed.
+- `claimRewards()` remains available for settled reward balances.
 
 # Observability
 
@@ -91,9 +109,9 @@ This TIP does not introduce new events. Deprecated opt-in and distribution calls
 
 # Invariants
 
-- After T6, `setRewardRecipient` does not change reward-recipient state, opted-in supply, or any balance.
-- After T6, `distributeReward` does not change global reward-per-token, opted-in supply, reward balances, token balances, or total supply.
-- After T6, ordinary TIP-20 balance-changing paths do not perform reward update checks.
+- After T7, `setRewardRecipient` does not change reward-recipient state, opted-in supply, or any balance.
+- After T7, `distributeReward` does not change global reward-per-token, opted-in supply, reward balances, token balances, or total supply.
+- After T8, ordinary TIP-20 balance-changing paths do not perform reward update checks.
 - Existing accrued reward balances remain claimable through `claimRewards()`.
 - Claiming rewards preserves the existing `claimRewards()` API and accounting.
 - Rewards-related storage is not migrated or cleaned up as part of activation.

--- a/tips/tip-1075.md
+++ b/tips/tip-1075.md
@@ -1,18 +1,18 @@
 ---
 id: TIP-1075
 title: Deprecate TIP-20 Rewards
-description: Progressively disable TIP-20 rewards across T7 and T8 while preserving settled reward claims.
-authors: TBD
+description: Disable TIP-20 rewards while preserving settled reward claims.
+authors: Dan Robinson (@danrobinson), @0xrusowsky 
 status: Draft
 related: TIP-20, TIP-1065
-protocolVersion: T7/T8
+protocolVersion: T7, T8
 ---
 
 # TIP-1075: Deprecate TIP-20 Rewards
 
 ## Abstract
 
-This TIP progressively deprecates TIP-20 rewards across T7 and T8.
+This TIP deprecates TIP-20 rewards at T7, with a rollout plan extending until T8.
 
 After activation, TIP-20 tokens no longer support new reward opt-ins or new reward distributions. Existing rewards-related state remains in storage, and already-accrued rewards remain claimable indefinitely through the existing `claimRewards()` API.
 
@@ -35,7 +35,7 @@ If the first assumption is wrong, deprecated opt-in and distribution calls still
 
 This TIP relies on TIP-20 callers tolerating successful no-op behavior for deprecated reward opt-in and distribution calls. Callers that require new rewards to accrue after T7 are out of scope because new reward accrual is intentionally disabled.
 
-The protocol must continue to protect already-accrued reward balances. Implementations must not remove, overwrite, or migrate legacy rewards-related storage in a way that prevents holders from claiming settled rewards accrued before T7 or checkpointed before T8.
+The protocol must continue to protect already-accrued reward balances. Implementations must not remove, overwrite, or migrate legacy rewards-related storage in a way that prevents holders from claiming rewards accrued before T8.
 
 ---
 
@@ -71,7 +71,7 @@ Already-accrued rewards remain claimable indefinitely.
 
 This TIP does not introduce a sunset period for claims.
 
-After T8 activation, TIP-20 transfer, `transferFrom`, mint, burn, fee-refund, and other internal balance-changing paths MUST NOT run reward update checks for ordinary balance movement.
+After T8 activation, TIP-20 transfers, mints, burns, fee-refunds, and other internal balance-changing paths MUST NOT run reward update checks for ordinary balance movement.
 
 This replaces the reward-accounting optimization proposed in TIP-1065. The reward-specific balance-bit optimization MUST NOT be activated if rewards are deprecated under this TIP.
 
@@ -81,7 +81,7 @@ Existing rewards-related storage, including reward recipient, reward balance, gl
 
 This TIP does not reserve any special pending or in-flight reward distributions before activation.
 
-Settled rewards accrued before T7, plus lazy rewards checkpointed before T8, remain claimable. New distributions after T7 are no-ops.
+Any rewards accrued and checkpointed before T8, remain claimable. New distributions after T7 are no-ops.
 
 # Rollout Plan
 
@@ -94,11 +94,11 @@ At T7 activation:
 - Existing reward update logic remains available only as needed to settle pre-T7 lazy rewards.
 - No new reward distributions or reward-recipient changes are accepted.
 
-Between T7 and T8, operators should checkpoint any opted-in holders that may have unclaimed lazy rewards. A zero-value or dust transfer to each affected holder can force lazy rewards to accrue into settled reward balances. This window covers rewards distributed before T7 and any additional reward distributions that may occur before the T7 activation block.
+Between T7 and T8, operators should checkpoint any opted-in holders that may have unclaimed, untracked rewards. A zero-value or dust transfer to each affected holder can force lazy rewards to accrue into settled reward balances. This window covers rewards distributed before the T7 activation block.
 
 At T8 activation:
 
-- The temporary reward tracking needed for T7-to-T8 checkpointing is removed.
+- Reward tracking is fully deprecated.
 - `claimRewards()` remains available for settled reward balances.
 
 # Observability
@@ -111,7 +111,7 @@ This TIP does not introduce new events. Deprecated opt-in and distribution calls
 
 - After T7, `setRewardRecipient` does not change reward-recipient state, opted-in supply, or any balance.
 - After T7, `distributeReward` does not change global reward-per-token, opted-in supply, reward balances, token balances, or total supply.
-- After T8, ordinary TIP-20 balance-changing paths do not perform reward update checks.
+- After T8, ordinary TIP-20 balance-changing paths do not perform reward update logic.
 - Existing accrued reward balances remain claimable through `claimRewards()`.
 - Claiming rewards preserves the existing `claimRewards()` API and accounting.
 - Rewards-related storage is not migrated or cleaned up as part of activation.


### PR DESCRIPTION
## Summary
- stack on https://github.com/tempoxyz/tempo/pull/5380
- update TIP metadata and schedule language for the T7/T8 rollout
- document that T7 disables new reward distribution/recipient changes and removes `UserState`, T7-to-T8 checkpoints lazy rewards, and T8 removes temporary checkpointing logic
- preserve `claimRewards()` for settled reward balances after the cleanup fork

## Testing
- not run; docs-only change

Prompted by: @0xrusowsky