### PR TITLE
chore(txpool): log transaction batch timings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10225,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10273,7 +10273,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "bytes",
  "eyre",
@@ -10302,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10314,7 +10314,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10338,7 +10338,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10350,7 +10350,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10373,7 +10373,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10416,7 +10416,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10465,7 +10465,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10493,7 +10493,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10600,7 +10600,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10673,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10693,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10724,7 +10724,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10771,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10822,7 +10822,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10867,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10918,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10960,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10980,7 +10980,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10995,7 +10995,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11021,7 +11021,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11039,7 +11039,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11060,7 +11060,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11086,7 +11086,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "clap",
  "eyre",
@@ -11106,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11125,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11170,7 +11170,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11196,7 +11196,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11223,7 +11223,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11243,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11272,7 +11272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
+source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10225,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10273,7 +10273,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "bytes",
  "eyre",
@@ -10302,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10314,7 +10314,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10338,7 +10338,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10350,7 +10350,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10373,7 +10373,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10416,7 +10416,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10465,7 +10465,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10493,7 +10493,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10600,7 +10600,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10673,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10693,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10724,7 +10724,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10771,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10822,7 +10822,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10867,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10918,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10960,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10980,7 +10980,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10995,7 +10995,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11021,7 +11021,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11039,7 +11039,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11060,7 +11060,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11086,7 +11086,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "clap",
  "eyre",
@@ -11106,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11125,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11170,7 +11170,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11196,7 +11196,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11223,7 +11223,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11243,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11272,7 +11272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/mattsse/reth?rev=cb46facf7f5e783b04f997a8cf09b1a7e03929eb#cb46facf7f5e783b04f997a8cf09b1a7e03929eb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10225,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10273,7 +10273,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "bytes",
  "eyre",
@@ -10302,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10314,7 +10314,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10338,7 +10338,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10350,7 +10350,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10373,7 +10373,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10416,7 +10416,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10465,7 +10465,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10493,7 +10493,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10600,7 +10600,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10673,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10693,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10724,7 +10724,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10771,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10822,7 +10822,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10867,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10918,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10960,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10980,7 +10980,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10995,7 +10995,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11021,7 +11021,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11039,7 +11039,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11060,7 +11060,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11086,7 +11086,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "clap",
  "eyre",
@@ -11106,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11125,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11170,7 +11170,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11196,7 +11196,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11223,7 +11223,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11243,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11272,7 +11272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/mattsse/reth?rev=7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd#7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd"
+source = "git+https://github.com/mattsse/reth?rev=1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c#1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,66 +144,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-chainspec = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb", default-features = false }
-reth-cli = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-cli-commands = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-cli-runner = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-cli-util = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-basic-payload-builder = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-chainspec = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd", default-features = false }
+reth-cli = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-cli-commands = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-cli-runner = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-cli-util = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-consensus-common = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-db = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-discv5 = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-db-api = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-e2e-test-utils = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-engine-local = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-engine-tree = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-errors = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-eth-wire-types = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-etl = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-ethereum = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-ethereum-cli = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-ethereum-consensus = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-ethereum-engine-primitives = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-ethereum-primitives = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb", default-features = false }
-reth-execution-cache = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-execution-types = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-evm = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-evm-ethereum = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-metrics = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-network-api = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-network-peers = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb", default-features = false }
-reth-node-api = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-node-builder = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-node-core = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-node-ethereum = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-node-metrics = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-payload-builder = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-payload-primitives = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-consensus = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-consensus-common = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-db = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-discv5 = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-db-api = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-e2e-test-utils = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-engine-local = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-engine-tree = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-errors = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-eth-wire-types = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-etl = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-ethereum = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-ethereum-cli = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-ethereum-consensus = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-ethereum-engine-primitives = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-ethereum-primitives = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd", default-features = false }
+reth-execution-cache = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-execution-types = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-evm = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-evm-ethereum = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-metrics = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-network-api = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-network-peers = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd", default-features = false }
+reth-node-api = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-node-builder = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-node-core = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-node-ethereum = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-node-metrics = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-payload-builder = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-payload-primitives = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-downloaders = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-provider = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-prune-types = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-rpc = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-rpc-api = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-rpc-builder = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-rpc-convert = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-rpc-eth-api = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-rpc-eth-types = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-rpc-server-types = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-stages = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-static-file = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-storage-api = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-tasks = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-tracing = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-transaction-pool = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-trie = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-trie-common = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
-reth-trie-db = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-config = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-downloaders = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-provider = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-prune-types = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-rpc = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-rpc-api = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-rpc-builder = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-rpc-convert = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-rpc-eth-api = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-rpc-eth-types = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-rpc-server-types = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-stages = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-static-file = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-storage-api = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-tasks = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-tracing = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-transaction-pool = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-trie = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-trie-common = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-trie-db = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
 
-reth-revm = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb", features = [
+reth-revm = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,66 +144,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-chainspec = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd", default-features = false }
-reth-cli = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-cli-commands = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-cli-runner = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-cli-util = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-basic-payload-builder = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-chainspec = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c", default-features = false }
+reth-cli = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-cli-commands = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-cli-runner = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-cli-util = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-consensus-common = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-db = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-discv5 = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-db-api = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-e2e-test-utils = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-engine-local = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-engine-tree = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-errors = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-eth-wire-types = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-etl = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-ethereum = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-ethereum-cli = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-ethereum-consensus = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-ethereum-engine-primitives = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-ethereum-primitives = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd", default-features = false }
-reth-execution-cache = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-execution-types = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-evm = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-evm-ethereum = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-metrics = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-network-api = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-network-peers = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd", default-features = false }
-reth-node-api = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-node-builder = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-node-core = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-node-ethereum = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-node-metrics = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-payload-builder = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-payload-primitives = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-consensus = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-consensus-common = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-db = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-discv5 = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-db-api = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-e2e-test-utils = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-engine-local = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-engine-tree = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-errors = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-eth-wire-types = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-etl = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-ethereum = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-ethereum-cli = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-ethereum-consensus = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-ethereum-engine-primitives = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-ethereum-primitives = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c", default-features = false }
+reth-execution-cache = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-execution-types = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-evm = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-evm-ethereum = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-metrics = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-network-api = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-network-peers = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c", default-features = false }
+reth-node-api = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-node-builder = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-node-core = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-node-ethereum = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-node-metrics = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-payload-builder = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-payload-primitives = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-downloaders = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-provider = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-prune-types = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-rpc = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-rpc-api = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-rpc-builder = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-rpc-convert = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-rpc-eth-api = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-rpc-eth-types = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-rpc-server-types = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-stages = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-static-file = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-storage-api = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-tasks = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-tracing = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-transaction-pool = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-trie = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-trie-common = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
-reth-trie-db = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd" }
+reth-config = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-downloaders = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-provider = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-prune-types = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-rpc = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-rpc-api = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-rpc-builder = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-rpc-convert = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-rpc-eth-api = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-rpc-eth-types = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-rpc-server-types = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-stages = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-static-file = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-storage-api = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-tasks = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-tracing = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-transaction-pool = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-trie = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-trie-common = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
+reth-trie-db = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c" }
 
-reth-revm = { git = "https://github.com/mattsse/reth", rev = "7e8d6afaf8f2eb1d7f8e9a5cce63a92270befbbd", features = [
+reth-revm = { git = "https://github.com/mattsse/reth", rev = "1ae3080b0fe8f2a4aec6dcebda1079b78f16f45c", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,66 +144,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
+reth-basic-payload-builder = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-chainspec = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb", default-features = false }
+reth-cli = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-cli-commands = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-cli-runner = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-cli-util = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
+reth-consensus = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-consensus-common = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-db = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-discv5 = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-db-api = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-e2e-test-utils = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-engine-local = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-engine-tree = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-errors = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-eth-wire-types = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-etl = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-ethereum = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-ethereum-cli = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-ethereum-consensus = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-ethereum-engine-primitives = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-ethereum-primitives = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb", default-features = false }
+reth-execution-cache = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-execution-types = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-evm = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-evm-ethereum = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-metrics = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-network-api = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-network-peers = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb", default-features = false }
+reth-node-api = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-node-builder = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-node-core = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-node-ethereum = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-node-metrics = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-payload-builder = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-payload-primitives = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
+reth-config = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-downloaders = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-provider = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-prune-types = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-rpc = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-rpc-api = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-rpc-builder = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-rpc-convert = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-rpc-eth-api = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-rpc-eth-types = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-rpc-server-types = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-stages = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-static-file = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-storage-api = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-tasks = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-tracing = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-transaction-pool = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-trie = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-trie-common = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
+reth-trie-db = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5", features = [
+reth-revm = { git = "https://github.com/mattsse/reth", rev = "cb46facf7f5e783b04f997a8cf09b1a7e03929eb", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -28,5 +28,18 @@ pub use maintain::TempoPoolUpdates;
 pub use metrics::{AA2dPoolMetrics, TempoPoolMaintenanceMetrics};
 pub use tt_2d_pool::{AA2dPool, AA2dPoolConfig, AASequenceId, DEFAULT_MAX_TXS_PER_SENDER};
 
+pub(crate) const TX_BATCH_METRICS_SAMPLE_TX_INTERVAL: u64 = 10_000;
+
+pub(crate) fn should_log_tx_batch_metrics(
+    counter: &std::sync::atomic::AtomicU64,
+    batch_size: usize,
+) -> bool {
+    let batch_size = u64::try_from(batch_size).unwrap_or(u64::MAX).max(1);
+    let previous = counter.fetch_add(batch_size, std::sync::atomic::Ordering::Relaxed);
+    previous == 0
+        || previous / TX_BATCH_METRICS_SAMPLE_TX_INTERVAL
+            != previous.saturating_add(batch_size) / TX_BATCH_METRICS_SAMPLE_TX_INTERVAL
+}
+
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -48,6 +48,7 @@ use tempo_primitives::Block;
 use tempo_revm::TempoStateAccess;
 
 static INSERTED_TEMPO_BATCH_LOG_TXS: AtomicU64 = AtomicU64::new(0);
+static AA_2D_INSERT_BREAKDOWN_LOG_TXS: AtomicU64 = AtomicU64::new(0);
 
 /// Tempo transaction pool that routes based on nonce_key
 pub struct TempoTransactionPool<Client> {
@@ -516,6 +517,9 @@ where
                 authorities,
             } => {
                 if transaction.transaction().is_aa_2d() {
+                    let should_log =
+                        crate::should_log_tx_batch_metrics(&AA_2D_INSERT_BREAKDOWN_LOG_TXS, 1);
+                    let total_started_at = should_log.then(Instant::now);
                     let transaction = transaction.into_transaction();
                     let sender_id = self
                         .protocol_pool
@@ -542,14 +546,40 @@ where
                         .tip_timestamp();
                     let hardfork = self.client().chain_spec().tempo_hardfork_at(tip_timestamp);
 
-                    let added = self.aa_2d_pool.write().add_transaction(
-                        Arc::new(tx),
-                        state_nonce,
-                        hardfork,
-                    )?;
+                    let setup_us = total_started_at
+                        .as_ref()
+                        .map(|started_at| started_at.elapsed().as_micros());
+                    let lock_wait_started_at = should_log.then(Instant::now);
+                    let mut aa_2d_pool = self.aa_2d_pool.write();
+                    let lock_wait_us =
+                        lock_wait_started_at.map(|started_at| started_at.elapsed().as_micros());
+                    let insert_started_at = should_log.then(Instant::now);
+                    let added = aa_2d_pool.add_transaction(Arc::new(tx), state_nonce, hardfork)?;
+                    let insert_us =
+                        insert_started_at.map(|started_at| started_at.elapsed().as_micros());
+                    drop(aa_2d_pool);
+
                     let hash = *added.hash();
+                    let notify_started_at = should_log.then(Instant::now);
                     if let Some(pending) = added.as_pending() {
                         if pending.discarded.iter().any(|tx| *tx.hash() == hash) {
+                            if let Some(total_started_at) = total_started_at {
+                                tracing::info!(
+                                    target: "tempo_tx_batch_metrics",
+                                    batch_size = 1usize,
+                                    setup_us = setup_us.unwrap_or_default(),
+                                    lock_wait_us = lock_wait_us.unwrap_or_default(),
+                                    insert_us = insert_us.unwrap_or_default(),
+                                    notify_us = notify_started_at
+                                        .map(|started_at| started_at.elapsed().as_micros())
+                                        .unwrap_or_default(),
+                                    total_us = total_started_at.elapsed().as_micros(),
+                                    result_status = "discarded_on_insert",
+                                    sample_interval_txs =
+                                        crate::TX_BATCH_METRICS_SAMPLE_TX_INTERVAL,
+                                    "inserted aa 2d transaction breakdown"
+                                );
+                            }
                             return Err(PoolError::new(hash, PoolErrorKind::DiscardedOnInsert));
                         }
                         self.protocol_pool
@@ -563,6 +593,23 @@ where
                     self.protocol_pool
                         .inner()
                         .on_new_transaction(added.into_new_transaction_event());
+
+                    if let Some(total_started_at) = total_started_at {
+                        tracing::info!(
+                            target: "tempo_tx_batch_metrics",
+                            batch_size = 1usize,
+                            setup_us = setup_us.unwrap_or_default(),
+                            lock_wait_us = lock_wait_us.unwrap_or_default(),
+                            insert_us = insert_us.unwrap_or_default(),
+                            notify_us = notify_started_at
+                                .map(|started_at| started_at.elapsed().as_micros())
+                                .unwrap_or_default(),
+                            total_us = total_started_at.elapsed().as_micros(),
+                            result_status = "ok",
+                            sample_interval_txs = crate::TX_BATCH_METRICS_SAMPLE_TX_INTERVAL,
+                            "inserted aa 2d transaction breakdown"
+                        );
+                    }
 
                     Ok(AddedTransactionOutcome { hash, state })
                 } else {

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -28,7 +28,10 @@ use reth_transaction_pool::{
     identifier::TransactionId,
 };
 use revm::database::BundleAccount;
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::{Arc, atomic::AtomicU64},
+    time::Instant,
+};
 use tempo_chainspec::{
     TempoChainSpec,
     hardfork::{TempoHardfork, TempoHardforks},
@@ -43,6 +46,8 @@ use tempo_precompiles::{
 };
 use tempo_primitives::Block;
 use tempo_revm::TempoStateAccess;
+
+static INSERTED_TEMPO_BATCH_LOG_TXS: AtomicU64 = AtomicU64::new(0);
 
 /// Tempo transaction pool that routes based on nonce_key
 pub struct TempoTransactionPool<Client> {
@@ -671,6 +676,7 @@ where
         if transactions.is_empty() {
             return Vec::new();
         }
+        let batch_size = transactions.len();
 
         // Fully delegate to protocol pool for non-2D transactions
         if !transactions.iter().any(|tx| tx.is_aa_2d()) {
@@ -680,13 +686,31 @@ where
                 .await;
         }
 
-        self.protocol_pool
+        let validated = self
+            .protocol_pool
             .validator()
             .validate_transactions_with_origin(origin, transactions)
-            .await
+            .await;
+        let validated_count = validated.len();
+        let should_log =
+            crate::should_log_tx_batch_metrics(&INSERTED_TEMPO_BATCH_LOG_TXS, batch_size);
+        let started_at = should_log.then(Instant::now);
+        let results = validated
             .into_iter()
             .map(|outcome| self.add_validated_transaction(origin, outcome))
-            .collect()
+            .collect::<Vec<_>>();
+        if let Some(started_at) = started_at {
+            tracing::info!(
+                target: "tempo_tx_batch_metrics",
+                batch_size,
+                validated_count,
+                result_count = results.len(),
+                duration_us = started_at.elapsed().as_micros(),
+                sample_interval_txs = crate::TX_BATCH_METRICS_SAMPLE_TX_INTERVAL,
+                "inserted validated tempo transaction batch"
+            );
+        }
+        results
     }
 
     async fn add_transactions_with_origins(
@@ -696,6 +720,7 @@ where
         if transactions.is_empty() {
             return Vec::new();
         }
+        let batch_size = transactions.len();
 
         // Fully delegate to protocol pool for non-2D transactions
         if !transactions.iter().any(|(_, tx)| tx.is_aa_2d()) {
@@ -710,14 +735,32 @@ where
             .map(|(origin, _)| *origin)
             .collect::<Vec<_>>();
 
-        self.protocol_pool
+        let validated = self
+            .protocol_pool
             .validator()
             .validate_transactions(transactions)
-            .await
+            .await;
+        let validated_count = validated.len();
+        let should_log =
+            crate::should_log_tx_batch_metrics(&INSERTED_TEMPO_BATCH_LOG_TXS, batch_size);
+        let started_at = should_log.then(Instant::now);
+        let results = validated
             .into_iter()
             .zip(origins)
             .map(|(outcome, origin)| self.add_validated_transaction(origin, outcome))
-            .collect()
+            .collect::<Vec<_>>();
+        if let Some(started_at) = started_at {
+            tracing::info!(
+                target: "tempo_tx_batch_metrics",
+                batch_size,
+                validated_count,
+                result_count = results.len(),
+                duration_us = started_at.elapsed().as_micros(),
+                sample_interval_txs = crate::TX_BATCH_METRICS_SAMPLE_TX_INTERVAL,
+                "inserted validated tempo transaction batch"
+            );
+        }
+        results
     }
 
     fn transaction_event_listener(&self, tx_hash: B256) -> Option<TransactionEvents> {

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -16,6 +16,7 @@ use reth_transaction_pool::{
     TransactionValidator, error::InvalidPoolTransactionError,
 };
 use revm::context::result::{EVMError, InvalidTransaction};
+use std::{sync::atomic::AtomicU64, time::Instant};
 use tempo_chainspec::{
     TempoChainSpec,
     hardfork::{TempoHardfork, TempoHardforks},
@@ -34,6 +35,8 @@ use tempo_revm::{
 
 // Reject AA txs where `valid_before` is too close to current time (or already expired) to prevent block invalidation.
 const AA_VALID_BEFORE_MIN_SECS: u64 = 3;
+
+static VALIDATED_TEMPO_BATCH_LOG_TXS: AtomicU64 = AtomicU64::new(0);
 
 /// Default maximum number of authorizations allowed in an AA transaction's authorization list.
 pub const DEFAULT_MAX_TEMPO_AUTHORIZATIONS: usize = 16;
@@ -593,14 +596,35 @@ where
         origin: TransactionOrigin,
         transaction: Self::Transaction,
     ) -> TransactionValidationOutcome<Self::Transaction> {
+        let should_log = crate::should_log_tx_batch_metrics(&VALIDATED_TEMPO_BATCH_LOG_TXS, 1);
+        let started_at = should_log.then(Instant::now);
         let state_provider = match self.inner.client().latest() {
             Ok(provider) => provider,
             Err(err) => {
+                if let Some(started_at) = started_at {
+                    tracing::info!(
+                        target: "tempo_tx_batch_metrics",
+                        batch_size = 1usize,
+                        duration_us = started_at.elapsed().as_micros(),
+                        sample_interval_txs = crate::TX_BATCH_METRICS_SAMPLE_TX_INTERVAL,
+                        "validated tempo transaction batch"
+                    );
+                }
                 return TransactionValidationOutcome::Error(*transaction.hash(), Box::new(err));
             }
         };
 
-        self.validate_one(origin, transaction, state_provider)
+        let outcome = self.validate_one(origin, transaction, state_provider);
+        if let Some(started_at) = started_at {
+            tracing::info!(
+                target: "tempo_tx_batch_metrics",
+                batch_size = 1usize,
+                duration_us = started_at.elapsed().as_micros(),
+                sample_interval_txs = crate::TX_BATCH_METRICS_SAMPLE_TX_INTERVAL,
+                "validated tempo transaction batch"
+            );
+        }
+        outcome
     }
 
     async fn validate_transactions(
@@ -608,22 +632,47 @@ where
         transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction), IntoIter: Send>
         + Send,
     ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        let transactions = transactions.into_iter();
+        let batch_size = transactions.size_hint().0;
+        let should_log =
+            crate::should_log_tx_batch_metrics(&VALIDATED_TEMPO_BATCH_LOG_TXS, batch_size);
+        let started_at = should_log.then(Instant::now);
         let state_provider = match self.inner.client().latest() {
             Ok(provider) => provider,
             Err(err) => {
-                return transactions
+                let outcomes = transactions
                     .into_iter()
                     .map(|(_, tx)| {
                         TransactionValidationOutcome::Error(*tx.hash(), Box::new(err.clone()))
                     })
                     .collect();
+                if let Some(started_at) = started_at {
+                    tracing::info!(
+                        target: "tempo_tx_batch_metrics",
+                        batch_size,
+                        duration_us = started_at.elapsed().as_micros(),
+                        sample_interval_txs = crate::TX_BATCH_METRICS_SAMPLE_TX_INTERVAL,
+                        "validated tempo transaction batch"
+                    );
+                }
+                return outcomes;
             }
         };
 
-        transactions
+        let outcomes = transactions
             .into_iter()
             .map(|(origin, tx)| self.validate_one(origin, tx, &state_provider))
-            .collect()
+            .collect();
+        if let Some(started_at) = started_at {
+            tracing::info!(
+                target: "tempo_tx_batch_metrics",
+                batch_size,
+                duration_us = started_at.elapsed().as_micros(),
+                sample_interval_txs = crate::TX_BATCH_METRICS_SAMPLE_TX_INTERVAL,
+                "validated tempo transaction batch"
+            );
+        }
+        outcomes
     }
 
     async fn validate_transactions_with_origin(
@@ -631,22 +680,47 @@ where
         origin: TransactionOrigin,
         transactions: impl IntoIterator<Item = Self::Transaction> + Send,
     ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        let transactions = transactions.into_iter();
+        let batch_size = transactions.size_hint().0;
+        let should_log =
+            crate::should_log_tx_batch_metrics(&VALIDATED_TEMPO_BATCH_LOG_TXS, batch_size);
+        let started_at = should_log.then(Instant::now);
         let state_provider = match self.inner.client().latest() {
             Ok(provider) => provider,
             Err(err) => {
-                return transactions
+                let outcomes = transactions
                     .into_iter()
                     .map(|tx| {
                         TransactionValidationOutcome::Error(*tx.hash(), Box::new(err.clone()))
                     })
                     .collect();
+                if let Some(started_at) = started_at {
+                    tracing::info!(
+                        target: "tempo_tx_batch_metrics",
+                        batch_size,
+                        duration_us = started_at.elapsed().as_micros(),
+                        sample_interval_txs = crate::TX_BATCH_METRICS_SAMPLE_TX_INTERVAL,
+                        "validated tempo transaction batch"
+                    );
+                }
+                return outcomes;
             }
         };
 
-        transactions
+        let outcomes = transactions
             .into_iter()
             .map(|tx| self.validate_one(origin, tx, &state_provider))
-            .collect()
+            .collect();
+        if let Some(started_at) = started_at {
+            tracing::info!(
+                target: "tempo_tx_batch_metrics",
+                batch_size,
+                duration_us = started_at.elapsed().as_micros(),
+                sample_interval_txs = crate::TX_BATCH_METRICS_SAMPLE_TX_INTERVAL,
+                "validated tempo transaction batch"
+            );
+        }
+        outcomes
     }
 
     fn on_new_head_block(&self, new_tip_block: &SealedBlock<Self::Block>) {


### PR DESCRIPTION
Pins Reth dependencies to `mattsse/reth@b6b5f1c71760d23aaebfa25505cbde46002da5bc` with txpool batch timing logs under `target: "tempo_tx_batch_metrics"`.

Adds Tempo-side validation and AA-routed insertion timing for `validate_transaction(s)` so batch size, validation duration, insertion duration, and forwarded `eth_sendRawTransaction` batch duration are easy to scan in node logs.