### PR TITLE
perf(precompiles): bypass keccak cache for unique mapping keys

### DIFF
--- a/crates/precompiles/src/nonce/mod.rs
+++ b/crates/precompiles/src/nonce/mod.rs
@@ -103,7 +103,7 @@ impl NonceManager {
     /// Checks if a hash has been seen and is still valid (not expired).
     /// NOTE: internally used by the transaction pool.
     pub fn is_expiring_nonce_seen(&self, hash: B256, now: u64) -> Result<bool> {
-        let expiry = self.expiring_nonce_seen[hash].read()?;
+        let expiry = self.expiring_nonce_seen.at_unique(&hash).read()?;
         Ok(expiry != 0 && expiry > now)
     }
 
@@ -141,7 +141,10 @@ impl NonceManager {
         }
 
         // 2. Replay check: reject if hash is already seen and not expired
-        let seen_expiry = self.expiring_nonce_seen[expiring_nonce_hash].read()?;
+        // The hashes are unique per transaction, so the handlers are computed without
+        // caching and held on to for the later writes.
+        let mut seen_handler = self.expiring_nonce_seen.at_unique(&expiring_nonce_hash);
+        let seen_expiry = seen_handler.read()?;
         if seen_expiry != 0 && seen_expiry > now {
             return Err(NonceError::expiring_nonce_replay().into());
         }
@@ -155,18 +158,19 @@ impl NonceManager {
         // Safety check: buffer is sized so entries should always be expired, but verify
         // in case TPS exceeds expectations.
         if old_hash != B256::ZERO {
-            let old_expiry = self.expiring_nonce_seen[old_hash].read()?;
+            let mut old_handler = self.expiring_nonce_seen.at_unique(&old_hash);
+            let old_expiry = old_handler.read()?;
             if old_expiry != 0 && old_expiry > now {
                 // Entry is still valid, cannot evict - buffer is full
                 return Err(NonceError::expiring_nonce_set_full().into());
             }
             // Clear the old entry from seen set
-            self.expiring_nonce_seen[old_hash].write(0)?;
+            old_handler.write(0)?;
         }
 
         // 5. Insert new entry
         self.expiring_nonce_ring[idx].write(expiring_nonce_hash)?;
-        self.expiring_nonce_seen[expiring_nonce_hash].write(valid_before)?;
+        seen_handler.write(valid_before)?;
 
         // 6. Advance pointer (wraps at CAPACITY, not u32::MAX)
         let next = if ptr + 1 >= EXPIRING_NONCE_SET_CAPACITY {

--- a/crates/precompiles/src/storage/types/mapping.rs
+++ b/crates/precompiles/src/storage/types/mapping.rs
@@ -99,6 +99,26 @@ impl<K, V: StorableType> Mapping<K, V> {
             V::handle(key.mapping_slot(base_slot), LayoutCtx::FULL, address)
         })
     }
+
+    /// Returns an owned `Handler` for the given key without any caching.
+    ///
+    /// Use for high-entropy keys that are unlikely to be accessed through this mapping
+    /// again, such as transaction hashes: the slot computation bypasses the global keccak
+    /// cache (unique keys never hit it and their insertion evicts reusable entries) and the
+    /// handler is not stored in the per-mapping handler cache.
+    ///
+    /// Hold on to the returned handler when performing multiple operations for the same
+    /// key, as every call recomputes the slot hash.
+    pub fn at_unique(&self, key: &K) -> V::Handler
+    where
+        K: StorageKey,
+    {
+        V::handle(
+            key.mapping_slot_uncached(self.base_slot),
+            LayoutCtx::FULL,
+            self.address,
+        )
+    }
 }
 
 impl<K, V: StorableType> Default for Mapping<K, V> {
@@ -241,6 +261,14 @@ mod tests {
         let derived_slot = &mapping[test_key];
         let expected_slot = test_key.mapping_slot(base_slot);
         assert_eq!(derived_slot.slot(), expected_slot);
+
+        // Property 4: The uncached path computes the same slot as the cached one
+        let unique_key = Address::random();
+        assert_eq!(
+            mapping.at_unique(&unique_key).slot(),
+            mapping[unique_key].slot(),
+            "at_unique should compute the same slot as the cached path"
+        );
     }
 
     #[test]

--- a/crates/precompiles/src/storage/types/mod.rs
+++ b/crates/precompiles/src/storage/types/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     error::Result,
     storage::{StorageOps, packing},
 };
-use alloy::primitives::{Address, U256, keccak256};
+use alloy::primitives::{Address, U256, keccak256, keccak256_uncached};
 
 /// Describes how a type is laid out in EVM storage.
 ///
@@ -359,14 +359,28 @@ pub trait StorageKey: sealed::OnlyPrimitives {
     ///
     /// Left-pads the key to 32 bytes, concatenates with the slot, and hashes.
     fn mapping_slot(&self, slot: U256) -> U256 {
-        let key_bytes = self.as_storage_bytes();
-        let key_bytes = key_bytes.as_ref();
-        debug_assert!(key_bytes.len() <= 32);
-
-        let mut buf = [0u8; 64];
-        buf[32 - key_bytes.len()..32].copy_from_slice(key_bytes);
-        buf[32..].copy_from_slice(&slot.to_be_bytes::<32>());
-
-        U256::from_be_bytes(keccak256(buf).0)
+        U256::from_be_bytes(keccak256(mapping_slot_input(self, slot)).0)
     }
+
+    /// Same as [`mapping_slot`](Self::mapping_slot) but bypasses the global keccak cache.
+    ///
+    /// Use for high-entropy keys that are unlikely to repeat (e.g. transaction hashes):
+    /// such keys never hit the cache, and inserting them evicts entries that would be
+    /// reused.
+    fn mapping_slot_uncached(&self, slot: U256) -> U256 {
+        U256::from_be_bytes(keccak256_uncached(mapping_slot_input(self, slot)).0)
+    }
+}
+
+/// Assembles the 64-byte keccak input `bytes32(key) | bytes32(slot)` for mapping slot
+/// computation.
+fn mapping_slot_input<K: StorageKey + ?Sized>(key: &K, slot: U256) -> [u8; 64] {
+    let key_bytes = key.as_storage_bytes();
+    let key_bytes = key_bytes.as_ref();
+    debug_assert!(key_bytes.len() <= 32);
+
+    let mut buf = [0u8; 64];
+    buf[32 - key_bytes.len()..32].copy_from_slice(key_bytes);
+    buf[32..].copy_from_slice(&slot.to_be_bytes::<32>());
+    buf
 }

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -412,17 +412,23 @@ impl TempoPooledTransaction {
     pub fn expiring_nonce_slot(&self) -> Option<U256> {
         *self.expiring_nonce_slot.get_or_init(|| {
             let hash = self.expiring_nonce_hash()?;
-            Some(NonceManager::new().expiring_nonce_seen[hash].slot())
+            Some(
+                NonceManager::new()
+                    .expiring_nonce_seen
+                    .at_unique(&hash)
+                    .slot(),
+            )
         })
     }
 
     /// Warms the global keccak cache with storage slot hashes that will be accessed
     /// during payment execution after pool validation.
     ///
-    /// Fee-path slots like `balances[fee_payer]`, `user_reward_info[fee_payer]`,
-    /// `user_tokens[fee_payer]`, and `expiring_nonce_seen[hash]` are already cached from
-    /// `validate_with_evm`. `validator_tokens[beneficiary]` depends on the block producer,
-    /// which is unknown at validation time.
+    /// Fee-path slots like `balances[fee_payer]`, `user_reward_info[fee_payer]` and
+    /// `user_tokens[fee_payer]` are already cached from `validate_with_evm`. The
+    /// `expiring_nonce_seen[hash]` slot is computed without the keccak cache (unique key).
+    /// `validator_tokens[beneficiary]` depends on the block producer, which is unknown at
+    /// validation time.
     pub fn precalculate_keccak_slots(&self) {
         if !self.is_payment {
             return;


### PR DESCRIPTION
The expiring nonce replay check reads and writes `expiring_nonce_seen[replay_hash]`, a mapping keyed by a hash that is unique per transaction. Computing that slot through `alloy_primitives::keccak256` routes through the global keccak cache, which is strictly counterproductive for such keys: the lookup never hits, the full hash is computed anyway, and the subsequent insert evicts an entry that could actually be reused (sender balance slots, fee token slots). Profiling txpool ingress showed the cache probe, insert and hashing at roughly a quarter of `check_and_mark_expiring_nonce`, with the probe/insert overhead alone around 10%.

This adds an explicit opt-out for high-entropy keys: `StorageKey::mapping_slot_uncached` computes the slot via `keccak256_uncached`, and `Mapping::at_unique` returns an owned handler computed through it, also skipping the per-mapping handler cache (whose insert is equally wasted on keys that never repeat). The expiring nonce paths (`check_and_mark_expiring_nonce`, `is_expiring_nonce_seen`, and the pool's `expiring_nonce_slot` precompute) now use it; the handler is held across the read/write pair so the slot is hashed once per key. Other `B256`-keyed mappings like fee manager pool IDs or TIP20 role hashes repeat heavily and intentionally keep the cached path.

Computed slots are identical to the cached path, so there is no behavioral or layout change.

Follow-up to #5572.