### PR TITLE
perf(transaction-pool): avoid tx env clone during validation

### DIFF
--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -97,6 +97,11 @@ impl<DB: Database, I> TempoEvm<DB, I> {
         &self.inner.inner.ctx
     }
 
+    /// Consumes this EVM wrapper and returns the EVM context.
+    pub fn into_ctx(self) -> TempoContext<DB> {
+        self.inner.inner.ctx
+    }
+
     /// Returns the [`EvmEnv`] for the current block.
     pub fn evm_env(&self) -> EvmEnv<TempoHardfork, TempoBlockEnv> {
         EvmEnv {

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -258,7 +258,7 @@ impl TempoPooledTransaction {
     }
 
     /// Computes the [`TempoTxEnv`] for this transaction.
-    fn tx_env_slow(&self) -> TempoTxEnv {
+    pub(crate) fn tx_env_slow(&self) -> TempoTxEnv {
         TempoTxEnv::from_recovered_tx(self.inner().inner(), self.sender())
     }
 
@@ -268,6 +268,16 @@ impl TempoPooledTransaction {
     /// ahead of time, avoiding it during payload building.
     pub fn tx_env(&self) -> &TempoTxEnv {
         self.tx_env.get_or_init(|| self.tx_env_slow())
+    }
+
+    /// Returns the cached [`TempoTxEnv`] if already prepared.
+    pub(crate) fn cached_tx_env(&self) -> Option<&TempoTxEnv> {
+        self.tx_env.get()
+    }
+
+    /// Attempts to cache a prepared [`TempoTxEnv`].
+    pub(crate) fn cache_tx_env(&self, tx_env: TempoTxEnv) {
+        let _ = self.tx_env.set(tx_env);
     }
 
     /// Returns a cloned [`TempoTxEnv`] for this transaction.

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -320,7 +320,14 @@ where
         evm.inner_mut().skip_valid_after_check = true;
         evm.inner_mut().skip_liquidity_check = true;
         evm.ctx_mut().cfg.disable_nonce_check = true;
-        evm.validate_transaction(transaction.tx_env().clone())
+
+        if let Some(tx_env) = transaction.cached_tx_env() {
+            evm.validate_transaction(tx_env.clone())
+        } else {
+            let result = evm.validate_transaction(transaction.tx_env_slow());
+            transaction.cache_tx_env(evm.into_ctx().tx);
+            result
+        }
     }
 
     fn validate_one(


### PR DESCRIPTION
Avoids cloning a freshly-built `TempoTxEnv` before EVM validation when the pooled transaction cache is still empty. Validation now moves the owned env into the throwaway EVM on cache misses, consumes the EVM context afterward to seed the existing cache for payload building, and leaves the hot-cache path as a direct clone of the cached env.