### PR TITLE
deps: update reth from main (2026-06-15)

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: master
+          ref: alexey/revm-41-tempo
           path: foundry
           persist-credentials: false
 
@@ -261,7 +261,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: master
+          ref: alexey/revm-41-tempo
           path: foundry
           persist-credentials: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -237,7 +237,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.93" # MSRV
+          toolchain: "1.95" # MSRV
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3197,9 +3197,9 @@ dependencies = [
  "getrandom 0.2.17",
  "governor",
  "libc",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0",
+ "opentelemetry-otlp 0.31.1",
+ "opentelemetry_sdk 0.31.0",
  "pin-project",
  "prometheus-client",
  "rand 0.8.6",
@@ -3210,7 +3210,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.32.1",
  "tracing-subscriber 0.3.23",
 ]
 
@@ -7272,12 +7272,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-appender-tracing"
-version = "0.31.1"
+name = "opentelemetry"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
- "opentelemetry",
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
+dependencies = [
+ "opentelemetry 0.32.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.23",
@@ -7292,8 +7306,21 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.0",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry 0.32.0",
+ "reqwest 0.13.3",
 ]
 
 [[package]]
@@ -7303,16 +7330,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http 1.4.0",
- "opentelemetry",
- "opentelemetry-http",
- "opentelemetry-proto",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0",
+ "opentelemetry-http 0.31.0",
+ "opentelemetry-proto 0.31.0",
+ "opentelemetry_sdk 0.31.0",
  "prost 0.14.3",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry 0.32.0",
+ "opentelemetry-http 0.32.0",
+ "opentelemetry-proto 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "prost 0.14.3",
+ "reqwest 0.13.3",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
@@ -7321,8 +7365,21 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0",
+ "opentelemetry_sdk 0.31.0",
+ "prost 0.14.3",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.1",
  "prost 0.14.3",
  "tonic",
  "tonic-prost",
@@ -7330,9 +7387,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+checksum = "6ca2f98a0437b427b4b08f19f1caa3c44db885a202bc12cfea13d6c702243d68"
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -7343,12 +7400,28 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "percent-encoding",
  "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8597,7 +8670,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8697,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8763,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8846,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8856,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8909,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -8866,7 +8939,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8952,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +9006,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +9032,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9102,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9126,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9150,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9293,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -9304,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9407,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9423,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9439,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9472,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9500,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9522,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9618,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9631,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9685,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -9637,7 +9710,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9730,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9761,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9780,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9832,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9870,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9890,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9907,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9916,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9929,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9952,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +10035,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -9986,7 +10059,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10001,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10015,7 +10088,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10032,7 +10105,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10056,7 +10129,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10124,7 +10197,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10179,7 +10252,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10226,7 +10299,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10250,7 +10323,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10274,7 +10347,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "bytes",
  "eyre",
@@ -10303,7 +10376,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10315,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10339,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10351,7 +10424,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10374,7 +10447,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10417,7 +10490,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -10466,7 +10539,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10494,7 +10567,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10510,7 +10583,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10525,7 +10598,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10602,7 +10675,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10632,7 +10705,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10675,7 +10748,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10695,7 +10768,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10726,7 +10799,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10773,7 +10846,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10824,7 +10897,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10838,7 +10911,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10869,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10920,7 +10993,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10948,7 +11021,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10962,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10982,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10997,7 +11070,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -11023,7 +11096,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11041,7 +11114,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11062,7 +11135,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11078,7 +11151,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11088,7 +11161,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "clap",
  "eyre",
@@ -11108,18 +11181,18 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "base64 0.22.1",
  "clap",
  "eyre",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "opentelemetry-appender-tracing",
- "opentelemetry-otlp",
+ "opentelemetry-otlp 0.32.0",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.32.1",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.33.0",
  "tracing-subscriber 0.3.23",
  "url",
 ]
@@ -11127,7 +11200,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11172,7 +11245,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11198,7 +11271,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11226,7 +11299,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11246,7 +11319,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "alloy-evm",
@@ -11275,7 +11348,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12849,7 +12922,7 @@ dependencies = [
  "eyre",
  "futures",
  "jiff",
- "opentelemetry-otlp",
+ "opentelemetry-otlp 0.31.1",
  "pyroscope",
  "pyroscope_pprofrs",
  "rand 0.8.6",
@@ -13986,6 +14059,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost 0.14.3",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14156,7 +14240,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "opentelemetry",
+ "opentelemetry 0.31.0",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber 0.3.23",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry 0.32.0",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -9986,7 +9986,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10001,7 +10001,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10015,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10032,7 +10032,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10056,7 +10056,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10124,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10179,7 +10179,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10226,7 +10226,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10250,7 +10250,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10274,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "bytes",
  "eyre",
@@ -10303,7 +10303,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10315,7 +10315,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10339,7 +10339,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10351,7 +10351,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10374,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10417,7 +10417,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -10466,7 +10466,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10494,7 +10494,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10510,7 +10510,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10602,7 +10602,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10632,7 +10632,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10675,7 +10675,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10695,7 +10695,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10726,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10773,7 +10773,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10824,7 +10824,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10838,7 +10838,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10869,7 +10869,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10920,7 +10920,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10948,7 +10948,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10962,7 +10962,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10982,7 +10982,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10997,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -11023,7 +11023,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11041,7 +11041,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11062,7 +11062,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11078,7 +11078,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11088,7 +11088,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "clap",
  "eyre",
@@ -11108,7 +11108,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11127,7 +11127,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11172,7 +11172,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11198,7 +11198,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11226,7 +11226,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11246,7 +11246,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "alloy-evm",
@@ -11275,7 +11275,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
+source = "git+https://github.com/paradigmxyz/reth?rev=606e2f1#606e2f152afccdd1a5ee5c7882510ecb25033a74"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d93ce7e41bcd2b9ee2c1d92c223c1be4a274d387538d6d3f956b768986ce451"
+checksum = "55c4584eaf235a861172e30d0d8adfa95957186f59b93f997851df90b32da7ba"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
+checksum = "70634e39510c13a4f69f51a474d98030ecb1dcff54b909d2a9a020ee05e44867"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8803,9 +8803,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c37bb4d1bac98661bf9128e1141b969034640d68697b22f70377e492fd332c"
+checksum = "312c1817d0e37c6112d30fcc9e92226d8e73cc66ea6bd640c80e0e0df956cc04"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8824,9 +8824,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceeb8dab90194305d3f7e3f043a22d2db1fb54b6dcf5d8e75c5a4fa8540e1f57"
+checksum = "526ee2bfded1897b7bb43f46410f487ee48a41b7e93cf18031079660b433550d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,10 +8852,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,10 +9245,10 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,11 +9427,11 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-hardforks",
  "alloy-primitives",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,10 +9612,10 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,9 +9962,10 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-primitives",
  "auto_impl",
@@ -9985,7 +9986,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10001,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10032,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10056,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10179,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10225,7 +10226,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10249,7 +10250,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10273,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "bytes",
  "eyre",
@@ -10302,7 +10303,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10314,7 +10315,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10338,7 +10339,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10350,7 +10351,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10373,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10382,9 +10383,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9102518f0bbf99bc8f0e656a56fb2a7513248630275b608d3706076a82fde42b"
+checksum = "66169f2c520c1c94192a18d11c5466565f079588def7d76abb631db80d353829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10416,10 +10417,10 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
@@ -10465,7 +10466,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10493,7 +10494,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10509,7 +10510,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10524,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10572,6 +10573,7 @@ dependencies = [
  "reth-network-peers",
  "reth-network-types",
  "reth-node-api",
+ "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-api",
@@ -10600,7 +10602,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10630,7 +10632,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10673,7 +10675,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10693,7 +10695,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10724,11 +10726,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-evm",
  "alloy-json-rpc",
@@ -10771,11 +10773,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-evm",
  "alloy-network",
@@ -10822,7 +10824,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10836,7 +10838,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10851,9 +10853,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa03a2c9681c385ae1c72b169ac9c3525163b71db0b3362f16e8929e19e45fd"
+checksum = "936ba1aa863f2bbb2a0b5f28ea8a114058154e74969385ab27355421d56f9a03"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10867,7 +10869,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10918,7 +10920,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10946,7 +10948,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10960,7 +10962,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10980,7 +10982,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10995,10 +10997,10 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -11021,7 +11023,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11039,7 +11041,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11060,7 +11062,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11076,7 +11078,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11086,7 +11088,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "clap",
  "eyre",
@@ -11106,7 +11108,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11125,7 +11127,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11170,7 +11172,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11196,7 +11198,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11216,6 +11218,7 @@ dependencies = [
  "reth-codecs",
  "reth-primitives-traits",
  "revm-database",
+ "revm-state",
  "serde",
  "serde_with",
 ]
@@ -11223,7 +11226,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11243,9 +11246,9 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -11272,7 +11275,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
+source = "git+https://github.com/paradigmxyz/reth?rev=f370008#f370008d40ab17a82ff5bc7bbc595c229c2afcec"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11293,18 +11296,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e86cf594718932d42cebce1fa48292fb7b92721f7c914631add1ca970e814"
+checksum = "bdd4e89ad5d14393bde9b2b152480d4fd7f2399d0f9efe80ea29ec7c0b76bcdc"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "40.0.3"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
+checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11321,9 +11324,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "11.0.1"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b378c2653331fe60969d9745e802cd773d82a20d8aaced914dfcf26ab8f0d9"
+checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
 dependencies = [
  "bitvec",
  "phf",
@@ -11333,9 +11336,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "18.0.3"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafa298114f3cab706945de14c04e73e6e6d7896302e4183dae273f968e52f80"
+checksum = "86e48fc736d9542c082ea5305be44b6a14b53a615f0147ad57f62189fd813068"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11350,9 +11353,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "19.0.3"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9c13f1dfc79425931fd184b6bd373dfac7baba50859b01107d5c0e20549cbb"
+checksum = "ac68282a454318246817486835a446519291dd0a8167d09de14c7e96f2147696"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11366,12 +11369,13 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "15.0.2"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69c3ce73454a09ef89a66177239d7c4f5f697227ae27254c99451866603b19d"
+checksum = "d761681a43e48408ea23f7f66ff56ff7b6128cadb8f9135d1b94787d0c0fc6b4"
 dependencies = [
  "alloy-eips",
  "derive_more",
+ "either",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -11381,9 +11385,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "12.1.1"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a2656187f9f9c22ef9dd9300ed71aeaeca3506a6a0a229a07f264649b960d68"
+checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
 dependencies = [
  "auto_impl",
  "either",
@@ -11395,9 +11399,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "20.0.3"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce1d66037ca1394128313bb995fa9f50d834927a389386bb34f8f0ef914648f"
+checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11414,9 +11418,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "21.0.3"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
+checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
 dependencies = [
  "auto_impl",
  "either",
@@ -11432,9 +11436,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.40.1"
+version = "0.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e0cdc845c8dbf41255c9add80923b45df7bf1dd0473e41483ac398005dba12"
+checksum = "ac492384995d832d6910920a932c000436623ec18668ff9291cb78f96c8b710f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11448,13 +11452,14 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
 name = "revm-interpreter"
-version = "37.0.3"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
+checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11465,9 +11470,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "36.0.3"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191db865091e07ecb80b12ce3048192c76071ca3d2b0a315b111b271cd4ced37"
+checksum = "6d785931e4b8750cf9d79c808c22f05979c8d191baafc8badd4651db82584c1c"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11491,9 +11496,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "24.0.1"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5102d804892908d4ebf68da29b8562895922dffa26c230ff2c4dadcf93916f"
+checksum = "66f39151a31afe93d97f7ac894dd9dcc989368d5ccba19ce079bfc1d73b77452"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -11502,11 +11507,11 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "12.0.1"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eff6067185cf80932e06f6a9c8045b012ecb6f99a8d6edc618ec2792373e14"
+checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
 dependencies = [
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "bitflags 2.11.1",
  "nonmax",
  "revm-bytecode",
@@ -13278,7 +13283,7 @@ name = "tempo-payload-builder"
 version = "1.8.2"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8596,8 +8596,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8623,8 +8623,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8656,8 +8656,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8676,8 +8676,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8689,8 +8689,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8772,8 +8772,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8782,8 +8782,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8835,8 +8835,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8851,8 +8851,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8865,8 +8865,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8878,8 +8878,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8903,8 +8903,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8932,8 +8932,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8958,8 +8958,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8988,8 +8988,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9003,8 +9003,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9028,8 +9028,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9052,8 +9052,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9076,8 +9076,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9111,8 +9111,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9168,8 +9168,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9196,8 +9196,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9219,8 +9219,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9244,8 +9244,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9303,8 +9303,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9333,8 +9333,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9349,8 +9349,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9365,8 +9365,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9387,8 +9387,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9398,8 +9398,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9426,8 +9426,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9448,8 +9448,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9489,8 +9489,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "clap",
  "eyre",
@@ -9512,8 +9512,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9528,8 +9528,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9544,8 +9544,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9557,8 +9557,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9587,8 +9587,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9601,8 +9601,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9611,8 +9611,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9636,8 +9636,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9656,8 +9656,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9674,8 +9674,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9687,8 +9687,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9706,8 +9706,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9744,8 +9744,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9758,8 +9758,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "serde",
  "serde_json",
@@ -9768,8 +9768,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9796,8 +9796,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "bytes",
  "futures",
@@ -9816,8 +9816,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9833,8 +9833,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "bindgen",
  "cc",
@@ -9842,8 +9842,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "futures",
  "metrics",
@@ -9855,8 +9855,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9864,8 +9864,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9878,8 +9878,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9936,8 +9936,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9961,8 +9961,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9984,8 +9984,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9999,8 +9999,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10013,8 +10013,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10030,8 +10030,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10054,8 +10054,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10122,8 +10122,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10177,8 +10177,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10224,8 +10224,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10248,8 +10248,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10272,8 +10272,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "bytes",
  "eyre",
@@ -10301,8 +10301,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10313,8 +10313,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10337,8 +10337,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10349,8 +10349,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10372,8 +10372,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10415,8 +10415,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10464,8 +10464,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10492,8 +10492,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10508,8 +10508,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10523,8 +10523,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10599,8 +10599,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10629,8 +10629,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10672,8 +10672,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10692,8 +10692,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10723,8 +10723,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10770,8 +10770,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10821,8 +10821,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10835,8 +10835,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10866,8 +10866,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10917,8 +10917,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10945,8 +10945,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10959,8 +10959,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10979,8 +10979,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10994,8 +10994,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11020,8 +11020,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11038,8 +11038,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11059,8 +11059,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11075,8 +11075,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11085,8 +11085,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "clap",
  "eyre",
@@ -11105,8 +11105,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11124,8 +11124,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11169,8 +11169,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11195,8 +11195,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11222,8 +11222,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11242,8 +11242,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11271,8 +11271,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8ca03e#b8ca03ed49a0e09bc3dd3d3f4526999ef1f4e17a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8670,7 +8670,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8697,7 +8697,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8730,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8750,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8763,7 +8763,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8846,7 +8846,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8856,7 +8856,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8909,7 +8909,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -8939,7 +8939,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8952,7 +8952,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9006,7 +9006,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9032,7 +9032,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9102,7 +9102,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9126,7 +9126,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9150,7 +9150,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9185,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9242,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9270,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9293,7 +9293,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9318,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9407,7 +9407,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9423,7 +9423,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9439,7 +9439,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9472,7 +9472,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9500,7 +9500,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9522,7 +9522,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "clap",
  "eyre",
@@ -9586,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9618,7 +9618,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9631,7 +9631,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9661,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9685,7 +9685,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -9710,7 +9710,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9730,7 +9730,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9761,7 +9761,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9780,7 +9780,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9818,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9832,7 +9832,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "serde",
  "serde_json",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9870,7 +9870,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "bytes",
  "futures",
@@ -9890,7 +9890,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9907,7 +9907,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "bindgen",
  "cc",
@@ -9916,7 +9916,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "futures",
  "metrics",
@@ -9929,7 +9929,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9938,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9952,7 +9952,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10010,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10035,7 +10035,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -10059,7 +10059,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10074,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10088,7 +10088,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10105,7 +10105,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10129,7 +10129,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10197,7 +10197,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10252,7 +10252,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10299,7 +10299,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10323,7 +10323,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10347,7 +10347,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "bytes",
  "eyre",
@@ -10376,7 +10376,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10388,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10424,7 +10424,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10447,7 +10447,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10490,7 +10490,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -10539,7 +10539,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10567,7 +10567,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10583,7 +10583,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10598,7 +10598,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10675,7 +10675,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10705,7 +10705,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10748,7 +10748,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10768,7 +10768,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10799,7 +10799,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10846,7 +10846,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10897,7 +10897,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10911,7 +10911,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10993,7 +10993,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11021,7 +11021,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11070,7 +11070,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -11096,7 +11096,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11114,7 +11114,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11135,7 +11135,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11151,7 +11151,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11161,7 +11161,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "clap",
  "eyre",
@@ -11181,7 +11181,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11200,7 +11200,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11245,7 +11245,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11271,7 +11271,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11299,7 +11299,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11319,7 +11319,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "alloy-evm",
@@ -11348,7 +11348,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc65271#fc65271365aa8df79b90a3e173a55749872f3791"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8597,7 +8597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8657,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9029,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9197,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9399,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "clap",
  "eyre",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "serde",
  "serde_json",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "bytes",
  "futures",
@@ -9817,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "bindgen",
  "cc",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "futures",
  "metrics",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10225,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10273,7 +10273,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "bytes",
  "eyre",
@@ -10302,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10314,7 +10314,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10338,7 +10338,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10350,7 +10350,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10373,7 +10373,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10416,7 +10416,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10465,7 +10465,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10493,7 +10493,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10600,7 +10600,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10673,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10693,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10724,7 +10724,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10771,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10822,7 +10822,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10867,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10918,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10960,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10980,7 +10980,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10995,7 +10995,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11021,7 +11021,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11039,7 +11039,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11060,7 +11060,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11086,7 +11086,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "clap",
  "eyre",
@@ -11106,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11125,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11170,7 +11170,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11196,7 +11196,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11223,7 +11223,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11243,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -11272,7 +11272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+source = "git+https://github.com/paradigmxyz/reth?rev=9f2837e#9f2837e1794baf7492b16d115f6c0ee7c6103d89"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11432,9 +11432,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2854f2c48cecac90e8ad48fe8d8842707f79df2b748913b67bd2439a9ea3b4ab"
+checksum = "15e0cdc845c8dbf41255c9add80923b45df7bf1dd0473e41483ac398005dba12"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,66 +144,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f370008", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
 reth-codecs = { version = "0.5.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f370008", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f370008", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
 reth-primitives-traits = { version = "0.5.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f370008", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,66 +144,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
 reth-codecs = { version = "0.5.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
 reth-primitives-traits = { version = "0.5.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "fa3859e", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "1.8.2"
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.95.0"
 authors = ["Tempo Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://docs.tempo.xyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,66 +144,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f370008", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f370008", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f370008", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f370008", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
 reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-codecs = { version = "0.4.0", default-features = false }
+reth-codecs = { version = "0.5.0", default-features = false }
 reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
 reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
 reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
@@ -181,7 +181,7 @@ reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f3700
 reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
 reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
-reth-primitives-traits = { version = "0.4.0", default-features = false }
+reth-primitives-traits = { version = "0.5.0", default-features = false }
 reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
 reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f370008" }
@@ -207,15 +207,15 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f370008", feat
   "std",
   "optional-checks",
 ] }
-revm = { version = "40.0.3", features = ["optional_fee_charge"], default-features = false }
+revm = { version = "41.0.0", features = ["optional_fee_charge"], default-features = false }
 
 alloy = { version = "2.0.5", default-features = false }
 alloy-consensus = { version = "2.0.5", default-features = false }
 alloy-contract = { version = "2.0.5", default-features = false }
-alloy-eip7928 = { version = "0.4.1", default-features = false }
+alloy-eip7928 = { version = "0.4.3", default-features = false }
 alloy-eips = { version = "2.0.5", default-features = false }
-alloy-evm = { version = "0.36.0", default-features = false }
-revm-inspectors = "0.40.0"
+alloy-evm = { version = "0.37.0", default-features = false }
+revm-inspectors = "0.41.1"
 alloy-genesis = { version = "2.0.5", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-abi = { version = "1.6.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,66 +144,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b8ca03e", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,66 +144,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
 reth-codecs = { version = "0.5.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
 reth-primitives-traits = { version = "0.5.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "606e2f1", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "fc65271", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,66 +144,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
 reth-codecs = { version = "0.4.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
 reth-primitives-traits = { version = "0.4.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "72fafb5", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9f2837e", features = [
   "std",
   "optional-checks",
 ] }

--- a/Dockerfile.chef
+++ b/Dockerfile.chef
@@ -1,4 +1,4 @@
-FROM rust:1.93-bookworm@sha256:7c4ae649a84014c467d79319bbf17ce2632ae8b8be123ac2fb2ea5be46823f31 AS chef
+FROM rust:1.95-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1 AS chef
 
 RUN cargo install cargo-chef --version 0.1.77 --locked \
  && cargo install sccache --version 0.14.0 --locked

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -15,7 +15,7 @@
 #   ./out/tempo                              the reproducible binary
 #
 # Reproducibility-critical decisions:
-#   * Pinned base image digest (rust 1.93.0 on Debian Bookworm).
+#   * Pinned base image digest (rust 1.95.0 on Debian Bookworm).
 #   * `cargo --locked` so registry deps cannot drift.
 #   * RUSTFLAGS strip every source of nondeterminism we know about:
 #     SOURCE_DATE_EPOCH for build timestamps, --remap-path-prefix for the
@@ -28,7 +28,7 @@
 #   * `[profile.reproducible]` (defined in Cargo.toml) disables incremental,
 #     emits no debuginfo, and inherits `release`'s fat LTO + 1 codegen-unit.
 
-ARG RUST_TOOLCHAIN=1.93.0
+ARG RUST_TOOLCHAIN=1.95.0
 FROM rust:${RUST_TOOLCHAIN}-bookworm@sha256:d0a4aa3ca2e1088ac0c81690914a0d810f2eee188197034edf366ed010a2b382 AS builder
 
 ARG SOURCE_DATE_EPOCH

--- a/bin/tempo/src/cli.rs
+++ b/bin/tempo/src/cli.rs
@@ -1,9 +1,7 @@
 //! CLI type definitions for the Tempo node.
 
 use crate::{defaults, follow, tempo_cmd};
-use reth_ethereum::chainspec::EthChainSpec as _;
 use reth_ethereum_cli::Cli;
-use reth_network_peers::pk2id;
 use reth_rpc_server_types::{RethRpcModule, RpcModuleSelection, RpcModuleValidator};
 use tempo_chainspec::spec::TempoChainSpecParser;
 use tempo_faucet::args::FaucetArgs;
@@ -122,21 +120,4 @@ pub(crate) struct PyroscopeArgs {
     /// Sample rate for profiling (default: 100 Hz)
     #[arg(long = "pyroscope.sample-rate", default_value_t = 100)]
     pub(crate) sample_rate: u32,
-}
-
-pub(crate) trait NodeCommandExt {
-    /// Derive the peer id from the p2p secret key without starting the network.
-    fn peer_id(&self) -> reth_network_peers::PeerId;
-}
-
-impl NodeCommandExt for reth_cli_commands::node::NodeCommand<TempoChainSpecParser, TempoArgs> {
-    fn peer_id(&self) -> reth_network_peers::PeerId {
-        let data_dir = self.datadir.clone().resolve_datadir(self.chain.chain());
-        let sk = self
-            .network
-            .secret_key(data_dir.p2p_secret())
-            .expect("unable to derive peer id from p2p secret");
-
-        pk2id(&sk.public_key(secp256k1::SECP256K1))
-    }
 }

--- a/bin/tempo/src/lib.rs
+++ b/bin/tempo/src/lib.rs
@@ -40,12 +40,9 @@ mod utils;
 pub(crate) use crate::cli::TempoRpcModuleValidator;
 pub(crate) use crate::cli::{TempoArgs, TempoCli};
 
-use crate::{
-    cli::NodeCommandExt as _,
-    utils::{
-        block_on_consensus_public_key, fetch_bootnodes, install_crypto_provider,
-        print_extensions_footer,
-    },
+use crate::utils::{
+    block_on_consensus_public_key, fetch_bootnodes, install_crypto_provider,
+    print_extensions_footer,
 };
 use clap::{CommandFactory, FromArgMatches};
 use commonware_runtime::{Metrics, Runner};
@@ -180,7 +177,10 @@ pub fn tempo_main() -> eyre::Result<()> {
             .wrap_err("failed parsing consensus key")?
             .map(|k| k.to_string());
 
-        let peer_id = format!("{:x}", node_cmd.peer_id());
+        let peer_id = format!(
+            "{:x}",
+            node_cmd.peer_id().wrap_err("failed to derive peer id")?
+        );
 
         // VictoriaMetrics does not support merging `extra_fields` query args like `extra_labels` for
         // metrics. A workaround for now is to directly hook into the `OTEL_RESOURCE_ATTRIBUTES` env var

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -1712,8 +1712,8 @@ mod tests {
         executor
             .evm_mut()
             .db_mut()
-            .set_state_hook(Some(Box::new(move |state: &EvmState| {
-                hook_calls_clone.lock().unwrap().push(state.clone());
+            .set_state_hook(Some(Box::new(move |state: EvmState| {
+                hook_calls_clone.lock().unwrap().push(state);
             })));
 
         let addr = Address::with_last_byte(0xff);
@@ -1761,8 +1761,8 @@ mod tests {
         executor
             .evm_mut()
             .db_mut()
-            .set_state_hook(Some(Box::new(move |state: &EvmState| {
-                hook_calls_clone.lock().unwrap().push(state.clone());
+            .set_state_hook(Some(Box::new(move |state: EvmState| {
+                hook_calls_clone.lock().unwrap().push(state);
             })));
 
         executor.deploy_precompile_at_boundary(addr).unwrap();

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1225,7 +1225,7 @@ where
                     BalMessage::State(state) => {
                         bal_state.commit(&state);
                         if let Some(state_root_task_hook) = &mut state_root_task_hook {
-                            state_root_task_hook.on_state(&state);
+                            state_root_task_hook.on_state(state);
                         }
                     }
                 }
@@ -1255,8 +1255,8 @@ struct BalTaskHandle {
 impl BalTaskHandle {
     fn state_hook(&self) -> impl OnStateHook {
         let msg_tx = self.msg_tx.clone();
-        move |state: &EvmState| {
-            let _ = msg_tx.send(BalMessage::State(state.clone()));
+        move |state: EvmState| {
+            let _ = msg_tx.send(BalMessage::State(state));
         }
     }
 

--- a/scripts/sanitize_toml.py
+++ b/scripts/sanitize_toml.py
@@ -1,20 +1,19 @@
 #!/usr/bin/env python3
 """Sanitize Cargo.toml files for publishing outside the workspace."""
-
 import re
 import sys
 from pathlib import Path
 
-# ── Depth-aware line skipping ─────────────────────────────────────────────────
 
+# ── Depth-aware line skipping ─────────────────────────────────────────────────
 
 def _strip_comment(line):
     """Return line with trailing # comments removed (string-aware)."""
     in_str = False
     for i, c in enumerate(line):
-        if c == '"' and (i == 0 or line[i - 1] != "\\"):
+        if c == '"' and (i == 0 or line[i - 1] != '\\'):
             in_str = not in_str
-        elif c == "#" and not in_str:
+        elif c == '#' and not in_str:
             return line[:i]
     return line
 
@@ -22,7 +21,7 @@ def _strip_comment(line):
 def _depth_delta(line):
     """Return (brace_delta, bracket_delta) for a line, ignoring comments."""
     s = _strip_comment(line)
-    return (s.count("{") - s.count("}"), s.count("[") - s.count("]"))
+    return (s.count('{') - s.count('}'), s.count('[') - s.count(']'))
 
 
 def strip_dep_lines(text, should_strip, removed=None):
@@ -38,7 +37,7 @@ def strip_dep_lines(text, should_strip, removed=None):
 
     If `removed` is a set, stripped dep names are added to it for downstream use.
     """
-    lines = text.split("\n")
+    lines = text.split('\n')
     result = []
     skip = False
     brace_depth = 0
@@ -46,10 +45,10 @@ def strip_dep_lines(text, should_strip, removed=None):
     for line in lines:
         if not skip:
             # Match inline table: name = { ... } or name = "..."
-            name_m = re.match(r"^([a-zA-Z0-9_-]+)\s*=\s", line)
+            name_m = re.match(r'^([a-zA-Z0-9_-]+)\s*=\s', line)
             # Match dot-notation: name.key = value
             if not name_m:
-                name_m = re.match(r"^([a-zA-Z0-9_-]+)\.", line)
+                name_m = re.match(r'^([a-zA-Z0-9_-]+)\.', line)
             if name_m and should_strip(name_m.group(1)):
                 if removed is not None:
                     removed.add(name_m.group(1))
@@ -68,7 +67,7 @@ def strip_dep_lines(text, should_strip, removed=None):
             if brace_depth <= 0 and bracket_depth <= 0:
                 skip = False
             continue
-    return "\n".join(result)
+    return '\n'.join(result)
 
 
 def strip_orphaned_feature_entries(text, removed_deps):
@@ -85,9 +84,9 @@ def strip_orphaned_feature_entries(text, removed_deps):
     for dep in sorted(removed_deps):
         escaped = re.escape(dep)
         # "dep?/feature" and "dep/feature" entries (with optional trailing comma)
-        text = re.sub(rf'\s*"{escaped}\??/[^"]*",?\n', "\n", text)
+        text = re.sub(rf'\s*"{escaped}\??/[^"]*",?\n', '\n', text)
         # "dep:dep" entries
-        text = re.sub(rf'\s*"dep:{escaped}",?\n', "\n", text)
+        text = re.sub(rf'\s*"dep:{escaped}",?\n', '\n', text)
     return text
 
 
@@ -97,13 +96,13 @@ def strip_feature_blocks(text, block_names):
     Uses bracket depth tracking to handle nested arrays.
     """
     names = set(block_names)
-    lines = text.split("\n")
+    lines = text.split('\n')
     result = []
     skip = False
     bracket_depth = 0
     for line in lines:
         if not skip:
-            m = re.match(r"^([a-zA-Z0-9_-]+)\s*=\s*\[", line)
+            m = re.match(r'^([a-zA-Z0-9_-]+)\s*=\s*\[', line)
             if m and m.group(1) in names:
                 _, kd = _depth_delta(line)
                 bracket_depth = kd
@@ -118,7 +117,7 @@ def strip_feature_blocks(text, block_names):
             if bracket_depth <= 0:
                 skip = False
             continue
-    return "\n".join(result)
+    return '\n'.join(result)
 
 
 def strip_feature_array_entries(text, entries_to_remove):
@@ -126,16 +125,16 @@ def strip_feature_array_entries(text, entries_to_remove):
 
     entries_to_remove: set of unquoted entry strings (e.g. {'reth', 'rand/serde'})
     """
-    lines = text.split("\n")
+    lines = text.split('\n')
     result = []
     in_features = False
     for line in lines:
         # Detect [features] section
-        if re.match(r"^\[features\]", line):
+        if re.match(r'^\[features\]', line):
             in_features = True
             result.append(line)
             continue
-        if in_features and re.match(r"^\[", line):
+        if in_features and re.match(r'^\[', line):
             in_features = False
 
         if in_features:
@@ -143,41 +142,40 @@ def strip_feature_array_entries(text, entries_to_remove):
             for entry in entries_to_remove:
                 escaped = re.escape(entry)
                 # Remove "entry", or "entry" (with comma handling)
-                modified = re.sub(rf'\s*"{escaped}"\s*,', "", modified)
-                modified = re.sub(rf',\s*"{escaped}"', "", modified)
-                modified = re.sub(rf'"{escaped}"', "", modified)
+                modified = re.sub(rf'\s*"{escaped}"\s*,', '', modified)
+                modified = re.sub(rf',\s*"{escaped}"', '', modified)
+                modified = re.sub(rf'"{escaped}"', '', modified)
             # Clean up artifacts: empty array elements, double commas
-            modified = re.sub(r",\s*\]", "]", modified)  # trailing comma before ]
-            modified = re.sub(r"\[\s*,", "[", modified)  # leading comma after [
-            modified = re.sub(r",\s*,", ",", modified)  # double commas
+            modified = re.sub(r',\s*\]', ']', modified)  # trailing comma before ]
+            modified = re.sub(r'\[\s*,', '[', modified)   # leading comma after [
+            modified = re.sub(r',\s*,', ',', modified)    # double commas
             # Skip lines that became empty array entries (just whitespace/tabs)
-            if modified.strip() == "" and line.strip() != "":
+            if modified.strip() == '' and line.strip() != '':
                 continue
             result.append(modified)
         else:
             result.append(line)
-    return "\n".join(result)
+    return '\n'.join(result)
 
 
 # ── Workspace parsing helpers ─────────────────────────────────────────────────
 
-
 def parse_workspace_package(ws_toml_path):
     """Parse [workspace.package] metadata from a workspace Cargo.toml."""
-    ws_text = Path(ws_toml_path).read_text(encoding="utf-8")
+    ws_text = Path(ws_toml_path).read_text(encoding='utf-8')
     meta = {}
     for key in (
-        "version",
-        "edition",
-        "rust-version",
-        "authors",
-        "license",
-        "homepage",
-        "repository",
-        "categories",
-        "keywords",
+        'version',
+        'edition',
+        'rust-version',
+        'authors',
+        'license',
+        'homepage',
+        'repository',
+        'categories',
+        'keywords',
     ):
-        m = re.search(rf"^{re.escape(key)}\s*=\s*(.+)$", ws_text, re.MULTILINE)
+        m = re.search(rf'^{re.escape(key)}\s*=\s*(.+)$', ws_text, re.MULTILINE)
         if m:
             meta[key] = m.group(1).strip()
     return meta
@@ -200,14 +198,13 @@ def parse_workspace_deps(ws_toml_path):
     - ws_pkg_version: the workspace package version string
     - ws_git_deps: {name: {"git": url, ...}} for deps using git sources
     """
-    ws_text = Path(ws_toml_path).read_text(encoding="utf-8")
+    ws_text = Path(ws_toml_path).read_text(encoding='utf-8')
 
     # Workspace package version
     ws_pkg_version = None
     m = re.search(
         r'^\[workspace\.package\]\s*\n(?:.*\n)*?version\s*=\s*"([^"]+)"',
-        ws_text,
-        re.MULTILINE,
+        ws_text, re.MULTILINE,
     )
     if m:
         ws_pkg_version = m.group(1)
@@ -221,15 +218,15 @@ def parse_workspace_deps(ws_toml_path):
     # Match inline table deps: name = { ... } (possibly multi-line)
     # Use depth-aware extraction
     in_ws_deps = False
-    lines = ws_text.split("\n")
+    lines = ws_text.split('\n')
     i = 0
     while i < len(lines):
         line = lines[i]
-        if re.match(r"^\[workspace\.dependencies\]", line):
+        if re.match(r'^\[workspace\.dependencies\]', line):
             in_ws_deps = True
             i += 1
             continue
-        if in_ws_deps and re.match(r"^\[", line):
+        if in_ws_deps and re.match(r'^\[', line):
             break
         if not in_ws_deps:
             i += 1
@@ -237,12 +234,12 @@ def parse_workspace_deps(ws_toml_path):
 
         # Skip comments and blank lines
         stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
+        if not stripped or stripped.startswith('#'):
             i += 1
             continue
 
         # Try to match a dep start
-        name_m = re.match(r"^([a-zA-Z0-9_-]+)\s*=\s*(.*)", line)
+        name_m = re.match(r'^([a-zA-Z0-9_-]+)\s*=\s*(.*)', line)
         if not name_m:
             i += 1
             continue
@@ -258,12 +255,12 @@ def parse_workspace_deps(ws_toml_path):
             continue
 
         # Inline table dep: collect full body across lines
-        if rest.startswith("{"):
+        if rest.startswith('{'):
             body = rest
             bd, _ = _depth_delta(rest)
             while bd > 0 and i + 1 < len(lines):
                 i += 1
-                body += "\n" + lines[i]
+                body += '\n' + lines[i]
                 d, _ = _depth_delta(lines[i])
                 bd += d
 
@@ -272,23 +269,19 @@ def parse_workspace_deps(ws_toml_path):
             if ver_m:
                 ws_deps[name] = ver_m.group(1)
 
-            if "default-features = false" in body:
+            if 'default-features = false' in body:
                 ws_no_default.add(name)
 
-            if "path = " in body or "path =" in body:
+            if 'path = ' in body or 'path =' in body:
                 ws_path_deps.add(name)
                 # Path-only deps: read version from the crate's own Cargo.toml
                 if name not in ws_deps:
                     path_m = re.search(r'path\s*=\s*"([^"]+)"', body)
                     if path_m:
-                        crate_toml = (
-                            Path(ws_toml_path).parent / path_m.group(1) / "Cargo.toml"
-                        )
+                        crate_toml = Path(ws_toml_path).parent / path_m.group(1) / "Cargo.toml"
                         if crate_toml.exists():
-                            crate_text = crate_toml.read_text(encoding="utf-8")
-                            cv = re.search(
-                                r'^version\s*=\s*"([^"]+)"', crate_text, re.MULTILINE
-                            )
+                            crate_text = crate_toml.read_text(encoding='utf-8')
+                            cv = re.search(r'^version\s*=\s*"([^"]+)"', crate_text, re.MULTILINE)
                             if cv:
                                 ws_deps[name] = cv.group(1)
                     # Fall back to workspace version if crate uses version.workspace = true
@@ -311,26 +304,20 @@ def parse_workspace_deps(ws_toml_path):
 
 # ── dot-notation dep matching ─────────────────────────────────────────────────
 
-
 def _match_dot_dep(line):
     """Match lines like `name.workspace = true` or `name = { workspace = true }`."""
-    m = re.match(r"^([a-zA-Z0-9_-]+)\.workspace\s*=\s*true", line)
+    m = re.match(r'^([a-zA-Z0-9_-]+)\.workspace\s*=\s*true', line)
     return m.group(1) if m else None
 
 
 # ── Actions ───────────────────────────────────────────────────────────────────
-
 
 def main():
     action = sys.argv[1]
     toml_path = sys.argv[2] if len(sys.argv) > 2 else None
 
     # Most actions operate on a target toml file; gen_workspace is the exception.
-    text = (
-        Path(toml_path).read_text(encoding="utf-8")
-        if toml_path and action not in ("gen_workspace", "get_version")
-        else ""
-    )
+    text = Path(toml_path).read_text(encoding='utf-8') if toml_path and action not in ("gen_workspace", "get_version") else ""
 
     if action == "sanitize_base":
         ws_version = sys.argv[3]
@@ -340,134 +327,113 @@ def main():
             meta = parse_workspace_package(ws_toml_path)
         else:
             meta = {
-                "edition": '"2024"',
-                "rust-version": '"1.95.0"',
-                "authors": '["Tempo Contributors"]',
-                "license": '"MIT OR Apache-2.0"',
-                "homepage": '"https://docs.tempo.xyz"',
-                "repository": '"https://github.com/tempoxyz/tempo"',
-                "categories": '["cryptography::cryptocurrencies"]',
-                "keywords": '["blockchain", "ethereum", "evm", "payments", "tempo"]',
+                'edition': '"2024"',
+                'rust-version': '"1.93.0"',
+                'authors': '["Tempo Contributors"]',
+                'license': '"MIT OR Apache-2.0"',
+                'homepage': '"https://docs.tempo.xyz"',
+                'repository': '"https://github.com/tempoxyz/tempo"',
+                'categories': '["cryptography::cryptocurrencies"]',
+                'keywords': '["blockchain", "ethereum", "evm", "payments", "tempo"]',
             }
 
         # Remove [lints] section
-        text = re.sub(r"\n\[lints\]\nworkspace = true\n", "\n", text)
+        text = re.sub(r'\n\[lints\]\nworkspace = true\n', '\n', text)
         # Resolve workspace package fields (order matters: longer keys first)
         for key in (
-            "rust-version",
-            "version",
-            "edition",
-            "authors",
-            "license",
-            "homepage",
-            "repository",
-            "categories",
-            "keywords",
+            'rust-version',
+            'version',
+            'edition',
+            'authors',
+            'license',
+            'homepage',
+            'repository',
+            'categories',
+            'keywords',
         ):
-            if key == "version":
-                text = text.replace(
-                    "version.workspace = true", f'version = "{ws_version}"'
-                )
+            if key == 'version':
+                text = text.replace('version.workspace = true', f'version = "{ws_version}"')
             elif key in meta:
-                text = text.replace(f"{key}.workspace = true", f"{key} = {meta[key]}")
+                text = text.replace(f'{key}.workspace = true', f'{key} = {meta[key]}')
         # Remove publish.workspace = true
-        text = re.sub(r"publish\.workspace = true\n", "", text)
+        text = re.sub(r'publish\.workspace = true\n', '', text)
 
     elif action == "sanitize_primitives":
         # Remove reth-related feature definitions (multi-line) FIRST,
         # before dependency removal which would strip the opening line
         # (e.g. "reth-codec = [") and orphan the block body.
-        text = strip_feature_blocks(
-            text, ["reth", "reth-codec", "serde-bincode-compat", "rpc"]
-        )
+        text = strip_feature_blocks(text, ['reth', 'reth-codec', 'serde-bincode-compat', 'rpc'])
 
         # Track removed deps so we can auto-strip orphaned feature entries
         removed = set()
 
         # Remove reth dependency lines (single- and multi-line)
-        text = strip_dep_lines(text, lambda n: n.startswith("reth-"), removed)
+        text = strip_dep_lines(text, lambda n: n.startswith('reth-'), removed)
         # Remove modular-bitfield
-        text = strip_dep_lines(text, lambda n: n == "modular-bitfield", removed)
+        text = strip_dep_lines(text, lambda n: n == 'modular-bitfield', removed)
         # Remove deps only used by the stripped rpc feature
-        text = strip_dep_lines(
-            text, lambda n: n in ("alloy-rpc-types-eth", "alloy-network"), removed
-        )
+        text = strip_dep_lines(text, lambda n: n in ('alloy-rpc-types-eth', 'alloy-network'), removed)
         # Remove # Reth comment
-        text = re.sub(r"^# Reth\n", "", text, flags=re.MULTILINE)
+        text = re.sub(r'^# Reth\n', '', text, flags=re.MULTILINE)
 
         # Auto-strip feature entries referencing removed deps
         text = strip_orphaned_feature_entries(text, removed)
 
         # Remove stripped feature names and dev-dep-only entries from feature arrays
-        text = strip_feature_array_entries(
-            text,
-            {
-                "reth",
-                "reth-codec",
-                "serde-bincode-compat",
-                "rpc",
-                "rand/serde",
-                "tracing-subscriber/serde",
-            },
-        )
+        text = strip_feature_array_entries(text, {
+            'reth', 'reth-codec', 'serde-bincode-compat', 'rpc',
+            'rand/serde', 'tracing-subscriber/serde',
+        })
 
     elif action == "sanitize_alloy":
         # Remove reth dependency lines
-        text = strip_dep_lines(text, lambda n: n.startswith("reth-"))
+        text = strip_dep_lines(text, lambda n: n.startswith('reth-'))
         # Remove internal non-publishable deps (path-only workspace crates, except
         # the crates we're publishing: tempo-contracts and tempo-primitives)
         ws_toml_path = sys.argv[3]
         _, _, ws_path_deps, _, _ = parse_workspace_deps(ws_toml_path)
-        publish_keep = {
-            "tempo-contracts",
-            "tempo-primitives",
-            "tempo-chainspec",
-            "tempo-alloy",
-        }
+        publish_keep = {'tempo-contracts', 'tempo-primitives', 'tempo-chainspec', 'tempo-alloy'}
         internal_deps = ws_path_deps - publish_keep
         text = strip_dep_lines(text, lambda n: n in internal_deps)
 
         # Strip the `reth` feature block
-        text = strip_feature_blocks(text, ["reth"])
+        text = strip_feature_blocks(text, ['reth'])
 
         # Strip "rpc" from tempo-primitives features (rpc feature is stripped during publish)
-        text = re.sub(r', "rpc"', "", text)
-        text = re.sub(r'"rpc", ', "", text)
+        text = re.sub(r', "rpc"', '', text)
+        text = re.sub(r'"rpc", ', '', text)
 
     elif action == "sanitize_chainspec":
         # Remove reth and cli feature blocks entirely
-        text = strip_feature_blocks(text, ["reth", "cli"])
+        text = strip_feature_blocks(text, ['reth', 'cli'])
 
         # Track removed deps so we can auto-strip orphaned feature entries
         removed = set()
 
         # Remove deps only used by stripped reth-gated chainspec code.
-        text = strip_dep_lines(text, lambda n: n.startswith("reth-"), removed)
+        text = strip_dep_lines(text, lambda n: n.startswith('reth-'), removed)
         text = strip_dep_lines(
             text,
-            lambda n: (
-                n
-                in (
-                    "commonware-codec",
-                    "commonware-cryptography",
-                    "eyre",
-                    "tempo-dkg-onchain-artifacts",
-                )
+            lambda n: n in (
+                'commonware-codec',
+                'commonware-cryptography',
+                'eyre',
+                'tempo-dkg-onchain-artifacts',
             ),
             removed,
         )
         # Remove # Reth comment
-        text = re.sub(r"^# Reth\n", "", text, flags=re.MULTILINE)
+        text = re.sub(r'^# Reth\n', '', text, flags=re.MULTILINE)
 
         # Auto-strip feature entries referencing removed deps
         text = strip_orphaned_feature_entries(text, removed)
 
         # Remove "reth" and "cli" from the default feature array
-        text = strip_feature_array_entries(text, {"reth", "cli"})
+        text = strip_feature_array_entries(text, {'reth', 'cli'})
 
         # The tempo_hardfork! macro generates #[cfg(feature = "reth")] blocks that remain in source.
         # Tell check-cfg that "reth" is an expected (but never enabled) feature to suppress warnings.
-        if "[lints.rust]" not in text:
+        if '[lints.rust]' not in text:
             text += '\n[lints.rust]\nunexpected_cfgs = { level = "allow", check-cfg = [\'cfg(feature, values("reth"))\'] }\n'
 
     elif action == "resolve_deps":
@@ -487,27 +453,27 @@ def main():
 
             parts = [f'version = "{version}"']
             # Preserve default-features = false from either workspace or local spec
-            if name in ws_no_default or "default-features = false" in body:
-                parts.append("default-features = false")
-            features_match = re.search(r"features\s*=\s*\[[^\]]*\]", body)
+            if name in ws_no_default or 'default-features = false' in body:
+                parts.append('default-features = false')
+            features_match = re.search(r'features\s*=\s*\[[^\]]*\]', body)
             if features_match:
                 parts.append(features_match.group(0))
-            if "optional = true" in body:
-                parts.append("optional = true")
-            if "package = " in body:
+            if 'optional = true' in body:
+                parts.append('optional = true')
+            if 'package = ' in body:
                 pkg_match = re.search(r'package\s*=\s*"[^"]*"', body)
                 if pkg_match:
                     parts.append(pkg_match.group(0))
-            return f"{name} = {{ {', '.join(parts)} }}"
+            return f'{name} = {{ {", ".join(parts)} }}'
 
         # Resolve inline table deps: name = { workspace = true, ... }
         # Use depth-aware line-by-line processing
-        lines = text.split("\n")
+        lines = text.split('\n')
         result = []
         i = 0
         while i < len(lines):
             line = lines[i]
-            name_m = re.match(r"^([a-zA-Z0-9_-]+)\s*=\s*(\{.*)", line)
+            name_m = re.match(r'^([a-zA-Z0-9_-]+)\s*=\s*(\{.*)', line)
             if name_m:
                 name = name_m.group(1)
                 rest = name_m.group(2)
@@ -518,12 +484,12 @@ def main():
                 while bd > 0 and i + 1 < len(lines):
                     i += 1
                     collected.append(lines[i])
-                    body += " " + lines[i]
+                    body += ' ' + lines[i]
                     d, _ = _depth_delta(lines[i])
                     bd += d
 
-                if "workspace = true" in body:
-                    result.append(resolve_dep_line("\n".join(collected), name, body))
+                if 'workspace = true' in body:
+                    result.append(resolve_dep_line('\n'.join(collected), name, body))
                 else:
                     result.extend(collected)
                 i += 1
@@ -542,15 +508,15 @@ def main():
                     sys.exit(1)
                 parts = [f'version = "{version}"']
                 if dot_name in ws_no_default:
-                    parts.append("default-features = false")
-                result.append(f"{dot_name} = {{ {', '.join(parts)} }}")
+                    parts.append('default-features = false')
+                result.append(f'{dot_name} = {{ {", ".join(parts)} }}')
                 i += 1
                 continue
 
             result.append(line)
             i += 1
 
-        text = "\n".join(result)
+        text = '\n'.join(result)
 
     elif action == "gen_workspace":
         # Generate a temporary workspace Cargo.toml with workspace deps,
@@ -559,14 +525,14 @@ def main():
         # Usage: sanitize_toml.py gen_workspace <ws_toml> <out_toml> [crate1,crate2,...]
         ws_toml_path = sys.argv[2]
         out_path = sys.argv[3]
-        publish_crates = set(sys.argv[4].split(",")) if len(sys.argv) > 4 else set()
+        publish_crates = set(sys.argv[4].split(',')) if len(sys.argv) > 4 else set()
 
         workspace_package = parse_workspace_package(ws_toml_path)
         ws_deps, ws_no_default, ws_path_deps, _, _ = parse_workspace_deps(ws_toml_path)
 
         # Read the [workspace.dependencies] section text
-        ws_text = Path(ws_toml_path).read_text(encoding="utf-8")
-        m = re.search(r"\[workspace\.dependencies\]\n((?:.*\n)*?)(?=\[|$)", ws_text)
+        ws_text = Path(ws_toml_path).read_text(encoding='utf-8')
+        m = re.search(r'\[workspace\.dependencies\]\n((?:.*\n)*?)(?=\[|$)', ws_text)
         if not m:
             print("error: could not find [workspace.dependencies]", file=sys.stderr)
             sys.exit(1)
@@ -579,43 +545,43 @@ def main():
             strip_names.add(name)
 
         def should_strip(name):
-            return name.startswith("reth-") or name in strip_names
+            return name.startswith('reth-') or name in strip_names
 
         filtered = strip_dep_lines(deps_block, should_strip)
 
         # Build output
-        existing = Path(out_path).read_text(encoding="utf-8")
+        existing = Path(out_path).read_text(encoding='utf-8')
         if workspace_package:
-            existing += "\n[workspace.package]\n"
+            existing += '\n[workspace.package]\n'
             for key in (
-                "version",
-                "edition",
-                "rust-version",
-                "authors",
-                "license",
-                "homepage",
-                "repository",
-                "categories",
-                "keywords",
+                'version',
+                'edition',
+                'rust-version',
+                'authors',
+                'license',
+                'homepage',
+                'repository',
+                'categories',
+                'keywords',
             ):
                 if key in workspace_package:
-                    existing += f"{key} = {workspace_package[key]}\n"
-        existing += "\n[workspace.dependencies]\n"
-        existing += filtered + "\n"
+                    existing += f'{key} = {workspace_package[key]}\n'
+        existing += '\n[workspace.dependencies]\n'
+        existing += filtered + '\n'
         for crate in sorted(publish_crates):
-            dirname = crate.removeprefix("tempo-")
+            dirname = crate.removeprefix('tempo-')
             parts = [f'path = "{dirname}"']
             if crate in ws_no_default:
-                parts.append("default-features = false")
-            existing += f"{crate} = {{ {', '.join(parts)} }}\n"
+                parts.append('default-features = false')
+            existing += f'{crate} = {{ {", ".join(parts)} }}\n'
 
-        Path(out_path).write_text(existing, encoding="utf-8")
+        Path(out_path).write_text(existing, encoding='utf-8')
         sys.exit(0)
 
     elif action == "get_version":
         ws_toml_path = sys.argv[2]
         meta = parse_workspace_package(ws_toml_path)
-        version = meta.get("version")
+        version = meta.get('version')
         if not version:
             print("error: could not find workspace version", file=sys.stderr)
             sys.exit(1)
@@ -627,10 +593,10 @@ def main():
         sys.exit(1)
 
     # Clean up excessive blank lines
-    text = re.sub(r"\n{3,}", "\n\n", text)
+    text = re.sub(r'\n{3,}', '\n\n', text)
 
-    Path(toml_path).write_text(text, encoding="utf-8")
+    Path(toml_path).write_text(text, encoding='utf-8')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/scripts/sanitize_toml.py
+++ b/scripts/sanitize_toml.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python3
 """Sanitize Cargo.toml files for publishing outside the workspace."""
+
 import re
 import sys
 from pathlib import Path
 
-
 # ── Depth-aware line skipping ─────────────────────────────────────────────────
+
 
 def _strip_comment(line):
     """Return line with trailing # comments removed (string-aware)."""
     in_str = False
     for i, c in enumerate(line):
-        if c == '"' and (i == 0 or line[i - 1] != '\\'):
+        if c == '"' and (i == 0 or line[i - 1] != "\\"):
             in_str = not in_str
-        elif c == '#' and not in_str:
+        elif c == "#" and not in_str:
             return line[:i]
     return line
 
@@ -21,7 +22,7 @@ def _strip_comment(line):
 def _depth_delta(line):
     """Return (brace_delta, bracket_delta) for a line, ignoring comments."""
     s = _strip_comment(line)
-    return (s.count('{') - s.count('}'), s.count('[') - s.count(']'))
+    return (s.count("{") - s.count("}"), s.count("[") - s.count("]"))
 
 
 def strip_dep_lines(text, should_strip, removed=None):
@@ -37,7 +38,7 @@ def strip_dep_lines(text, should_strip, removed=None):
 
     If `removed` is a set, stripped dep names are added to it for downstream use.
     """
-    lines = text.split('\n')
+    lines = text.split("\n")
     result = []
     skip = False
     brace_depth = 0
@@ -45,10 +46,10 @@ def strip_dep_lines(text, should_strip, removed=None):
     for line in lines:
         if not skip:
             # Match inline table: name = { ... } or name = "..."
-            name_m = re.match(r'^([a-zA-Z0-9_-]+)\s*=\s', line)
+            name_m = re.match(r"^([a-zA-Z0-9_-]+)\s*=\s", line)
             # Match dot-notation: name.key = value
             if not name_m:
-                name_m = re.match(r'^([a-zA-Z0-9_-]+)\.', line)
+                name_m = re.match(r"^([a-zA-Z0-9_-]+)\.", line)
             if name_m and should_strip(name_m.group(1)):
                 if removed is not None:
                     removed.add(name_m.group(1))
@@ -67,7 +68,7 @@ def strip_dep_lines(text, should_strip, removed=None):
             if brace_depth <= 0 and bracket_depth <= 0:
                 skip = False
             continue
-    return '\n'.join(result)
+    return "\n".join(result)
 
 
 def strip_orphaned_feature_entries(text, removed_deps):
@@ -84,9 +85,9 @@ def strip_orphaned_feature_entries(text, removed_deps):
     for dep in sorted(removed_deps):
         escaped = re.escape(dep)
         # "dep?/feature" and "dep/feature" entries (with optional trailing comma)
-        text = re.sub(rf'\s*"{escaped}\??/[^"]*",?\n', '\n', text)
+        text = re.sub(rf'\s*"{escaped}\??/[^"]*",?\n', "\n", text)
         # "dep:dep" entries
-        text = re.sub(rf'\s*"dep:{escaped}",?\n', '\n', text)
+        text = re.sub(rf'\s*"dep:{escaped}",?\n', "\n", text)
     return text
 
 
@@ -96,13 +97,13 @@ def strip_feature_blocks(text, block_names):
     Uses bracket depth tracking to handle nested arrays.
     """
     names = set(block_names)
-    lines = text.split('\n')
+    lines = text.split("\n")
     result = []
     skip = False
     bracket_depth = 0
     for line in lines:
         if not skip:
-            m = re.match(r'^([a-zA-Z0-9_-]+)\s*=\s*\[', line)
+            m = re.match(r"^([a-zA-Z0-9_-]+)\s*=\s*\[", line)
             if m and m.group(1) in names:
                 _, kd = _depth_delta(line)
                 bracket_depth = kd
@@ -117,7 +118,7 @@ def strip_feature_blocks(text, block_names):
             if bracket_depth <= 0:
                 skip = False
             continue
-    return '\n'.join(result)
+    return "\n".join(result)
 
 
 def strip_feature_array_entries(text, entries_to_remove):
@@ -125,16 +126,16 @@ def strip_feature_array_entries(text, entries_to_remove):
 
     entries_to_remove: set of unquoted entry strings (e.g. {'reth', 'rand/serde'})
     """
-    lines = text.split('\n')
+    lines = text.split("\n")
     result = []
     in_features = False
     for line in lines:
         # Detect [features] section
-        if re.match(r'^\[features\]', line):
+        if re.match(r"^\[features\]", line):
             in_features = True
             result.append(line)
             continue
-        if in_features and re.match(r'^\[', line):
+        if in_features and re.match(r"^\[", line):
             in_features = False
 
         if in_features:
@@ -142,40 +143,41 @@ def strip_feature_array_entries(text, entries_to_remove):
             for entry in entries_to_remove:
                 escaped = re.escape(entry)
                 # Remove "entry", or "entry" (with comma handling)
-                modified = re.sub(rf'\s*"{escaped}"\s*,', '', modified)
-                modified = re.sub(rf',\s*"{escaped}"', '', modified)
-                modified = re.sub(rf'"{escaped}"', '', modified)
+                modified = re.sub(rf'\s*"{escaped}"\s*,', "", modified)
+                modified = re.sub(rf',\s*"{escaped}"', "", modified)
+                modified = re.sub(rf'"{escaped}"', "", modified)
             # Clean up artifacts: empty array elements, double commas
-            modified = re.sub(r',\s*\]', ']', modified)  # trailing comma before ]
-            modified = re.sub(r'\[\s*,', '[', modified)   # leading comma after [
-            modified = re.sub(r',\s*,', ',', modified)    # double commas
+            modified = re.sub(r",\s*\]", "]", modified)  # trailing comma before ]
+            modified = re.sub(r"\[\s*,", "[", modified)  # leading comma after [
+            modified = re.sub(r",\s*,", ",", modified)  # double commas
             # Skip lines that became empty array entries (just whitespace/tabs)
-            if modified.strip() == '' and line.strip() != '':
+            if modified.strip() == "" and line.strip() != "":
                 continue
             result.append(modified)
         else:
             result.append(line)
-    return '\n'.join(result)
+    return "\n".join(result)
 
 
 # ── Workspace parsing helpers ─────────────────────────────────────────────────
 
+
 def parse_workspace_package(ws_toml_path):
     """Parse [workspace.package] metadata from a workspace Cargo.toml."""
-    ws_text = Path(ws_toml_path).read_text(encoding='utf-8')
+    ws_text = Path(ws_toml_path).read_text(encoding="utf-8")
     meta = {}
     for key in (
-        'version',
-        'edition',
-        'rust-version',
-        'authors',
-        'license',
-        'homepage',
-        'repository',
-        'categories',
-        'keywords',
+        "version",
+        "edition",
+        "rust-version",
+        "authors",
+        "license",
+        "homepage",
+        "repository",
+        "categories",
+        "keywords",
     ):
-        m = re.search(rf'^{re.escape(key)}\s*=\s*(.+)$', ws_text, re.MULTILINE)
+        m = re.search(rf"^{re.escape(key)}\s*=\s*(.+)$", ws_text, re.MULTILINE)
         if m:
             meta[key] = m.group(1).strip()
     return meta
@@ -198,13 +200,14 @@ def parse_workspace_deps(ws_toml_path):
     - ws_pkg_version: the workspace package version string
     - ws_git_deps: {name: {"git": url, ...}} for deps using git sources
     """
-    ws_text = Path(ws_toml_path).read_text(encoding='utf-8')
+    ws_text = Path(ws_toml_path).read_text(encoding="utf-8")
 
     # Workspace package version
     ws_pkg_version = None
     m = re.search(
         r'^\[workspace\.package\]\s*\n(?:.*\n)*?version\s*=\s*"([^"]+)"',
-        ws_text, re.MULTILINE,
+        ws_text,
+        re.MULTILINE,
     )
     if m:
         ws_pkg_version = m.group(1)
@@ -218,15 +221,15 @@ def parse_workspace_deps(ws_toml_path):
     # Match inline table deps: name = { ... } (possibly multi-line)
     # Use depth-aware extraction
     in_ws_deps = False
-    lines = ws_text.split('\n')
+    lines = ws_text.split("\n")
     i = 0
     while i < len(lines):
         line = lines[i]
-        if re.match(r'^\[workspace\.dependencies\]', line):
+        if re.match(r"^\[workspace\.dependencies\]", line):
             in_ws_deps = True
             i += 1
             continue
-        if in_ws_deps and re.match(r'^\[', line):
+        if in_ws_deps and re.match(r"^\[", line):
             break
         if not in_ws_deps:
             i += 1
@@ -234,12 +237,12 @@ def parse_workspace_deps(ws_toml_path):
 
         # Skip comments and blank lines
         stripped = line.strip()
-        if not stripped or stripped.startswith('#'):
+        if not stripped or stripped.startswith("#"):
             i += 1
             continue
 
         # Try to match a dep start
-        name_m = re.match(r'^([a-zA-Z0-9_-]+)\s*=\s*(.*)', line)
+        name_m = re.match(r"^([a-zA-Z0-9_-]+)\s*=\s*(.*)", line)
         if not name_m:
             i += 1
             continue
@@ -255,12 +258,12 @@ def parse_workspace_deps(ws_toml_path):
             continue
 
         # Inline table dep: collect full body across lines
-        if rest.startswith('{'):
+        if rest.startswith("{"):
             body = rest
             bd, _ = _depth_delta(rest)
             while bd > 0 and i + 1 < len(lines):
                 i += 1
-                body += '\n' + lines[i]
+                body += "\n" + lines[i]
                 d, _ = _depth_delta(lines[i])
                 bd += d
 
@@ -269,19 +272,23 @@ def parse_workspace_deps(ws_toml_path):
             if ver_m:
                 ws_deps[name] = ver_m.group(1)
 
-            if 'default-features = false' in body:
+            if "default-features = false" in body:
                 ws_no_default.add(name)
 
-            if 'path = ' in body or 'path =' in body:
+            if "path = " in body or "path =" in body:
                 ws_path_deps.add(name)
                 # Path-only deps: read version from the crate's own Cargo.toml
                 if name not in ws_deps:
                     path_m = re.search(r'path\s*=\s*"([^"]+)"', body)
                     if path_m:
-                        crate_toml = Path(ws_toml_path).parent / path_m.group(1) / "Cargo.toml"
+                        crate_toml = (
+                            Path(ws_toml_path).parent / path_m.group(1) / "Cargo.toml"
+                        )
                         if crate_toml.exists():
-                            crate_text = crate_toml.read_text(encoding='utf-8')
-                            cv = re.search(r'^version\s*=\s*"([^"]+)"', crate_text, re.MULTILINE)
+                            crate_text = crate_toml.read_text(encoding="utf-8")
+                            cv = re.search(
+                                r'^version\s*=\s*"([^"]+)"', crate_text, re.MULTILINE
+                            )
                             if cv:
                                 ws_deps[name] = cv.group(1)
                     # Fall back to workspace version if crate uses version.workspace = true
@@ -304,20 +311,26 @@ def parse_workspace_deps(ws_toml_path):
 
 # ── dot-notation dep matching ─────────────────────────────────────────────────
 
+
 def _match_dot_dep(line):
     """Match lines like `name.workspace = true` or `name = { workspace = true }`."""
-    m = re.match(r'^([a-zA-Z0-9_-]+)\.workspace\s*=\s*true', line)
+    m = re.match(r"^([a-zA-Z0-9_-]+)\.workspace\s*=\s*true", line)
     return m.group(1) if m else None
 
 
 # ── Actions ───────────────────────────────────────────────────────────────────
+
 
 def main():
     action = sys.argv[1]
     toml_path = sys.argv[2] if len(sys.argv) > 2 else None
 
     # Most actions operate on a target toml file; gen_workspace is the exception.
-    text = Path(toml_path).read_text(encoding='utf-8') if toml_path and action not in ("gen_workspace", "get_version") else ""
+    text = (
+        Path(toml_path).read_text(encoding="utf-8")
+        if toml_path and action not in ("gen_workspace", "get_version")
+        else ""
+    )
 
     if action == "sanitize_base":
         ws_version = sys.argv[3]
@@ -327,113 +340,134 @@ def main():
             meta = parse_workspace_package(ws_toml_path)
         else:
             meta = {
-                'edition': '"2024"',
-                'rust-version': '"1.93.0"',
-                'authors': '["Tempo Contributors"]',
-                'license': '"MIT OR Apache-2.0"',
-                'homepage': '"https://docs.tempo.xyz"',
-                'repository': '"https://github.com/tempoxyz/tempo"',
-                'categories': '["cryptography::cryptocurrencies"]',
-                'keywords': '["blockchain", "ethereum", "evm", "payments", "tempo"]',
+                "edition": '"2024"',
+                "rust-version": '"1.95.0"',
+                "authors": '["Tempo Contributors"]',
+                "license": '"MIT OR Apache-2.0"',
+                "homepage": '"https://docs.tempo.xyz"',
+                "repository": '"https://github.com/tempoxyz/tempo"',
+                "categories": '["cryptography::cryptocurrencies"]',
+                "keywords": '["blockchain", "ethereum", "evm", "payments", "tempo"]',
             }
 
         # Remove [lints] section
-        text = re.sub(r'\n\[lints\]\nworkspace = true\n', '\n', text)
+        text = re.sub(r"\n\[lints\]\nworkspace = true\n", "\n", text)
         # Resolve workspace package fields (order matters: longer keys first)
         for key in (
-            'rust-version',
-            'version',
-            'edition',
-            'authors',
-            'license',
-            'homepage',
-            'repository',
-            'categories',
-            'keywords',
+            "rust-version",
+            "version",
+            "edition",
+            "authors",
+            "license",
+            "homepage",
+            "repository",
+            "categories",
+            "keywords",
         ):
-            if key == 'version':
-                text = text.replace('version.workspace = true', f'version = "{ws_version}"')
+            if key == "version":
+                text = text.replace(
+                    "version.workspace = true", f'version = "{ws_version}"'
+                )
             elif key in meta:
-                text = text.replace(f'{key}.workspace = true', f'{key} = {meta[key]}')
+                text = text.replace(f"{key}.workspace = true", f"{key} = {meta[key]}")
         # Remove publish.workspace = true
-        text = re.sub(r'publish\.workspace = true\n', '', text)
+        text = re.sub(r"publish\.workspace = true\n", "", text)
 
     elif action == "sanitize_primitives":
         # Remove reth-related feature definitions (multi-line) FIRST,
         # before dependency removal which would strip the opening line
         # (e.g. "reth-codec = [") and orphan the block body.
-        text = strip_feature_blocks(text, ['reth', 'reth-codec', 'serde-bincode-compat', 'rpc'])
+        text = strip_feature_blocks(
+            text, ["reth", "reth-codec", "serde-bincode-compat", "rpc"]
+        )
 
         # Track removed deps so we can auto-strip orphaned feature entries
         removed = set()
 
         # Remove reth dependency lines (single- and multi-line)
-        text = strip_dep_lines(text, lambda n: n.startswith('reth-'), removed)
+        text = strip_dep_lines(text, lambda n: n.startswith("reth-"), removed)
         # Remove modular-bitfield
-        text = strip_dep_lines(text, lambda n: n == 'modular-bitfield', removed)
+        text = strip_dep_lines(text, lambda n: n == "modular-bitfield", removed)
         # Remove deps only used by the stripped rpc feature
-        text = strip_dep_lines(text, lambda n: n in ('alloy-rpc-types-eth', 'alloy-network'), removed)
+        text = strip_dep_lines(
+            text, lambda n: n in ("alloy-rpc-types-eth", "alloy-network"), removed
+        )
         # Remove # Reth comment
-        text = re.sub(r'^# Reth\n', '', text, flags=re.MULTILINE)
+        text = re.sub(r"^# Reth\n", "", text, flags=re.MULTILINE)
 
         # Auto-strip feature entries referencing removed deps
         text = strip_orphaned_feature_entries(text, removed)
 
         # Remove stripped feature names and dev-dep-only entries from feature arrays
-        text = strip_feature_array_entries(text, {
-            'reth', 'reth-codec', 'serde-bincode-compat', 'rpc',
-            'rand/serde', 'tracing-subscriber/serde',
-        })
+        text = strip_feature_array_entries(
+            text,
+            {
+                "reth",
+                "reth-codec",
+                "serde-bincode-compat",
+                "rpc",
+                "rand/serde",
+                "tracing-subscriber/serde",
+            },
+        )
 
     elif action == "sanitize_alloy":
         # Remove reth dependency lines
-        text = strip_dep_lines(text, lambda n: n.startswith('reth-'))
+        text = strip_dep_lines(text, lambda n: n.startswith("reth-"))
         # Remove internal non-publishable deps (path-only workspace crates, except
         # the crates we're publishing: tempo-contracts and tempo-primitives)
         ws_toml_path = sys.argv[3]
         _, _, ws_path_deps, _, _ = parse_workspace_deps(ws_toml_path)
-        publish_keep = {'tempo-contracts', 'tempo-primitives', 'tempo-chainspec', 'tempo-alloy'}
+        publish_keep = {
+            "tempo-contracts",
+            "tempo-primitives",
+            "tempo-chainspec",
+            "tempo-alloy",
+        }
         internal_deps = ws_path_deps - publish_keep
         text = strip_dep_lines(text, lambda n: n in internal_deps)
 
         # Strip the `reth` feature block
-        text = strip_feature_blocks(text, ['reth'])
+        text = strip_feature_blocks(text, ["reth"])
 
         # Strip "rpc" from tempo-primitives features (rpc feature is stripped during publish)
-        text = re.sub(r', "rpc"', '', text)
-        text = re.sub(r'"rpc", ', '', text)
+        text = re.sub(r', "rpc"', "", text)
+        text = re.sub(r'"rpc", ', "", text)
 
     elif action == "sanitize_chainspec":
         # Remove reth and cli feature blocks entirely
-        text = strip_feature_blocks(text, ['reth', 'cli'])
+        text = strip_feature_blocks(text, ["reth", "cli"])
 
         # Track removed deps so we can auto-strip orphaned feature entries
         removed = set()
 
         # Remove deps only used by stripped reth-gated chainspec code.
-        text = strip_dep_lines(text, lambda n: n.startswith('reth-'), removed)
+        text = strip_dep_lines(text, lambda n: n.startswith("reth-"), removed)
         text = strip_dep_lines(
             text,
-            lambda n: n in (
-                'commonware-codec',
-                'commonware-cryptography',
-                'eyre',
-                'tempo-dkg-onchain-artifacts',
+            lambda n: (
+                n
+                in (
+                    "commonware-codec",
+                    "commonware-cryptography",
+                    "eyre",
+                    "tempo-dkg-onchain-artifacts",
+                )
             ),
             removed,
         )
         # Remove # Reth comment
-        text = re.sub(r'^# Reth\n', '', text, flags=re.MULTILINE)
+        text = re.sub(r"^# Reth\n", "", text, flags=re.MULTILINE)
 
         # Auto-strip feature entries referencing removed deps
         text = strip_orphaned_feature_entries(text, removed)
 
         # Remove "reth" and "cli" from the default feature array
-        text = strip_feature_array_entries(text, {'reth', 'cli'})
+        text = strip_feature_array_entries(text, {"reth", "cli"})
 
         # The tempo_hardfork! macro generates #[cfg(feature = "reth")] blocks that remain in source.
         # Tell check-cfg that "reth" is an expected (but never enabled) feature to suppress warnings.
-        if '[lints.rust]' not in text:
+        if "[lints.rust]" not in text:
             text += '\n[lints.rust]\nunexpected_cfgs = { level = "allow", check-cfg = [\'cfg(feature, values("reth"))\'] }\n'
 
     elif action == "resolve_deps":
@@ -453,27 +487,27 @@ def main():
 
             parts = [f'version = "{version}"']
             # Preserve default-features = false from either workspace or local spec
-            if name in ws_no_default or 'default-features = false' in body:
-                parts.append('default-features = false')
-            features_match = re.search(r'features\s*=\s*\[[^\]]*\]', body)
+            if name in ws_no_default or "default-features = false" in body:
+                parts.append("default-features = false")
+            features_match = re.search(r"features\s*=\s*\[[^\]]*\]", body)
             if features_match:
                 parts.append(features_match.group(0))
-            if 'optional = true' in body:
-                parts.append('optional = true')
-            if 'package = ' in body:
+            if "optional = true" in body:
+                parts.append("optional = true")
+            if "package = " in body:
                 pkg_match = re.search(r'package\s*=\s*"[^"]*"', body)
                 if pkg_match:
                     parts.append(pkg_match.group(0))
-            return f'{name} = {{ {", ".join(parts)} }}'
+            return f"{name} = {{ {', '.join(parts)} }}"
 
         # Resolve inline table deps: name = { workspace = true, ... }
         # Use depth-aware line-by-line processing
-        lines = text.split('\n')
+        lines = text.split("\n")
         result = []
         i = 0
         while i < len(lines):
             line = lines[i]
-            name_m = re.match(r'^([a-zA-Z0-9_-]+)\s*=\s*(\{.*)', line)
+            name_m = re.match(r"^([a-zA-Z0-9_-]+)\s*=\s*(\{.*)", line)
             if name_m:
                 name = name_m.group(1)
                 rest = name_m.group(2)
@@ -484,12 +518,12 @@ def main():
                 while bd > 0 and i + 1 < len(lines):
                     i += 1
                     collected.append(lines[i])
-                    body += ' ' + lines[i]
+                    body += " " + lines[i]
                     d, _ = _depth_delta(lines[i])
                     bd += d
 
-                if 'workspace = true' in body:
-                    result.append(resolve_dep_line('\n'.join(collected), name, body))
+                if "workspace = true" in body:
+                    result.append(resolve_dep_line("\n".join(collected), name, body))
                 else:
                     result.extend(collected)
                 i += 1
@@ -508,15 +542,15 @@ def main():
                     sys.exit(1)
                 parts = [f'version = "{version}"']
                 if dot_name in ws_no_default:
-                    parts.append('default-features = false')
-                result.append(f'{dot_name} = {{ {", ".join(parts)} }}')
+                    parts.append("default-features = false")
+                result.append(f"{dot_name} = {{ {', '.join(parts)} }}")
                 i += 1
                 continue
 
             result.append(line)
             i += 1
 
-        text = '\n'.join(result)
+        text = "\n".join(result)
 
     elif action == "gen_workspace":
         # Generate a temporary workspace Cargo.toml with workspace deps,
@@ -525,14 +559,14 @@ def main():
         # Usage: sanitize_toml.py gen_workspace <ws_toml> <out_toml> [crate1,crate2,...]
         ws_toml_path = sys.argv[2]
         out_path = sys.argv[3]
-        publish_crates = set(sys.argv[4].split(',')) if len(sys.argv) > 4 else set()
+        publish_crates = set(sys.argv[4].split(",")) if len(sys.argv) > 4 else set()
 
         workspace_package = parse_workspace_package(ws_toml_path)
         ws_deps, ws_no_default, ws_path_deps, _, _ = parse_workspace_deps(ws_toml_path)
 
         # Read the [workspace.dependencies] section text
-        ws_text = Path(ws_toml_path).read_text(encoding='utf-8')
-        m = re.search(r'\[workspace\.dependencies\]\n((?:.*\n)*?)(?=\[|$)', ws_text)
+        ws_text = Path(ws_toml_path).read_text(encoding="utf-8")
+        m = re.search(r"\[workspace\.dependencies\]\n((?:.*\n)*?)(?=\[|$)", ws_text)
         if not m:
             print("error: could not find [workspace.dependencies]", file=sys.stderr)
             sys.exit(1)
@@ -545,43 +579,43 @@ def main():
             strip_names.add(name)
 
         def should_strip(name):
-            return name.startswith('reth-') or name in strip_names
+            return name.startswith("reth-") or name in strip_names
 
         filtered = strip_dep_lines(deps_block, should_strip)
 
         # Build output
-        existing = Path(out_path).read_text(encoding='utf-8')
+        existing = Path(out_path).read_text(encoding="utf-8")
         if workspace_package:
-            existing += '\n[workspace.package]\n'
+            existing += "\n[workspace.package]\n"
             for key in (
-                'version',
-                'edition',
-                'rust-version',
-                'authors',
-                'license',
-                'homepage',
-                'repository',
-                'categories',
-                'keywords',
+                "version",
+                "edition",
+                "rust-version",
+                "authors",
+                "license",
+                "homepage",
+                "repository",
+                "categories",
+                "keywords",
             ):
                 if key in workspace_package:
-                    existing += f'{key} = {workspace_package[key]}\n'
-        existing += '\n[workspace.dependencies]\n'
-        existing += filtered + '\n'
+                    existing += f"{key} = {workspace_package[key]}\n"
+        existing += "\n[workspace.dependencies]\n"
+        existing += filtered + "\n"
         for crate in sorted(publish_crates):
-            dirname = crate.removeprefix('tempo-')
+            dirname = crate.removeprefix("tempo-")
             parts = [f'path = "{dirname}"']
             if crate in ws_no_default:
-                parts.append('default-features = false')
-            existing += f'{crate} = {{ {", ".join(parts)} }}\n'
+                parts.append("default-features = false")
+            existing += f"{crate} = {{ {', '.join(parts)} }}\n"
 
-        Path(out_path).write_text(existing, encoding='utf-8')
+        Path(out_path).write_text(existing, encoding="utf-8")
         sys.exit(0)
 
     elif action == "get_version":
         ws_toml_path = sys.argv[2]
         meta = parse_workspace_package(ws_toml_path)
-        version = meta.get('version')
+        version = meta.get("version")
         if not version:
             print("error: could not find workspace version", file=sys.stderr)
             sys.exit(1)
@@ -593,10 +627,10 @@ def main():
         sys.exit(1)
 
     # Clean up excessive blank lines
-    text = re.sub(r'\n{3,}', '\n\n', text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
 
-    Path(toml_path).write_text(text, encoding='utf-8')
+    Path(toml_path).write_text(text, encoding="utf-8")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`72fafb5...fa3859e`](https://github.com/paradigmxyz/reth/compare/72fafb5...fa3859e)

::warning::Failed to summarize upstream reth commits with Amp (exit 1)

- fix(cli): target `reth download --force` cleanup (#25015)
- fix(chain-state): publish deferred trie data from task (#24995)
- fix(chain-state): avoid state overlay cache deadlock (#24875)
- feat(net): add outbound peer rotation to prevent slot saturation (#24776)
- perf(transaction-pool): specialize same-origin batch insertion (#25037)
- fix(rlpx): bound mux outbound buffer fairly (#25031)
- chore(deps): bump revm-inspectors to 0.40.1 (#25047)
- feat(revm): add CachedReads account capacity constructor (#25048)
- chore(release): bump version to 2.3.0 (#25071)
- perf(net): track queued response count in ActiveSession (#25073)
- perf(txpool): update pool metrics incrementally (#25080)
- perf(txpool): select worst senders instead of sorting during eviction (#25078)
- fix(net): respect configured full transaction broadcast peer count (#25086)
- fix(rpc): fix nonce related fails in eth_simulate (#25079)
- perf(net): preallocate transaction broadcast message builders (#25095)
- perf(net): remove redundant lookups in tx propagation (#25097)
- perf(net): track transactions_by_peers with a SmallVec (#25096)
- fix(rpc): align eth simulate missing block error code (#25074)
- perf(net): propagate pending transactions in the same poll iteration (#25087)
- feat(rpc): add testing commit block endpoint (#25070)
- feat(revm): introduce `DatabaseStateProvider` (#25121)
- feat(cli): support ERE (.erae) files in import-era (#25122)
- feat(txpool): make additional validation fn type aliases public (#25134)
- feat: add NodeCommand::peer_id helper (#25136)
- feat: integrate revmc JIT (#23230)
- perf(txpool): reduce allocations on reorg (#25145)
- perf(net): mark transactions seen by peer while building broadcast messages (#25088)
- fix(docs): preserve rustdocs navigation (#25132)
- refactor(net): reuse primitive sealed block wrapper (#25162)
- refactor(rpc): store decoded revm BALs behind Arc (#25165)
- chore(deps): bump revm to 41, alloy-evm 0.37, reth-core 0.5 (#25170)
- perf(trie): reuse storage trie cursor in state root (#25163)
- chore(hive): remove eth_syncing from  rpc-compat expected failure list (#25172)
- refactor: `MultiProofTargetsV2::from_state` (#25144)
- refactor: use RawBal for block access lists (#25169)
- feat: make JIT opt-in for library crates (#25178)
- fix(cli): give --jit arg a unique clap id (#25183)
- chore(deps): bump revmc to 7e3536d6 (engine deadlock fix) (#25185)
- fix(rpc): remove unused ipc middleware lifetimes (#25199)
- chore: bump opentelemetry dependencies (#25215)
- feat(rpc): add admin peer ban and unban methods (#25140)
- chore(deps): bump the cargo-weekly group across 1 directory with 12 updates (#25173)

## Migrations

::warning::Failed to summarize source migrations with Amp (exit 1)

 Cargo.toml                        | 128 +++++++++++++++++++-------------------
 bin/tempo/src/cli.rs              |  19 ------
 bin/tempo/src/lib.rs              |  14 ++---
 crates/evm/src/block.rs           |   8 +--
 crates/payload/builder/src/lib.rs |   6 +-
 5 files changed, 78 insertions(+), 97 deletions(-)

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/27524139557)
