### PR TITLE
fix(transaction-pool): avoid eager transaction collection

### DIFF
--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -601,7 +601,6 @@ where
         transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction), IntoIter: Send>
         + Send,
     ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
-        let transactions: Vec<_> = transactions.into_iter().collect();
         let state_provider = match self.inner.client().latest() {
             Ok(provider) => provider,
             Err(err) => {


### PR DESCRIPTION
Avoids collecting transaction batches before acquiring the latest state provider in `validate_transactions`. The iterator is now consumed directly in the success or error path, matching `validate_transactions_with_origin` and avoiding an unnecessary allocation on successful validation.