### PR TITLE
Use raw short string storage slot keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13352,6 +13352,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
+ "blake3",
  "codspeed-criterion-compat",
  "commonware-codec",
  "commonware-cryptography",
@@ -13380,6 +13381,7 @@ name = "tempo-precompiles-macros"
 version = "1.8.1"
 dependencies = [
  "alloy",
+ "blake3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13404,6 +13404,7 @@ dependencies = [
  "arbitrary",
  "aws-lc-rs",
  "base64 0.22.1",
+ "blake3",
  "derive_more",
  "ed25519-consensus",
  "modular-bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
+blake3 = "1.8.5"
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5", default-features = false }
 reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-blake3 = "1.8.5"
+blake3 = { version = "1.8.5", default-features = false }
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5", default-features = false }
 reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }

--- a/crates/precompiles-macros/Cargo.toml
+++ b/crates/precompiles-macros/Cargo.toml
@@ -24,6 +24,7 @@ syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
 alloy = { workspace = true }
+blake3.workspace = true
 
 [dev-dependencies]
 alloy = { workspace = true }

--- a/crates/precompiles-macros/src/utils.rs
+++ b/crates/precompiles-macros/src/utils.rs
@@ -10,7 +10,8 @@ type ExtractedAttributes = (Option<U256>, Option<U256>);
 ///
 /// Supports:
 /// - Integer literals: decimal (`42`) or hexadecimal (`0x2a`)
-/// - String literals: computes the BLAKE3 hash of the string
+/// - String literals up to 32 bytes: uses the raw string bytes as the slot key
+/// - Longer string literals: computes the BLAKE3 hash of the string
 fn parse_slot_value(value: &Lit) -> syn::Result<U256> {
     match value {
         Lit::Int(int) => {
@@ -23,9 +24,15 @@ fn parse_slot_value(value: &Lit) -> syn::Result<U256> {
             .map_err(|_| syn::Error::new_spanned(int, "Invalid slot number"))?;
             Ok(slot)
         }
-        Lit::Str(lit) => Ok(U256::from_be_bytes(
-            *blake3::hash(lit.value().as_bytes()).as_bytes(),
-        )),
+        Lit::Str(lit) => {
+            let value = lit.value();
+            let bytes = value.as_bytes();
+            if bytes.len() <= 32 {
+                Ok(U256::from_be_slice(bytes))
+            } else {
+                Ok(U256::from_be_bytes(*blake3::hash(bytes).as_bytes()))
+            }
+        }
         _ => Err(syn::Error::new_spanned(
             value,
             "slot attribute must be an integer or a string literal",

--- a/crates/precompiles-macros/src/utils.rs
+++ b/crates/precompiles-macros/src/utils.rs
@@ -1,6 +1,6 @@
 //! Utility functions for the contract macro implementation.
 
-use alloy::primitives::{U256, keccak256};
+use alloy::primitives::U256;
 use syn::{Attribute, Lit, Type};
 
 /// Return type for [`extract_attributes`]: (slot, base_slot)
@@ -10,7 +10,7 @@ type ExtractedAttributes = (Option<U256>, Option<U256>);
 ///
 /// Supports:
 /// - Integer literals: decimal (`42`) or hexadecimal (`0x2a`)
-/// - String literals: computes keccak256 hash of the string
+/// - String literals: computes the BLAKE3 hash of the string
 fn parse_slot_value(value: &Lit) -> syn::Result<U256> {
     match value {
         Lit::Int(int) => {
@@ -23,7 +23,9 @@ fn parse_slot_value(value: &Lit) -> syn::Result<U256> {
             .map_err(|_| syn::Error::new_spanned(int, "Invalid slot number"))?;
             Ok(slot)
         }
-        Lit::Str(lit) => Ok(keccak256(lit.value().as_bytes()).into()),
+        Lit::Str(lit) => Ok(U256::from_be_bytes(
+            *blake3::hash(lit.value().as_bytes()).as_bytes(),
+        )),
         _ => Err(syn::Error::new_spanned(
             value,
             "slot attribute must be an integer or a string literal",

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -32,6 +32,7 @@ commonware-codec.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 derive_more.workspace = true
+blake3.workspace = true
 scoped-tls = "1.0"
 
 [dev-dependencies]

--- a/crates/precompiles/src/nonce/mod.rs
+++ b/crates/precompiles/src/nonce/mod.rs
@@ -109,13 +109,13 @@ impl NonceManager {
 
     /// Validates and records an expiring nonce transaction. Uses a
     /// circular buffer that overwrites expired entries as the pointer
-    /// advances. The hash is `keccak256(encode_for_signing || sender)`,
+    /// advances. The hash is `blake3(encode_for_signing || sender)`,
     /// invariant to fee payer changes.
     ///
     /// Uses a circular buffer that overwrites expired entries as the pointer advances.
     ///
     /// The `expiring_nonce_hash` parameter is
-    /// (`keccak256(encode_for_signing || sender)`), which is invariant to fee payer changes.
+    /// (`blake3(encode_for_signing || sender)`), which is invariant to fee payer changes.
     ///
     /// This is called during transaction execution to:
     /// 1. Validate the expiry is within the allowed window

--- a/crates/precompiles/src/storage/types/array.rs
+++ b/crates/precompiles/src/storage/types/array.rs
@@ -3,7 +3,7 @@
 //! # Storage Layout
 //!
 //! Fixed-size arrays `[T; N]` use Solidity-compatible array storage:
-//! - **Base slot**: Arrays start directly at `base_slot` (not at keccak256)
+//! - **Base slot**: Arrays start directly at `base_slot` (not hash-derived)
 //! - **Data slots**: Elements are stored sequentially, either packed or unpacked
 //!
 //! ## Packing Strategy
@@ -31,7 +31,7 @@ tempo_precompiles_macros::storable_nested_arrays!();
 /// Type-safe handler for accessing fixed-size arrays `[T; N]` in storage.
 ///
 /// Unlike `VecHandler`, arrays have a fixed compile-time size and store elements
-/// directly at the base slot (not at `keccak256(base_slot)`).
+/// directly at the base slot (not hash-derived from `base_slot`).
 ///
 /// # Element Access
 ///

--- a/crates/precompiles/src/storage/types/bytes_like.rs
+++ b/crates/precompiles/src/storage/types/bytes_like.rs
@@ -2,20 +2,21 @@
 //!
 //! # Storage Layout
 //!
-//! Bytes-like types use Solidity-compatible:
+//! Bytes-like types use Tempo storage encoding:
 //! **Short strings (≤31 bytes)** are stored inline in a single slot:
 //! - Bytes 0..len: UTF-8 string data (left-aligned)
 //! - Byte 31 (LSB): length * 2 (bit 0 = 0 indicates short string)
 //!
-//! **Long strings (≥32 bytes)** use keccak256-based storage:
+//! **Long strings (≥32 bytes)** use BLAKE3-based storage:
 //! - Base slot: stores `length * 2 + 1` (bit 0 = 1 indicates long string)
-//! - Data slots: stored at `keccak256(main_slot) + i` for each 32-byte chunk
+//! - Data slots: stored at `blake3(main_slot) + i` for each 32-byte chunk
 
+use super::storage_slot_hash;
 use crate::{
     error::{Result, TempoPrecompileError},
     storage::{StorageCtx, StorageOps, types::*},
 };
-use alloy::primitives::{Address, Bytes, U256, keccak256};
+use alloy::primitives::{Address, Bytes, U256};
 use std::marker::PhantomData;
 
 impl StorableType for Bytes {
@@ -126,7 +127,7 @@ impl Storable for Bytes {
         store_bytes_like(self.as_ref(), storage, slot, ctx)
     }
 
-    /// Custom delete for bytes-like types: clears keccak256-addressed data slots for long values.
+    /// Custom delete for bytes-like types: clears BLAKE3-addressed data slots for long values.
     #[inline]
     fn delete<S: StorageOps>(storage: &mut S, slot: U256, ctx: LayoutCtx) -> Result<()> {
         debug_assert!(ctx.is_full(), "Bytes cannot be packed");
@@ -151,7 +152,7 @@ impl Storable for String {
         store_bytes_like(self.as_bytes(), storage, slot, ctx)
     }
 
-    /// Custom delete for bytes-like types: clears keccak256-addressed data slots for long values.
+    /// Custom delete for bytes-like types: clears BLAKE3-addressed data slots for long values.
     #[inline]
     fn delete<S: StorageOps>(storage: &mut S, slot: U256, ctx: LayoutCtx) -> Result<()> {
         debug_assert!(ctx.is_full(), "String cannot be packed");
@@ -173,7 +174,7 @@ where
     let length = calc_string_length(base_value, is_long)?;
 
     if is_long {
-        // Long string: read data from keccak256(base_slot) + i
+        // Long string: read data from blake3(base_slot) + i
         let slot_start = calc_data_slot(base_slot);
         let chunks = calc_chunks(length);
         let mut data = Vec::new();
@@ -235,7 +236,7 @@ fn store_bytes_like<S: StorageOps>(
     } else {
         storage.store(base_slot, encode_long_string_length(new_len))?;
 
-        // Store data in chunks at keccak256(base_slot) + i
+        // Store data in chunks at blake3(base_slot) + i
         let slot_start = data_slot.unwrap_or_else(|| calc_data_slot(base_slot));
         let chunks = calc_chunks(new_len);
         for i in 0..chunks {
@@ -257,7 +258,7 @@ fn store_bytes_like<S: StorageOps>(
 
 /// Generic delete implementation for byte-like types (String, Bytes) using Solidity's encoding.
 ///
-/// Clears both the main slot and any keccak256-addressed data slots for long strings.
+/// Clears both the main slot and any BLAKE3-addressed data slots for long strings.
 #[inline]
 fn delete_bytes_like<S: StorageOps>(storage: &mut S, base_slot: U256) -> Result<()> {
     let base_value = storage.load(base_slot)?;
@@ -282,10 +283,10 @@ fn delete_bytes_like<S: StorageOps>(storage: &mut S, base_slot: U256) -> Result<
 
 /// Compute the storage slot where long string data begins.
 ///
-/// For long strings (≥32 bytes), data is stored starting at `keccak256(base_slot)`.
+/// For long strings (≥32 bytes), data is stored starting at `blake3(base_slot)`.
 #[inline]
 fn calc_data_slot(base_slot: U256) -> U256 {
-    U256::from_be_bytes(keccak256(base_slot.to_be_bytes::<32>()).0)
+    storage_slot_hash(base_slot.to_be_bytes::<32>())
 }
 
 /// Check if a storage slot value represents a long string.
@@ -415,16 +416,16 @@ mod tests {
     // -- UNIT TESTS FOR HELPER FUNCTIONS (NO STORAGE) ------------------------
 
     #[test]
-    fn test_calc_data_slot_matches_manual_keccak() {
+    fn test_calc_data_slot_matches_manual_blake3() {
         let base_slot = U256::random();
         let data_slot = calc_data_slot(base_slot);
 
         // Manual computation
-        let expected = U256::from_be_bytes(keccak256(base_slot.to_be_bytes::<32>()).0);
+        let expected = storage_slot_hash(base_slot.to_be_bytes::<32>());
 
         assert_eq!(
             data_slot, expected,
-            "calc_data_slot should match manual keccak256 computation"
+            "calc_data_slot should match manual BLAKE3 computation"
         );
     }
 
@@ -672,12 +673,12 @@ mod tests {
                 // Calculate how many data slots were used
                 let chunks = calc_chunks(s.len());
 
-                // Verify delete works (clears both main slot and keccak256-addressed data)
+                // Verify delete works (clears both main slot and BLAKE3-addressed data)
                 slot.delete().unwrap();
                 let after_delete = slot.read().unwrap();
                 prop_assert_eq!(after_delete, String::new(), "Long string not empty after delete");
 
-                // Verify all keccak256-addressed data slots are actually zero
+                // Verify all BLAKE3-addressed data slots are actually zero
                 let data_slot_start = calc_data_slot(base_slot);
                 for i in 0..chunks {
                     let slot = Slot::<U256>::new_at_offset(data_slot_start, i, address);
@@ -746,12 +747,12 @@ mod tests {
                 // Calculate how many data slots were used
                 let chunks = calc_chunks(b.len());
 
-                // Verify delete works (clears both main slot and keccak256-addressed data)
+                // Verify delete works (clears both main slot and BLAKE3-addressed data)
                 slot.delete().unwrap();
                 let after_delete = slot.read().unwrap();
                 prop_assert_eq!(after_delete, Bytes::new(), "Long bytes not empty after delete");
 
-                // Verify all keccak256-addressed data slots are actually zero
+                // Verify all BLAKE3-addressed data slots are actually zero
                 let data_slot_start = calc_data_slot(base_slot);
                 for i in 0..chunks {
                     let slot = Slot::<U256>::new_at_offset(data_slot_start, i, address);

--- a/crates/precompiles/src/storage/types/mapping.rs
+++ b/crates/precompiles/src/storage/types/mapping.rs
@@ -11,7 +11,7 @@ use crate::storage::{Layout, LayoutCtx, StorableType, StorageKey, types::Handler
 /// Type-safe access wrapper for EVM storage mappings (hash-based key-value storage).
 ///
 /// This struct does not store data itself. Instead, it provides a zero-cost abstraction
-/// for accessing mapping storage slots using Solidity's hash-based layout. It wraps a
+/// for accessing mapping storage slots using Tempo's hash-based layout. It wraps a
 /// base slot number and provides methods to compute the actual storage slots for keys.
 ///
 /// # Type Parameters
@@ -20,14 +20,14 @@ use crate::storage::{Layout, LayoutCtx, StorableType, StorageKey, types::Handler
 /// - `V`: Value type (must implement `StorableType`)
 ///
 /// `Mapping<K, V>` is essentially a slot computation helper. The `[key]` method
-/// performs the keccak256 hash to compute the actual storage slot and returns a
+/// performs the BLAKE3 hash to compute the actual storage slot and returns a
 /// `Handler` that can be used for read/write operations.
 ///
 /// # Storage Layout
 ///
-/// Mappings use a Solidity-equivalent storage layout:
+/// Mappings use Tempo's storage layout:
 /// - Base slot: stored in `base_slot` field (never accessed directly)
-/// - Actual slot for key `k`: `keccak256(k || base_slot)`
+/// - Actual slot for key `k`: `blake3(k || base_slot)`
 ///
 /// # Usage Pattern
 ///
@@ -157,15 +157,14 @@ where
 mod tests {
     use super::*;
     use crate::storage::StorageKey;
-    use alloy::primitives::{Address, B256, keccak256};
+    use alloy::primitives::{Address, B256};
 
-    // Backward compatibility helper to verify the trait impl.
-    fn old_mapping_slot<K: AsRef<[u8]>>(key: K, slot: U256) -> U256 {
+    fn expected_mapping_slot<K: AsRef<[u8]>>(key: K, slot: U256) -> U256 {
         let key = key.as_ref();
         let mut buf = [0u8; 64];
         buf[32 - key.len()..32].copy_from_slice(key);
         buf[32..].copy_from_slice(&slot.to_be_bytes::<32>());
-        U256::from_be_bytes(keccak256(buf).0)
+        U256::from_be_bytes(*blake3::hash(&buf).as_bytes())
     }
 
     #[test]
@@ -180,7 +179,7 @@ mod tests {
         // Slot in big-endian
         buf[32..].copy_from_slice(&base_slot.to_be_bytes::<32>());
 
-        let expected = U256::from_be_bytes(keccak256(buf).0);
+        let expected = U256::from_be_bytes(*blake3::hash(&buf).as_bytes());
         let computed = key.mapping_slot(base_slot);
 
         assert_eq!(computed, expected, "mapping_slot encoding mismatch");
@@ -193,19 +192,19 @@ mod tests {
         let addr = Address::random();
         assert_eq!(
             addr.mapping_slot(slot),
-            old_mapping_slot(addr.as_slice(), slot),
+            expected_mapping_slot(addr.as_slice(), slot),
         );
 
         let b256 = B256::random();
         assert_eq!(
             b256.mapping_slot(slot),
-            old_mapping_slot(b256.as_slice(), slot),
+            expected_mapping_slot(b256.as_slice(), slot),
         );
 
         let u256 = U256::random();
         assert_eq!(
             u256.mapping_slot(slot),
-            old_mapping_slot(u256.to_be_bytes::<32>(), slot),
+            expected_mapping_slot(u256.to_be_bytes::<32>(), slot),
         );
     }
 

--- a/crates/precompiles/src/storage/types/mod.rs
+++ b/crates/precompiles/src/storage/types/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     error::Result,
     storage::{StorageOps, packing},
 };
-use alloy::primitives::{Address, U256, keccak256};
+use alloy::primitives::{Address, U256};
 
 /// Describes how a type is laid out in EVM storage.
 ///
@@ -179,7 +179,7 @@ pub trait StorableType {
 
     /// Whether this type stores it's data in its base slot or not.
     ///
-    /// Dynamic types (`Bytes`, `String`, `Vec`) store data at keccak256-addressed
+    /// Dynamic types (`Bytes`, `String`, `Vec`) store data at BLAKE3-addressed
     /// slots and need special cleanup. Non-dynamic types just zero their slots.
     const IS_DYNAMIC: bool = false;
 
@@ -325,7 +325,7 @@ impl<T: Packable> Storable for T {
 
 /// Trait for types that can be used as storage mapping keys.
 ///
-/// Keys are hashed using keccak256 along with the mapping's base slot
+/// Keys are hashed using BLAKE3 along with the mapping's base slot
 /// to determine the final storage location. This trait provides the
 /// byte representation used in that hash.
 ///
@@ -337,20 +337,11 @@ impl<T: Packable> Storable for T {
 ///
 /// # Encoding
 ///
-/// Mapping slots are computed as `keccak256(bytes32(key) | bytes32(slot))`, where the
+/// Mapping slots are computed as `blake3(bytes32(key) | bytes32(slot))`, where the
 /// key's raw bytes are left-padded to 32 bytes and the slot is appended in big-endian.
 ///
-/// This differs from Solidity's `keccak256(abi.encode(key, slot))`, where signed integers
-/// are sign-extended and `bytesN` (N < 32) are right-padded. Per-type equivalence:
-///
-/// - **Unsigned integers, `Address`, `bytes32`**: identical — both zero-left-pad.
-/// - **Signed integers**: diverges — Solidity sign-extends negative values to 32 bytes,
-///   we zero-left-pad the two's complement representation.
-/// - **`bytesN` (N < 32)**: diverges — Solidity right-pads, we left-pad.
-///
-/// This is **not** a soundness issue — there are no slot collision risks — but off-chain
-/// tools that reconstruct storage slots using Solidity's `abi.encode` rules will compute
-/// different locations for the divergent types. View functions should be used instead.
+/// This is intentionally different from Solidity's `keccak256(abi.encode(key, slot))`;
+/// off-chain tools must use Tempo's BLAKE3 slot derivation for macro-backed storage.
 pub trait StorageKey: sealed::OnlyPrimitives {
     /// Returns key bytes for storage slot computation.
     fn as_storage_bytes(&self) -> impl AsRef<[u8]>;
@@ -367,6 +358,11 @@ pub trait StorageKey: sealed::OnlyPrimitives {
         buf[32 - key_bytes.len()..32].copy_from_slice(key_bytes);
         buf[32..].copy_from_slice(&slot.to_be_bytes::<32>());
 
-        U256::from_be_bytes(keccak256(buf).0)
+        storage_slot_hash(buf)
     }
+}
+
+#[inline]
+pub(crate) fn storage_slot_hash(data: impl AsRef<[u8]>) -> U256 {
+    U256::from_be_bytes(*blake3::hash(data.as_ref()).as_bytes())
 }

--- a/crates/precompiles/src/storage/types/set.rs
+++ b/crates/precompiles/src/storage/types/set.rs
@@ -4,7 +4,7 @@
 //! # Storage Layout
 //!
 //! EnumerableSet uses two storage structures:
-//! - **Values Vec**: A `Vec<T>` storing all set elements at `keccak256(base_slot)`
+//! - **Values Vec**: A `Vec<T>` storing all set elements at `blake3(base_slot)`
 //! - **Positions Mapping**: A `Mapping<T, u32>` at `base_slot + 1` storing 1-indexed positions
 //!   - Position 0 means the value is not in the set
 //!   - Position N means the value is at index N-1 in the values array
@@ -190,7 +190,7 @@ where
 
 /// Set occupies 2 slots:
 ///
-/// - Slot 0: `Vec` length slot, with data at `keccak256(slot)`
+/// - Slot 0: `Vec` length slot, with data at `blake3(slot)`
 /// - Slot 1: `Mapping` base slot for positions
 impl<T> StorableType for Set<T>
 where

--- a/crates/precompiles/src/storage/types/vec.rs
+++ b/crates/precompiles/src/storage/types/vec.rs
@@ -2,9 +2,9 @@
 //!
 //! # Storage Layout
 //!
-//! Vec uses Solidity-compatible dynamic array storage:
+//! Vec uses Tempo dynamic array storage:
 //! - **Base slot**: Stores the array length (number of elements)
-//! - **Data slots**: Start at `keccak256(len_slot)`, elements packed efficiently
+//! - **Data slots**: Start at `blake3(len_slot)`, elements packed efficiently
 //!
 //! ## Multi-Slot Support
 //!
@@ -14,6 +14,7 @@
 use alloy::primitives::{Address, U256};
 use std::ops::{Index, IndexMut};
 
+use super::storage_slot_hash;
 use crate::{
     error::{Result, TempoPrecompileError},
     storage::{
@@ -390,10 +391,10 @@ fn load_checked_len<S: StorageOps>(storage: &S, slot: U256) -> Result<usize> {
 
 /// Calculate the starting slot for dynamic array data.
 ///
-/// For Solidity compatibility, dynamic array data is stored at `keccak256(len_slot)`.
+/// Dynamic array data is stored at `blake3(len_slot)`.
 #[inline]
 pub(crate) fn calc_data_slot(len_slot: U256) -> U256 {
-    U256::from_be_bytes(alloy::primitives::keccak256(len_slot.to_be_bytes::<32>()).0)
+    storage_slot_hash(len_slot.to_be_bytes::<32>())
 }
 
 /// Clears storage occupied exclusively by `Vec` elements in the index range `[from, to)`.
@@ -617,15 +618,11 @@ mod tests {
     fn test_vec_data_slot_derivation() {
         let len_slot = U256::random();
 
-        // Verify data slot matches keccak256(len_slot)
+        // Verify data slot matches blake3(len_slot)
         let data_slot = calc_data_slot(len_slot);
-        let expected =
-            U256::from_be_bytes(alloy::primitives::keccak256(len_slot.to_be_bytes::<32>()).0);
+        let expected = storage_slot_hash(len_slot.to_be_bytes::<32>());
 
-        assert_eq!(
-            data_slot, expected,
-            "Data slot should be keccak256(len_slot)"
-        );
+        assert_eq!(data_slot, expected, "Data slot should be blake3(len_slot)");
     }
 
     #[test]
@@ -1319,7 +1316,7 @@ mod tests {
                 .unwrap();
             assert_eq!(length_value, U256::from(3), "Length slot incorrect");
 
-            // Verify data starts at keccak256(len_slot), not len_slot + 1
+            // Verify data starts at blake3(len_slot), not len_slot + 1
             let data_start = calc_data_slot(len_slot);
             assert_ne!(
                 data_start,

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -103,7 +103,7 @@ impl TIP20ChannelReserve {
 
     /// Seeds the enclosing transaction's replay-protected context hash for `open` calls.
     ///
-    /// The handler seeds `keccak256(encode_for_signing || sender)` for every real transaction
+    /// The handler seeds `blake3(encode_for_signing || sender)` for every real transaction
     /// type. The value is stored in transient storage so batched `open` calls share the same
     /// transaction-derived hash and the context is automatically cleared before the next
     /// transaction. If this is not called, `open` reads zero from transient storage and reverts.

--- a/crates/precompiles/tests/storage_tests/layouts.rs
+++ b/crates/precompiles/tests/storage_tests/layouts.rs
@@ -205,7 +205,7 @@ fn test_string_literal_slots() {
     #[contract]
     pub struct Layout {
         #[slot("id")]
-        pub field: U256, // slot: blake3("id")
+        pub field: U256, // slot: raw "id" bytes
     }
 
     let (mut storage, address) = setup_storage();
@@ -219,7 +219,7 @@ fn test_string_literal_slots() {
         assert_eq!(layout.field.read().unwrap(), U256::ONE);
 
         // Verify slot assignment
-        let slot = U256::from_be_bytes(*blake3::hash(b"id").as_bytes());
+        let slot = U256::from_be_slice(b"id");
         assert_eq!(layout.field.slot(), slot);
         assert_eq!(slots::FIELD, slot);
 

--- a/crates/precompiles/tests/storage_tests/layouts.rs
+++ b/crates/precompiles/tests/storage_tests/layouts.rs
@@ -205,7 +205,7 @@ fn test_string_literal_slots() {
     #[contract]
     pub struct Layout {
         #[slot("id")]
-        pub field: U256, // slot: keccak256("id")
+        pub field: U256, // slot: blake3("id")
     }
 
     let (mut storage, address) = setup_storage();
@@ -219,7 +219,7 @@ fn test_string_literal_slots() {
         assert_eq!(layout.field.read().unwrap(), U256::ONE);
 
         // Verify slot assignment
-        let slot: U256 = keccak256("id").into();
+        let slot = U256::from_be_bytes(*blake3::hash(b"id").as_bytes());
         assert_eq!(layout.field.slot(), slot);
         assert_eq!(slots::FIELD, slot);
 

--- a/crates/precompiles/tests/storage_tests/mod.rs
+++ b/crates/precompiles/tests/storage_tests/mod.rs
@@ -73,9 +73,9 @@ pub(crate) fn test_address(byte: u8) -> Address {
 }
 
 /// Compute the i-th tail slot of a dynamic value (`String`/`Bytes`/`Vec`) whose
-/// base/length slot is `base_slot`. Solidity stores tail data at `keccak256(base_slot) + i`.
+/// base/length slot is `base_slot`. Tempo stores tail data at `blake3(base_slot) + i`.
 pub(crate) fn dyn_tail_slot(base_slot: U256, i: u64) -> U256 {
-    U256::from_be_bytes(keccak256(base_slot.to_be_bytes::<32>()).0) + U256::from(i)
+    U256::from_be_bytes(*blake3::hash(&base_slot.to_be_bytes::<32>()).as_bytes()) + U256::from(i)
 }
 
 /// Helper to test store + load roundtrip

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -49,6 +49,7 @@ once_cell = { version = "1.21", default-features = false }
 # Cryptography
 aws-lc-rs = { version = "1.16.2", optional = true, default-features = false, features = ["alloc", "non-fips", "ring-sig-verify"] }
 base64.workspace = true
+blake3.workspace = true
 ed25519-consensus = { workspace = true, default-features = false }
 p256 = { workspace = true, features = ["ecdsa"] }
 sha2.workspace = true

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -32,7 +32,7 @@ use alloy_primitives::{Address, B256, Signature, U256, uint};
 
 /// Computes the sender-scoped transaction identifier used for replay-sensitive features.
 ///
-/// The identifier is `keccak256(encode_for_signing || sender)`, making it unique per recovered
+/// The identifier is `blake3(encode_for_signing || sender)`, making it unique per recovered
 /// sender while remaining invariant to signatures that do not change the signed payload.
 pub(crate) fn unique_tx_identifier_from_signable<T>(tx: &T, sender: Address) -> B256
 where
@@ -41,7 +41,7 @@ where
     let mut buf = Vec::with_capacity(tx.payload_len_for_signature() + sender.as_slice().len());
     tx.encode_for_signing(&mut buf);
     buf.extend_from_slice(sender.as_slice());
-    alloy_primitives::keccak256(buf)
+    B256::from(*blake3::hash(&buf).as_bytes())
 }
 
 /// Scaling factor for converting gas prices (attodollars) to TIP-20 token amounts (microdollars).

--- a/crates/primitives/src/transaction/tt_signed.rs
+++ b/crates/primitives/src/transaction/tt_signed.rs
@@ -115,7 +115,7 @@ impl AASigned {
 
     /// Calculate the expiring nonce dedup hash for replay protection.
     ///
-    /// This hash is `keccak256(encode_for_signing || sender)`. It is:
+    /// This hash is `blake3(encode_for_signing || sender)`. It is:
     /// - **Invariant to fee payer changes**: the fee payer signature and fee token are excluded
     ///   (since `encode_for_signing` doesn't commit to them when a fee payer is present).
     /// - **Unique per sender**: different signers produce different recovered addresses, so the

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -993,7 +993,7 @@ where
         if is_expiring_nonce {
             // Expiring nonce transaction replay protection:
             // - Pre-T1B: use tx_hash for backwards-compatible behavior.
-            // - T1B+: use the sender-scoped tx identifier (keccak256(encode_for_signing || sender))
+            // - T1B+: use the sender-scoped tx identifier (blake3(encode_for_signing || sender))
             //   to prevent replay via different fee payer signatures.
             let tempo_tx_env = tx
                 .tempo_tx_env

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -121,7 +121,7 @@ impl TempoTxEnv {
 
     /// Returns the sender-scoped transaction identifier.
     ///
-    /// This is `keccak256(encode_for_signing || sender)` for every real transaction type. For
+    /// This is `blake3(encode_for_signing || sender)` for every real transaction type. For
     /// Tempo AA transactions, this matches the existing expiring nonce hash helper.
     pub fn unique_tx_identifier(&self) -> Option<B256> {
         self.unique_tx_identifier

--- a/xtask/src/generate_state_bloat.rs
+++ b/xtask/src/generate_state_bloat.rs
@@ -23,7 +23,7 @@ use std::{
     path::PathBuf,
     sync::Arc,
 };
-use tempo_precompiles::tip20::tip20_slots;
+use tempo_precompiles::{storage::StorageKey, tip20::tip20_slots};
 use tempo_primitives::transaction::TIP20_PAYMENT_PREFIX;
 
 /// Magic bytes for the state bloat binary format (8 bytes)
@@ -265,14 +265,9 @@ fn derive_parent_key(mnemonic_phrase: &str) -> eyre::Result<XPriv> {
     Ok(master)
 }
 
-/// Compute a Solidity mapping slot: keccak256(pad32(key) || pad32(base_slot))
+/// Compute a Tempo mapping slot using the same BLAKE3 encoding as storage macros.
 fn compute_mapping_slot(key: Address, base_slot: U256) -> U256 {
-    let mut buf = [0u8; 64];
-    // Left-pad address to 32 bytes
-    buf[12..32].copy_from_slice(key.as_slice());
-    // Base slot as big-endian 32 bytes
-    buf[32..].copy_from_slice(&base_slot.to_be_bytes::<32>());
-    U256::from_be_bytes(keccak256(buf).0)
+    key.mapping_slot(base_slot)
 }
 
 /// Write a block header to the output.
@@ -311,7 +306,6 @@ mod tests {
 
     #[test]
     fn test_compute_mapping_slot() {
-        // Verify the slot computation matches Solidity's keccak256(abi.encode(key, slot))
         let addr: Address = "0x1234567890123456789012345678901234567890"
             .parse()
             .unwrap();


### PR DESCRIPTION
## Summary
- derive string literal storage slots from raw bytes when the literal fits in 32 bytes
- keep BLAKE3 fallback for longer string literals
- update the storage layout test expectation for `#[slot("id")]`

Prompted by: @shekhirin

## Tests
- cargo fmt --all --check
- cargo test -p tempo-precompiles --features test-utils --test storage test_string_literal_slots