### PR TITLE
Patch keccak-asm to Zen 5 perf PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6302,8 +6302,7 @@ dependencies = [
 [[package]]
 name = "keccak-asm"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1766b89733097006f3a1388a02849865d6bc98c89273cb622e29fdd209922183"
+source = "git+https://github.com/DaniPopes/keccak-asm?rev=525fef6fb0a273e50c098ecb350c6c35bf099514#525fef6fb0a273e50c098ecb350c6c35bf099514"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -12375,8 +12374,7 @@ dependencies = [
 [[package]]
 name = "sha3-asm"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3f15d4e239ebe08413eed880e0f9b5af4b40ee0472543320efa91d488e96a7"
+source = "git+https://github.com/DaniPopes/keccak-asm?rev=525fef6fb0a273e50c098ecb350c6c35bf099514#525fef6fb0a273e50c098ecb350c6c35bf099514"
 dependencies = [
  "cc",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3828,7 +3828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -399,6 +399,8 @@ vergen-git2 = "9.1.0"
 # reth-trie-sparse = { path = "../reth/crates/trie/sparse" }
 
 [patch.crates-io]
+keccak-asm = { git = "https://github.com/DaniPopes/keccak-asm", rev = "525fef6fb0a273e50c098ecb350c6c35bf099514" }
+
 # Commonware at HEAD after PR #3588 was merged
 commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }


### PR DESCRIPTION
## Summary
- Patch `keccak-asm` to DaniPopes/keccak-asm PR #18 at `525fef6fb0a273e50c098ecb350c6c35bf099514`
- Update `Cargo.lock` so `keccak-asm` and `sha3-asm` resolve from the patched git source

## Validation
- `cargo metadata --locked --format-version 1`

Prompted by: @DaniPopes