### PR TITLE
Add TIP-1080 vault-backed TIP-20 tokens

### DIFF
--- a/tips/tip-1066.md
+++ b/tips/tip-1066.md
@@ -1,0 +1,277 @@
+---
+id: TIP-1066
+title: Vault-Backed TIP-20 Tokens
+description: Add a TIP-20 factory path for tokens backed by an external ERC-4626-compatible vault.
+authors: Dan Robinson (@danrobinson)
+status: Draft
+related: TIP-20, TIP-403
+protocolVersion: TBD
+---
+
+# TIP-1066: Vault-Backed TIP-20 Tokens
+
+## Abstract
+
+This TIP adds a `createVaultToken` function to the TIP-20 factory. A vault-backed TIP-20 is a normal transferable TIP-20 token whose balances represent pro-rata claims on an immutable external vault that exposes the ERC-4626 asset, accounting, deposit, and withdrawal interface.
+
+The wrapped vault remains responsible for all yield, reward, donation, fee, limit, and risk logic. The vault-backed TIP-20 only exposes a TIP-20 transfer surface plus an ERC-4626-like deposit and withdrawal surface that mints or burns TIP-20 balances and moves assets through the configured vault.
+
+## Motivation
+
+TIP-20 tokens are the native token surface for Tempo wallets, policy checks, indexing, and payment flows. ERC-4626 vaults are the standard surface for tokenized vault deposits and redemptions. Some integrations need both properties at once: users should hold and transfer a native TIP-20 balance, while that balance should also represent a claim on assets managed by a vault.
+
+This can be done without requiring the vault to become a TIP-20 token. Instead, the TIP-20 can act as the vault's aggregate depositor. From the vault's perspective, the TIP-20 token contract is an ordinary holder. From the user's perspective, TIP-20 balances are transferable vault claims, and deposit or withdrawal uses an ERC-4626-like interface on the TIP-20 token.
+
+This keeps responsibilities separated:
+
+- TIP-20 handles transfers, allowances, metadata, factory registration, and TIP-403 policy enforcement.
+- The vault handles share-price growth, rewards, donations, allocation, fees, limits, and withdrawal mechanics.
+- The factory binds the TIP-20 to a fixed vault and a fixed TIP-403 policy at creation time.
+
+## Assumptions
+
+- The wrapped vault exposes ERC-4626-compatible `asset`, accounting, deposit, and withdrawal functions. The vault MAY also expose ERC-20 share functions, but the vault-backed TIP-20 MUST NOT rely on vault share transferability.
+- The wrapped vault's `asset()` return value is immutable for the lifetime of the vault-backed TIP-20.
+- The wrapped vault MAY accept other depositors. The vault-backed TIP-20 MUST NOT assume it is the only vault participant.
+- All reward, donation, fee, allocation, pause, withdrawal-limit, and risk logic is owned by the wrapped vault and is outside the TIP-20 wrapper.
+- The vault-backed TIP-20's configured vault and TIP-403 policy are immutable after deployment.
+
+## Threat Model
+
+- **Vault operator or vault logic:** trusted to account for deposits, withdrawals, share-price growth, rewards, fees, and limits correctly. A malicious or buggy vault can reduce or block the value represented by the vault-backed TIP-20.
+- **TIP-20 holder:** may transfer balances, approve allowances, deposit assets, and withdraw assets subject to TIP-20 policy and vault behavior.
+- **External depositor into the vault:** may deposit directly into the wrapped vault if the vault permits it. This can affect the vault's global share price but MUST NOT corrupt the vault-backed TIP-20's pro-rata accounting.
+- **TIP-403 policy:** controls TIP-20 transfer authorization. The policy is immutable for the vault-backed TIP-20.
+- **Factory:** trusted to bind each vault-backed TIP-20 to the intended immutable vault and policy during creation.
+
+---
+
+# Specification
+
+## Factory Interface
+
+The TIP-20 factory is extended with:
+
+```solidity
+/// @notice Creates a TIP-20 token whose balances are backed by an external
+///         ERC-4626-compatible vault.
+/// @param name The TIP-20 name.
+/// @param symbol The TIP-20 symbol.
+/// @param currency The ISO or issuer-defined currency string.
+/// @param quoteToken The quote token used by existing TIP-20 factory rules.
+/// @param policyId The immutable TIP-403 policy ID for this token.
+/// @param vault The immutable external vault backing this token.
+/// @param salt The deterministic address salt.
+/// @return token The created vault-backed TIP-20 token address.
+function createVaultToken(
+    string memory name,
+    string memory symbol,
+    string memory currency,
+    address quoteToken,
+    uint64 policyId,
+    address vault,
+    bytes32 salt
+) external returns (address token);
+```
+
+`createVaultToken` MUST:
+
+1. Validate `vault != address(0)`.
+2. Validate that `vault.asset()` returns a nonzero address.
+3. Validate `policyId` using the same TIP-403 policy existence rules that apply to ordinary TIP-20 token policy configuration.
+4. Deploy or initialize a TIP-20 token whose `vault` and `policyId` are immutable.
+5. Register the created token as a TIP-20 token, so `isTIP20(token) == true`.
+6. Emit `VaultTokenCreated`.
+
+```solidity
+event VaultTokenCreated(
+    address indexed token,
+    address indexed vault,
+    uint64 indexed policyId,
+    string name,
+    string symbol,
+    string currency,
+    address quoteToken,
+    bytes32 salt
+);
+```
+
+The factory MAY also emit the existing `TokenCreated` event for compatibility with indexers that already consume TIP-20 factory events.
+
+## Vault Interface
+
+The wrapped vault MUST expose the following ERC-4626-compatible functions:
+
+```solidity
+function asset() external view returns (address);
+function totalAssets() external view returns (uint256);
+function convertToShares(uint256 assets) external view returns (uint256);
+function convertToAssets(uint256 shares) external view returns (uint256);
+function maxDeposit(address receiver) external view returns (uint256);
+function maxMint(address receiver) external view returns (uint256);
+function maxWithdraw(address owner) external view returns (uint256);
+function maxRedeem(address owner) external view returns (uint256);
+function previewDeposit(uint256 assets) external view returns (uint256);
+function previewMint(uint256 shares) external view returns (uint256);
+function previewWithdraw(uint256 assets) external view returns (uint256);
+function previewRedeem(uint256 shares) external view returns (uint256);
+function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+function mint(uint256 shares, address receiver) external returns (uint256 assets);
+function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares);
+function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
+```
+
+The wrapped vault MAY omit ERC-20 functions such as `balanceOf`, `transfer`, `transferFrom`, and `allowance`. The vault-backed TIP-20 MUST track the amount of vault shares attributable to the TIP-20 contract through the shares returned by vault deposit, mint, withdraw, and redeem calls, rather than by assuming ERC-20 share-balance reads are available.
+
+## Vault-Backed TIP-20 Interface
+
+A vault-backed TIP-20 MUST expose all ordinary TIP-20 behavior and the following ERC-4626-like methods:
+
+```solidity
+function asset() external view returns (address);
+function vault() external view returns (address);
+function policyId() external view returns (uint64);
+function totalAssets() external view returns (uint256);
+function convertToShares(uint256 assets) external view returns (uint256);
+function convertToAssets(uint256 shares) external view returns (uint256);
+function maxDeposit(address receiver) external view returns (uint256);
+function maxMint(address receiver) external view returns (uint256);
+function maxWithdraw(address owner) external view returns (uint256);
+function maxRedeem(address owner) external view returns (uint256);
+function previewDeposit(uint256 assets) external view returns (uint256);
+function previewMint(uint256 shares) external view returns (uint256);
+function previewWithdraw(uint256 assets) external view returns (uint256);
+function previewRedeem(uint256 shares) external view returns (uint256);
+function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+function mint(uint256 shares, address receiver) external returns (uint256 assets);
+function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares);
+function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
+```
+
+In this interface, "shares" means vault-backed TIP-20 units. A user's TIP-20 balance is their share balance. Transferring TIP-20 balances transfers the corresponding pro-rata vault claim without interacting with the wrapped vault.
+
+## Accounting Model
+
+The vault-backed TIP-20 stores:
+
+```solidity
+address immutable vault;
+address immutable asset;
+uint64 immutable policyId;
+uint256 accountedVaultShares;
+```
+
+`accountedVaultShares` is the total number of wrapped-vault shares attributable to all outstanding TIP-20 balances. It is updated only by successful deposit, mint, withdraw, and redeem operations through the vault-backed TIP-20.
+
+TIP-20 `totalSupply()` MUST equal the sum of all holder balances and MUST also equal `accountedVaultShares`, except during the internal execution of a deposit, mint, withdraw, or redeem call before the final state transition completes.
+
+`totalAssets()` MUST return `vault.convertToAssets(accountedVaultShares)`.
+
+`convertToAssets(shares)` MUST return `vault.convertToAssets(shares)`.
+
+`convertToShares(assets)` MUST return `vault.convertToShares(assets)`.
+
+`maxDeposit(receiver)` MUST return `0` if minting TIP-20 shares to `receiver` would fail the immutable TIP-403 policy. Otherwise, it MUST return `vault.maxDeposit(address(this))`.
+
+`maxMint(receiver)` MUST return `0` if minting TIP-20 shares to `receiver` would fail the immutable TIP-403 policy. Otherwise, it MUST return `vault.maxMint(address(this))`.
+
+`maxWithdraw(owner)` MUST return the smaller of `convertToAssets(balanceOf(owner))` and `vault.maxWithdraw(address(this))`.
+
+`maxRedeem(owner)` MUST return the smaller of `balanceOf(owner)` and `vault.maxRedeem(address(this))`.
+
+If the wrapped vault's share price increases because of yield, rewards, donations, or any other vault-native mechanism, the vault-backed TIP-20's `totalAssets()` and `convertToAssets(balanceOf(user))` reflect that increase automatically. The TIP-20 wrapper MUST NOT implement separate reward accounting.
+
+## Deposits and Mints
+
+`deposit(assets, receiver)` MUST:
+
+1. Reject `receiver == address(0)`.
+2. Enforce the token's immutable TIP-403 policy for minting to `receiver`.
+3. Transfer `assets` of `asset()` from `msg.sender` to the vault-backed TIP-20.
+4. Approve or otherwise provide those assets to the wrapped vault.
+5. Call `vault.deposit(assets, address(this))`.
+6. Let `shares` be the number of vault shares returned by the wrapped vault.
+7. Increase `accountedVaultShares` by `shares`.
+8. Mint exactly `shares` TIP-20 units to `receiver`.
+9. Emit the ordinary TIP-20 `Transfer(address(0), receiver, shares)` event and `Deposit`.
+
+`mint(shares, receiver)` MUST follow the same rules, except it calls `vault.mint(shares, address(this))`, transfers the returned asset amount from `msg.sender`, and mints exactly `shares` TIP-20 units to `receiver`.
+
+```solidity
+event Deposit(
+    address indexed caller,
+    address indexed owner,
+    uint256 assets,
+    uint256 shares
+);
+```
+
+## Withdrawals and Redeems
+
+`withdraw(assets, receiver, owner)` MUST:
+
+1. Reject `receiver == address(0)`.
+2. Spend TIP-20 allowance from `owner` when `msg.sender != owner`, using ordinary TIP-20 allowance rules.
+3. Compute `shares` using the wrapped vault's withdrawal semantics.
+4. Burn exactly `shares` TIP-20 units from `owner`.
+5. Decrease `accountedVaultShares` by `shares`.
+6. Call `vault.withdraw(assets, receiver, address(this))`, causing the wrapped vault to send assets directly to `receiver`.
+7. Emit the ordinary TIP-20 `Transfer(owner, address(0), shares)` event and `Withdraw`.
+
+`redeem(shares, receiver, owner)` MUST follow the same rules, except it burns exactly `shares`, decreases `accountedVaultShares` by `shares`, and calls `vault.redeem(shares, receiver, address(this))`.
+
+```solidity
+event Withdraw(
+    address indexed caller,
+    address indexed receiver,
+    address indexed owner,
+    uint256 assets,
+    uint256 shares
+);
+```
+
+If a wrapped vault's `withdraw` or `redeem` sends assets to a different address than `receiver`, returns inconsistent shares or assets, or otherwise violates the ERC-4626-compatible interface, the vault is outside the assumptions of this TIP.
+
+## TIP-403 Policy
+
+The vault-backed TIP-20's TIP-403 policy is immutable. There is no token admin that can update the policy after creation.
+
+The policy applies to the TIP-20 balance movement:
+
+- Deposits and mints check the policy as a mint to `receiver`.
+- Transfers and `transferFrom` check the policy as ordinary TIP-20 transfers.
+- Withdrawals and redeems burn TIP-20 balances and do not create a new TIP-20 recipient, so they do not require a TIP-403 recipient check for the asset receiver. Any withdrawal restriction on the underlying asset receiver is the wrapped vault's responsibility.
+
+## Non-Goals
+
+This TIP does not:
+
+- Define a vault reward, donation, or accumulator mechanism.
+- Require the wrapped vault to exclude other depositors.
+- Require the wrapped vault to expose ERC-20 share functions.
+- Allow changing the wrapped vault after token creation.
+- Allow changing the TIP-403 policy after token creation.
+- Add admin powers to the vault-backed TIP-20.
+- Define migration from an existing ordinary TIP-20 into a vault-backed TIP-20.
+
+# Observability
+
+Implementations MUST emit:
+
+- `VaultTokenCreated`: answers which factory-created TIP-20 tokens are vault-backed, and which immutable vault and policy each token uses.
+- `Deposit`: answers who deposited assets and which owner received new TIP-20 shares.
+- `Withdraw`: answers who initiated a withdrawal or redemption, which owner burned TIP-20 shares, and which receiver received assets.
+
+Ordinary TIP-20 `Transfer` and approval events remain sufficient for balance, supply, transfer, and allowance indexing.
+
+# Invariants
+
+- `vault`, `asset`, and `policyId` are immutable for the lifetime of the vault-backed TIP-20.
+- `asset == IERC4626(vault).asset()`.
+- `totalSupply() == accountedVaultShares` after every successful external call.
+- `balanceOf(account)` is the account's transferable vault-share claim.
+- `convertToAssets(balanceOf(account))` is the account's current pro-rata claim on wrapped-vault assets according to the wrapped vault.
+- TIP-20 transfers do not call the wrapped vault and do not change `accountedVaultShares`.
+- Deposits and mints increase `accountedVaultShares` and `totalSupply()` by exactly the vault shares returned by the wrapped vault.
+- Withdrawals and redeems decrease `accountedVaultShares` and `totalSupply()` by exactly the vault shares burned from the owner.
+- The vault-backed TIP-20 never mints, burns, or transfers TIP-20 balances without applying the same policy and allowance rules that apply to the equivalent ordinary TIP-20 operation.

--- a/tips/tip-1080.md
+++ b/tips/tip-1080.md
@@ -34,7 +34,7 @@ This keeps responsibilities separated:
 - The wrapped vault's `asset()` return value is immutable for the lifetime of the vault-backed TIP-20.
 - The wrapped vault's share balances SHOULD NOT rebase. Yield, rewards, donations, fees, losses, and other value changes SHOULD be reflected through the vault's asset-per-share accounting rather than by changing share balances.
 - The wrapped vault MAY accept other depositors. The vault-backed TIP-20 MUST NOT assume it is the only vault participant.
-- The wrapped vault MUST be compatible with the vault-backed TIP-20 contract acting as an aggregate depositor. Vault limits, allowlists, fees, and other depositor-specific behavior apply to the vault-backed TIP-20 contract, not to the end holders of the TIP-20 balances.
+- The wrapped vault MUST be compatible with the vault-backed TIP-20 contract acting as an aggregate depositor. Vault limits, allowlists, fees, and other depositor-specific behavior apply to the vault-backed TIP-20 contract, not to the end holders of the TIP-20 balances. End-holder-specific checks MAY be implemented by the vault-backed TIP-20's optional hook contract.
 - All reward, donation, fee, allocation, rounding, withdrawal-limit, and risk logic is owned by the wrapped vault and is outside the TIP-20 wrapper.
 - The vault-backed TIP-20's configured vault is immutable after deployment. Its TIP-403 policy MAY be updated by `DEFAULT_ADMIN_ROLE`.
 
@@ -43,7 +43,8 @@ This keeps responsibilities separated:
 - **Vault operator or vault logic:** trusted to account for deposits, withdrawals, share-price growth, rewards, fees, and limits correctly. A malicious or buggy vault can reduce or block the value represented by the vault-backed TIP-20.
 - **TIP-20 holder:** may transfer balances, approve allowances, deposit assets, and withdraw assets subject to TIP-20 policy and vault behavior.
 - **External depositor into the vault:** may deposit directly into the wrapped vault if the vault permits it. This can affect the vault's global share price but MUST NOT corrupt the vault-backed TIP-20's pro-rata accounting.
-- **Wrapped vault depositor checks:** apply to the vault-backed TIP-20 contract as the vault depositor. Per-end-holder vault limits or allowlists are outside the assumptions of this TIP.
+- **Wrapped vault depositor checks:** apply to the vault-backed TIP-20 contract as the vault depositor. Per-end-holder limits or allowlists can be implemented by the optional hook contract, but the wrapped vault itself only sees the vault-backed TIP-20 contract.
+- **Hook contract:** optionally trusted to enforce additional per-user deposit, mint, withdrawal, or redemption limits. A malicious or buggy hook can block otherwise valid operations or return incorrect max values.
 - **TIP-403 policy:** controls TIP-20 transfer authorization. The current policy can be updated by `DEFAULT_ADMIN_ROLE`.
 - **Admin roles:** trusted to update the TIP-403 policy and pause or unpause vault-backed TIP-20 operations.
 - **Factory:** trusted to bind each vault-backed TIP-20 to the intended immutable vault and initial policy during creation.
@@ -135,6 +136,7 @@ A vault-backed TIP-20 MUST expose all ordinary TIP-20 behavior and the following
 function asset() external view returns (address);
 function vault() external view returns (address);
 function policyId() external view returns (uint64);
+function hook() external view returns (address);
 function totalAssets() external view returns (uint256);
 function convertToShares(uint256 assets) external view returns (uint256);
 function convertToAssets(uint256 shares) external view returns (uint256);
@@ -152,6 +154,7 @@ function withdraw(uint256 assets, address receiver, address owner) external retu
 function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
 function paused() external view returns (bool);
 function updatePolicy(uint64 newPolicyId) external;
+function updateHook(address newHook) external;
 function pause() external;
 function unpause() external;
 ```
@@ -166,6 +169,7 @@ The vault-backed TIP-20 stores:
 address immutable vault;
 address immutable asset;
 uint64 policyId;
+address hook;
 ```
 
 TIP-20 `totalSupply()` is the total number of wrapped-vault shares attributable to all outstanding TIP-20 balances.
@@ -178,13 +182,13 @@ TIP-20 `totalSupply()` MUST equal the sum of all holder balances after every suc
 
 `convertToShares(assets)` MUST return `vault.convertToShares(assets)`.
 
-`maxDeposit(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return `vault.maxDeposit(address(this))`, because the vault-backed TIP-20 contract is the depositor into the wrapped vault.
+`maxDeposit(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return the smaller of `vault.maxDeposit(address(this))` and the current hook's `maxDeposit` value for `msg.sender` and `receiver`. If no hook is configured, the hook limit is treated as `type(uint256).max`.
 
-`maxMint(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return `vault.maxMint(address(this))`, because the vault-backed TIP-20 contract is the depositor into the wrapped vault.
+`maxMint(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return the smaller of `vault.maxMint(address(this))` and the current hook's `maxMint` value for `msg.sender` and `receiver`. If no hook is configured, the hook limit is treated as `type(uint256).max`.
 
-`maxWithdraw(owner)` MUST return `0` if the vault-backed TIP-20 is paused. Otherwise, it MUST return the smaller of `convertToAssets(balanceOf(owner))` and `vault.maxWithdraw(address(this))`.
+`maxWithdraw(owner)` MUST return `0` if the vault-backed TIP-20 is paused. Otherwise, it MUST return the smaller of `convertToAssets(balanceOf(owner))`, `vault.maxWithdraw(address(this))`, and the current hook's `maxWithdraw` value for `msg.sender` and `owner`. If no hook is configured, the hook limit is treated as `type(uint256).max`.
 
-`maxRedeem(owner)` MUST return `0` if the vault-backed TIP-20 is paused. Otherwise, it MUST return the smaller of `balanceOf(owner)` and `vault.maxRedeem(address(this))`.
+`maxRedeem(owner)` MUST return `0` if the vault-backed TIP-20 is paused. Otherwise, it MUST return the smaller of `balanceOf(owner)`, `vault.maxRedeem(address(this))`, and the current hook's `maxRedeem` value for `msg.sender` and `owner`. If no hook is configured, the hook limit is treated as `type(uint256).max`.
 
 If the wrapped vault's share price changes because of yield, rewards, donations, fees, losses, rounding, or any other vault-native mechanism, the vault-backed TIP-20's `totalAssets()` and `convertToAssets(balanceOf(user))` reflect that change automatically. The TIP-20 wrapper MUST NOT implement separate reward, fee, or rounding accounting.
 
@@ -195,14 +199,15 @@ If the wrapped vault's share price changes because of yield, rewards, donations,
 1. Reject `receiver == address(0)`.
 2. Reject if the vault-backed TIP-20 is paused.
 3. Enforce the token's current TIP-403 policy for minting to `receiver`.
-4. Transfer `assets` of `asset()` from `msg.sender` to the vault-backed TIP-20.
-5. Approve or otherwise provide those assets to the wrapped vault.
-6. Call `vault.deposit(assets, address(this))`.
-7. Let `shares` be the number of vault shares returned by the wrapped vault.
-8. Mint exactly `shares` TIP-20 units to `receiver`.
-9. Emit the ordinary TIP-20 `Transfer(address(0), receiver, shares)` event and `Deposit`.
+4. Enforce the current hook's deposit check, if a hook is configured.
+5. Transfer `assets` of `asset()` from `msg.sender` to the vault-backed TIP-20.
+6. Approve or otherwise provide those assets to the wrapped vault.
+7. Call `vault.deposit(assets, address(this))`.
+8. Let `shares` be the number of vault shares returned by the wrapped vault.
+9. Mint exactly `shares` TIP-20 units to `receiver`.
+10. Emit the ordinary TIP-20 `Transfer(address(0), receiver, shares)` event and `Deposit`.
 
-`mint(shares, receiver)` MUST follow the same rules, except it calls `vault.mint(shares, address(this))`, transfers the returned asset amount from `msg.sender`, and mints exactly `shares` TIP-20 units to `receiver`.
+`mint(shares, receiver)` MUST follow the same rules, except it computes the required asset amount using the wrapped vault's mint semantics, enforces the current hook's mint check if a hook is configured, transfers the required asset amount from `msg.sender`, approves or otherwise provides those assets to the wrapped vault, calls `vault.mint(shares, address(this))`, and mints exactly `shares` TIP-20 units to `receiver`.
 
 ```solidity
 event Deposit(
@@ -221,11 +226,12 @@ event Deposit(
 2. Reject if the vault-backed TIP-20 is paused.
 3. Spend TIP-20 allowance from `owner` when `msg.sender != owner`, using ordinary TIP-20 allowance rules.
 4. Compute `shares` using the wrapped vault's withdrawal semantics.
-5. Burn exactly `shares` TIP-20 units from `owner`.
-6. Call `vault.withdraw(assets, receiver, address(this))`, causing the wrapped vault to send assets directly to `receiver`.
-7. Emit the ordinary TIP-20 `Transfer(owner, address(0), shares)` event and `Withdraw`.
+5. Enforce the current hook's withdrawal check, if a hook is configured.
+6. Burn exactly `shares` TIP-20 units from `owner`.
+7. Call `vault.withdraw(assets, receiver, address(this))`, causing the wrapped vault to send assets directly to `receiver`.
+8. Emit the ordinary TIP-20 `Transfer(owner, address(0), shares)` event and `Withdraw`.
 
-`redeem(shares, receiver, owner)` MUST follow the same rules, except it burns exactly `shares` and calls `vault.redeem(shares, receiver, address(this))`.
+`redeem(shares, receiver, owner)` MUST follow the same rules, except it computes the returned asset amount using the wrapped vault's redemption semantics, enforces the current hook's redeem check if a hook is configured, burns exactly `shares`, and calls `vault.redeem(shares, receiver, address(this))`.
 
 ```solidity
 event Withdraw(
@@ -261,6 +267,7 @@ A vault-backed TIP-20 MUST have `DEFAULT_ADMIN_ROLE`. The initial holder of `DEF
 
 - Grant and revoke other roles.
 - Update the token's current TIP-403 policy.
+- Update the token's current hook contract.
 
 A vault-backed TIP-20 MUST support a `PAUSER_ROLE`. An account with `PAUSER_ROLE` MAY pause and unpause the vault-backed TIP-20. When paused:
 
@@ -276,13 +283,95 @@ event Paused(address indexed account);
 event Unpaused(address indexed account);
 ```
 
+## Hook Contract
+
+A vault-backed TIP-20 MAY have an optional hook contract. The hook is not part of the wrapped vault. It is called by the vault-backed TIP-20 before deposits, mints, withdrawals, and redeems, and by max functions to compute additional end-holder-specific limits.
+
+The hook interface is:
+
+```solidity
+interface IVaultTokenHook {
+    function maxDeposit(
+        address caller,
+        address receiver,
+        uint256 vaultMaxAssets
+    ) external view returns (uint256 maxAssets);
+
+    function maxMint(
+        address caller,
+        address receiver,
+        uint256 vaultMaxShares
+    ) external view returns (uint256 maxShares);
+
+    function maxWithdraw(
+        address caller,
+        address owner,
+        uint256 ownerAssets,
+        uint256 vaultMaxAssets
+    ) external view returns (uint256 maxAssets);
+
+    function maxRedeem(
+        address caller,
+        address owner,
+        uint256 ownerShares,
+        uint256 vaultMaxShares
+    ) external view returns (uint256 maxShares);
+
+    function beforeDeposit(
+        address caller,
+        address receiver,
+        uint256 assets,
+        uint256 previewShares
+    ) external view;
+
+    function beforeMint(
+        address caller,
+        address receiver,
+        uint256 shares,
+        uint256 assets
+    ) external view;
+
+    function beforeWithdraw(
+        address caller,
+        address receiver,
+        address owner,
+        uint256 assets,
+        uint256 shares
+    ) external view;
+
+    function beforeRedeem(
+        address caller,
+        address receiver,
+        address owner,
+        uint256 shares,
+        uint256 assets
+    ) external view;
+}
+```
+
+`DEFAULT_ADMIN_ROLE` MAY set the hook to any address or to `address(0)` to disable hooks. Hook updates MUST emit:
+
+```solidity
+event HookUpdated(address indexed oldHook, address indexed newHook);
+```
+
+When a hook is configured:
+
+- `deposit` MUST compute the expected share amount using `previewDeposit(assets)`, then call `beforeDeposit(msg.sender, receiver, assets, previewShares)` before transferring assets.
+- `mint` MUST compute the required asset amount using the wrapped vault's mint semantics, then call `beforeMint(msg.sender, receiver, shares, assets)` before transferring assets.
+- `withdraw` MUST compute the required share amount using the wrapped vault's withdrawal semantics, then call `beforeWithdraw(msg.sender, receiver, owner, assets, shares)` before burning shares.
+- `redeem` MUST compute the asset amount using the wrapped vault's redemption semantics, then call `beforeRedeem(msg.sender, receiver, owner, shares, assets)` before burning shares.
+
+Hook `before*` functions authorize by returning successfully and reject by reverting. Hook `max*` functions MUST NOT revert during normal operation; if a hook `max*` call reverts, the vault-backed TIP-20 max function MUST return `0`. Because ERC-4626 max functions do not include an explicit caller argument, the vault-backed TIP-20 passes `msg.sender` as the hook `caller` for max queries; a max query made by a relayer or offchain caller only answers for that caller.
+
+The hook cannot change the wrapped vault, cannot mint or burn vault-backed TIP-20 balances directly, and cannot move assets by itself. It only constrains the wrapper's own deposit, mint, withdrawal, and redemption entrypoints.
+
 ## Non-Goals
 
 This TIP does not:
 
 - Define a vault reward, donation, or accumulator mechanism.
 - Require the wrapped vault to exclude other depositors.
-- Support wrapped vaults that need per-end-holder vault limits, per-end-holder vault allowlists, or other per-end-holder vault depositor logic.
 - Require the wrapped vault to expose ERC-20 share functions.
 - Allow changing the wrapped vault after token creation.
 - Add privileged mint or burn powers to the vault-backed TIP-20.
@@ -296,6 +385,7 @@ Implementations MUST emit:
 - `Deposit`: answers who deposited assets and which owner received new TIP-20 shares.
 - `Withdraw`: answers who initiated a withdrawal or redemption, which owner burned TIP-20 shares, and which receiver received assets.
 - `PolicyUpdated`: answers when the current TIP-403 policy changes.
+- `HookUpdated`: answers when the current hook contract changes.
 - `Paused` and `Unpaused`: answer when vault-backed TIP-20 operations are paused or resumed.
 
 Ordinary TIP-20 `Transfer` and approval events remain sufficient for balance, supply, transfer, and allowance indexing.

--- a/tips/tip-1080.md
+++ b/tips/tip-1080.md
@@ -67,6 +67,7 @@ The TIP-20 factory is extended with:
 /// @param symbol The TIP-20 symbol.
 /// @param currency The ISO or issuer-defined currency string.
 /// @param quoteToken The quote token used by existing TIP-20 factory rules.
+/// @param admin The initial holder of DEFAULT_ADMIN_ROLE.
 /// @param policyId The initial TIP-403 policy ID for this token.
 /// @param vault The immutable external vault backing this token.
 /// @param salt The deterministic address salt.
@@ -76,6 +77,7 @@ function createVaultToken(
     string memory symbol,
     string memory currency,
     address quoteToken,
+    address admin,
     uint64 policyId,
     address vault,
     bytes32 salt
@@ -85,11 +87,12 @@ function createVaultToken(
 `createVaultToken` MUST:
 
 1. Validate `vault != address(0)`.
-2. Validate that `vault.asset()` returns a nonzero TIP-20 token address.
-3. Validate `policyId` using the same TIP-403 policy existence rules that apply to ordinary TIP-20 token policy configuration.
-4. Deploy a TIP-20 token whose `vault` is immutable and whose initial `policyId` is `policyId`.
-5. Register the created token as a TIP-20 token, so `isTIP20(token) == true`.
-6. Emit `VaultTokenCreated` and the existing `TokenCreated` event.
+2. Validate `admin != address(0)`.
+3. Validate that `vault.asset()` returns a nonzero TIP-20 token address.
+4. Validate `policyId` using the same TIP-403 policy existence rules that apply to ordinary TIP-20 token policy configuration.
+5. Deploy a TIP-20 token whose `vault` is immutable, whose initial `policyId` is `policyId`, and whose initial `DEFAULT_ADMIN_ROLE` holder is `admin`.
+6. Register the created token as a TIP-20 token, so `isTIP20(token) == true`.
+7. Emit `VaultTokenCreated` and the existing `TokenCreated` event.
 
 ```solidity
 event VaultTokenCreated(
@@ -100,6 +103,7 @@ event VaultTokenCreated(
     string symbol,
     string currency,
     address quoteToken,
+    address admin,
     bytes32 salt
 );
 ```
@@ -263,7 +267,7 @@ The policy applies to the TIP-20 balance movement:
 
 ## Admin Roles and Pause
 
-A vault-backed TIP-20 MUST have `DEFAULT_ADMIN_ROLE`. The initial holder of `DEFAULT_ADMIN_ROLE` is the caller of `createVaultToken` unless the factory specifies another admin in a future interface.
+A vault-backed TIP-20 MUST have `DEFAULT_ADMIN_ROLE`. The initial holder of `DEFAULT_ADMIN_ROLE` is the `admin` passed to `createVaultToken`.
 
 `DEFAULT_ADMIN_ROLE` MAY:
 

--- a/tips/tip-1080.md
+++ b/tips/tip-1080.md
@@ -145,7 +145,7 @@ For clarity, a vault-backed TIP-20 MUST support the following ordinary TIP-20 fu
 - Transfers and approvals: `transfer`, `transferWithMemo`, `approve`, `allowance`, `transferFrom`, `transferFromWithMemo`, `permit`, `nonces`, and `DOMAIN_SEPARATOR`.
 - Transfer-policy, pause, logo, and role administration: `transferPolicyId`, `changeTransferPolicyId`, `paused`, `pause`, `unpause`, `setLogoURI`, `PAUSE_ROLE`, `UNPAUSE_ROLE`, and ordinary role-management functions.
 
-A vault-backed TIP-20 MUST NOT support ordinary TIP-20 standalone issuance, burn-blocked, supply-cap mutation, quote-token mutation, or reward functions. Calls to ordinary TIP-20 `mint(address,uint256)`, `mintWithMemo`, `burn`, `burnWithMemo`, `burnBlocked`, `setSupplyCap`, `setNextQuoteToken`, `completeQuoteTokenUpdate`, `distributeReward`, `setRewardRecipient`, and `claimRewards` MUST revert. `supplyCap()` MUST return `type(uint256).max`, `nextQuoteToken()` MUST return `address(0)`, and reward read functions MUST report no TIP-20-native rewards. Vault or hook limits are represented through the ERC-4626-like `maxDeposit` and `maxMint` functions instead.
+A vault-backed TIP-20 MUST NOT support ordinary TIP-20 standalone issuance or direct burn entrypoints that bypass the vault. Calls to ordinary TIP-20 `mint(address,uint256)`, `mintWithMemo`, `burn`, and `burnWithMemo` MUST revert. Minting and burning vault-backed TIP-20 balances remains available only through the ERC-4626-like `deposit`, `mint(uint256,address)`, `withdraw`, and `redeem` functions, which keep TIP-20 supply synchronized with the wrapped vault share balance. Vault or hook limits are represented through the ERC-4626-like `maxDeposit` and `maxMint` functions.
 
 The additional vault-backed interface is:
 

--- a/tips/tip-1080.md
+++ b/tips/tip-1080.md
@@ -34,6 +34,7 @@ This keeps responsibilities separated:
 - The wrapped vault's `asset()` return value is immutable for the lifetime of the vault-backed TIP-20.
 - The wrapped vault's share balances SHOULD NOT rebase. Yield, rewards, donations, fees, losses, and other value changes SHOULD be reflected through the vault's asset-per-share accounting rather than by changing share balances.
 - The wrapped vault MAY accept other depositors. The vault-backed TIP-20 MUST NOT assume it is the only vault participant.
+- The wrapped vault MUST be compatible with the vault-backed TIP-20 contract acting as an aggregate depositor. Vault limits, allowlists, fees, and other depositor-specific behavior apply to the vault-backed TIP-20 contract, not to the end holders of the TIP-20 balances.
 - All reward, donation, fee, allocation, rounding, withdrawal-limit, and risk logic is owned by the wrapped vault and is outside the TIP-20 wrapper.
 - The vault-backed TIP-20's configured vault is immutable after deployment. Its TIP-403 policy MAY be updated by `DEFAULT_ADMIN_ROLE`.
 
@@ -42,6 +43,7 @@ This keeps responsibilities separated:
 - **Vault operator or vault logic:** trusted to account for deposits, withdrawals, share-price growth, rewards, fees, and limits correctly. A malicious or buggy vault can reduce or block the value represented by the vault-backed TIP-20.
 - **TIP-20 holder:** may transfer balances, approve allowances, deposit assets, and withdraw assets subject to TIP-20 policy and vault behavior.
 - **External depositor into the vault:** may deposit directly into the wrapped vault if the vault permits it. This can affect the vault's global share price but MUST NOT corrupt the vault-backed TIP-20's pro-rata accounting.
+- **Wrapped vault depositor checks:** apply to the vault-backed TIP-20 contract as the vault depositor. Per-end-holder vault limits or allowlists are outside the assumptions of this TIP.
 - **TIP-403 policy:** controls TIP-20 transfer authorization. The current policy can be updated by `DEFAULT_ADMIN_ROLE`.
 - **Admin roles:** trusted to update the TIP-403 policy and pause or unpause vault-backed TIP-20 operations.
 - **Factory:** trusted to bind each vault-backed TIP-20 to the intended immutable vault and initial policy during creation.
@@ -164,22 +166,21 @@ The vault-backed TIP-20 stores:
 address immutable vault;
 address immutable asset;
 uint64 policyId;
-uint256 accountedVaultShares;
 ```
 
-`accountedVaultShares` is the total number of wrapped-vault shares attributable to all outstanding TIP-20 balances. It is updated only by successful deposit, mint, withdraw, and redeem operations through the vault-backed TIP-20.
+TIP-20 `totalSupply()` is the total number of wrapped-vault shares attributable to all outstanding TIP-20 balances.
 
-TIP-20 `totalSupply()` MUST equal the sum of all holder balances and MUST also equal `accountedVaultShares`, except during the internal execution of a deposit, mint, withdraw, or redeem call before the final state transition completes.
+TIP-20 `totalSupply()` MUST equal the sum of all holder balances after every successful external call.
 
-`totalAssets()` MUST return `vault.convertToAssets(accountedVaultShares)`.
+`totalAssets()` MUST return `vault.convertToAssets(totalSupply())`.
 
 `convertToAssets(shares)` MUST return `vault.convertToAssets(shares)`.
 
 `convertToShares(assets)` MUST return `vault.convertToShares(assets)`.
 
-`maxDeposit(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return `vault.maxDeposit(address(this))`.
+`maxDeposit(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return `vault.maxDeposit(address(this))`, because the vault-backed TIP-20 contract is the depositor into the wrapped vault.
 
-`maxMint(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return `vault.maxMint(address(this))`.
+`maxMint(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return `vault.maxMint(address(this))`, because the vault-backed TIP-20 contract is the depositor into the wrapped vault.
 
 `maxWithdraw(owner)` MUST return `0` if the vault-backed TIP-20 is paused. Otherwise, it MUST return the smaller of `convertToAssets(balanceOf(owner))` and `vault.maxWithdraw(address(this))`.
 
@@ -198,9 +199,8 @@ If the wrapped vault's share price changes because of yield, rewards, donations,
 5. Approve or otherwise provide those assets to the wrapped vault.
 6. Call `vault.deposit(assets, address(this))`.
 7. Let `shares` be the number of vault shares returned by the wrapped vault.
-8. Increase `accountedVaultShares` by `shares`.
-9. Mint exactly `shares` TIP-20 units to `receiver`.
-10. Emit the ordinary TIP-20 `Transfer(address(0), receiver, shares)` event and `Deposit`.
+8. Mint exactly `shares` TIP-20 units to `receiver`.
+9. Emit the ordinary TIP-20 `Transfer(address(0), receiver, shares)` event and `Deposit`.
 
 `mint(shares, receiver)` MUST follow the same rules, except it calls `vault.mint(shares, address(this))`, transfers the returned asset amount from `msg.sender`, and mints exactly `shares` TIP-20 units to `receiver`.
 
@@ -222,11 +222,10 @@ event Deposit(
 3. Spend TIP-20 allowance from `owner` when `msg.sender != owner`, using ordinary TIP-20 allowance rules.
 4. Compute `shares` using the wrapped vault's withdrawal semantics.
 5. Burn exactly `shares` TIP-20 units from `owner`.
-6. Decrease `accountedVaultShares` by `shares`.
-7. Call `vault.withdraw(assets, receiver, address(this))`, causing the wrapped vault to send assets directly to `receiver`.
-8. Emit the ordinary TIP-20 `Transfer(owner, address(0), shares)` event and `Withdraw`.
+6. Call `vault.withdraw(assets, receiver, address(this))`, causing the wrapped vault to send assets directly to `receiver`.
+7. Emit the ordinary TIP-20 `Transfer(owner, address(0), shares)` event and `Withdraw`.
 
-`redeem(shares, receiver, owner)` MUST follow the same rules, except it burns exactly `shares`, decreases `accountedVaultShares` by `shares`, and calls `vault.redeem(shares, receiver, address(this))`.
+`redeem(shares, receiver, owner)` MUST follow the same rules, except it burns exactly `shares` and calls `vault.redeem(shares, receiver, address(this))`.
 
 ```solidity
 event Withdraw(
@@ -283,6 +282,7 @@ This TIP does not:
 
 - Define a vault reward, donation, or accumulator mechanism.
 - Require the wrapped vault to exclude other depositors.
+- Support wrapped vaults that need per-end-holder vault limits, per-end-holder vault allowlists, or other per-end-holder vault depositor logic.
 - Require the wrapped vault to expose ERC-20 share functions.
 - Allow changing the wrapped vault after token creation.
 - Add privileged mint or burn powers to the vault-backed TIP-20.
@@ -304,10 +304,10 @@ Ordinary TIP-20 `Transfer` and approval events remain sufficient for balance, su
 
 - `vault` and `asset` are immutable for the lifetime of the vault-backed TIP-20.
 - `asset == IERC4626(vault).asset()`.
-- `totalSupply() == accountedVaultShares` after every successful external call.
+- `totalSupply()` equals the sum of all holder balances after every successful external call.
 - `balanceOf(account)` is the account's transferable vault-share claim.
 - `convertToAssets(balanceOf(account))` is the account's current pro-rata claim on wrapped-vault assets according to the wrapped vault.
-- TIP-20 transfers do not call the wrapped vault and do not change `accountedVaultShares`.
-- Deposits and mints increase `accountedVaultShares` and `totalSupply()` by exactly the vault shares returned by the wrapped vault.
-- Withdrawals and redeems decrease `accountedVaultShares` and `totalSupply()` by exactly the vault shares burned from the owner.
+- TIP-20 transfers do not call the wrapped vault and do not change `totalSupply()`.
+- Deposits and mints increase `totalSupply()` by exactly the vault shares returned by the wrapped vault.
+- Withdrawals and redeems decrease `totalSupply()` by exactly the vault shares burned from the owner.
 - The vault-backed TIP-20 never mints, burns, or transfers TIP-20 balances without applying the same current policy and allowance rules that apply to the equivalent ordinary TIP-20 operation.

--- a/tips/tip-1080.md
+++ b/tips/tip-1080.md
@@ -22,6 +22,8 @@ TIP-20 tokens are the native token surface for Tempo wallets, policy checks, ind
 
 This can be done without requiring the vault to become a TIP-20 token. Instead, the TIP-20 can act as the vault's aggregate depositor. From the vault's perspective, the TIP-20 token contract is an ordinary holder. From the user's perspective, TIP-20 balances are transferable vault claims, and deposit or withdrawal uses an ERC-4626-like interface on the TIP-20 token.
 
+The vault can be an existing ERC-4626 vault, or it can be a custom vault-like contract that exposes the required ERC-4626-compatible interface only to the vault-backed TIP-20. A custom vault-like contract used only through one vault-backed TIP-20 can keep its own accounting simpler than a general-purpose ERC-4626 vault, because the vault-backed TIP-20 tracks end-holder balances and the vault only needs to account for the aggregate wrapper position.
+
 This keeps responsibilities separated:
 
 - TIP-20 handles transfers, allowances, metadata, factory registration, and TIP-403 policy enforcement.
@@ -31,7 +33,8 @@ This keeps responsibilities separated:
 ## Assumptions
 
 - The wrapped vault exposes ERC-4626-compatible `asset`, accounting, deposit, and withdrawal functions. The vault MAY also expose ERC-20 share functions, but the vault-backed TIP-20 MUST NOT rely on vault share transferability.
-- The wrapped vault's `asset()` return value is immutable for the lifetime of the vault-backed TIP-20.
+- The wrapped vault's `asset()` return value is immutable.
+- The wrapped vault's `asset()` return value is a TIP-20 token.
 - The wrapped vault's share balances SHOULD NOT rebase. Yield, rewards, donations, fees, losses, and other value changes SHOULD be reflected through the vault's asset-per-share accounting rather than by changing share balances.
 - The wrapped vault MAY accept other depositors. The vault-backed TIP-20 MUST NOT assume it is the only vault participant.
 - The wrapped vault MUST be compatible with the vault-backed TIP-20 contract acting as an aggregate depositor. Vault limits, allowlists, fees, and other depositor-specific behavior apply to the vault-backed TIP-20 contract, not to the end holders of the TIP-20 balances. End-holder-specific checks MAY be implemented by the vault-backed TIP-20's optional hook contract.
@@ -82,11 +85,11 @@ function createVaultToken(
 `createVaultToken` MUST:
 
 1. Validate `vault != address(0)`.
-2. Validate that `vault.asset()` returns a nonzero address.
+2. Validate that `vault.asset()` returns a nonzero TIP-20 token address.
 3. Validate `policyId` using the same TIP-403 policy existence rules that apply to ordinary TIP-20 token policy configuration.
-4. Deploy or initialize a TIP-20 token whose `vault` is immutable and whose initial `policyId` is `policyId`.
+4. Deploy a TIP-20 token whose `vault` is immutable and whose initial `policyId` is `policyId`.
 5. Register the created token as a TIP-20 token, so `isTIP20(token) == true`.
-6. Emit `VaultTokenCreated`.
+6. Emit `VaultTokenCreated` and the existing `TokenCreated` event.
 
 ```solidity
 event VaultTokenCreated(
@@ -101,7 +104,7 @@ event VaultTokenCreated(
 );
 ```
 
-The factory MAY also emit the existing `TokenCreated` event for compatibility with indexers that already consume TIP-20 factory events.
+The factory MUST also emit the existing `TokenCreated` event for compatibility with indexers that already consume TIP-20 factory events.
 
 ## Vault Interface
 
@@ -130,7 +133,7 @@ The wrapped vault MAY omit ERC-20 functions such as `balanceOf`, `transfer`, `tr
 
 ## Vault-Backed TIP-20 Interface
 
-A vault-backed TIP-20 MUST expose all ordinary TIP-20 behavior and the following ERC-4626-like methods:
+A vault-backed TIP-20 MUST expose ordinary TIP-20 transfer, approval, metadata, factory-registration, and policy behavior, but MUST NOT expose standalone TIP-20 mint or burn entrypoints. The only ways to mint or burn vault-backed TIP-20 balances are the ERC-4626-like methods below:
 
 ```solidity
 function asset() external view returns (address);
@@ -348,7 +351,8 @@ This TIP does not:
 
 Implementations MUST emit:
 
-- `VaultTokenCreated`: answers which factory-created TIP-20 tokens are vault-backed, and which immutable vault and policy each token uses.
+- `VaultTokenCreated`: answers which factory-created TIP-20 tokens are vault-backed, and which immutable vault and initial policy each token uses.
+- `TokenCreated`: preserves compatibility with existing TIP-20 factory indexers.
 - `Deposit`: answers who deposited assets and which owner received new TIP-20 shares.
 - `Withdraw`: answers who initiated a withdrawal or redemption, which owner burned TIP-20 shares, and which receiver received assets.
 - `PolicyUpdated`: answers when the current TIP-403 policy changes.
@@ -361,6 +365,7 @@ Ordinary TIP-20 `Transfer` and approval events remain sufficient for balance, su
 
 - `vault` and `asset` are immutable for the lifetime of the vault-backed TIP-20.
 - `asset == IERC4626(vault).asset()`.
+- `isTIP20(asset) == true`.
 - `totalSupply()` equals the sum of all holder balances after every successful external call.
 - `balanceOf(account)` is the account's transferable vault-share claim.
 - `convertToAssets(balanceOf(account))` is the account's current pro-rata claim on wrapped-vault assets according to the wrapped vault.

--- a/tips/tip-1080.md
+++ b/tips/tip-1080.md
@@ -26,23 +26,25 @@ This keeps responsibilities separated:
 
 - TIP-20 handles transfers, allowances, metadata, factory registration, and TIP-403 policy enforcement.
 - The vault handles share-price growth, rewards, donations, allocation, fees, limits, and withdrawal mechanics.
-- The factory binds the TIP-20 to a fixed vault and a fixed TIP-403 policy at creation time.
+- The factory binds the TIP-20 to a fixed vault and an initial TIP-403 policy at creation time.
 
 ## Assumptions
 
 - The wrapped vault exposes ERC-4626-compatible `asset`, accounting, deposit, and withdrawal functions. The vault MAY also expose ERC-20 share functions, but the vault-backed TIP-20 MUST NOT rely on vault share transferability.
 - The wrapped vault's `asset()` return value is immutable for the lifetime of the vault-backed TIP-20.
+- The wrapped vault's share balances SHOULD NOT rebase. Yield, rewards, donations, fees, losses, and other value changes SHOULD be reflected through the vault's asset-per-share accounting rather than by changing share balances.
 - The wrapped vault MAY accept other depositors. The vault-backed TIP-20 MUST NOT assume it is the only vault participant.
-- All reward, donation, fee, allocation, pause, withdrawal-limit, and risk logic is owned by the wrapped vault and is outside the TIP-20 wrapper.
-- The vault-backed TIP-20's configured vault and TIP-403 policy are immutable after deployment.
+- All reward, donation, fee, allocation, rounding, withdrawal-limit, and risk logic is owned by the wrapped vault and is outside the TIP-20 wrapper.
+- The vault-backed TIP-20's configured vault is immutable after deployment. Its TIP-403 policy MAY be updated by `DEFAULT_ADMIN_ROLE`.
 
 ## Threat Model
 
 - **Vault operator or vault logic:** trusted to account for deposits, withdrawals, share-price growth, rewards, fees, and limits correctly. A malicious or buggy vault can reduce or block the value represented by the vault-backed TIP-20.
 - **TIP-20 holder:** may transfer balances, approve allowances, deposit assets, and withdraw assets subject to TIP-20 policy and vault behavior.
 - **External depositor into the vault:** may deposit directly into the wrapped vault if the vault permits it. This can affect the vault's global share price but MUST NOT corrupt the vault-backed TIP-20's pro-rata accounting.
-- **TIP-403 policy:** controls TIP-20 transfer authorization. The policy is immutable for the vault-backed TIP-20.
-- **Factory:** trusted to bind each vault-backed TIP-20 to the intended immutable vault and policy during creation.
+- **TIP-403 policy:** controls TIP-20 transfer authorization. The current policy can be updated by `DEFAULT_ADMIN_ROLE`.
+- **Admin roles:** trusted to update the TIP-403 policy and pause or unpause vault-backed TIP-20 operations.
+- **Factory:** trusted to bind each vault-backed TIP-20 to the intended immutable vault and initial policy during creation.
 
 ---
 
@@ -59,7 +61,7 @@ The TIP-20 factory is extended with:
 /// @param symbol The TIP-20 symbol.
 /// @param currency The ISO or issuer-defined currency string.
 /// @param quoteToken The quote token used by existing TIP-20 factory rules.
-/// @param policyId The immutable TIP-403 policy ID for this token.
+/// @param policyId The initial TIP-403 policy ID for this token.
 /// @param vault The immutable external vault backing this token.
 /// @param salt The deterministic address salt.
 /// @return token The created vault-backed TIP-20 token address.
@@ -79,7 +81,7 @@ function createVaultToken(
 1. Validate `vault != address(0)`.
 2. Validate that `vault.asset()` returns a nonzero address.
 3. Validate `policyId` using the same TIP-403 policy existence rules that apply to ordinary TIP-20 token policy configuration.
-4. Deploy or initialize a TIP-20 token whose `vault` and `policyId` are immutable.
+4. Deploy or initialize a TIP-20 token whose `vault` is immutable and whose initial `policyId` is `policyId`.
 5. Register the created token as a TIP-20 token, so `isTIP20(token) == true`.
 6. Emit `VaultTokenCreated`.
 
@@ -146,6 +148,10 @@ function deposit(uint256 assets, address receiver) external returns (uint256 sha
 function mint(uint256 shares, address receiver) external returns (uint256 assets);
 function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares);
 function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
+function paused() external view returns (bool);
+function updatePolicy(uint64 newPolicyId) external;
+function pause() external;
+function unpause() external;
 ```
 
 In this interface, "shares" means vault-backed TIP-20 units. A user's TIP-20 balance is their share balance. Transferring TIP-20 balances transfers the corresponding pro-rata vault claim without interacting with the wrapped vault.
@@ -157,7 +163,7 @@ The vault-backed TIP-20 stores:
 ```solidity
 address immutable vault;
 address immutable asset;
-uint64 immutable policyId;
+uint64 policyId;
 uint256 accountedVaultShares;
 ```
 
@@ -171,29 +177,30 @@ TIP-20 `totalSupply()` MUST equal the sum of all holder balances and MUST also e
 
 `convertToShares(assets)` MUST return `vault.convertToShares(assets)`.
 
-`maxDeposit(receiver)` MUST return `0` if minting TIP-20 shares to `receiver` would fail the immutable TIP-403 policy. Otherwise, it MUST return `vault.maxDeposit(address(this))`.
+`maxDeposit(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return `vault.maxDeposit(address(this))`.
 
-`maxMint(receiver)` MUST return `0` if minting TIP-20 shares to `receiver` would fail the immutable TIP-403 policy. Otherwise, it MUST return `vault.maxMint(address(this))`.
+`maxMint(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return `vault.maxMint(address(this))`.
 
-`maxWithdraw(owner)` MUST return the smaller of `convertToAssets(balanceOf(owner))` and `vault.maxWithdraw(address(this))`.
+`maxWithdraw(owner)` MUST return `0` if the vault-backed TIP-20 is paused. Otherwise, it MUST return the smaller of `convertToAssets(balanceOf(owner))` and `vault.maxWithdraw(address(this))`.
 
-`maxRedeem(owner)` MUST return the smaller of `balanceOf(owner)` and `vault.maxRedeem(address(this))`.
+`maxRedeem(owner)` MUST return `0` if the vault-backed TIP-20 is paused. Otherwise, it MUST return the smaller of `balanceOf(owner)` and `vault.maxRedeem(address(this))`.
 
-If the wrapped vault's share price increases because of yield, rewards, donations, or any other vault-native mechanism, the vault-backed TIP-20's `totalAssets()` and `convertToAssets(balanceOf(user))` reflect that increase automatically. The TIP-20 wrapper MUST NOT implement separate reward accounting.
+If the wrapped vault's share price changes because of yield, rewards, donations, fees, losses, rounding, or any other vault-native mechanism, the vault-backed TIP-20's `totalAssets()` and `convertToAssets(balanceOf(user))` reflect that change automatically. The TIP-20 wrapper MUST NOT implement separate reward, fee, or rounding accounting.
 
 ## Deposits and Mints
 
 `deposit(assets, receiver)` MUST:
 
 1. Reject `receiver == address(0)`.
-2. Enforce the token's immutable TIP-403 policy for minting to `receiver`.
-3. Transfer `assets` of `asset()` from `msg.sender` to the vault-backed TIP-20.
-4. Approve or otherwise provide those assets to the wrapped vault.
-5. Call `vault.deposit(assets, address(this))`.
-6. Let `shares` be the number of vault shares returned by the wrapped vault.
-7. Increase `accountedVaultShares` by `shares`.
-8. Mint exactly `shares` TIP-20 units to `receiver`.
-9. Emit the ordinary TIP-20 `Transfer(address(0), receiver, shares)` event and `Deposit`.
+2. Reject if the vault-backed TIP-20 is paused.
+3. Enforce the token's current TIP-403 policy for minting to `receiver`.
+4. Transfer `assets` of `asset()` from `msg.sender` to the vault-backed TIP-20.
+5. Approve or otherwise provide those assets to the wrapped vault.
+6. Call `vault.deposit(assets, address(this))`.
+7. Let `shares` be the number of vault shares returned by the wrapped vault.
+8. Increase `accountedVaultShares` by `shares`.
+9. Mint exactly `shares` TIP-20 units to `receiver`.
+10. Emit the ordinary TIP-20 `Transfer(address(0), receiver, shares)` event and `Deposit`.
 
 `mint(shares, receiver)` MUST follow the same rules, except it calls `vault.mint(shares, address(this))`, transfers the returned asset amount from `msg.sender`, and mints exactly `shares` TIP-20 units to `receiver`.
 
@@ -211,12 +218,13 @@ event Deposit(
 `withdraw(assets, receiver, owner)` MUST:
 
 1. Reject `receiver == address(0)`.
-2. Spend TIP-20 allowance from `owner` when `msg.sender != owner`, using ordinary TIP-20 allowance rules.
-3. Compute `shares` using the wrapped vault's withdrawal semantics.
-4. Burn exactly `shares` TIP-20 units from `owner`.
-5. Decrease `accountedVaultShares` by `shares`.
-6. Call `vault.withdraw(assets, receiver, address(this))`, causing the wrapped vault to send assets directly to `receiver`.
-7. Emit the ordinary TIP-20 `Transfer(owner, address(0), shares)` event and `Withdraw`.
+2. Reject if the vault-backed TIP-20 is paused.
+3. Spend TIP-20 allowance from `owner` when `msg.sender != owner`, using ordinary TIP-20 allowance rules.
+4. Compute `shares` using the wrapped vault's withdrawal semantics.
+5. Burn exactly `shares` TIP-20 units from `owner`.
+6. Decrease `accountedVaultShares` by `shares`.
+7. Call `vault.withdraw(assets, receiver, address(this))`, causing the wrapped vault to send assets directly to `receiver`.
+8. Emit the ordinary TIP-20 `Transfer(owner, address(0), shares)` event and `Withdraw`.
 
 `redeem(shares, receiver, owner)` MUST follow the same rules, except it burns exactly `shares`, decreases `accountedVaultShares` by `shares`, and calls `vault.redeem(shares, receiver, address(this))`.
 
@@ -234,13 +242,40 @@ If a wrapped vault's `withdraw` or `redeem` sends assets to a different address 
 
 ## TIP-403 Policy
 
-The vault-backed TIP-20's TIP-403 policy is immutable. There is no token admin that can update the policy after creation.
+The vault-backed TIP-20 has a current TIP-403 policy. `DEFAULT_ADMIN_ROLE` MAY update the policy after creation. A policy update MUST validate the new policy ID using the same TIP-403 policy existence rules that apply to ordinary TIP-20 token policy configuration.
+
+```solidity
+event PolicyUpdated(uint64 indexed oldPolicyId, uint64 indexed newPolicyId);
+```
 
 The policy applies to the TIP-20 balance movement:
 
 - Deposits and mints check the policy as a mint to `receiver`.
 - Transfers and `transferFrom` check the policy as ordinary TIP-20 transfers.
 - Withdrawals and redeems burn TIP-20 balances and do not create a new TIP-20 recipient, so they do not require a TIP-403 recipient check for the asset receiver. Any withdrawal restriction on the underlying asset receiver is the wrapped vault's responsibility.
+
+## Admin Roles and Pause
+
+A vault-backed TIP-20 MUST have `DEFAULT_ADMIN_ROLE`. The initial holder of `DEFAULT_ADMIN_ROLE` is the caller of `createVaultToken` unless the factory specifies another admin in a future interface.
+
+`DEFAULT_ADMIN_ROLE` MAY:
+
+- Grant and revoke other roles.
+- Update the token's current TIP-403 policy.
+
+A vault-backed TIP-20 MUST support a `PAUSER_ROLE`. An account with `PAUSER_ROLE` MAY pause and unpause the vault-backed TIP-20. When paused:
+
+- Deposits and mints MUST revert.
+- Withdrawals and redeems MUST revert.
+- Transfers and `transferFrom` MUST revert.
+- Approvals MAY remain available under ordinary TIP-20 rules.
+
+Admin roles MUST NOT add privileged mint or burn functions. The only ways to mint or burn vault-backed TIP-20 balances are the deposit, mint, withdraw, and redeem paths specified above.
+
+```solidity
+event Paused(address indexed account);
+event Unpaused(address indexed account);
+```
 
 ## Non-Goals
 
@@ -250,8 +285,7 @@ This TIP does not:
 - Require the wrapped vault to exclude other depositors.
 - Require the wrapped vault to expose ERC-20 share functions.
 - Allow changing the wrapped vault after token creation.
-- Allow changing the TIP-403 policy after token creation.
-- Add admin powers to the vault-backed TIP-20.
+- Add privileged mint or burn powers to the vault-backed TIP-20.
 - Define migration from an existing ordinary TIP-20 into a vault-backed TIP-20.
 
 # Observability
@@ -261,12 +295,14 @@ Implementations MUST emit:
 - `VaultTokenCreated`: answers which factory-created TIP-20 tokens are vault-backed, and which immutable vault and policy each token uses.
 - `Deposit`: answers who deposited assets and which owner received new TIP-20 shares.
 - `Withdraw`: answers who initiated a withdrawal or redemption, which owner burned TIP-20 shares, and which receiver received assets.
+- `PolicyUpdated`: answers when the current TIP-403 policy changes.
+- `Paused` and `Unpaused`: answer when vault-backed TIP-20 operations are paused or resumed.
 
 Ordinary TIP-20 `Transfer` and approval events remain sufficient for balance, supply, transfer, and allowance indexing.
 
 # Invariants
 
-- `vault`, `asset`, and `policyId` are immutable for the lifetime of the vault-backed TIP-20.
+- `vault` and `asset` are immutable for the lifetime of the vault-backed TIP-20.
 - `asset == IERC4626(vault).asset()`.
 - `totalSupply() == accountedVaultShares` after every successful external call.
 - `balanceOf(account)` is the account's transferable vault-share claim.
@@ -274,4 +310,4 @@ Ordinary TIP-20 `Transfer` and approval events remain sufficient for balance, su
 - TIP-20 transfers do not call the wrapped vault and do not change `accountedVaultShares`.
 - Deposits and mints increase `accountedVaultShares` and `totalSupply()` by exactly the vault shares returned by the wrapped vault.
 - Withdrawals and redeems decrease `accountedVaultShares` and `totalSupply()` by exactly the vault shares burned from the owner.
-- The vault-backed TIP-20 never mints, burns, or transfers TIP-20 balances without applying the same policy and allowance rules that apply to the equivalent ordinary TIP-20 operation.
+- The vault-backed TIP-20 never mints, burns, or transfers TIP-20 balances without applying the same current policy and allowance rules that apply to the equivalent ordinary TIP-20 operation.

--- a/tips/tip-1080.md
+++ b/tips/tip-1080.md
@@ -1,5 +1,5 @@
 ---
-id: TIP-1066
+id: TIP-1080
 title: Vault-Backed TIP-20 Tokens
 description: Add a TIP-20 factory path for tokens backed by an external ERC-4626-compatible vault.
 authors: Dan Robinson (@danrobinson)
@@ -8,7 +8,7 @@ related: TIP-20, TIP-403
 protocolVersion: TBD
 ---
 
-# TIP-1066: Vault-Backed TIP-20 Tokens
+# TIP-1080: Vault-Backed TIP-20 Tokens
 
 ## Abstract
 

--- a/tips/tip-1080.md
+++ b/tips/tip-1080.md
@@ -28,7 +28,7 @@ This keeps responsibilities separated:
 
 - TIP-20 handles transfers, allowances, metadata, factory registration, and TIP-403 policy enforcement.
 - The vault handles share-price growth, rewards, donations, allocation, fees, limits, and withdrawal mechanics.
-- The factory binds the TIP-20 to a fixed vault and an initial TIP-403 policy at creation time.
+- The factory binds the TIP-20 to a fixed vault and an initial TIP-403 transfer policy at creation time.
 
 ## Assumptions
 
@@ -39,7 +39,7 @@ This keeps responsibilities separated:
 - The wrapped vault MAY accept other depositors. The vault-backed TIP-20 MUST NOT assume it is the only vault participant.
 - The wrapped vault MUST be compatible with the vault-backed TIP-20 contract acting as one aggregated depositor. Vault limits, allowlists, fees, and other depositor-specific behavior apply to the vault-backed TIP-20 contract, not to the end holders of the TIP-20 balances. End-holder-specific checks MAY be implemented by the vault-backed TIP-20's optional hook contract.
 - All reward, donation, fee, allocation, rounding, withdrawal-limit, and risk logic is owned by the wrapped vault and is outside the TIP-20 wrapper.
-- The vault-backed TIP-20's configured vault is immutable after deployment. Its TIP-403 policy MAY be updated by `DEFAULT_ADMIN_ROLE`.
+- The vault-backed TIP-20's configured vault is immutable after deployment. Its TIP-403 transfer policy MAY be updated by `DEFAULT_ADMIN_ROLE`.
 
 ## Threat Model
 
@@ -48,9 +48,9 @@ This keeps responsibilities separated:
 - **External depositor into the vault:** may deposit directly into the wrapped vault if the vault permits it. This can affect the vault's global share price but MUST NOT corrupt the vault-backed TIP-20's pro-rata accounting.
 - **Wrapped vault depositor checks:** apply to the vault-backed TIP-20 contract as the vault depositor. Per-end-holder limits or allowlists can be implemented by the optional hook contract, but the wrapped vault itself only sees the vault-backed TIP-20 contract.
 - **Hook contract:** optionally trusted to enforce additional per-user deposit or mint limits. A malicious or buggy hook can block otherwise valid deposits or mints, or return incorrect max values.
-- **TIP-403 policy:** controls TIP-20 transfer authorization. The current policy can be updated by `DEFAULT_ADMIN_ROLE`.
-- **Admin roles:** trusted to update the TIP-403 policy, grant and revoke roles, and pause or unpause vault-backed TIP-20 operations according to ordinary TIP-20 role rules.
-- **Factory:** trusted to bind each vault-backed TIP-20 to the intended immutable vault and initial policy during creation.
+- **TIP-403 transfer policy:** controls TIP-20 transfer authorization. The current policy can be updated by `DEFAULT_ADMIN_ROLE`.
+- **Admin roles:** trusted to update the TIP-403 transfer policy, grant and revoke roles, and pause or unpause vault-backed TIP-20 operations according to ordinary TIP-20 role rules.
+- **Factory:** trusted to bind each vault-backed TIP-20 to the intended immutable vault and initial transfer policy during creation.
 
 ---
 
@@ -68,7 +68,7 @@ The TIP-20 factory is extended with:
 /// @param currency The ISO or issuer-defined currency string.
 /// @param quoteToken The quote token used by existing TIP-20 factory rules.
 /// @param admin The initial holder of DEFAULT_ADMIN_ROLE.
-/// @param policyId The initial TIP-403 policy ID for this token.
+/// @param transferPolicyId The initial TIP-403 transfer policy ID for this token.
 /// @param vault The immutable external vault backing this token.
 /// @param salt The deterministic address salt.
 /// @return token The created vault-backed TIP-20 token address.
@@ -78,7 +78,7 @@ function createVaultToken(
     string memory currency,
     address quoteToken,
     address admin,
-    uint64 policyId,
+    uint64 transferPolicyId,
     address vault,
     bytes32 salt
 ) external returns (address token);
@@ -89,8 +89,8 @@ function createVaultToken(
 1. Validate `vault != address(0)`.
 2. Validate `admin != address(0)`.
 3. Validate that `vault.asset()` returns a TIP-20 token address.
-4. Validate `policyId` using the same TIP-403 policy existence rules that apply to ordinary TIP-20 token policy configuration.
-5. Deploy a TIP-20 token whose `vault` is immutable, whose initial `policyId` is `policyId`, and whose initial `DEFAULT_ADMIN_ROLE` holder is `admin`.
+4. Validate `transferPolicyId` using the same TIP-403 policy existence rules that apply to ordinary TIP-20 token policy configuration.
+5. Deploy a TIP-20 token whose `vault` is immutable, whose initial `transferPolicyId` is `transferPolicyId`, and whose initial `DEFAULT_ADMIN_ROLE` holder is `admin`.
 6. Register the created token as a TIP-20 token, so `isTIP20(token) == true`.
 7. Emit the existing `TokenCreated` event and then `VaultTokenCreated`.
 
@@ -98,7 +98,7 @@ function createVaultToken(
 event VaultTokenCreated(
     address indexed token,
     address indexed vault,
-    uint64 indexed policyId,
+    uint64 indexed transferPolicyId,
     string name,
     string symbol,
     string currency,
@@ -133,7 +133,7 @@ function withdraw(uint256 assets, address receiver, address owner) external retu
 function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
 ```
 
-The wrapped vault MAY omit ERC-20 functions such as `balanceOf`, `transfer`, `transferFrom`, and `allowance`. The vault-backed TIP-20 MUST track the amount of vault shares attributable to the TIP-20 contract through the shares returned by vault deposit, mint, withdraw, and redeem calls, rather than by assuming ERC-20 share-balance reads are available.
+The wrapped vault MAY omit ERC-20 functions such as `balanceOf`, `transfer`, `transferFrom`, and `allowance`. The vault-backed TIP-20 MUST derive the number of vault shares minted or burned from the shares returned by vault deposit, mint, withdraw, and redeem calls, rather than by assuming ERC-20 share-balance reads are available.
 
 ## Vault-Backed TIP-20 Interface
 
@@ -142,7 +142,7 @@ A vault-backed TIP-20 MUST expose ordinary TIP-20 transfer, approval, metadata, 
 ```solidity
 function asset() external view returns (address);
 function vault() external view returns (address);
-function policyId() external view returns (uint64);
+function transferPolicyId() external view returns (uint64);
 function hook() external view returns (address);
 function totalAssets() external view returns (uint256);
 function convertToShares(uint256 assets) external view returns (uint256);
@@ -160,7 +160,7 @@ function mint(uint256 shares, address receiver) external returns (uint256 assets
 function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares);
 function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
 function paused() external view returns (bool);
-function updatePolicy(uint64 newPolicyId) external;
+function changeTransferPolicyId(uint64 newPolicyId) external;
 function updateHook(address newHook) external;
 function pause() external;
 function unpause() external;
@@ -175,7 +175,7 @@ The vault-backed TIP-20 stores:
 ```solidity
 address immutable vault;
 address immutable asset;
-uint64 policyId;
+uint64 transferPolicyId;
 address hook;
 ```
 
@@ -189,9 +189,9 @@ TIP-20 `totalSupply()` MUST equal the sum of all holder balances after every suc
 
 `convertToShares(assets)` MUST return `vault.convertToShares(assets)`.
 
-`maxDeposit(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return the smaller of `vault.maxDeposit(address(this))` and the current hook's `maxDeposit` value for `msg.sender` and `receiver`. If no hook is configured, the hook limit is treated as `type(uint128).max`.
+`maxDeposit(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 transfer policy. Otherwise, it MUST return the smaller of `vault.maxDeposit(address(this))` and the current hook's `maxDeposit` value for `msg.sender` and `receiver`. If no hook is configured, the hook limit is treated as `type(uint128).max`.
 
-`maxMint(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return the smaller of `vault.maxMint(address(this))` and the current hook's `maxMint` value for `msg.sender` and `receiver`. If no hook is configured, the hook limit is treated as `type(uint128).max`.
+`maxMint(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 transfer policy. Otherwise, it MUST return the smaller of `vault.maxMint(address(this))` and the current hook's `maxMint` value for `msg.sender` and `receiver`. If no hook is configured, the hook limit is treated as `type(uint128).max`.
 
 `maxWithdraw(owner)` MUST return `0` if the vault-backed TIP-20 is paused. Otherwise, it MUST return the smaller of `convertToAssets(balanceOf(owner))` and `vault.maxWithdraw(address(this))`.
 
@@ -205,16 +205,16 @@ If the wrapped vault's share price changes because of yield, rewards, donations,
 
 1. Reject `receiver == address(0)`.
 2. Reject if the vault-backed TIP-20 is paused.
-3. Enforce the token's current TIP-403 policy for minting to `receiver`.
+3. Enforce the token's current TIP-403 transfer policy for minting to `receiver`.
 4. Enforce the current hook's deposit check, if a hook is configured.
 5. Transfer `assets` of `asset()` from `msg.sender` to the vault-backed TIP-20.
 6. Approve or otherwise provide those assets to the wrapped vault.
 7. Call `vault.deposit(assets, address(this))`.
 8. Let `shares` be the number of vault shares returned by the wrapped vault.
 9. Mint exactly `shares` TIP-20 units to `receiver`.
-10. Emit the ordinary TIP-20 `Transfer(address(0), receiver, shares)` event and `Deposit`.
+10. Emit the ordinary TIP-20 `Transfer(address(0), receiver, shares)` event, the ordinary TIP-20 `Mint(receiver, shares)` event, and `Deposit`, in that order.
 
-`mint(shares, receiver)` MUST follow the same rules, except it computes the required asset amount using the wrapped vault's mint semantics, enforces the current hook's mint check if a hook is configured, transfers the required asset amount from `msg.sender`, approves or otherwise provides those assets to the wrapped vault, calls `vault.mint(shares, address(this))`, and mints exactly `shares` TIP-20 units to `receiver`.
+`mint(shares, receiver)` MUST follow the same rules, except it computes the required asset amount using the wrapped vault's mint semantics, enforces the current hook's mint check if a hook is configured, transfers the required asset amount from `msg.sender`, approves or otherwise provides those assets to the wrapped vault, calls `vault.mint(shares, address(this))`, mints exactly `shares` TIP-20 units to `receiver`, and emits the ordinary TIP-20 `Transfer(address(0), receiver, shares)` event, the ordinary TIP-20 `Mint(receiver, shares)` event, and `Deposit`, in that order.
 
 ```solidity
 event Deposit(
@@ -235,9 +235,9 @@ event Deposit(
 4. Compute `shares` using the wrapped vault's withdrawal semantics.
 5. Burn exactly `shares` TIP-20 units from `owner`.
 6. Call `vault.withdraw(assets, receiver, address(this))`, causing the wrapped vault to send assets directly to `receiver`.
-7. Emit the ordinary TIP-20 `Transfer(owner, address(0), shares)` event and `Withdraw`.
+7. Emit the ordinary TIP-20 `Transfer(owner, address(0), shares)` event, the ordinary TIP-20 `Burn(owner, shares)` event, and `Withdraw`, in that order.
 
-`redeem(shares, receiver, owner)` MUST follow the same rules, except it burns exactly `shares` and calls `vault.redeem(shares, receiver, address(this))`.
+`redeem(shares, receiver, owner)` MUST follow the same rules, except it burns exactly `shares`, calls `vault.redeem(shares, receiver, address(this))`, lets `assets` be the number of assets returned by the wrapped vault, and emits the ordinary TIP-20 `Transfer(owner, address(0), shares)` event, the ordinary TIP-20 `Burn(owner, shares)` event, and `Withdraw`, in that order.
 
 ```solidity
 event Withdraw(
@@ -251,12 +251,12 @@ event Withdraw(
 
 If a wrapped vault's `withdraw` or `redeem` sends assets to a different address than `receiver`, returns inconsistent shares or assets, or otherwise violates the ERC-4626-compatible interface, the vault is outside the assumptions of this TIP.
 
-## TIP-403 Policy
+## TIP-403 Transfer Policy
 
-The vault-backed TIP-20 has a current TIP-403 policy. `DEFAULT_ADMIN_ROLE` MAY update the policy after creation. A policy update MUST validate the new policy ID using the same TIP-403 policy existence rules that apply to ordinary TIP-20 token policy configuration.
+The vault-backed TIP-20 has a current TIP-403 transfer policy. `DEFAULT_ADMIN_ROLE` MAY update the policy after creation using ordinary TIP-20 `changeTransferPolicyId` behavior. A policy update MUST validate the new policy ID using the same TIP-403 policy existence rules that apply to ordinary TIP-20 token policy configuration.
 
 ```solidity
-event PolicyUpdated(uint64 indexed oldPolicyId, uint64 indexed newPolicyId);
+event TransferPolicyUpdate(address indexed updater, uint64 indexed newPolicyId);
 ```
 
 The policy applies to the TIP-20 balance movement:
@@ -272,7 +272,7 @@ A vault-backed TIP-20 MUST have `DEFAULT_ADMIN_ROLE`. The initial holder of `DEF
 `DEFAULT_ADMIN_ROLE` MAY:
 
 - Grant and revoke other roles.
-- Update the token's current TIP-403 policy.
+- Update the token's current TIP-403 transfer policy.
 - Update the token's current hook contract.
 
 A vault-backed TIP-20 MUST support the ordinary TIP-20 `PAUSE_ROLE` and `UNPAUSE_ROLE`. An account with `PAUSE_ROLE` MAY pause the vault-backed TIP-20. An account with `UNPAUSE_ROLE` MAY unpause the vault-backed TIP-20. When paused:
@@ -285,8 +285,7 @@ A vault-backed TIP-20 MUST support the ordinary TIP-20 `PAUSE_ROLE` and `UNPAUSE
 Admin roles MUST NOT add privileged mint or burn functions. The only ways to mint or burn vault-backed TIP-20 balances are the deposit, mint, withdraw, and redeem paths specified above.
 
 ```solidity
-event Paused(address indexed account);
-event Unpaused(address indexed account);
+event PauseStateUpdate(address indexed updater, bool isPaused);
 ```
 
 ## Hook Contract
@@ -355,15 +354,15 @@ This TIP does not:
 
 Implementations MUST emit:
 
-- `VaultTokenCreated`: answers which factory-created TIP-20 tokens are vault-backed, and which immutable vault and initial policy each token uses.
 - `TokenCreated`: preserves compatibility with existing TIP-20 factory indexers.
+- `VaultTokenCreated`: answers which factory-created TIP-20 tokens are vault-backed, and which immutable vault and initial transfer policy each token uses.
 - `Deposit`: answers who deposited assets and which owner received new TIP-20 shares.
 - `Withdraw`: answers who initiated a withdrawal or redemption, which owner burned TIP-20 shares, and which receiver received assets.
-- `PolicyUpdated`: answers when the current TIP-403 policy changes.
+- `TransferPolicyUpdate`: answers when the current TIP-403 transfer policy changes.
 - `HookUpdated`: answers when the current hook contract changes.
-- `Paused` and `Unpaused`: answer when vault-backed TIP-20 operations are paused or resumed.
+- `PauseStateUpdate`: answers when vault-backed TIP-20 operations are paused or resumed.
 
-Ordinary TIP-20 `Transfer` and approval events remain sufficient for balance, supply, transfer, and allowance indexing.
+Ordinary TIP-20 `Transfer`, `Mint`, `Burn`, and approval events remain sufficient for balance, supply, transfer, and allowance indexing.
 
 # Invariants
 

--- a/tips/tip-1080.md
+++ b/tips/tip-1080.md
@@ -33,11 +33,11 @@ This keeps responsibilities separated:
 ## Assumptions
 
 - The wrapped vault exposes ERC-4626-compatible `asset`, accounting, deposit, and withdrawal functions. The vault MAY also expose ERC-20 share functions, but the vault-backed TIP-20 MUST NOT rely on vault share transferability.
-- The wrapped vault's `asset()` return value is immutable.
+- The wrapped vault's `asset()` return value MUST be immutable. If this assumption is violated, the vault-backed TIP-20's `asset()` value changes with the wrapped vault, and withdrawals or redeems will return the new asset when unwrapped.
 - The wrapped vault's `asset()` return value is a TIP-20 token.
 - The wrapped vault's share balances SHOULD NOT rebase. Yield, rewards, donations, fees, losses, and other value changes SHOULD be reflected through the vault's asset-per-share accounting rather than by changing share balances.
 - The wrapped vault MAY accept other depositors. The vault-backed TIP-20 MUST NOT assume it is the only vault participant.
-- The wrapped vault MUST be compatible with the vault-backed TIP-20 contract acting as one aggregated depositor. Vault limits, allowlists, fees, and other depositor-specific behavior apply to the vault-backed TIP-20 contract, not to the end holders of the TIP-20 balances. End-holder-specific checks MAY be implemented by the vault-backed TIP-20's optional hook contract.
+- The wrapped vault MUST be compatible with the vault-backed TIP-20 contract acting as one aggregated depositor. Vault limits, allowlists, fees, and other depositor-specific behavior apply to the vault-backed TIP-20 contract, not to the end holders of the TIP-20 balances. End-holder-specific checks MAY be implemented by the vault-backed TIP-20's optional vault hook contract.
 - All reward, donation, fee, allocation, rounding, withdrawal-limit, and risk logic is owned by the wrapped vault and is outside the TIP-20 wrapper.
 - The vault-backed TIP-20's configured vault is immutable after deployment. Its TIP-403 transfer policy MAY be updated by `DEFAULT_ADMIN_ROLE`.
 
@@ -46,8 +46,8 @@ This keeps responsibilities separated:
 - **Vault operator or vault logic:** trusted to account for deposits, withdrawals, share-price growth, rewards, fees, and limits correctly. A malicious or buggy vault can reduce or block the value represented by the vault-backed TIP-20.
 - **TIP-20 holder:** may transfer balances, approve allowances, deposit assets, and withdraw assets subject to TIP-20 policy and vault behavior.
 - **External depositor into the vault:** may deposit directly into the wrapped vault if the vault permits it. This can affect the vault's global share price but MUST NOT corrupt the vault-backed TIP-20's pro-rata accounting.
-- **Wrapped vault depositor checks:** apply to the vault-backed TIP-20 contract as the vault depositor. Per-end-holder limits or allowlists can be implemented by the optional hook contract, but the wrapped vault itself only sees the vault-backed TIP-20 contract.
-- **Hook contract:** optionally trusted to enforce additional per-user deposit or mint limits. A malicious or buggy hook can block otherwise valid deposits or mints, or return incorrect max values.
+- **Wrapped vault depositor checks:** apply to the vault-backed TIP-20 contract as the vault depositor. Per-end-holder limits or allowlists can be implemented by the optional vault hook contract, but the wrapped vault itself only sees the vault-backed TIP-20 contract.
+- **Vault hook contract:** optionally trusted to enforce additional per-user deposit or mint limits. A malicious or buggy vault hook can block otherwise valid deposits or mints, or return incorrect max values.
 - **TIP-403 transfer policy:** controls TIP-20 transfer authorization. The current policy can be updated by `DEFAULT_ADMIN_ROLE`.
 - **Admin roles:** trusted to update the TIP-403 transfer policy, grant and revoke roles, and pause or unpause vault-backed TIP-20 operations according to ordinary TIP-20 role rules.
 - **Factory:** trusted to bind each vault-backed TIP-20 to the intended immutable vault and initial transfer policy during creation.
@@ -145,7 +145,7 @@ For clarity, a vault-backed TIP-20 MUST support the following ordinary TIP-20 fu
 - Transfers and approvals: `transfer`, `transferWithMemo`, `approve`, `allowance`, `transferFrom`, `transferFromWithMemo`, `permit`, `nonces`, and `DOMAIN_SEPARATOR`.
 - Transfer-policy, pause, logo, and role administration: `transferPolicyId`, `changeTransferPolicyId`, `paused`, `pause`, `unpause`, `setLogoURI`, `PAUSE_ROLE`, `UNPAUSE_ROLE`, and ordinary role-management functions.
 
-A vault-backed TIP-20 MUST NOT support ordinary TIP-20 standalone issuance or direct burn entrypoints that bypass the vault. Calls to ordinary TIP-20 `mint(address,uint256)`, `mintWithMemo`, `burn`, and `burnWithMemo` MUST revert. Minting and burning vault-backed TIP-20 balances remains available only through the ERC-4626-like `deposit`, `mint(uint256,address)`, `withdraw`, and `redeem` functions, which keep TIP-20 supply synchronized with the wrapped vault share balance. Vault or hook limits are represented through the ERC-4626-like `maxDeposit` and `maxMint` functions.
+A vault-backed TIP-20 MUST NOT support ordinary TIP-20 standalone issuance or direct burn entrypoints that bypass the vault. Calls to ordinary TIP-20 `mint(address,uint256)`, `mintWithMemo`, `burn`, and `burnWithMemo` MUST revert. Minting and burning vault-backed TIP-20 balances remains available only through the ERC-4626-like `deposit`, `mint(uint256,address)`, `withdraw`, and `redeem` functions, which keep TIP-20 supply synchronized with the wrapped vault share balance. Vault or vault hook limits are represented through the ERC-4626-like `maxDeposit` and `maxMint` functions.
 
 The additional vault-backed interface is:
 
@@ -153,7 +153,7 @@ The additional vault-backed interface is:
 function asset() external view returns (address);
 function vault() external view returns (address);
 function transferPolicyId() external view returns (uint64);
-function hook() external view returns (address);
+function vaultHook() external view returns (address);
 function totalAssets() external view returns (uint256);
 function convertToShares(uint256 assets) external view returns (uint256);
 function convertToAssets(uint256 shares) external view returns (uint256);
@@ -171,7 +171,7 @@ function withdraw(uint256 assets, address receiver, address owner) external retu
 function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
 function paused() external view returns (bool);
 function changeTransferPolicyId(uint64 newPolicyId) external;
-function updateHook(address newHook) external;
+function updateVaultHook(address newVaultHook) external;
 function pause() external;
 function unpause() external;
 ```
@@ -186,7 +186,7 @@ The vault-backed TIP-20 stores:
 address immutable vault;
 address immutable asset;
 uint64 transferPolicyId;
-address hook;
+address vaultHook;
 ```
 
 TIP-20 `totalSupply()` is the total number of wrapped-vault shares attributable to all outstanding TIP-20 balances.
@@ -199,9 +199,9 @@ TIP-20 `totalSupply()` MUST equal the sum of all holder balances after every suc
 
 `convertToShares(assets)` MUST return `vault.convertToShares(assets)`.
 
-`maxDeposit(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 transfer policy. Otherwise, it MUST return the smaller of `vault.maxDeposit(address(this))` and the current hook's `maxDeposit` value for `msg.sender` and `receiver`. If no hook is configured, the hook limit is treated as `type(uint128).max`.
+`maxDeposit(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 transfer policy. Otherwise, it MUST return the smaller of `vault.maxDeposit(address(this))` and the current vault hook's `maxDeposit` value for `msg.sender` and `receiver`. If no vault hook is configured, the vault hook limit is treated as `type(uint128).max`.
 
-`maxMint(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 transfer policy. Otherwise, it MUST return the smaller of `vault.maxMint(address(this))` and the current hook's `maxMint` value for `msg.sender` and `receiver`. If no hook is configured, the hook limit is treated as `type(uint128).max`.
+`maxMint(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 transfer policy. Otherwise, it MUST return the smaller of `vault.maxMint(address(this))` and the current vault hook's `maxMint` value for `msg.sender` and `receiver`. If no vault hook is configured, the vault hook limit is treated as `type(uint128).max`.
 
 `maxWithdraw(owner)` MUST return `0` if the vault-backed TIP-20 is paused. Otherwise, it MUST return the smaller of `convertToAssets(balanceOf(owner))` and `vault.maxWithdraw(address(this))`.
 
@@ -216,7 +216,7 @@ If the wrapped vault's share price changes because of yield, rewards, donations,
 1. Reject `receiver == address(0)`.
 2. Reject if the vault-backed TIP-20 is paused.
 3. Enforce the token's current TIP-403 transfer policy for minting to `receiver`.
-4. Enforce the current hook's deposit check, if a hook is configured.
+4. Enforce the current vault hook's deposit check, if a vault hook is configured.
 5. Transfer `assets` of `asset()` from `msg.sender` to the vault-backed TIP-20.
 6. Approve or otherwise provide those assets to the wrapped vault.
 7. Call `vault.deposit(assets, address(this))`.
@@ -224,7 +224,7 @@ If the wrapped vault's share price changes because of yield, rewards, donations,
 9. Mint exactly `shares` TIP-20 units to `receiver`.
 10. Emit the ordinary TIP-20 `Transfer(address(0), receiver, shares)` event, the ordinary TIP-20 `Mint(receiver, shares)` event, and `Deposit`, in that order.
 
-`mint(shares, receiver)` MUST follow the same rules, except it computes the required asset amount using the wrapped vault's mint semantics, enforces the current hook's mint check if a hook is configured, transfers the required asset amount from `msg.sender`, approves or otherwise provides those assets to the wrapped vault, calls `vault.mint(shares, address(this))`, mints exactly `shares` TIP-20 units to `receiver`, and emits the ordinary TIP-20 `Transfer(address(0), receiver, shares)` event, the ordinary TIP-20 `Mint(receiver, shares)` event, and `Deposit`, in that order.
+`mint(shares, receiver)` MUST follow the same rules, except it computes the required asset amount using the wrapped vault's mint semantics, enforces the current vault hook's mint check if a vault hook is configured, transfers the required asset amount from `msg.sender`, approves or otherwise provides those assets to the wrapped vault, calls `vault.mint(shares, address(this))`, mints exactly `shares` TIP-20 units to `receiver`, and emits the ordinary TIP-20 `Transfer(address(0), receiver, shares)` event, the ordinary TIP-20 `Mint(receiver, shares)` event, and `Deposit`, in that order.
 
 ```solidity
 event Deposit(
@@ -283,7 +283,7 @@ A vault-backed TIP-20 MUST have `DEFAULT_ADMIN_ROLE`. The initial holder of `DEF
 
 - Grant and revoke other roles.
 - Update the token's current TIP-403 transfer policy.
-- Update the token's current hook contract.
+- Update the token's current vault hook contract.
 
 A vault-backed TIP-20 MUST support the ordinary TIP-20 `PAUSE_ROLE` and `UNPAUSE_ROLE`. An account with `PAUSE_ROLE` MAY pause the vault-backed TIP-20. An account with `UNPAUSE_ROLE` MAY unpause the vault-backed TIP-20. When paused:
 
@@ -298,11 +298,11 @@ Admin roles MUST NOT add privileged mint or burn functions. The only ways to min
 event PauseStateUpdate(address indexed updater, bool isPaused);
 ```
 
-## Hook Contract
+## Vault Hook Contract
 
-A vault-backed TIP-20 MAY have an optional hook contract. The hook is not part of the wrapped vault. It is called by the vault-backed TIP-20 before deposits and mints, and by `maxDeposit` and `maxMint` to compute additional end-holder-specific limits.
+A vault-backed TIP-20 MAY have an optional vault hook contract. The vault hook is not part of the wrapped vault. It is called by the vault-backed TIP-20 before deposits and mints, and by `maxDeposit` and `maxMint` to compute additional end-holder-specific limits.
 
-The hook interface is:
+The vault hook interface is:
 
 ```solidity
 interface IVaultTokenHook {
@@ -334,20 +334,20 @@ interface IVaultTokenHook {
 }
 ```
 
-`DEFAULT_ADMIN_ROLE` MAY set the hook to any address or to `address(0)` to disable hooks. Hook updates MUST emit:
+`DEFAULT_ADMIN_ROLE` MAY set the vault hook to any address or to `address(0)` to disable vault hooks. Vault hook updates MUST emit:
 
 ```solidity
-event HookUpdated(address indexed oldHook, address indexed newHook);
+event HookUpdate(address indexed oldVaultHook, address indexed newVaultHook);
 ```
 
-When a hook is configured:
+When a vault hook is configured:
 
 - `deposit` MUST compute the expected share amount using `previewDeposit(assets)`, then call `beforeDeposit(msg.sender, receiver, assets, previewShares)` before transferring assets.
 - `mint` MUST compute the required asset amount using the wrapped vault's mint semantics, then call `beforeMint(msg.sender, receiver, shares, assets)` before transferring assets.
 
-Hook `before*` functions authorize by returning successfully and reject by reverting. Hook `max*` functions MUST NOT revert during normal operation; if a hook `max*` call reverts, the corresponding vault-backed TIP-20 max function MUST return `0`. Because ERC-4626 `maxDeposit` and `maxMint` do not include an explicit caller argument, the vault-backed TIP-20 passes `msg.sender` as the hook `caller` for max queries; a max query made by a relayer or offchain caller only answers for that caller.
+Vault hook `before*` functions authorize by returning successfully and reject by reverting. Vault hook `max*` functions MUST NOT revert during normal operation; if a vault hook `max*` call reverts, the corresponding vault-backed TIP-20 max function MUST return `0`. Because ERC-4626 `maxDeposit` and `maxMint` do not include an explicit caller argument, the vault-backed TIP-20 passes `msg.sender` as the vault hook `caller` for max queries; a max query made by a relayer or offchain caller only answers for that caller.
 
-The hook cannot change the wrapped vault, cannot mint or burn vault-backed TIP-20 balances directly, and cannot move assets by itself. It only constrains the wrapper's own deposit and mint entrypoints.
+The vault hook cannot change the wrapped vault, cannot mint or burn vault-backed TIP-20 balances directly, and cannot move assets by itself. It only constrains the wrapper's own deposit and mint entrypoints.
 
 ## Non-Goals
 
@@ -369,7 +369,7 @@ Implementations MUST emit:
 - `Deposit`: answers who deposited assets and which owner received new TIP-20 shares.
 - `Withdraw`: answers who initiated a withdrawal or redemption, which owner burned TIP-20 shares, and which receiver received assets.
 - `TransferPolicyUpdate`: answers when the current TIP-403 transfer policy changes.
-- `HookUpdated`: answers when the current hook contract changes.
+- `HookUpdate`: answers when the current vault hook contract changes.
 - `PauseStateUpdate`: answers when vault-backed TIP-20 operations are paused or resumed.
 
 Ordinary TIP-20 `Transfer`, `Mint`, `Burn`, and approval events remain sufficient for balance, supply, transfer, and allowance indexing.

--- a/tips/tip-1080.md
+++ b/tips/tip-1080.md
@@ -44,7 +44,7 @@ This keeps responsibilities separated:
 - **TIP-20 holder:** may transfer balances, approve allowances, deposit assets, and withdraw assets subject to TIP-20 policy and vault behavior.
 - **External depositor into the vault:** may deposit directly into the wrapped vault if the vault permits it. This can affect the vault's global share price but MUST NOT corrupt the vault-backed TIP-20's pro-rata accounting.
 - **Wrapped vault depositor checks:** apply to the vault-backed TIP-20 contract as the vault depositor. Per-end-holder limits or allowlists can be implemented by the optional hook contract, but the wrapped vault itself only sees the vault-backed TIP-20 contract.
-- **Hook contract:** optionally trusted to enforce additional per-user deposit, mint, withdrawal, or redemption limits. A malicious or buggy hook can block otherwise valid operations or return incorrect max values.
+- **Hook contract:** optionally trusted to enforce additional per-user deposit or mint limits. A malicious or buggy hook can block otherwise valid deposits or mints, or return incorrect max values.
 - **TIP-403 policy:** controls TIP-20 transfer authorization. The current policy can be updated by `DEFAULT_ADMIN_ROLE`.
 - **Admin roles:** trusted to update the TIP-403 policy and pause or unpause vault-backed TIP-20 operations.
 - **Factory:** trusted to bind each vault-backed TIP-20 to the intended immutable vault and initial policy during creation.
@@ -186,9 +186,9 @@ TIP-20 `totalSupply()` MUST equal the sum of all holder balances after every suc
 
 `maxMint(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return the smaller of `vault.maxMint(address(this))` and the current hook's `maxMint` value for `msg.sender` and `receiver`. If no hook is configured, the hook limit is treated as `type(uint256).max`.
 
-`maxWithdraw(owner)` MUST return `0` if the vault-backed TIP-20 is paused. Otherwise, it MUST return the smaller of `convertToAssets(balanceOf(owner))`, `vault.maxWithdraw(address(this))`, and the current hook's `maxWithdraw` value for `msg.sender` and `owner`. If no hook is configured, the hook limit is treated as `type(uint256).max`.
+`maxWithdraw(owner)` MUST return `0` if the vault-backed TIP-20 is paused. Otherwise, it MUST return the smaller of `convertToAssets(balanceOf(owner))` and `vault.maxWithdraw(address(this))`.
 
-`maxRedeem(owner)` MUST return `0` if the vault-backed TIP-20 is paused. Otherwise, it MUST return the smaller of `balanceOf(owner)`, `vault.maxRedeem(address(this))`, and the current hook's `maxRedeem` value for `msg.sender` and `owner`. If no hook is configured, the hook limit is treated as `type(uint256).max`.
+`maxRedeem(owner)` MUST return `0` if the vault-backed TIP-20 is paused. Otherwise, it MUST return the smaller of `balanceOf(owner)` and `vault.maxRedeem(address(this))`.
 
 If the wrapped vault's share price changes because of yield, rewards, donations, fees, losses, rounding, or any other vault-native mechanism, the vault-backed TIP-20's `totalAssets()` and `convertToAssets(balanceOf(user))` reflect that change automatically. The TIP-20 wrapper MUST NOT implement separate reward, fee, or rounding accounting.
 
@@ -226,12 +226,11 @@ event Deposit(
 2. Reject if the vault-backed TIP-20 is paused.
 3. Spend TIP-20 allowance from `owner` when `msg.sender != owner`, using ordinary TIP-20 allowance rules.
 4. Compute `shares` using the wrapped vault's withdrawal semantics.
-5. Enforce the current hook's withdrawal check, if a hook is configured.
-6. Burn exactly `shares` TIP-20 units from `owner`.
-7. Call `vault.withdraw(assets, receiver, address(this))`, causing the wrapped vault to send assets directly to `receiver`.
-8. Emit the ordinary TIP-20 `Transfer(owner, address(0), shares)` event and `Withdraw`.
+5. Burn exactly `shares` TIP-20 units from `owner`.
+6. Call `vault.withdraw(assets, receiver, address(this))`, causing the wrapped vault to send assets directly to `receiver`.
+7. Emit the ordinary TIP-20 `Transfer(owner, address(0), shares)` event and `Withdraw`.
 
-`redeem(shares, receiver, owner)` MUST follow the same rules, except it computes the returned asset amount using the wrapped vault's redemption semantics, enforces the current hook's redeem check if a hook is configured, burns exactly `shares`, and calls `vault.redeem(shares, receiver, address(this))`.
+`redeem(shares, receiver, owner)` MUST follow the same rules, except it burns exactly `shares` and calls `vault.redeem(shares, receiver, address(this))`.
 
 ```solidity
 event Withdraw(
@@ -285,7 +284,7 @@ event Unpaused(address indexed account);
 
 ## Hook Contract
 
-A vault-backed TIP-20 MAY have an optional hook contract. The hook is not part of the wrapped vault. It is called by the vault-backed TIP-20 before deposits, mints, withdrawals, and redeems, and by max functions to compute additional end-holder-specific limits.
+A vault-backed TIP-20 MAY have an optional hook contract. The hook is not part of the wrapped vault. It is called by the vault-backed TIP-20 before deposits and mints, and by `maxDeposit` and `maxMint` to compute additional end-holder-specific limits.
 
 The hook interface is:
 
@@ -303,20 +302,6 @@ interface IVaultTokenHook {
         uint256 vaultMaxShares
     ) external view returns (uint256 maxShares);
 
-    function maxWithdraw(
-        address caller,
-        address owner,
-        uint256 ownerAssets,
-        uint256 vaultMaxAssets
-    ) external view returns (uint256 maxAssets);
-
-    function maxRedeem(
-        address caller,
-        address owner,
-        uint256 ownerShares,
-        uint256 vaultMaxShares
-    ) external view returns (uint256 maxShares);
-
     function beforeDeposit(
         address caller,
         address receiver,
@@ -327,22 +312,6 @@ interface IVaultTokenHook {
     function beforeMint(
         address caller,
         address receiver,
-        uint256 shares,
-        uint256 assets
-    ) external view;
-
-    function beforeWithdraw(
-        address caller,
-        address receiver,
-        address owner,
-        uint256 assets,
-        uint256 shares
-    ) external view;
-
-    function beforeRedeem(
-        address caller,
-        address receiver,
-        address owner,
         uint256 shares,
         uint256 assets
     ) external view;
@@ -359,12 +328,10 @@ When a hook is configured:
 
 - `deposit` MUST compute the expected share amount using `previewDeposit(assets)`, then call `beforeDeposit(msg.sender, receiver, assets, previewShares)` before transferring assets.
 - `mint` MUST compute the required asset amount using the wrapped vault's mint semantics, then call `beforeMint(msg.sender, receiver, shares, assets)` before transferring assets.
-- `withdraw` MUST compute the required share amount using the wrapped vault's withdrawal semantics, then call `beforeWithdraw(msg.sender, receiver, owner, assets, shares)` before burning shares.
-- `redeem` MUST compute the asset amount using the wrapped vault's redemption semantics, then call `beforeRedeem(msg.sender, receiver, owner, shares, assets)` before burning shares.
 
-Hook `before*` functions authorize by returning successfully and reject by reverting. Hook `max*` functions MUST NOT revert during normal operation; if a hook `max*` call reverts, the vault-backed TIP-20 max function MUST return `0`. Because ERC-4626 max functions do not include an explicit caller argument, the vault-backed TIP-20 passes `msg.sender` as the hook `caller` for max queries; a max query made by a relayer or offchain caller only answers for that caller.
+Hook `before*` functions authorize by returning successfully and reject by reverting. Hook `max*` functions MUST NOT revert during normal operation; if a hook `max*` call reverts, the corresponding vault-backed TIP-20 max function MUST return `0`. Because ERC-4626 `maxDeposit` and `maxMint` do not include an explicit caller argument, the vault-backed TIP-20 passes `msg.sender` as the hook `caller` for max queries; a max query made by a relayer or offchain caller only answers for that caller.
 
-The hook cannot change the wrapped vault, cannot mint or burn vault-backed TIP-20 balances directly, and cannot move assets by itself. It only constrains the wrapper's own deposit, mint, withdrawal, and redemption entrypoints.
+The hook cannot change the wrapped vault, cannot mint or burn vault-backed TIP-20 balances directly, and cannot move assets by itself. It only constrains the wrapper's own deposit and mint entrypoints.
 
 ## Non-Goals
 

--- a/tips/tip-1080.md
+++ b/tips/tip-1080.md
@@ -20,7 +20,7 @@ The wrapped vault remains responsible for all yield, reward, donation, fee, limi
 
 TIP-20 tokens are the native token surface for Tempo wallets, policy checks, indexing, and payment flows. ERC-4626 vaults are the standard surface for tokenized vault deposits and redemptions. Some integrations need both properties at once: users should hold and transfer a native TIP-20 balance, while that balance should also represent a claim on assets managed by a vault.
 
-This can be done without requiring the vault to become a TIP-20 token. Instead, the TIP-20 can act as the vault's aggregate depositor. From the vault's perspective, the TIP-20 token contract is an ordinary holder. From the user's perspective, TIP-20 balances are transferable vault claims, and deposit or withdrawal uses an ERC-4626-like interface on the TIP-20 token.
+This can be done without requiring the vault to become a TIP-20 token. Instead, the TIP-20 can act as one aggregated depositor on the vault. From the vault's perspective, the TIP-20 token contract is an ordinary holder. From the user's perspective, TIP-20 balances are transferable vault claims, and deposit or withdrawal uses an ERC-4626-like interface on the TIP-20 token.
 
 The vault can be an existing ERC-4626 vault, or it can be a custom vault-like contract that exposes the required ERC-4626-compatible interface only to the vault-backed TIP-20. A custom vault-like contract used only through one vault-backed TIP-20 can keep its own accounting simpler than a general-purpose ERC-4626 vault, because the vault-backed TIP-20 tracks end-holder balances and the vault only needs to account for the aggregate wrapper position.
 
@@ -37,7 +37,7 @@ This keeps responsibilities separated:
 - The wrapped vault's `asset()` return value is a TIP-20 token.
 - The wrapped vault's share balances SHOULD NOT rebase. Yield, rewards, donations, fees, losses, and other value changes SHOULD be reflected through the vault's asset-per-share accounting rather than by changing share balances.
 - The wrapped vault MAY accept other depositors. The vault-backed TIP-20 MUST NOT assume it is the only vault participant.
-- The wrapped vault MUST be compatible with the vault-backed TIP-20 contract acting as an aggregate depositor. Vault limits, allowlists, fees, and other depositor-specific behavior apply to the vault-backed TIP-20 contract, not to the end holders of the TIP-20 balances. End-holder-specific checks MAY be implemented by the vault-backed TIP-20's optional hook contract.
+- The wrapped vault MUST be compatible with the vault-backed TIP-20 contract acting as one aggregated depositor. Vault limits, allowlists, fees, and other depositor-specific behavior apply to the vault-backed TIP-20 contract, not to the end holders of the TIP-20 balances. End-holder-specific checks MAY be implemented by the vault-backed TIP-20's optional hook contract.
 - All reward, donation, fee, allocation, rounding, withdrawal-limit, and risk logic is owned by the wrapped vault and is outside the TIP-20 wrapper.
 - The vault-backed TIP-20's configured vault is immutable after deployment. Its TIP-403 policy MAY be updated by `DEFAULT_ADMIN_ROLE`.
 
@@ -49,7 +49,7 @@ This keeps responsibilities separated:
 - **Wrapped vault depositor checks:** apply to the vault-backed TIP-20 contract as the vault depositor. Per-end-holder limits or allowlists can be implemented by the optional hook contract, but the wrapped vault itself only sees the vault-backed TIP-20 contract.
 - **Hook contract:** optionally trusted to enforce additional per-user deposit or mint limits. A malicious or buggy hook can block otherwise valid deposits or mints, or return incorrect max values.
 - **TIP-403 policy:** controls TIP-20 transfer authorization. The current policy can be updated by `DEFAULT_ADMIN_ROLE`.
-- **Admin roles:** trusted to update the TIP-403 policy and pause or unpause vault-backed TIP-20 operations.
+- **Admin roles:** trusted to update the TIP-403 policy, grant and revoke roles, and pause or unpause vault-backed TIP-20 operations according to ordinary TIP-20 role rules.
 - **Factory:** trusted to bind each vault-backed TIP-20 to the intended immutable vault and initial policy during creation.
 
 ---
@@ -88,11 +88,11 @@ function createVaultToken(
 
 1. Validate `vault != address(0)`.
 2. Validate `admin != address(0)`.
-3. Validate that `vault.asset()` returns a nonzero TIP-20 token address.
+3. Validate that `vault.asset()` returns a TIP-20 token address.
 4. Validate `policyId` using the same TIP-403 policy existence rules that apply to ordinary TIP-20 token policy configuration.
 5. Deploy a TIP-20 token whose `vault` is immutable, whose initial `policyId` is `policyId`, and whose initial `DEFAULT_ADMIN_ROLE` holder is `admin`.
 6. Register the created token as a TIP-20 token, so `isTIP20(token) == true`.
-7. Emit `VaultTokenCreated` and the existing `TokenCreated` event.
+7. Emit the existing `TokenCreated` event and then `VaultTokenCreated`.
 
 ```solidity
 event VaultTokenCreated(
@@ -108,7 +108,7 @@ event VaultTokenCreated(
 );
 ```
 
-The factory MUST also emit the existing `TokenCreated` event for compatibility with indexers that already consume TIP-20 factory events.
+The factory MUST emit the existing `TokenCreated` event for compatibility with indexers that already consume TIP-20 factory events, then emit `VaultTokenCreated`.
 
 ## Vault Interface
 
@@ -189,9 +189,9 @@ TIP-20 `totalSupply()` MUST equal the sum of all holder balances after every suc
 
 `convertToShares(assets)` MUST return `vault.convertToShares(assets)`.
 
-`maxDeposit(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return the smaller of `vault.maxDeposit(address(this))` and the current hook's `maxDeposit` value for `msg.sender` and `receiver`. If no hook is configured, the hook limit is treated as `type(uint256).max`.
+`maxDeposit(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return the smaller of `vault.maxDeposit(address(this))` and the current hook's `maxDeposit` value for `msg.sender` and `receiver`. If no hook is configured, the hook limit is treated as `type(uint128).max`.
 
-`maxMint(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return the smaller of `vault.maxMint(address(this))` and the current hook's `maxMint` value for `msg.sender` and `receiver`. If no hook is configured, the hook limit is treated as `type(uint256).max`.
+`maxMint(receiver)` MUST return `0` if the vault-backed TIP-20 is paused or if minting TIP-20 shares to `receiver` would fail the current TIP-403 policy. Otherwise, it MUST return the smaller of `vault.maxMint(address(this))` and the current hook's `maxMint` value for `msg.sender` and `receiver`. If no hook is configured, the hook limit is treated as `type(uint128).max`.
 
 `maxWithdraw(owner)` MUST return `0` if the vault-backed TIP-20 is paused. Otherwise, it MUST return the smaller of `convertToAssets(balanceOf(owner))` and `vault.maxWithdraw(address(this))`.
 
@@ -275,7 +275,7 @@ A vault-backed TIP-20 MUST have `DEFAULT_ADMIN_ROLE`. The initial holder of `DEF
 - Update the token's current TIP-403 policy.
 - Update the token's current hook contract.
 
-A vault-backed TIP-20 MUST support a `PAUSER_ROLE`. An account with `PAUSER_ROLE` MAY pause and unpause the vault-backed TIP-20. When paused:
+A vault-backed TIP-20 MUST support the ordinary TIP-20 `PAUSE_ROLE` and `UNPAUSE_ROLE`. An account with `PAUSE_ROLE` MAY pause the vault-backed TIP-20. An account with `UNPAUSE_ROLE` MAY unpause the vault-backed TIP-20. When paused:
 
 - Deposits and mints MUST revert.
 - Withdrawals and redeems MUST revert.

--- a/tips/tip-1080.md
+++ b/tips/tip-1080.md
@@ -50,7 +50,7 @@ This keeps responsibilities separated:
 - **Vault hook contract:** optionally trusted to enforce additional per-user deposit or mint limits. A malicious or buggy vault hook can block otherwise valid deposits or mints, or return incorrect max values.
 - **TIP-403 transfer policy:** controls TIP-20 transfer authorization. The current policy can be updated by `DEFAULT_ADMIN_ROLE`.
 - **Admin roles:** trusted to update the TIP-403 transfer policy, grant and revoke roles, and pause or unpause vault-backed TIP-20 operations according to ordinary TIP-20 role rules.
-- **Factory:** trusted to bind each vault-backed TIP-20 to the intended immutable vault and initial transfer policy during creation.
+- **Factory:** creates each vault-backed TIP-20 with the caller-provided immutable vault and initial transfer policy, and MUST validate them as specified below.
 
 ---
 

--- a/tips/tip-1080.md
+++ b/tips/tip-1080.md
@@ -137,7 +137,17 @@ The wrapped vault MAY omit ERC-20 functions such as `balanceOf`, `transfer`, `tr
 
 ## Vault-Backed TIP-20 Interface
 
-A vault-backed TIP-20 MUST expose ordinary TIP-20 transfer, approval, metadata, factory-registration, and policy behavior, but MUST NOT expose standalone TIP-20 mint or burn entrypoints. The only ways to mint or burn vault-backed TIP-20 balances are the ERC-4626-like methods below:
+A vault-backed TIP-20 MUST expose ordinary TIP-20 transfer, approval, metadata, factory-registration, and policy behavior, plus the vault-specific functions below. The only ways to mint or burn vault-backed TIP-20 balances are the ERC-4626-like `deposit`, `mint`, `withdraw`, and `redeem` methods below.
+
+For clarity, a vault-backed TIP-20 MUST support the following ordinary TIP-20 functions with ordinary TIP-20 semantics, except where this TIP states otherwise:
+
+- Metadata and supply reads: `name`, `symbol`, `decimals`, `currency`, `quoteToken`, `logoURI`, `totalSupply`, and `balanceOf`.
+- Transfers and approvals: `transfer`, `transferWithMemo`, `approve`, `allowance`, `transferFrom`, `transferFromWithMemo`, `permit`, `nonces`, and `DOMAIN_SEPARATOR`.
+- Transfer-policy, pause, logo, and role administration: `transferPolicyId`, `changeTransferPolicyId`, `paused`, `pause`, `unpause`, `setLogoURI`, `PAUSE_ROLE`, `UNPAUSE_ROLE`, and ordinary role-management functions.
+
+A vault-backed TIP-20 MUST NOT support ordinary TIP-20 standalone issuance, burn-blocked, supply-cap mutation, quote-token mutation, or reward functions. Calls to ordinary TIP-20 `mint(address,uint256)`, `mintWithMemo`, `burn`, `burnWithMemo`, `burnBlocked`, `setSupplyCap`, `setNextQuoteToken`, `completeQuoteTokenUpdate`, `distributeReward`, `setRewardRecipient`, and `claimRewards` MUST revert. `supplyCap()` MUST return `type(uint256).max`, `nextQuoteToken()` MUST return `address(0)`, and reward read functions MUST report no TIP-20-native rewards. Vault or hook limits are represented through the ERC-4626-like `maxDeposit` and `maxMint` functions instead.
+
+The additional vault-backed interface is:
 
 ```solidity
 function asset() external view returns (address);


### PR DESCRIPTION
## Summary
- Adds TIP-1080 for vault-backed TIP-20 tokens, where transferable TIP-20 balances represent pro-rata claims on an immutable external ERC-4626-compatible vault.
- Specifies `createVaultToken` with a TIP-20 `asset()`, immutable vault, initial `DEFAULT_ADMIN_ROLE` holder, initial TIP-403 transfer policy, and compatibility `TokenCreated` plus `VaultTokenCreated` events.
- Defines ERC-4626-like deposit, mint, withdrawal, redeem, accounting, max/preview, observability, and invariants while keeping standalone TIP-20 issuance and direct burn paths disabled.
- Adds admin-controlled transfer-policy updates, pause/unpause behavior, and an optional `vaultHook` for end-holder-specific deposit and mint limits.

Prompted by: @danrobinson
