### PR TITLE
Add 0xrusowsky to crate CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,12 +3,12 @@ bin/tempo-sidecar @Zygimantass
 contrib/ @Zygimantass
 scripts/ @0xKitsune
 xtask/ @0xKitsune @Zygimantass @SuperFluffy 
-crates/alloy/ @klkvr @onbjerg @mattsse
-crates/chainspec/ @0xKitsune @klkvr @mattsse
+crates/alloy/ @0xrusowsky @klkvr @onbjerg @mattsse
+crates/chainspec/ @0xrusowsky @0xKitsune @klkvr @mattsse
 crates/commonware-node/ @joshieDo @SuperFluffy @hamdiallam
 crates/commonware-node-config/ @joshieDo @SuperFluffy @hamdiallam
 crates/consensus/ @joshieDo @SuperFluffy @hamdiallam
-crates/contracts/ @0xKitsune @fgimenez @klkvr @mattsse @legion2002 @howydev
+crates/contracts/ @0xrusowsky @0xKitsune @fgimenez @klkvr @mattsse @legion2002 @howydev
 crates/e2e/ @joshieDo @SuperFluffy @hamdiallam
 crates/evm/ @0xKitsune @klkvr @mattsse
 crates/eyre/ @SuperFluffy


### PR DESCRIPTION
## Summary
- Add @0xrusowsky as CODEOWNER for crates/alloy, crates/chainspec, and crates/contracts.

## Testing
- Not run; CODEOWNERS-only change.

Prompted by: @0xrusowsky