### PR TITLE
docs(tip-1063): remove feature digest model

### DIFF
--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -18,7 +18,7 @@ Today, a Tempo hardfork ties protocol code and activation into the same upgrade 
 
 Protocol features are assigned feature IDs in one source-controlled ordered list. The chain stores a single cursor, `features_tip`, where feature tip `N` means feature IDs `1..=N` are active.
 
-Activation is controlled by an onchain feature registry. The registry owner schedules a target feature tip and future activation epoch, and validators report the highest feature tip they support plus the registry digest for that prefix. Activation can be delayed or cancelled before it happens without cutting another release.
+Activation is controlled by an onchain feature registry. The registry owner schedules a target feature tip and future activation epoch, and validators report the highest feature tip they support. Activation can be delayed or cancelled before it happens without cutting another release.
 
 ## Motivation
 
@@ -31,7 +31,7 @@ Validators report the highest feature tip they support. A feature tip MAY be act
 ## Assumptions
 
 - TIP-1070 provides the validator identity and active-validator-set model used for support reporting and quorum checks.
-- Releases that report support for feature tip `N` agree on the source-controlled feature registry prefix for feature IDs `1..=N`.
+- Releases that report support for feature tip `N` agree on the source-controlled feature registry list for feature IDs `1..=N`.
 - Feature support reporting is deterministic from the binary and chain state. Operators do not locally choose which subset of supported protocol features to report.
 - Active feature tips are forward-only. Fixing, disabling, or replacing active behavior requires a new higher feature ID, or a hardfork if the feature registry mechanism cannot express the emergency change.
 
@@ -53,7 +53,7 @@ The chain MUST store `features_tip` in the feature registry. A feature tip is th
 
 Activation is cumulative. The chain can move from feature tip `1` to feature tip `3`, but doing so activates both feature `2` and feature `3`. It MUST NOT activate feature `3` while leaving feature `2` inactive.
 
-To skip or withdraw a feature ID, it MUST either become a reserved no-op slot or the deferred feature MUST move to a higher ID. This is a source-code change to the feature registry and requires a release whose binary can report support for the resulting feature tip and digest. For example:
+To skip or withdraw a feature ID, it MUST either become a reserved no-op slot or the deferred feature MUST move to a higher ID. This is a source-code change to the feature registry and requires a release whose binary can report support for the resulting feature tip. For example:
 
 ```text
 1: feature A
@@ -67,7 +67,7 @@ Once a released binary can report a feature tip, the feature IDs included in tha
 
 Feature ordering is the dependency model. A feature that depends on another feature MUST receive a higher feature ID than the feature it depends on. Source-controlled metadata records human-readable feature names, TIP references, minimum supported version keys, and implementation notes keyed by `feature_id`; the chain stores only the state required for activation.
 
-Validators report the highest feature tip they support. A validator supports target feature tip `N` when its latest reported feature tip is greater than or equal to `N` and it has reported the canonical registry digest for `N`. This works because support is cumulative: support for feature tip `N` includes every lower feature ID, while the digest binds the report to the ordered feature-list prefix.
+Validators report the highest feature tip they support. A validator supports target feature tip `N` when its latest reported feature tip is greater than or equal to `N`. This works because support is cumulative: support for feature tip `N` includes every lower feature ID.
 
 Activation eligibility is bound to consensus epochs rather than wall-clock timestamps. The registry owner schedules a target feature tip and an activation epoch. Feature activation occurs during block processing for that epoch, where the chain advances `features_tip` if the current active validator set has quorum for the scheduled target. No external activation transaction is required.
 
@@ -83,7 +83,6 @@ The registry MUST store:
 - `scheduled_features_tip`: the next target feature tip, or `0` when no tip is scheduled
 - `scheduled_activation_epoch`: the earliest epoch in which the scheduled tip may activate, or `0` when no tip is scheduled
 - `validator_supported_features_tip`: the latest supported feature tip reported by each validator
-- `validator_supported_features_digest`: the registry digest reported by each validator for each feature tip
 
 ```solidity
 contract FeatureRegistry {
@@ -94,13 +93,12 @@ contract FeatureRegistry {
   uint64 scheduled_activation_epoch;
 
   mapping(address validator => uint64 supported_features_tip) validator_supported_features_tip;
-  mapping(address validator => mapping(uint64 features_tip => bytes32 digest)) validator_supported_features_digest;
 
   // --snip--
 }
 ```
 
-The registry digest comes from the node binary's source-controlled protocol feature registry. For feature tip `N > 0`, the digest commits to the ordered `(feature_id, name)` prefix for feature IDs `1..=N`. Feature tip `0` uses the zero digest. The onchain registry validates the submitted digest against the canonical digest computed by the local binary before accepting a validator support report.
+The registry should expose read methods for nodes, indexers, and operators to inspect the active feature tip, scheduled feature tip, validator reports, computed support for a target feature tip, and the global activation quorum threshold. Callers should be able to determine whether a proposed feature tip has quorum before its activation epoch.
 
 Registry state changes MUST be observable through events for scheduling, cancellation, validator support updates, support changes, and activation.
 
@@ -116,7 +114,7 @@ Feature activation occurs in the first block of `scheduled_activation_epoch`. Du
 
 For quorum checks, the active validator set is the effective committee for `scheduled_activation_epoch` exposed by TIP-1070. The registry MUST NOT keep a separate validator roster for feature activation and MUST NOT derive quorum membership from `ValidatorConfigV2.getActiveValidators()`.
 
-To evaluate support for tip `N`, the quorum check computes the canonical registry digest for `N`, then iterates the active validator set and counts each validator that supports `N` where `validator_supported_features_tip[validator] >= N` and `validator_supported_features_digest[validator][N]` == the canonical registry digest. A scheduled feature tip has quorum when at least 80% of active validators support it. The quorum denominator is the size of the active validator set at feature activation, and the required validator count is `ceil(4 * active_validator_count / 5)`.
+To evaluate support for target feature tip `N`, the quorum check iterates the active validator set and counts each validator whose `validator_supported_features_tip[validator] >= N`. A scheduled feature tip has quorum when at least 80% of active validators support it. The quorum denominator is the size of the active validator set at feature activation, and the required validator count is `ceil(4 * active_validator_count / 5)`.
 
 If quorum is satisfied at feature activation, the chain MUST set `features_tip` to `scheduled_features_tip`, clear the scheduled feature tip fields, and emit an activation event. Protocol behavior gated by newly active features applies to subsequent blocks unless a feature's own TIP specifies transition-block behavior.
 
@@ -128,24 +126,21 @@ Support for the active feature tip is a requirement for any validator joining th
 
 ## Validator Feature Tip Reporting
 
-Validators indicate feature support by reporting the protocol feature tip and the registry digest for that tip, e.g. a report of `3` means the validator supports the ordered feature list through feature ID `3`.
+Validators indicate feature support by reporting the highest protocol feature tip they support, e.g. a report of `3` means the validator supports the ordered feature list through feature ID `3`.
 
 A report MUST be deterministic from chain history and MUST NOT decrease the validator's previously reported supported feature tip.
 
-Validator feature-tip reports MUST use the validator identity and authorization model defined by TIP-1070. A validator report is submitted through a system transaction and identifies the validator by public key. The registry resolves that public key to the active validator address, accepts `setSupportedFeaturesTip(publicKey, featuresTip, featuresDigest)` only from the system caller, and rejects arbitrary external callers as unauthorized.
+Validator feature-tip reports MUST use the validator identity and authorization model defined by TIP-1070. A validator report is submitted through a system transaction and identifies the validator by public key. The registry resolves that public key to the active validator address, accepts `setSupportedFeaturesTip(publicKey, featuresTip)` only from the system caller, and rejects arbitrary external callers as unauthorized.
 
 ```solidity
 mapping(address validator => uint64 supported_features_tip) validator_supported_features_tip;
-mapping(address validator => mapping(uint64 features_tip => bytes32 digest)) validator_supported_features_digest;
 
-function setSupportedFeaturesTip(bytes32 publicKey, uint64 featuresTip, bytes32 featuresDigest) external;
+function setSupportedFeaturesTip(bytes32 publicKey, uint64 featuresTip) external;
 ```
 
-For feature tip `0`, the canonical digest is `bytes32(0)`. For feature tip `N > 0`, the canonical digest commits to the ordered `(feature_id, name)` prefix of the source-controlled feature registry for feature IDs `1..=N`. A report with an unknown feature tip or an incorrect digest MUST be rejected.
+If `featuresTip` is greater than the validator's previous report, the registry updates `validator_supported_features_tip[validator]`.
 
-If `featuresTip` is greater than the validator's previous report, the registry updates `validator_supported_features_tip[validator]`. The registry also records `validator_supported_features_digest[validator][featuresTip] = featuresDigest`. A validator may re-submit its current feature tip to repair the digest for that tip without lowering its high-water mark.
-
-Support for a target feature tip MUST be evaluated against the active validator set. Exited validators stop contributing to quorum, and newly active validators contribute according to their latest reported supported feature tip and matching digest at the target feature tip.
+Support for a target feature tip MUST be evaluated against the active validator set. Exited validators stop contributing to quorum, and newly active validators contribute according to their latest reported supported feature tip.
 
 For a target tip `N`, a validator contributes to quorum when `validator_supported_features_tip[validator] >= N`. A validator running a newer Tempo release can therefore support older scheduled tips without additional per-feature signaling.
 
@@ -159,7 +154,7 @@ If an active feature needs to be fixed, disabled, or replaced, the change ships 
 
 ## Tooling and Operational Impact
 
-Nodes, indexers, dashboards, and operator tooling need to expose the active feature tip, scheduled feature tip, validator support reports, digest reports, quorum status, and feature names for the IDs in the source-controlled feature list.
+Nodes, indexers, dashboards, and operator tooling need to expose the active feature tip, scheduled feature tip, validator support reports, quorum status, and feature names for the IDs in the source-controlled feature list.
 
 Release notes must distinguish features that are supported by a binary from features that are active on a network.
 
@@ -173,13 +168,13 @@ The main risks are registry disagreement, false validator support, incorrect quo
 
 Threat: Validators could report the same feature tip while using different registry prefixes.
 
-Mitigation: Feature IDs are assigned in one source-controlled ordered list, and release and audit processes must ensure that implementation, tests, generated artifacts, and operator documentation match that list. Validator reports include the canonical registry digest for the reported feature tip. A validator counts toward quorum for target feature tip `N` only if its latest reported feature tip is greater than or equal to `N` and its digest report for `N` matches the canonical digest for the source-controlled registry prefix.
+Mitigation: Feature IDs are assigned in one source-controlled ordered list, and release and audit processes must ensure that implementation, tests, generated artifacts, and operator documentation match that list.
 
 ### Validator Misreport
 
 Threat: A validator could claim support for code it is not running.
 
-Mitigation: The digest does not prove semantic correctness. A node whose binary does not support the active feature tip must fail closed rather than validate, build, simulate, or serve old behavior. After activation, a validator that misreported support will fail to follow the chain rather than safely continue with old behavior.
+Mitigation: A node whose binary does not support the active feature tip must fail closed rather than validate, build, simulate, or serve old behavior. After activation, a validator that misreported support will fail to follow the chain rather than safely continue with old behavior.
 
 ### Activation Quorum
 
@@ -221,10 +216,9 @@ The tradeoff is that features do not activate in arbitrary order. If an earlier 
 8. Only the registry owner can schedule or cancel feature tip activation.
 9. Only the system caller can record validator support reports or activate a scheduled feature tip during block processing.
 10. A validator's supported feature-tip high-water mark is monotonic and cannot decrease.
-11. The canonical digest for feature tip `0` is `bytes32(0)`. The canonical digest for feature tip `N > 0` commits to the ordered `(feature_id, name)` prefix for feature IDs `1..=N`.
-12. Quorum for target feature tip `N` counts a validator if and only if its latest reported supported feature tip is greater than or equal to `N` and its reported digest for `N` equals the canonical digest for `N`.
-13. A scheduled feature tip activates only if the active validator set has quorum for that target feature tip.
-14. A node must not validate, build, simulate, or serve post-activation protocol behavior for a chain whose active feature tip is higher than the node's supported feature tip.
+11. Quorum for target feature tip `N` counts a validator if and only if its latest reported supported feature tip is greater than or equal to `N`.
+12. A scheduled feature tip activates only if the active validator set has quorum for that target feature tip.
+13. A node must not validate, build, simulate, or serve post-activation protocol behavior for a chain whose active feature tip is higher than the node's supported feature tip.
 
 ## Interfaces
 
@@ -248,8 +242,8 @@ interface IFeatureRegistry {
     /// @notice Returns the scheduled feature tip and activation epoch.
     function scheduledFeaturesTip() external view returns (uint64 featuresTip, uint64 activationEpoch);
 
-    /// @notice Records the highest protocol feature tip and registry digest reported by a validator public key. System caller only.
-    function setSupportedFeaturesTip(bytes32 publicKey, uint64 featuresTip, bytes32 featuresDigest) external;
+    /// @notice Records the highest protocol feature tip reported by a validator public key. System caller only.
+    function setSupportedFeaturesTip(bytes32 publicKey, uint64 featuresTip) external;
 
     /// @notice Schedules a higher feature tip for activation at the target epoch.
     function scheduleFeaturesTip(uint64 featuresTip, uint64 activationEpoch) external;
@@ -263,9 +257,6 @@ interface IFeatureRegistry {
     /// @notice Returns the latest feature tip reported by a validator.
     function validatorSupportedFeaturesTip(address validator) external view returns (uint64 featuresTip);
 
-    /// @notice Returns the registry digest reported by a validator for a feature tip.
-    function validatorSupportedFeaturesDigest(address validator, uint64 featuresTip) external view returns (bytes32 featuresDigest);
-
     /// @notice Returns current active-validator support for a feature tip.
     function featuresTipSupport(uint64 featuresTip) external view returns (uint256 support, uint256 required);
 
@@ -278,7 +269,7 @@ interface IFeatureRegistry {
 
 ```solidity
 /// @notice Emitted when a validator reports support for a feature tip.
-event SupportedFeaturesTipSet(address indexed validator, uint64 featuresTip, bytes32 featuresDigest, uint256 supportCount);
+event SupportedFeaturesTipSet(address indexed validator, uint64 featuresTip, uint256 supportCount);
 
 /// @notice Emitted when a higher feature tip is scheduled for activation.
 event FeaturesTipScheduled(uint64 featuresTip, uint64 activationEpoch);


### PR DESCRIPTION
Removes the unagreed digest reporting and quorum guard language from TIP-1063 so the spec stays aligned with the current high-water feature tip implementation.