### PR TITLE
chore: disable codeowners enforcement by VK

### DIFF
--- a/review.yml
+++ b/review.yml
@@ -1,3 +1,3 @@
 required-approvals: 1
-require-codeowners: true
+require-codeowners: false
 allow-self-reviews: false


### PR DESCRIPTION
When we enabled this in 2a704cbb we mistakenly thought CODEOWNERS were enforced by GitHub. That is not (currently) our posture.

Change the configuration to go back to the old setting.
