### PR TITLE
ci: limit CodSpeed microbenches to relevant crates

### DIFF
--- a/.github/workflows/codspeed-microbench.yml
+++ b/.github/workflows/codspeed-microbench.yml
@@ -7,7 +7,25 @@ permissions:
 on:
   push:
     branches: [main]
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**/Cargo.toml"
+      - "crates/primitives/**"
+      - "crates/alloy/**"
+      - "crates/precompiles/**"
+      - "crates/revm/**"
+      - "crates/evm/**"
   pull_request:
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**/Cargo.toml"
+      - "crates/primitives/**"
+      - "crates/alloy/**"
+      - "crates/precompiles/**"
+      - "crates/revm/**"
+      - "crates/evm/**"
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Add path filters to the CodSpeed microbenchmark workflow for the crates that affect these benches
- Keep manual workflow dispatch available for backtests and initial data generation

## Validation
- `uv run --with pyyaml python -c 'import yaml; yaml.safe_load(open(".github/workflows/codspeed-microbench.yml")); print("ok")'`\n\nPrompted by: @0xrusowsky