### PR TITLE
Add TIP-1066 vault-backed TIP-20 tokens

### DIFF
--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -1,0 +1,277 @@
+---
+id: TIP-1066
+title: Vault-Backed TIP-20 Tokens
+description: Add a TIP-20 factory path for tokens backed by an external ERC-4626-compatible vault.
+authors: Dan Robinson (@danrobinson)
+status: Draft
+related: TIP-20, TIP-403
+protocolVersion: TBD
+---
+
+# TIP-1066: Vault-Backed TIP-20 Tokens
+
+## Abstract
+
+This TIP adds a `createVaultToken` function to the TIP-20 factory. A vault-backed TIP-20 is a normal transferable TIP-20 token whose balances represent pro-rata claims on an immutable external vault that exposes the ERC-4626 asset, accounting, deposit, and withdrawal interface.
+
+The wrapped vault remains responsible for all yield, reward, donation, fee, limit, and risk logic. The vault-backed TIP-20 only exposes a TIP-20 transfer surface plus an ERC-4626-like deposit and withdrawal surface that mints or burns TIP-20 balances and moves assets through the configured vault.
+
+## Motivation
+
+TIP-20 tokens are the native token surface for Tempo wallets, policy checks, indexing, and payment flows. ERC-4626 vaults are the standard surface for tokenized vault deposits and redemptions. Some integrations need both properties at once: users should hold and transfer a native TIP-20 balance, while that balance should also represent a claim on assets managed by a vault.
+
+This can be done without requiring the vault to become a TIP-20 token. Instead, the TIP-20 can act as the vault's aggregate depositor. From the vault's perspective, the TIP-20 token contract is an ordinary holder. From the user's perspective, TIP-20 balances are transferable vault claims, and deposit or withdrawal uses an ERC-4626-like interface on the TIP-20 token.
+
+This keeps responsibilities separated:
+
+- TIP-20 handles transfers, allowances, metadata, factory registration, and TIP-403 policy enforcement.
+- The vault handles share-price growth, rewards, donations, allocation, fees, limits, and withdrawal mechanics.
+- The factory binds the TIP-20 to a fixed vault and a fixed TIP-403 policy at creation time.
+
+## Assumptions
+
+- The wrapped vault exposes ERC-4626-compatible `asset`, accounting, deposit, and withdrawal functions. The vault MAY also expose ERC-20 share functions, but the vault-backed TIP-20 MUST NOT rely on vault share transferability.
+- The wrapped vault's `asset()` return value is immutable for the lifetime of the vault-backed TIP-20.
+- The wrapped vault MAY accept other depositors. The vault-backed TIP-20 MUST NOT assume it is the only vault participant.
+- All reward, donation, fee, allocation, pause, withdrawal-limit, and risk logic is owned by the wrapped vault and is outside the TIP-20 wrapper.
+- The vault-backed TIP-20's configured vault and TIP-403 policy are immutable after deployment.
+
+## Threat Model
+
+- **Vault operator or vault logic:** trusted to account for deposits, withdrawals, share-price growth, rewards, fees, and limits correctly. A malicious or buggy vault can reduce or block the value represented by the vault-backed TIP-20.
+- **TIP-20 holder:** may transfer balances, approve allowances, deposit assets, and withdraw assets subject to TIP-20 policy and vault behavior.
+- **External depositor into the vault:** may deposit directly into the wrapped vault if the vault permits it. This can affect the vault's global share price but MUST NOT corrupt the vault-backed TIP-20's pro-rata accounting.
+- **TIP-403 policy:** controls TIP-20 transfer authorization. The policy is immutable for the vault-backed TIP-20.
+- **Factory:** trusted to bind each vault-backed TIP-20 to the intended immutable vault and policy during creation.
+
+---
+
+# Specification
+
+## Factory Interface
+
+The TIP-20 factory is extended with:
+
+```solidity
+/// @notice Creates a TIP-20 token whose balances are backed by an external
+///         ERC-4626-compatible vault.
+/// @param name The TIP-20 name.
+/// @param symbol The TIP-20 symbol.
+/// @param currency The ISO or issuer-defined currency string.
+/// @param quoteToken The quote token used by existing TIP-20 factory rules.
+/// @param policyId The immutable TIP-403 policy ID for this token.
+/// @param vault The immutable external vault backing this token.
+/// @param salt The deterministic address salt.
+/// @return token The created vault-backed TIP-20 token address.
+function createVaultToken(
+    string memory name,
+    string memory symbol,
+    string memory currency,
+    address quoteToken,
+    uint64 policyId,
+    address vault,
+    bytes32 salt
+) external returns (address token);
+```
+
+`createVaultToken` MUST:
+
+1. Validate `vault != address(0)`.
+2. Validate that `vault.asset()` returns a nonzero address.
+3. Validate `policyId` using the same TIP-403 policy existence rules that apply to ordinary TIP-20 token policy configuration.
+4. Deploy or initialize a TIP-20 token whose `vault` and `policyId` are immutable.
+5. Register the created token as a TIP-20 token, so `isTIP20(token) == true`.
+6. Emit `VaultTokenCreated`.
+
+```solidity
+event VaultTokenCreated(
+    address indexed token,
+    address indexed vault,
+    uint64 indexed policyId,
+    string name,
+    string symbol,
+    string currency,
+    address quoteToken,
+    bytes32 salt
+);
+```
+
+The factory MAY also emit the existing `TokenCreated` event for compatibility with indexers that already consume TIP-20 factory events.
+
+## Vault Interface
+
+The wrapped vault MUST expose the following ERC-4626-compatible functions:
+
+```solidity
+function asset() external view returns (address);
+function totalAssets() external view returns (uint256);
+function convertToShares(uint256 assets) external view returns (uint256);
+function convertToAssets(uint256 shares) external view returns (uint256);
+function maxDeposit(address receiver) external view returns (uint256);
+function maxMint(address receiver) external view returns (uint256);
+function maxWithdraw(address owner) external view returns (uint256);
+function maxRedeem(address owner) external view returns (uint256);
+function previewDeposit(uint256 assets) external view returns (uint256);
+function previewMint(uint256 shares) external view returns (uint256);
+function previewWithdraw(uint256 assets) external view returns (uint256);
+function previewRedeem(uint256 shares) external view returns (uint256);
+function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+function mint(uint256 shares, address receiver) external returns (uint256 assets);
+function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares);
+function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
+```
+
+The wrapped vault MAY omit ERC-20 functions such as `balanceOf`, `transfer`, `transferFrom`, and `allowance`. The vault-backed TIP-20 MUST track the amount of vault shares attributable to the TIP-20 contract through the shares returned by vault deposit, mint, withdraw, and redeem calls, rather than by assuming ERC-20 share-balance reads are available.
+
+## Vault-Backed TIP-20 Interface
+
+A vault-backed TIP-20 MUST expose all ordinary TIP-20 behavior and the following ERC-4626-like methods:
+
+```solidity
+function asset() external view returns (address);
+function vault() external view returns (address);
+function policyId() external view returns (uint64);
+function totalAssets() external view returns (uint256);
+function convertToShares(uint256 assets) external view returns (uint256);
+function convertToAssets(uint256 shares) external view returns (uint256);
+function maxDeposit(address receiver) external view returns (uint256);
+function maxMint(address receiver) external view returns (uint256);
+function maxWithdraw(address owner) external view returns (uint256);
+function maxRedeem(address owner) external view returns (uint256);
+function previewDeposit(uint256 assets) external view returns (uint256);
+function previewMint(uint256 shares) external view returns (uint256);
+function previewWithdraw(uint256 assets) external view returns (uint256);
+function previewRedeem(uint256 shares) external view returns (uint256);
+function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+function mint(uint256 shares, address receiver) external returns (uint256 assets);
+function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares);
+function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
+```
+
+In this interface, "shares" means vault-backed TIP-20 units. A user's TIP-20 balance is their share balance. Transferring TIP-20 balances transfers the corresponding pro-rata vault claim without interacting with the wrapped vault.
+
+## Accounting Model
+
+The vault-backed TIP-20 stores:
+
+```solidity
+address immutable vault;
+address immutable asset;
+uint64 immutable policyId;
+uint256 accountedVaultShares;
+```
+
+`accountedVaultShares` is the total number of wrapped-vault shares attributable to all outstanding TIP-20 balances. It is updated only by successful deposit, mint, withdraw, and redeem operations through the vault-backed TIP-20.
+
+TIP-20 `totalSupply()` MUST equal the sum of all holder balances and MUST also equal `accountedVaultShares`, except during the internal execution of a deposit, mint, withdraw, or redeem call before the final state transition completes.
+
+`totalAssets()` MUST return `vault.convertToAssets(accountedVaultShares)`.
+
+`convertToAssets(shares)` MUST return `vault.convertToAssets(shares)`.
+
+`convertToShares(assets)` MUST return `vault.convertToShares(assets)`.
+
+`maxDeposit(receiver)` MUST return `0` if minting TIP-20 shares to `receiver` would fail the immutable TIP-403 policy. Otherwise, it MUST return `vault.maxDeposit(address(this))`.
+
+`maxMint(receiver)` MUST return `0` if minting TIP-20 shares to `receiver` would fail the immutable TIP-403 policy. Otherwise, it MUST return `vault.maxMint(address(this))`.
+
+`maxWithdraw(owner)` MUST return the smaller of `convertToAssets(balanceOf(owner))` and `vault.maxWithdraw(address(this))`.
+
+`maxRedeem(owner)` MUST return the smaller of `balanceOf(owner)` and `vault.maxRedeem(address(this))`.
+
+If the wrapped vault's share price increases because of yield, rewards, donations, or any other vault-native mechanism, the vault-backed TIP-20's `totalAssets()` and `convertToAssets(balanceOf(user))` reflect that increase automatically. The TIP-20 wrapper MUST NOT implement separate reward accounting.
+
+## Deposits and Mints
+
+`deposit(assets, receiver)` MUST:
+
+1. Reject `receiver == address(0)`.
+2. Enforce the token's immutable TIP-403 policy for minting to `receiver`.
+3. Transfer `assets` of `asset()` from `msg.sender` to the vault-backed TIP-20.
+4. Approve or otherwise provide those assets to the wrapped vault.
+5. Call `vault.deposit(assets, address(this))`.
+6. Let `shares` be the number of vault shares returned by the wrapped vault.
+7. Increase `accountedVaultShares` by `shares`.
+8. Mint exactly `shares` TIP-20 units to `receiver`.
+9. Emit the ordinary TIP-20 `Transfer(address(0), receiver, shares)` event and `Deposit`.
+
+`mint(shares, receiver)` MUST follow the same rules, except it calls `vault.mint(shares, address(this))`, transfers the returned asset amount from `msg.sender`, and mints exactly `shares` TIP-20 units to `receiver`.
+
+```solidity
+event Deposit(
+    address indexed caller,
+    address indexed owner,
+    uint256 assets,
+    uint256 shares
+);
+```
+
+## Withdrawals and Redeems
+
+`withdraw(assets, receiver, owner)` MUST:
+
+1. Reject `receiver == address(0)`.
+2. Spend TIP-20 allowance from `owner` when `msg.sender != owner`, using ordinary TIP-20 allowance rules.
+3. Compute `shares` using the wrapped vault's withdrawal semantics.
+4. Burn exactly `shares` TIP-20 units from `owner`.
+5. Decrease `accountedVaultShares` by `shares`.
+6. Call `vault.withdraw(assets, receiver, address(this))`, causing the wrapped vault to send assets directly to `receiver`.
+7. Emit the ordinary TIP-20 `Transfer(owner, address(0), shares)` event and `Withdraw`.
+
+`redeem(shares, receiver, owner)` MUST follow the same rules, except it burns exactly `shares`, decreases `accountedVaultShares` by `shares`, and calls `vault.redeem(shares, receiver, address(this))`.
+
+```solidity
+event Withdraw(
+    address indexed caller,
+    address indexed receiver,
+    address indexed owner,
+    uint256 assets,
+    uint256 shares
+);
+```
+
+If a wrapped vault's `withdraw` or `redeem` sends assets to a different address than `receiver`, returns inconsistent shares or assets, or otherwise violates the ERC-4626-compatible interface, the vault is outside the assumptions of this TIP.
+
+## TIP-403 Policy
+
+The vault-backed TIP-20's TIP-403 policy is immutable. There is no token admin that can update the policy after creation.
+
+The policy applies to the TIP-20 balance movement:
+
+- Deposits and mints check the policy as a mint to `receiver`.
+- Transfers and `transferFrom` check the policy as ordinary TIP-20 transfers.
+- Withdrawals and redeems burn TIP-20 balances and do not create a new TIP-20 recipient, so they do not require a TIP-403 recipient check for the asset receiver. Any withdrawal restriction on the underlying asset receiver is the wrapped vault's responsibility.
+
+## Non-Goals
+
+This TIP does not:
+
+- Define a vault reward, donation, or accumulator mechanism.
+- Require the wrapped vault to exclude other depositors.
+- Require the wrapped vault to expose ERC-20 share functions.
+- Allow changing the wrapped vault after token creation.
+- Allow changing the TIP-403 policy after token creation.
+- Add admin powers to the vault-backed TIP-20.
+- Define migration from an existing ordinary TIP-20 into a vault-backed TIP-20.
+
+# Observability
+
+Implementations MUST emit:
+
+- `VaultTokenCreated`: answers which factory-created TIP-20 tokens are vault-backed, and which immutable vault and policy each token uses.
+- `Deposit`: answers who deposited assets and which owner received new TIP-20 shares.
+- `Withdraw`: answers who initiated a withdrawal or redemption, which owner burned TIP-20 shares, and which receiver received assets.
+
+Ordinary TIP-20 `Transfer` and approval events remain sufficient for balance, supply, transfer, and allowance indexing.
+
+# Invariants
+
+- `vault`, `asset`, and `policyId` are immutable for the lifetime of the vault-backed TIP-20.
+- `asset == IERC4626(vault).asset()`.
+- `totalSupply() == accountedVaultShares` after every successful external call.
+- `balanceOf(account)` is the account's transferable vault-share claim.
+- `convertToAssets(balanceOf(account))` is the account's current pro-rata claim on wrapped-vault assets according to the wrapped vault.
+- TIP-20 transfers do not call the wrapped vault and do not change `accountedVaultShares`.
+- Deposits and mints increase `accountedVaultShares` and `totalSupply()` by exactly the vault shares returned by the wrapped vault.
+- Withdrawals and redeems decrease `accountedVaultShares` and `totalSupply()` by exactly the vault shares burned from the owner.
+- The vault-backed TIP-20 never mints, burns, or transfers TIP-20 balances without applying the same policy and allowance rules that apply to the equivalent ordinary TIP-20 operation.


### PR DESCRIPTION
## Summary
- Adds TIP-1066 for vault-backed TIP-20 tokens.
- Specifies `createVaultToken` with immutable vault and TIP-403 policy.
- Defines ERC-4626-like deposit, withdrawal, accounting, observability, and invariants.

Prompted by: @danrobinson