### PR TITLE
perf(builder): enable sparse trie and execution cache sharing

### DIFF
--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -211,6 +211,7 @@ fn init_engine_defaults() {
         .with_always_process_payload_attributes_on_canonical_head(true)
         // Defer persistence I/O during active payload builds.
         .with_suppress_persistence_during_build(true)
+        .with_share_execution_cache_with_payload_builder(true)
         .with_share_sparse_trie_with_payload_builder(true)
         .try_init()
         .expect("failed to initialize engine defaults");

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -152,6 +152,17 @@ struct TempoArgs {
     #[command(flatten)]
     pub node_args: TempoNodeArgs,
 
+    /// Disable sharing the engine sparse trie pipeline with the payload builder.
+    ///
+    /// Sparse trie sharing is enabled by default. The legacy
+    /// `--engine.share-sparse-trie-with-payload-builder` flag remains accepted
+    /// for compatibility and is now a no-op unless this opt-out is set.
+    #[arg(
+        long = "engine.disable-sparse-trie-with-payload-builder",
+        default_value_t = false
+    )]
+    pub disable_sparse_trie_with_payload_builder: bool,
+
     #[command(flatten)]
     #[cfg(feature = "pyroscope")]
     pub pyroscope_args: PyroscopeArgs,
@@ -167,6 +178,17 @@ impl TempoArgs {
     /// The engine runs when not in dev mode and not following uncertified.
     fn has_consensus_engine(&self, dev: bool) -> bool {
         !dev && !self.is_following_uncertified()
+    }
+}
+
+fn apply_tempo_default_overrides(cli: &mut TempoCli) {
+    if let Commands::Node(node_cmd) = &mut cli.command {
+        if node_cmd.ext.disable_sparse_trie_with_payload_builder {
+            node_cmd.engine.share_sparse_trie_with_payload_builder = false;
+        }
+        if node_cmd.ext.node_args.builder_disable_execution_cache {
+            node_cmd.engine.share_execution_cache_with_payload_builder = false;
+        }
     }
 }
 
@@ -356,6 +378,8 @@ fn main() -> eyre::Result<()> {
             err.exit();
         }
     };
+
+    apply_tempo_default_overrides(&mut cli);
 
     if let Commands::Node(node_cmd) = &cli.command
         && node_cmd.engine.share_sparse_trie_with_payload_builder
@@ -756,7 +780,7 @@ mod tests {
 
     use clap::Parser;
 
-    use super::{Commands, TempoCli, defaults};
+    use super::{Commands, TempoCli, apply_tempo_default_overrides, defaults};
 
     fn init_defaults_once() {
         static INIT: Once = Once::new();
@@ -767,12 +791,15 @@ mod tests {
     fn consensus_block_budget_defaults_are_stable() {
         init_defaults_once();
 
-        let cli = TempoCli::try_parse_from(["tempo", "node", "--dev"]).unwrap();
+        let mut cli = TempoCli::try_parse_from(["tempo", "node", "--dev"]).unwrap();
+        apply_tempo_default_overrides(&mut cli);
         let Commands::Node(node_cmd) = cli.command else {
             panic!("expected node command");
         };
+        assert!(node_cmd.engine.share_execution_cache_with_payload_builder);
         assert!(node_cmd.engine.share_sparse_trie_with_payload_builder);
         assert_eq!(node_cmd.builder.max_payload_tasks, 1);
+        assert!(!node_cmd.ext.node_args.builder_disable_execution_cache);
         assert_eq!(
             node_cmd.ext.consensus.target_block_time.into_duration(),
             Duration::from_millis(550)
@@ -787,16 +814,20 @@ mod tests {
         );
         assert_eq!(node_cmd.ext.node_args.builder_build_time_multiplier, 1.35);
 
-        let cli = TempoCli::try_parse_from([
+        let mut cli = TempoCli::try_parse_from([
             "tempo",
             "node",
             "--dev",
             "--engine.share-sparse-trie-with-payload-builder",
+            "--engine.share-execution-cache-with-payload-builder",
         ])
         .unwrap();
+        apply_tempo_default_overrides(&mut cli);
         let Commands::Node(node_cmd) = cli.command else {
             panic!("expected node command");
         };
+        assert!(node_cmd.engine.share_execution_cache_with_payload_builder);
+        assert!(node_cmd.engine.share_sparse_trie_with_payload_builder);
         assert_eq!(
             node_cmd.ext.consensus.target_block_time.into_duration(),
             Duration::from_millis(550)
@@ -809,5 +840,21 @@ mod tests {
             node_cmd.ext.consensus.network_budget.into_duration(),
             Duration::from_millis(50)
         );
+
+        let mut cli = TempoCli::try_parse_from([
+            "tempo",
+            "node",
+            "--dev",
+            "--engine.disable-sparse-trie-with-payload-builder",
+            "--builder.disable-execution-cache",
+        ])
+        .unwrap();
+        apply_tempo_default_overrides(&mut cli);
+        let Commands::Node(node_cmd) = cli.command else {
+            panic!("expected node command");
+        };
+        assert!(!node_cmd.engine.share_execution_cache_with_payload_builder);
+        assert!(!node_cmd.engine.share_sparse_trie_with_payload_builder);
+        assert!(node_cmd.ext.node_args.builder_disable_execution_cache);
     }
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -74,6 +74,10 @@ pub struct TempoNodeArgs {
     #[arg(long = "builder.enable-prewarming", default_value_t = false)]
     pub builder_enable_prewarming: bool,
 
+    /// Disable the payload builder execution cache and restore parent state pre-caching.
+    #[arg(long = "builder.disable-execution-cache", default_value_t = false)]
+    pub builder_disable_execution_cache: bool,
+
     /// Initial estimate of total replayable payload build work divided by work
     /// at transaction cutoff.
     ///
@@ -93,6 +97,7 @@ impl Default for TempoNodeArgs {
             max_tempo_authorizations: DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
             builder_state_provider_metrics: false,
             builder_enable_prewarming: false,
+            builder_disable_execution_cache: false,
             builder_build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
         }
     }
@@ -112,6 +117,7 @@ impl TempoNodeArgs {
         TempoPayloadBuilderBuilder {
             state_provider_metrics: self.builder_state_provider_metrics,
             enable_prewarming: self.builder_enable_prewarming,
+            disable_execution_cache: self.builder_disable_execution_cache,
             build_time_multiplier: self.builder_build_time_multiplier,
         }
     }
@@ -159,9 +165,10 @@ impl TempoNode {
             .pool(pool_builder)
             .executor(TempoExecutorBuilder::default())
             .payload(
-                BasicPayloadServiceBuilder::new(payload_builder_builder)
-                    // we can disable basic parent state caching because tempo builder always uses execution cache
-                    .with_pre_cache_state(false),
+                BasicPayloadServiceBuilder::new(payload_builder_builder.clone())
+                    // The Tempo builder uses execution cache by default. Re-enable
+                    // parent state pre-caching only when explicitly opting out.
+                    .with_pre_cache_state(payload_builder_builder.disable_execution_cache),
             )
             .network(EthereumNetworkBuilder::default())
             .consensus(TempoConsensusBuilder::default())
@@ -542,6 +549,8 @@ pub struct TempoPayloadBuilderBuilder {
     pub state_provider_metrics: bool,
     /// Enable prewarming for the payload builder.
     pub enable_prewarming: bool,
+    /// Disable execution cache for payload builds.
+    pub disable_execution_cache: bool,
     /// Initial estimate of total replayable payload build work divided by work
     /// at transaction cutoff.
     pub build_time_multiplier: f64,
@@ -552,6 +561,7 @@ impl Default for TempoPayloadBuilderBuilder {
         Self {
             state_provider_metrics: false,
             enable_prewarming: false,
+            disable_execution_cache: false,
             build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
         }
     }


### PR DESCRIPTION
## Summary
- keep sparse trie sharing enabled by default while making the legacy enable flag a compatibility no-op
- re-enable execution-cache sharing with the payload builder by default, matching the behavior reverted in #4709, but add --builder.disable-execution-cache as an explicit opt-out
- add --engine.disable-sparse-trie-with-payload-builder to opt out of sparse trie sharing
- leave builder prewarming default off; #4710 reverted that separately and this PR does not reintroduce it

## Tests
- cargo fmt
- cargo test -p tempo consensus_block_budget_defaults_are_stable

Prompted by: @shekhirin