### PR TITLE
fix(evm): reset collected fee per transaction

### DIFF
--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -125,6 +125,7 @@ impl<DB: Database, I> TempoEvm<DB, I> {
 
     /// Clears all intermediate state from the EVM.
     pub fn clear(&mut self) {
+        self.collected_fee = U256::ZERO;
         self.fee_token = None;
         self.key_expiry = None;
     }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1624,7 +1624,8 @@ where
     /// - Time window validation (validAfter/validBefore)
     #[inline]
     fn validate_env(&self, evm: &mut Self::Evm) -> Result<(), Self::Error> {
-        // Reset per-tx validator fee.
+        // Reset per-tx fee state.
+        evm.collected_fee = U256::ZERO;
         evm.validator_fee = U256::ZERO;
 
         // Validate the fee payer signature
@@ -5756,6 +5757,51 @@ mod tests {
                     .all(|log| log.address != ACCOUNT_KEYCHAIN_ADDRESS),
                 "fee-limit rejection must happen before key authorization emits events"
             );
+        }
+
+        #[test]
+        fn test_stale_collected_fee_not_charged_to_zero_fee_same_tx_auth_use() {
+            let (signer, user) = generate_keypair();
+            let key = Address::random();
+            let stale_fee = U256::from(100_000);
+            let spending_limit = stale_fee - U256::ONE;
+
+            let signed = sign_key_auth(
+                &signer,
+                KeyAuthorization::unrestricted(1, SignatureType::Secp256k1, key).with_limits(vec![
+                    PrimTokenLimit {
+                        token: DEFAULT_FEE_TOKEN,
+                        limit: spending_limit,
+                        period: 60,
+                    },
+                ]),
+            );
+            let (mut evm, h) = make_evm(user, key, Some(signed), TempoHardfork::T3, None, false);
+            evm.collected_fee = stale_fee;
+            evm.inner.ctx.tx.inner.gas_limit = 100_000;
+            evm.inner.ctx.tx.inner.gas_price = 0;
+            evm.inner.ctx.tx.inner.gas_priority_fee = Some(0);
+
+            StorageCtx::enter_ctx(&mut evm.inner.ctx, || {
+                TIP20Setup::path_usd(user)
+                    .with_issuer(user)
+                    .with_mint(user, stale_fee * U256::from(2))
+                    .apply()
+                    .expect("pathUSD setup succeeds");
+            });
+
+            h.validate_env(&mut evm)
+                .expect("zero-fee same-tx auth/use env validation should pass");
+            assert_eq!(evm.collected_fee, U256::ZERO);
+
+            let result =
+                h.validate_against_state_and_deduct_caller(&mut evm, &mut Default::default());
+
+            assert!(
+                result.is_ok(),
+                "zero-fee same-tx auth/use must not charge stale fee, got: {result:?}"
+            );
+            assert_eq!(evm.collected_fee, U256::ZERO);
         }
     }
 


### PR DESCRIPTION
Fixes ZELLIC-222.

Resets `collected_fee` alongside other per-transaction EVM fee state so stale fee collection cannot be observed by a later same-transaction key authorization/use path. Adds a regression for zero-fee same-tx auth/use with a stale prior fee.

Validated with `cargo +nightly fmt`, `cargo test -p tempo-revm test_stale_collected_fee_not_charged_to_zero_fee_same_tx_auth_use -- --nocapture`, and `cargo test -p tempo-revm`.