### PR TITLE
fix: add `tempo-chainspec` to gh action releases

### DIFF
--- a/.changelog/config.toml
+++ b/.changelog/config.toml
@@ -7,7 +7,6 @@ dependent_bump = "patch"
 # Ignore all workspace-only crates (not published to crates.io).
 ignore = [
     "tempo",
-    "tempo-chainspec",
     "tempo-commonware-node",
     "tempo-commonware-node-config",
     "tempo-consensus",
@@ -35,4 +34,4 @@ format = "per-crate"
 
 # The published SDK crates release together and share one version.
 [[fixed]]
-members = ["tempo-contracts", "tempo-primitives", "tempo-alloy"]
+members = ["tempo-contracts", "tempo-primitives", "tempo-alloy", "tempo-chainspec"]

--- a/.changelog/release-chainspec-1-8-1.md
+++ b/.changelog/release-chainspec-1-8-1.md
@@ -1,0 +1,5 @@
+---
+tempo-chainspec: patch
+---
+
+Release tempo-chainspec with the SDK crate set.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12942,7 +12942,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.5.4"
+version = "1.8.1"
 dependencies = [
  "alloy-eips",
  "alloy-evm",

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tempo-chainspec"
 description = "Tempo hardfork configuration and chain specification helpers"
 
-version = "1.5.4"
+version = "1.8.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
this PR adds tempo-chainspec to the automated release flow