### PR TITLE
Optimize T7 fee and TIP20 transfer paths

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -132,6 +132,14 @@ pub static UNPAUSE_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"UNPAUSE_R
 pub static ISSUER_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"ISSUER_ROLE"));
 /// Role hash that authorizes burning tokens from blocked accounts.
 pub static BURN_BLOCKED_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"BURN_BLOCKED_ROLE"));
+static FEE_TRANSFER_CONTEXT_ACTIVE_SLOT: LazyLock<U256> =
+    LazyLock::new(|| U256::from_be_bytes(keccak256(b"tempo.tip20.fee_transfer_context.active").0));
+static FEE_TRANSFER_CONTEXT_PAUSED_SLOT: LazyLock<U256> =
+    LazyLock::new(|| U256::from_be_bytes(keccak256(b"tempo.tip20.fee_transfer_context.paused").0));
+static FEE_TRANSFER_CONTEXT_POLICY_SLOT: LazyLock<U256> =
+    LazyLock::new(|| U256::from_be_bytes(keccak256(b"tempo.tip20.fee_transfer_context.policy").0));
+static FEE_TRANSFER_CONTEXT_USD_SLOT: LazyLock<U256> =
+    LazyLock::new(|| U256::from_be_bytes(keccak256(b"tempo.tip20.fee_transfer_context.usd").0));
 
 #[rustfmt::skip]
 /// System custody addresses added to burn-blocked protection at each hardfork.
@@ -141,7 +149,79 @@ pub const PROTECTED: &[(TempoHardfork, &[Address])] = &[
     (TempoHardfork::T6, &[RECEIVE_POLICY_GUARD_ADDRESS]),
 ];
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Tip20FeeTransferContext {
+    paused: bool,
+    transfer_policy_id: u64,
+    usd_valid: bool,
+}
+
 impl TIP20Token {
+    /// Seeds a transaction-local fast path for a known same-token user transfer.
+    pub fn seed_fee_transfer_context(&mut self) -> Result<()> {
+        let paused = self.paused()?;
+        let policy_id = self.transfer_policy_id()?;
+        let usd_valid = self.currency()? == USD_CURRENCY;
+
+        let mut storage = crate::storage::StorageCtx;
+        storage.tstore(
+            self.address,
+            *FEE_TRANSFER_CONTEXT_ACTIVE_SLOT,
+            U256::from(1),
+        )?;
+        storage.tstore(
+            self.address,
+            *FEE_TRANSFER_CONTEXT_PAUSED_SLOT,
+            U256::from(paused as u8),
+        )?;
+        storage.tstore(
+            self.address,
+            *FEE_TRANSFER_CONTEXT_POLICY_SLOT,
+            U256::from(policy_id),
+        )?;
+        storage.tstore(
+            self.address,
+            *FEE_TRANSFER_CONTEXT_USD_SLOT,
+            U256::from(usd_valid as u8),
+        )
+    }
+
+    fn fee_transfer_context(&self) -> Result<Option<Tip20FeeTransferContext>> {
+        if !self.storage.spec().is_t7() {
+            return Ok(None);
+        }
+
+        let storage = crate::storage::StorageCtx;
+        if storage
+            .tload(self.address, *FEE_TRANSFER_CONTEXT_ACTIVE_SLOT)?
+            .is_zero()
+        {
+            return Ok(None);
+        }
+
+        Ok(Some(Tip20FeeTransferContext {
+            paused: !storage
+                .tload(self.address, *FEE_TRANSFER_CONTEXT_PAUSED_SLOT)?
+                .is_zero(),
+            transfer_policy_id: storage
+                .tload(self.address, *FEE_TRANSFER_CONTEXT_POLICY_SLOT)?
+                .try_into()
+                .map_err(|_| TempoPrecompileError::under_overflow())?,
+            usd_valid: !storage
+                .tload(self.address, *FEE_TRANSFER_CONTEXT_USD_SLOT)?
+                .is_zero(),
+        }))
+    }
+
+    fn consume_fee_transfer_context(&mut self) -> Result<Option<Tip20FeeTransferContext>> {
+        let context = self.fee_transfer_context()?;
+        if context.is_some() {
+            let mut storage = crate::storage::StorageCtx;
+            storage.tstore(self.address, *FEE_TRANSFER_CONTEXT_ACTIVE_SLOT, U256::ZERO)?;
+        }
+        Ok(context)
+    }
+
     /// Returns the token name.
     pub fn name(&self) -> Result<String> {
         self.name.read()
@@ -1043,9 +1123,26 @@ impl TIP20Token {
         memo: B256,
     ) -> Result<Option<Recipient>> {
         let to = Recipient::resolve(to)?;
-        self.check_not_paused()?;
-        to.validate()?;
-        self.ensure_transfer_authorized(from, to.target)?;
+        let fee_context = if spender.is_none() {
+            self.consume_fee_transfer_context()?
+        } else {
+            None
+        };
+        if let Some(context) = fee_context {
+            if context.paused || !context.usd_valid {
+                return Err(TIP20Error::contract_paused().into());
+            }
+            to.validate()?;
+            self.ensure_transfer_authorized_with_policy_id(
+                context.transfer_policy_id,
+                from,
+                to.target,
+            )?;
+        } else {
+            self.check_not_paused()?;
+            to.validate()?;
+            self.ensure_transfer_authorized(from, to.target)?;
+        }
 
         if let Some(spender) = spender {
             self.consume_allowance(from, spender, amount)?;
@@ -1120,7 +1217,23 @@ impl TIP20Token {
     /// # Errors
     /// - `PolicyForbids` — sender or recipient is not authorized by the active transfer policy
     pub fn ensure_transfer_authorized(&self, from: Address, to: Address) -> Result<()> {
-        if !self.is_transfer_authorized(from, to)? {
+        let policy_id = self.transfer_policy_id()?;
+        self.ensure_transfer_authorized_with_policy_id(policy_id, from, to)
+    }
+
+    fn ensure_transfer_authorized_with_policy_id(
+        &self,
+        policy_id: u64,
+        from: Address,
+        to: Address,
+    ) -> Result<()> {
+        let registry = TIP403Registry::new();
+        let sender_auth = registry.is_authorized_as(policy_id, from, AuthRole::sender())?;
+        if self.storage.spec().is_t2() && !sender_auth {
+            return Err(TIP20Error::policy_forbids().into());
+        }
+        let recipient_auth = registry.is_authorized_as(policy_id, to, AuthRole::recipient())?;
+        if !(sender_auth && recipient_auth) {
             return Err(TIP20Error::policy_forbids().into());
         }
 
@@ -1162,7 +1275,24 @@ impl TIP20Token {
             .into());
         }
 
-        let (from_flag, to_flag) = self.handle_rewards_on_transfer(from, to.target, amount)?;
+        let from_flag = if self.storage.spec().is_t7() {
+            self.update_rewards_with_loaded_balance(from, from_balance, false)?
+        } else {
+            self.update_rewards(from)?
+        };
+        let to_flag = if to.target != Address::ZERO {
+            self.update_rewards(to.target)?
+        } else {
+            RewardFlag::OptedOut
+        };
+
+        match (from_flag, to_flag) {
+            // Increase supply: from opted-out, to opted-in.
+            (RewardFlag::OptedOut, RewardFlag::OptedIn) => self.increase_opted_in_supply(amount)?,
+            // Decrease supply: from opted-in, to opted-out.
+            (RewardFlag::OptedIn, RewardFlag::OptedOut) => self.decrease_opted_in_supply(amount)?,
+            _ => (),
+        }
 
         // Adjust balances
         self.set_balance(
@@ -1289,7 +1419,11 @@ impl TIP20Token {
         self.check_and_update_spending_limit(from, amount)?;
 
         // Update rewards for the sender and get their reward recipient
-        let from_flag = self.update_rewards(from)?;
+        let from_flag = if self.storage.spec().is_t7() {
+            self.update_rewards_with_loaded_balance(from, from_balance, false)?
+        } else {
+            self.update_rewards(from)?
+        };
 
         // If user is opted into rewards, decrease opted-in supply
         if from_flag.is_opted_in() {
@@ -1330,7 +1464,15 @@ impl TIP20Token {
         }
 
         // Update rewards for the recipient and get their reward recipient
-        let to_flag = self.update_rewards(to)?;
+        let use_loaded_balance = self.storage.spec().is_t7();
+        let to_balance = use_loaded_balance
+            .then(|| self.get_balance(to))
+            .transpose()?;
+        let to_flag = if let Some(to_balance) = to_balance {
+            self.update_rewards_with_loaded_balance(to, to_balance, false)?
+        } else {
+            self.update_rewards(to)?
+        };
 
         // If user is opted into rewards, increase opted-in supply by refund amount
         if to_flag.is_opted_in() {
@@ -1346,8 +1488,9 @@ impl TIP20Token {
             UserState::new(new_from_balance, from_balance.flag)?,
         )?;
 
-        let new_to_balance = self
-            .get_balance(to)?
+        let new_to_balance = to_balance
+            .map(Ok)
+            .unwrap_or_else(|| self.get_balance(to))?
             .checked_add(refund)
             .map_err(|_| TIP20Error::supply_cap_exceeded())?;
         self.set_balance(to, UserState::new(new_to_balance, to_flag)?)

--- a/crates/precompiles/src/tip20/rewards.rs
+++ b/crates/precompiles/src/tip20/rewards.rs
@@ -77,10 +77,20 @@ impl TIP20Token {
     /// reward per token difference since their last update. Rewards are accumulated in the
     /// delegated recipient's rewardBalance. Returns the holder's delegated recipient address.
     pub fn update_rewards(&mut self, holder: Address) -> Result<RewardFlag> {
+        let holder_balance = self.get_balance(holder)?;
+        self.update_rewards_with_loaded_balance(holder, holder_balance, false)
+    }
+
+    pub(crate) fn update_rewards_with_loaded_balance(
+        &mut self,
+        holder: Address,
+        holder_balance: UserState,
+        checkpoint_opted_out_rewards: bool,
+    ) -> Result<RewardFlag> {
         let flag = if self.storage.spec().is_t6() {
-            self.update_rewards_t6(holder, false)?
+            self.update_rewards_t6(holder, holder_balance, checkpoint_opted_out_rewards)?
         } else {
-            self.update_rewards_legacy(holder)?
+            self.update_rewards_legacy(holder, holder_balance)?
         };
         // RewardFlag output of reward updates MUST be binary (opted-in/out).
         // UserState has built-in logic to ensure pre-T6 we always store RewardFlag::Uninitialized.
@@ -91,19 +101,15 @@ impl TIP20Token {
 
     /// Updates rewards and ensures the holder is checkpointed before cold-path state transitions.
     fn update_rewards_with_checkpoint(&mut self, holder: Address) -> Result<RewardFlag> {
-        let flag = if self.storage.spec().is_t6() {
-            self.update_rewards_t6(holder, true)?
-        } else {
-            self.update_rewards_legacy(holder)?
-        };
-        // RewardFlag output of reward updates MUST be binary (opted-in/out).
-        // UserState has built-in logic to ensure pre-T6 we always store RewardFlag::Uninitialized.
-        debug_assert!(matches!(flag, RewardFlag::OptedIn | RewardFlag::OptedOut));
-
-        Ok(flag)
+        let holder_balance = self.get_balance(holder)?;
+        self.update_rewards_with_loaded_balance(holder, holder_balance, true)
     }
 
-    fn update_rewards_legacy(&mut self, holder: Address) -> Result<RewardFlag> {
+    fn update_rewards_legacy(
+        &mut self,
+        holder: Address,
+        holder_balance: UserState,
+    ) -> Result<RewardFlag> {
         let mut info = self.user_reward_info[holder].read()?;
         let cached_delegate = info.reward_recipient;
 
@@ -114,7 +120,6 @@ impl TIP20Token {
 
         if reward_per_token_delta != U256::ZERO {
             if cached_delegate != Address::ZERO {
-                let holder_balance = self.get_balance(holder)?;
                 let reward = holder_balance
                     .checked_mul(reward_per_token_delta)?
                     .div(ACC_PRECISION);
@@ -144,11 +149,10 @@ impl TIP20Token {
     fn update_rewards_t6(
         &mut self,
         holder: Address,
+        holder_balance: UserState,
         checkpoint_opted_out_rewards: bool,
     ) -> Result<RewardFlag> {
         // On T6, once initialized, the balance flag is the source of truth for user reward state.
-        let holder_balance = self.get_balance(holder)?;
-
         // Check uninitialized opt-outs before loading global rewards; first transfers hit this path.
         let delegate = if holder_balance.flag.is_uninitialized() {
             Some(self.user_reward_info[holder].reward_recipient.read()?)
@@ -345,27 +349,6 @@ impl TIP20Token {
     /// Sets the total supply of tokens opted into rewards.
     pub fn set_opted_in_supply(&mut self, value: u128) -> Result<()> {
         self.opted_in_supply.write(value)
-    }
-
-    /// Handles reward accounting for both sender and receiver during token transfers.
-    pub(crate) fn handle_rewards_on_transfer(
-        &mut self,
-        from: Address,
-        to: Address,
-        amount: U256,
-    ) -> Result<(RewardFlag, RewardFlag)> {
-        let from_flag = self.update_rewards(from)?;
-        let to_flag = self.update_rewards(to)?;
-
-        match (from_flag, to_flag) {
-            // Increase supply: from opted-out, to opted-in.
-            (RewardFlag::OptedOut, RewardFlag::OptedIn) => self.increase_opted_in_supply(amount)?,
-            // Decrease supply: from opted-in, to opted-out.
-            (RewardFlag::OptedIn, RewardFlag::OptedOut) => self.decrease_opted_in_supply(amount)?,
-            _ => (), // All other cases don't have effect
-        }
-
-        Ok((from_flag, to_flag))
     }
 
     /// Handles reward accounting when tokens are minted to an address.

--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -98,6 +98,15 @@ pub enum FeeRoute {
     TwoHop(Address),
 }
 
+impl FeeRoute {
+    pub const fn hop_token(self) -> Address {
+        match self {
+            Self::TwoHop(token) => token,
+            Self::SameToken | Self::Direct => Address::ZERO,
+        }
+    }
+}
+
 /// Pools read during planning, paired with their observed validator-token reserve.
 pub type PoolData = ((Address, Address), u128);
 

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -19,6 +19,15 @@ pub use tempo_contracts::precompiles::{
 };
 use tempo_precompiles_macros::contract;
 
+/// Transaction-local fee route state derived during pre-charge and reused during settlement.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FeeRouteState {
+    pub fee_token: Address,
+    pub validator_token: Address,
+    pub route: FeeRoute,
+    pub hop_token: Address,
+}
+
 /// Fee manager precompile that handles transaction fee collection and distribution.
 ///
 /// Users and validators choose their preferred TIP-20 fee token. When they differ, fees are
@@ -148,7 +157,7 @@ impl TipFeeManager {
     /// Transfers `max_amount` of `user_token` to the fee manager via [`TIP20Token`] and, if the
     /// validator prefers a different token, verifies sufficient pool liquidity.
     /// Reserves liquidity on T1C+, with a two-hop fallback through `userToken.quoteToken()` on T5+.
-    /// Returns the user's fee token.
+    /// Returns the transaction-local route selected for settlement.
     ///
     /// # Errors
     /// - `InvalidToken` — `user_token` does not have a valid TIP-20 prefix
@@ -161,7 +170,7 @@ impl TipFeeManager {
         max_amount: U256,
         beneficiary: Address,
         skip_liquidity_check: bool,
-    ) -> Result<Address> {
+    ) -> Result<FeeRouteState> {
         // Get the validator's token preference
         let validator_token = self.get_validator_token(beneficiary)?;
 
@@ -171,14 +180,25 @@ impl TipFeeManager {
         tip20_token.ensure_transfer_authorized(fee_payer, self.address)?;
         tip20_token.transfer_fee_pre_tx(fee_payer, max_amount)?;
 
-        if !skip_liquidity_check {
+        let route = if skip_liquidity_check {
+            if user_token == validator_token {
+                FeeRoute::SameToken
+            } else {
+                FeeRoute::Direct
+            }
+        } else {
             let (route, ..) = self.plan_fee_route(user_token, validator_token, max_amount)?;
             let route = route.ok_or_else(TIPFeeAMMError::insufficient_liquidity)?;
             self.reserve_fee_liquidity(user_token, validator_token, max_amount, route)?;
-        }
+            route
+        };
 
-        // Return the user's token preference
-        Ok(user_token)
+        Ok(FeeRouteState {
+            fee_token: user_token,
+            validator_token,
+            route,
+            hop_token: route.hop_token(),
+        })
     }
 
     /// Reserves AMM liquidity needed to settle the selected fee route after transaction execution.
@@ -233,30 +253,49 @@ impl TipFeeManager {
         refund_amount: U256,
         fee_token: Address,
         beneficiary: Address,
+        route_state: Option<FeeRouteState>,
     ) -> Result<U256> {
         // Refund unused tokens to user
         let mut tip20_token = TIP20Token::from_address(fee_token)?;
         tip20_token.transfer_fee_post_tx(fee_payer, refund_amount, actual_spending)?;
 
         // Execute fee swap and track collected fees
-        let hop_token = self.two_hop_intermediate.t_read()?;
-        let validator_token = self.get_validator_token(beneficiary)?;
-
-        let amount = if fee_token == validator_token {
-            actual_spending
-        } else if hop_token.is_zero() {
-            // Single-hop (direct) swap
-            if !actual_spending.is_zero() {
-                self.execute_fee_swap(fee_token, validator_token, actual_spending)?;
-            }
-            compute_amount_out(actual_spending)?
+        let (validator_token, route, hop_token) = if let Some(state) = route_state {
+            debug_assert_eq!(state.fee_token, fee_token);
+            (state.validator_token, state.route, state.hop_token)
         } else {
-            // Two-hop swap (only in T5+): each hop applies M = 9970/10000 sequentially
-            if !actual_spending.is_zero() {
-                let out1 = self.execute_fee_swap(fee_token, hop_token, actual_spending)?;
-                self.execute_fee_swap(hop_token, validator_token, out1)?;
+            let hop_token = self.two_hop_intermediate.t_read()?;
+            let validator_token = self.get_validator_token(beneficiary)?;
+            let route = if fee_token == validator_token {
+                FeeRoute::SameToken
+            } else if hop_token.is_zero() {
+                FeeRoute::Direct
+            } else {
+                FeeRoute::TwoHop(hop_token)
+            };
+            (validator_token, route, hop_token)
+        };
+
+        let amount = match route {
+            FeeRoute::SameToken => actual_spending,
+            FeeRoute::Direct => {
+                if !actual_spending.is_zero() {
+                    self.execute_fee_swap(fee_token, validator_token, actual_spending)?;
+                }
+                compute_amount_out(actual_spending)?
             }
-            compute_amount_out(compute_amount_out(actual_spending)?)?
+            FeeRoute::TwoHop(intermediate) => {
+                let hop_token = if intermediate.is_zero() {
+                    hop_token
+                } else {
+                    intermediate
+                };
+                if !actual_spending.is_zero() {
+                    let out1 = self.execute_fee_swap(fee_token, hop_token, actual_spending)?;
+                    self.execute_fee_swap(hop_token, validator_token, out1)?;
+                }
+                compute_amount_out(compute_amount_out(actual_spending)?)?
+            }
         };
 
         self.increment_collected_fees(beneficiary, validator_token, amount)?;
@@ -511,7 +550,10 @@ mod tests {
             let result =
                 fee_manager.collect_fee_pre_tx(user, token.address(), max_amount, validator, false);
             assert!(result.is_ok());
-            assert_eq!(result?, token.address());
+            let route_state = result?;
+            assert_eq!(route_state.fee_token, token.address());
+            assert_eq!(route_state.validator_token, token.address());
+            assert_eq!(route_state.route, FeeRoute::SameToken);
 
             Ok(())
         })
@@ -560,6 +602,7 @@ mod tests {
                 refund_amount,
                 token.address(),
                 validator,
+                None,
             )?;
             assert_eq!(credited, actual_used);
 
@@ -748,6 +791,7 @@ mod tests {
                 refund_amount,
                 user_token.address(),
                 validator,
+                None,
             )?;
 
             // Expected output: 800 * 9970 / 10000 = 797
@@ -877,7 +921,10 @@ mod tests {
                 true,
             );
             assert!(result.is_ok());
-            assert_eq!(result?, user_token.address());
+            let route_state = result?;
+            assert_eq!(route_state.fee_token, user_token.address());
+            assert_eq!(route_state.validator_token, validator_token.address());
+            assert_eq!(route_state.route, FeeRoute::Direct);
 
             Ok(())
         })
@@ -1209,8 +1256,14 @@ mod tests {
 
                     let amount_u = U256::from(amount);
                     fm.collect_fee_pre_tx(user, t.user, amount_u, validator, false)?;
-                    let credited =
-                        fm.collect_fee_post_tx(user, amount_u, U256::ZERO, t.user, validator)?;
+                    let credited = fm.collect_fee_post_tx(
+                        user,
+                        amount_u,
+                        U256::ZERO,
+                        t.user,
+                        validator,
+                        None,
+                    )?;
                     let one_hop_amount = compute_amount_out(amount_u)?;
                     assert!(
                         credited < one_hop_amount,
@@ -1280,7 +1333,7 @@ mod tests {
             );
 
             // Post-tx MUST use the cached two_hop_intermediate (hop), not the new quote token.
-            fm.collect_fee_post_tx(user, amount, U256::ZERO, t.user, validator)?;
+            fm.collect_fee_post_tx(user, amount, U256::ZERO, t.user, validator, None)?;
 
             let out1: u128 = compute_amount_out(amount)?.try_into().unwrap();
             let out2: u128 = compute_amount_out(U256::from(out1))?.try_into().unwrap();
@@ -1334,7 +1387,7 @@ mod tests {
                 let amount = U256::from(1_000);
                 fm.collect_fee_pre_tx(user, t.user, amount, validator, false)?;
                 assert_eq!(fm.two_hop_intermediate.t_read()?, t.hop, "tx1: cached");
-                fm.collect_fee_post_tx(user, amount, U256::ZERO, t.user, validator)?;
+                fm.collect_fee_post_tx(user, amount, U256::ZERO, t.user, validator, None)?;
                 // Note: post_tx leaves the slot non-zero in-tx; EVM clears it at tx boundary.
                 assert_eq!(
                     fm.two_hop_intermediate.t_read()?,
@@ -1361,7 +1414,7 @@ mod tests {
                     fm.two_hop_intermediate.t_read()?.is_zero(),
                     "tx2: pre_tx took direct route, must not set intermediate",
                 );
-                fm.collect_fee_post_tx(user, amount, U256::ZERO, t.user, validator)?;
+                fm.collect_fee_post_tx(user, amount, U256::ZERO, t.user, validator, None)?;
 
                 // tx2 settled via direct pool: validator received single-hop fee.
                 let out_single: U256 = compute_amount_out(amount)?;

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -11,6 +11,7 @@ use revm::{
     interpreter::{InitialAndFloorGas, interpreter::EthInterpreter},
 };
 use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_precompiles::tip_fee_manager::FeeRouteState;
 
 /// The Tempo EVM context type.
 pub type TempoContext<DB> = Context<TempoBlockEnv, TempoTxEnv, CfgEnv<TempoHardfork>, DB>;
@@ -38,6 +39,8 @@ pub struct TempoEvm<DB: Database, I> {
     pub validator_fee: U256,
     /// The fee token used to pay fees for the current transaction.
     pub(crate) fee_token: Option<Address>,
+    /// Transaction-local route selected during `collectFeePreTx`.
+    pub(crate) fee_route_state: Option<FeeRouteState>,
     /// The expiry timestamp of the access key used by the current transaction.
     /// Populated during validation for keychain-signed transactions or transactions carrying a KeyAuthorization.
     pub(crate) key_expiry: Option<u64>,
@@ -84,6 +87,7 @@ impl<DB: Database, I> TempoEvm<DB, I> {
             collected_fee: U256::ZERO,
             validator_fee: U256::ZERO,
             fee_token: None,
+            fee_route_state: None,
             key_expiry: None,
             skip_valid_after_check: false,
             skip_liquidity_check: false,
@@ -126,6 +130,7 @@ impl<DB: Database, I> TempoEvm<DB, I> {
     /// Clears all intermediate state from the EVM.
     pub fn clear(&mut self) {
         self.fee_token = None;
+        self.fee_route_state = None;
         self.key_expiry = None;
     }
 }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use alloy_primitives::{Address, TxKind, U256};
+use alloy_sol_types::SolCall;
 use reth_evm::{EvmError, EvmInternals};
 use revm::{
     Database,
@@ -52,7 +53,10 @@ use tempo_precompiles::{
         Handler as _, PrecompileStorageProvider, StorageCtx, evm::EvmPrecompileStorageProvider,
     },
     tip_fee_manager::TipFeeManager,
-    tip20::{ITIP20::InsufficientBalance, TIP20Error, TIP20Token, decode_tip20_balance},
+    tip20::{
+        ITIP20::{InsufficientBalance, transferCall},
+        TIP20Error, TIP20Token, decode_tip20_balance,
+    },
     tip20_channel_reserve::TIP20ChannelReserve,
 };
 use tempo_primitives::{
@@ -251,6 +255,12 @@ fn call_scope_extra_gas(auth: &tempo_primitives::transaction::KeyAuthorization) 
         + TARGET_SCOPE_GAS.saturating_mul(num_targets)
         + SELECTOR_SCOPE_GAS.saturating_mul(num_selectors)
         + RECIPIENT_SCOPE_GAS.saturating_mul(num_recipients)
+}
+
+fn is_single_direct_tip20_transfer(tx: &TempoTxEnv, token: Address) -> bool {
+    tx.tempo_tx_env.is_none()
+        && tx.inner.kind.to() == Some(&token)
+        && tx.inner.data.first_chunk::<4>() == Some(&transferCall::SELECTOR)
 }
 
 /// Rewrites a failed batch step's gas accounting to match whole-transaction semantics.
@@ -1297,51 +1307,61 @@ where
             let checkpoint = journal.checkpoint();
 
             let skip_liquidity_check = evm.skip_liquidity_check;
+            let seed_tip20_fee_transfer_context =
+                cfg.spec.is_t7() && is_single_direct_tip20_transfer(tx, fee_token);
             let result = StorageCtx::enter_evm(journal, &block, cfg, tx, || {
-                TipFeeManager::new().collect_fee_pre_tx(
+                let route_state = TipFeeManager::new().collect_fee_pre_tx(
                     fee_payer,
                     fee_token,
                     gas_balance_spending,
                     block.beneficiary(),
                     skip_liquidity_check,
-                )
+                )?;
+                if seed_tip20_fee_transfer_context {
+                    TIP20Token::from_address(fee_token)?.seed_fee_transfer_context()?;
+                }
+                Ok(route_state)
             });
 
-            if let Err(err) = result {
-                // Revert the journal to checkpoint before `collectFeePreTx` call if something went wrong.
-                journal.checkpoint_revert(checkpoint);
+            let route_state = match result {
+                Ok(route_state) => route_state,
+                Err(err) => {
+                    // Revert the journal to checkpoint before `collectFeePreTx` call if something went wrong.
+                    journal.checkpoint_revert(checkpoint);
 
-                // Map fee collection errors to transaction validation errors since they
-                // indicate the transaction cannot be included (e.g., insufficient liquidity
-                // in FeeAMM pool for fee swaps)
-                return Err(match err {
-                    TempoPrecompileError::TIPFeeAMMError(
-                        TIPFeeAMMError::InsufficientLiquidity(_),
-                    ) => FeePaymentError::InsufficientAmmLiquidity {
-                        fee: gas_balance_spending,
-                    }
-                    .into(),
+                    // Map fee collection errors to transaction validation errors since they
+                    // indicate the transaction cannot be included (e.g., insufficient liquidity
+                    // in FeeAMM pool for fee swaps)
+                    return Err(match err {
+                        TempoPrecompileError::TIPFeeAMMError(
+                            TIPFeeAMMError::InsufficientLiquidity(_),
+                        ) => FeePaymentError::InsufficientAmmLiquidity {
+                            fee: gas_balance_spending,
+                        }
+                        .into(),
 
-                    TempoPrecompileError::TIP20(TIP20Error::InsufficientBalance(
-                        InsufficientBalance { available, .. },
-                    )) => FeePaymentError::InsufficientFeeTokenBalance {
-                        fee: gas_balance_spending,
-                        balance: available,
-                    }
-                    .into(),
+                        TempoPrecompileError::TIP20(TIP20Error::InsufficientBalance(
+                            InsufficientBalance { available, .. },
+                        )) => FeePaymentError::InsufficientFeeTokenBalance {
+                            fee: gas_balance_spending,
+                            balance: available,
+                        }
+                        .into(),
 
-                    TempoPrecompileError::TIP20(TIP20Error::ContractPaused(_)) => {
-                        TempoInvalidTransaction::FeeTokenPaused { address: fee_token }.into()
-                    }
+                        TempoPrecompileError::TIP20(TIP20Error::ContractPaused(_)) => {
+                            TempoInvalidTransaction::FeeTokenPaused { address: fee_token }.into()
+                        }
 
-                    TempoPrecompileError::Fatal(e) => EVMError::Custom(e),
+                        TempoPrecompileError::Fatal(e) => EVMError::Custom(e),
 
-                    _ => FeePaymentError::Other(err.to_string()).into(),
-                });
-            }
+                        _ => FeePaymentError::Other(err.to_string()).into(),
+                    });
+                }
+            };
 
             journal.checkpoint_commit();
             evm.collected_fee = gas_balance_spending;
+            evm.fee_route_state = cfg.spec.is_t7().then_some(route_state);
         }
 
         // If the transaction includes a KeyAuthorization, validate and authorize the key
@@ -1593,6 +1613,12 @@ where
                         refund_amount,
                         fee_token,
                         beneficiary,
+                        context
+                            .cfg
+                            .spec
+                            .is_t7()
+                            .then(|| evm.fee_route_state)
+                            .flatten(),
                     )
                     .map_err(|e| EVMError::Custom(format!("{e:?}")))
             } else {
@@ -1626,6 +1652,7 @@ where
     fn validate_env(&self, evm: &mut Self::Evm) -> Result<(), Self::Error> {
         // Reset per-tx validator fee.
         evm.validator_fee = U256::ZERO;
+        evm.fee_route_state = None;
 
         // Validate the fee payer signature
         let fee_payer = evm.ctx.tx.fee_payer()?;


### PR DESCRIPTION
## Summary
- add transaction-local fee route state from fee precharge and reuse it during T7 fee settlement
- add a T7 transient TIP-20 fee-transfer context for direct same-token `transfer` calls, carrying paused/policy/USD validation state from precharge into user transfer validation
- add T7-gated loaded-balance reward helpers for TIP-20 transfer, fee debit, and refund paths
- keep pre-T7 settlement and balance read behavior on the legacy paths

Prompted by: @shekhirin

## Tests
- cargo fmt --check
- cargo check -p tempo-precompiles -p tempo-revm
- cargo test -p tempo-precompiles tip_fee_manager:: --lib
- cargo test -p tempo-precompiles tip20:: --lib