### PR TITLE
docs(tip-1077): add expiring nonce time wheel

### DIFF
--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -79,7 +79,8 @@ PRE_TIP_1077_MAX_EXPIRY_SECS  = 30
 EXPIRING_NONCE_MAX_EXPIRY_SECS = 300
 EXPIRING_NONCE_BUCKET_COUNT    = 301
 EXPIRING_NONCE_BUCKET_CAPACITY = 131_072
-EXPIRING_NONCE_MAX_PROBES      = 32
+EXPIRING_NONCE_POSITION_BITS   = 17
+EXPIRING_NONCE_MAX_PROBES      = 5
 
 EXPIRING_NONCE_CELL_COUNT      = 39_452_672
 EXPIRING_NONCE_CELL_BASE_SLOT  = 0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa2400000
@@ -94,6 +95,8 @@ old ring entries.
 
 `EXPIRING_NONCE_BUCKET_COUNT` MUST be greater than `EXPIRING_NONCE_MAX_EXPIRY_SECS`.
 `EXPIRING_NONCE_BUCKET_CAPACITY` MUST be a power of two.
+`EXPIRING_NONCE_POSITION_BITS` MUST equal `log2(EXPIRING_NONCE_BUCKET_CAPACITY)`.
+`EXPIRING_NONCE_POSITION_BITS * EXPIRING_NONCE_MAX_PROBES` MUST be less than or equal to 256.
 `EXPIRING_NONCE_CELL_COUNT` MUST equal
 `EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY`.
 
@@ -170,25 +173,18 @@ The transaction first chooses its time bucket:
 bucket = V % EXPIRING_NONCE_BUCKET_COUNT
 ```
 
-It then chooses a deterministic probe path inside that bucket:
+It then chooses a deterministic probe path inside that bucket. For probe `i`:
 
 ```text
-home = uint32_be(H[0..4]) % EXPIRING_NONCE_BUCKET_CAPACITY
-step = (uint32_be(H[4..8]) | 1) % EXPIRING_NONCE_BUCKET_CAPACITY
-```
-
-For probe `i`:
-
-```text
-position_i = (home + i * step) % EXPIRING_NONCE_BUCKET_CAPACITY
+position_i = uint17(H[i * EXPIRING_NONCE_POSITION_BITS
+                    .. (i + 1) * EXPIRING_NONCE_POSITION_BITS])
 cell_id_i  = bucket * EXPIRING_NONCE_BUCKET_CAPACITY + position_i
 slot_i     = EXPIRING_NONCE_CELL_BASE_SLOT + cell_id_i
 ```
 
-`step` is forced odd so that, with power-of-two bucket capacity, the probe path can cycle through
-the bucket instead of being trapped in a smaller divisor-sized subset.
-Since `EXPIRING_NONCE_BUCKET_CAPACITY` is a power of two, implementations MAY use bit masks instead
-of modulo operations for `home`, `step`, and `position_i`.
+With the chosen constants, the five probe positions are `H[0..17]`, `H[17..34]`, `H[34..51]`,
+`H[51..68]`, and `H[68..85]`. Since `EXPIRING_NONCE_BUCKET_CAPACITY` is `2^17`, each 17-bit chunk
+selects one cell in the bucket without modulo bias or rejection sampling.
 
 ## Replay Algorithm
 
@@ -263,7 +259,7 @@ Examples:
 | ---: | ---: |
 | 1 | 5,000 |
 | 2 | 7,100 |
-| 32 | 70,100 |
+| 5 | 13,400 |
 
 This charge intentionally does not apply TIP-1000 permanent new-slot pricing to first-touch replay
 cells. Expiring nonce cells are bounded temporary protocol state, not user-created permanent state.
@@ -279,7 +275,7 @@ bookkeeping.
 No expiring nonce insertion or later overwrite mints or consumes TIP-1060 storage credits.
 
 The time-wheel lookup performs no Keccak beyond the canonical replay hash `H`. If `H` has already
-been computed by transaction validation or pool deduplication, deriving `bucket`, `home`, `step`,
+been computed by transaction validation or pool deduplication, deriving `bucket`, `position_i`,
 `fingerprint`, `cell_id`, and `slot` requires only slicing and arithmetic:
 
 ```text
@@ -328,8 +324,7 @@ The wheel has two independent dimensions:
 - `EXPIRING_NONCE_BUCKET_COUNT` separates expiry seconds. It only needs to be greater than the
   maximum expiry window, so 301 buckets covers a 300 second window.
 - `EXPIRING_NONCE_BUCKET_CAPACITY` controls collision probability within one exact
-  `valid_before` second. This value must be a power of two so the odd probe step can cover every
-  cell in the bucket.
+  `valid_before` second.
 
 Rounding the time-bucket count from 301 to 512 would not reduce same-second collisions: each exact
 `valid_before` second would still use one bucket with 131,072 cells. It would only reserve 211
@@ -344,22 +339,23 @@ The table below models random hash placement inside one bucket.
 slot+value bytes = 301 buckets * cells_per_bucket * 64
 ```
 
-| Cells per bucket | Load at 20k TPS | First-cell collisions per 20k txs | Avg probes per tx | Max slot+value bloat |
-| ---: | ---: | ---: | ---: | ---: |
-| 16,777,216 | 0.12% | ~12 | 1.0006 | 301.00 GiB |
-| 1,048,576 | 1.91% | ~190 | 1.0097 | 18.81 GiB |
-| 524,288 | 3.81% | ~377 | 1.0196 | 9.41 GiB |
-| 262,144 | 7.63% | ~744 | 1.0402 | 4.70 GiB |
-| 131,072 | 15.26% | ~1,451 | 1.0851 | 2.35 GiB |
-| 65,536 | 30.52% | ~2,764 | 1.1931 | 1.18 GiB |
-| 32,768 | 61.04% | ~5,030 | 1.5442 | 602.00 MiB |
-| 25,000 | 80.00% | ~6,233 | 2.0118 | 459.29 MiB |
-| 20,000 | 100.00% | ~7,358 | unstable | 367.43 MiB |
-| 16,384 | 122.07% | ~8,450 | overloaded | 301.00 MiB |
+| Cells per bucket | Load at 20k TPS | First-probe misses per 20k txs | Avg reads per attempted tx | Probe-exhausted txs per 20k | Max slot+value bloat |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 16,777,216 | 0.12% | ~12 | 1.0006 | ~0 | 301.00 GiB |
+| 1,048,576 | 1.91% | ~191 | 1.0097 | ~0 | 18.81 GiB |
+| 524,288 | 3.81% | ~381 | 1.0196 | ~0 | 9.41 GiB |
+| 262,144 | 7.63% | ~763 | 1.0402 | ~0.009 | 4.70 GiB |
+| 131,072 | 15.26% | ~1,526 | 1.0850 | ~0.28 | 2.35 GiB |
+| 65,536 | 30.52% | ~3,052 | 1.1925 | ~8.8 | 1.18 GiB |
+| 32,768 | 61.04% | ~6,103 | 1.5139 | ~282 | 602.00 MiB |
+| 25,000 | 80.00% | ~8,000 | 1.8232 | ~1,092 | 459.29 MiB |
+| 20,000 | 100.00% | ~10,000 | 2.2832 | ~3,333 | 367.43 MiB |
+| 16,384 | 122.07% | overloaded | overloaded | overloaded | 301.00 MiB |
 
 This TIP chooses 301 time buckets and 131,072 cells per bucket. The bucket count is the minimum
 that preserves the cheap expiry proof for a 300 second window, and the cell count keeps the
-per-`valid_before` load at 15.26% with an average accepted path of about 1.085 probes at 20k TPS.
+per-`valid_before` load at 15.26% with about 1.085 replay-cell reads per attempted transaction at
+20k TPS.
 
 Smaller tables reduce the maximum footprint but increase average reads and tail risk. In
 particular, 65,536 cells per bucket would halve the footprint to 1.18 GiB but double load to
@@ -506,7 +502,7 @@ expiringNonceCells[cell_id] = valid_before || fingerprint
 This keeps the storage layout familiar, but every probed cell requires computing
 `keccak256(cell_id || mapping_slot)` before the `SLOAD`. At the chosen capacity, the expected
 accepted transaction reads about 1.085 cells, so mapping layout would add about 1.085 Keccak
-computations per accepted transaction on average and up to 32 in the worst probe path. The direct
+computations per accepted transaction on average and up to 5 in the worst probe path. The direct
 slot range preserves the same bounded table and probe behavior while making each probe slot
 derivable with integer addition.
 

--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -1,7 +1,7 @@
 ---
 id: TIP-1077
 title: Expiring Nonce Time Wheel
-description: Replaces the expiring nonce ring pointer with a bounded time-wheel replay table sized for 20k TPS.
+description: Replaces the expiring nonce ring pointer with a bounded time-wheel replay table sized for 20k TPS and a 5-minute expiry window.
 authors: Brian Picciano, Tanishk Goyal
 status: Draft
 related: TIP-1000, TIP-1009, TIP-1060, TIP-1073
@@ -12,12 +12,13 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP replaces TIP-1009's expiring nonce circular buffer with a fixed time-wheel replay table.
-`valid_before` selects one of 32 reusable time buckets, and the sender-scoped transaction replay
+This TIP replaces TIP-1009's expiring nonce circular buffer with a fixed time-wheel replay table
+and increases the maximum expiring nonce validity window from 30 seconds to 5 minutes.
+`valid_before` selects one of 301 reusable time buckets, and the sender-scoped transaction replay
 hash directly selects a deterministic probe path inside that bucket.
 
-The table is sized at 131,072 cells per bucket, for 4,194,304 total cells. A fully populated table
-is 128 MiB of cell values, or 256 MiB when counted as `(storage slot, storage value)` pairs.
+The table is sized at 131,072 cells per bucket, for 39,452,672 total cells. A fully populated table
+is 1.18 GiB of cell values, or 2.35 GiB when counted as `(storage slot, storage value)` pairs.
 
 ## Motivation
 
@@ -33,17 +34,21 @@ prewarm the first cell directly from `(replay_hash, valid_before)`. Replay cells
 direct storage range rather than Solidity mapping layout, so probing a cell does not require a
 mapping-slot hash.
 
+Increasing the validity window to 5 minutes gives partners and relayers more flexibility around
+submission, batching, and network delay without requiring them to continuously refresh signatures
+inside a 30 second window.
+
 ## Assumptions
 
-1. Expiring nonce transactions keep the TIP-1009 validity window:
-   `block.timestamp < valid_before <= block.timestamp + 30`.
+1. Expiring nonce transactions use the TIP-1077 validity window:
+   `block.timestamp < valid_before <= block.timestamp + 300`.
 2. Block timestamps are monotonically nondecreasing across canonical blocks.
 3. Replay hashes are uniformly distributed enough that bucket positions are random for operational
    sizing. Adversaries can grind transaction contents, so probe exhaustion remains a consensus
    error rather than an impossible case.
 4. The target load for this parameter set is 20,000 expiring nonce transactions per second,
-   sustained over the 30 second validity window.
-5. Traffic is assumed to be roughly constant over the 30 valid `valid_before` seconds. A workload
+   sustained over the 5-minute validity window.
+5. Traffic is assumed to be roughly constant over the 300 valid `valid_before` seconds. A workload
    that intentionally concentrates all transactions into one exact `valid_before` second is still
    accepted probabilistically, but has higher collision pressure.
 6. Expiring nonce replay cells are bounded temporary protocol state. They do not pay TIP-1000
@@ -70,25 +75,30 @@ transaction whose probe path is exhausted is invalid.
 ## Constants
 
 ```text
-EXPIRING_NONCE_MAX_EXPIRY_SECS = 30
-EXPIRING_NONCE_BUCKET_COUNT    = 32
+PRE_TIP_1077_MAX_EXPIRY_SECS  = 30
+EXPIRING_NONCE_MAX_EXPIRY_SECS = 300
+EXPIRING_NONCE_BUCKET_COUNT    = 301
 EXPIRING_NONCE_BUCKET_CAPACITY = 131_072
 EXPIRING_NONCE_MAX_PROBES      = 32
 
-EXPIRING_NONCE_CELL_COUNT      = 4_194_304
+EXPIRING_NONCE_CELL_COUNT      = 39_452_672
 EXPIRING_NONCE_CELL_BASE_SLOT  = 0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa2400000
-EXPIRING_NONCE_CELL_END_SLOT   = 0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa27fffff
+EXPIRING_NONCE_CELL_END_SLOT   = 0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa499ffff
 EXPIRING_NONCE_CELL_SLOT_DOMAIN = "tempo.expiringNonceCells.v1"
 EXPIRING_NONCE_FINGERPRINT_BITS = 192
 ```
+
+`EXPIRING_NONCE_MAX_EXPIRY_SECS` increases TIP-1009's maximum expiry from 30 seconds to
+300 seconds. `PRE_TIP_1077_MAX_EXPIRY_SECS` is used only by the hardfork migration dual-check for
+old ring entries.
 
 `EXPIRING_NONCE_BUCKET_COUNT` MUST be greater than `EXPIRING_NONCE_MAX_EXPIRY_SECS`.
 `EXPIRING_NONCE_BUCKET_CAPACITY` MUST be a power of two.
 `EXPIRING_NONCE_CELL_COUNT` MUST equal
 `EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY`.
 
-`EXPIRING_NONCE_CELL_BASE_SLOT` is the 4,194,304-slot-aligned value of
-`keccak256(EXPIRING_NONCE_CELL_SLOT_DOMAIN)`, with the low 22 bits cleared.
+`EXPIRING_NONCE_CELL_BASE_SLOT` is the fixed direct-range base derived from
+`keccak256(EXPIRING_NONCE_CELL_SLOT_DOMAIN)` by clearing the low 22 bits.
 `EXPIRING_NONCE_CELL_END_SLOT` is
 `EXPIRING_NONCE_CELL_BASE_SLOT + EXPIRING_NONCE_CELL_COUNT - 1`.
 The domain documents how the range was selected; implementations MUST use the fixed constants and
@@ -182,7 +192,8 @@ of modulo operations for `home`, `step`, and `position_i`.
 
 ## Replay Algorithm
 
-An expiring nonce transaction MUST satisfy the existing TIP-1009 transaction constraints:
+An expiring nonce transaction MUST satisfy the TIP-1009 transaction constraints as updated by this
+TIP:
 
 ```text
 tx.nonce_key == TEMPO_EXPIRING_NONCE_KEY
@@ -216,8 +227,8 @@ reject ExpiringNonceSetFull
 ```
 
 `stored_v != V` is safe to overwrite because the bucket count is larger than the expiry window. Two
-different `valid_before` values in the same bucket differ by at least 32 seconds, while expiring
-nonce transactions are live for at most 30 seconds.
+different `valid_before` values in the same bucket differ by at least 301 seconds, while expiring
+nonce transactions are live for at most 300 seconds.
 
 `ExpiringNonceSetFull` means the transaction's own deterministic probe path is full of different
 live fingerprints for the same `valid_before`. Under the time-wheel design this is local
@@ -255,51 +266,81 @@ steady-state lookup keccaks total   = 1, if H must be computed
 ```
 
 During the temporary hardfork migration dual-check, implementations still perform the old
-`expiringNonceSeen[H]` mapping lookup until `migration_cutoff`; that compatibility check adds one
+`expiringNonceSeen[H]` mapping lookup until `old_seen_cutoff`; that compatibility check adds one
 old mapping-slot hash during the migration window only.
 
 ## Parameter Selection
 
-At 20,000 expiring nonce transactions per second and a 30 second validity window, the live replay
+At 20,000 expiring nonce transactions per second and a 5-minute validity window, the live replay
 set is:
 
 ```text
-20_000 * 30 = 600_000 records
+20_000 * 300 = 6_000_000 records
 ```
 
-With constant load across the 30 valid `valid_before` seconds, each exact `valid_before` bucket
-receives about 20,000 records. The table below models random hash placement inside one bucket.
+The time wheel does not size one bucket for all 6 million live records. With constant load across
+the 300 valid `valid_before` seconds, each exact `valid_before` bucket receives about 20,000
+records:
+
+```text
+6_000_000 / 300 = 20_000 records per live bucket
+```
+
+The bucket count must be greater than the maximum expiry window so that two different
+`valid_before` values in the same bucket cannot both be live:
+
+```text
+minimum bucket count = EXPIRING_NONCE_MAX_EXPIRY_SECS + 1
+                     = 300 + 1
+                     = 301
+```
+
+The wheel has two independent dimensions:
+
+- `EXPIRING_NONCE_BUCKET_COUNT` separates expiry seconds. It only needs to be greater than the
+  maximum expiry window, so 301 buckets covers a 300 second window.
+- `EXPIRING_NONCE_BUCKET_CAPACITY` controls collision probability within one exact
+  `valid_before` second. This value must be a power of two so the odd probe step can cover every
+  cell in the bucket.
+
+Rounding the time-bucket count from 301 to 512 would not reduce same-second collisions: each exact
+`valid_before` second would still use one bucket with 131,072 cells. It would only reserve 211
+additional time buckets, increasing the 131,072-cell full-table footprint from 2.35 GiB to
+4.00 GiB.
+
+The table below models random hash placement inside one bucket.
 
 `Slot+value bloat` counts the full logical table as `(storage slot, storage value)` pairs:
 
 ```text
-slot+value bytes = 32 buckets * cells_per_bucket * 64
+slot+value bytes = 301 buckets * cells_per_bucket * 64
 ```
 
 | Cells per bucket | Load at 20k TPS | First-cell collisions per 20k txs | Avg probes per tx | Max slot+value bloat |
 | ---: | ---: | ---: | ---: | ---: |
-| 16,777,216 | 0.12% | ~12 | 1.0006 | 32.00 GiB |
-| 1,048,576 | 1.91% | ~190 | 1.0097 | 2.00 GiB |
-| 524,288 | 3.81% | ~377 | 1.0196 | 1.00 GiB |
-| 262,144 | 7.63% | ~744 | 1.0402 | 512.00 MiB |
-| 131,072 | 15.26% | ~1,451 | 1.0851 | 256.00 MiB |
-| 65,536 | 30.52% | ~2,764 | 1.1931 | 128.00 MiB |
-| 32,768 | 61.04% | ~5,030 | 1.5442 | 64.00 MiB |
-| 25,000 | 80.00% | ~6,233 | 2.0118 | 48.83 MiB |
-| 20,000 | 100.00% | ~7,358 | unstable | 39.06 MiB |
-| 16,384 | 122.07% | ~8,450 | overloaded | 32.00 MiB |
+| 16,777,216 | 0.12% | ~12 | 1.0006 | 301.00 GiB |
+| 1,048,576 | 1.91% | ~190 | 1.0097 | 18.81 GiB |
+| 524,288 | 3.81% | ~377 | 1.0196 | 9.41 GiB |
+| 262,144 | 7.63% | ~744 | 1.0402 | 4.70 GiB |
+| 131,072 | 15.26% | ~1,451 | 1.0851 | 2.35 GiB |
+| 65,536 | 30.52% | ~2,764 | 1.1931 | 1.18 GiB |
+| 32,768 | 61.04% | ~5,030 | 1.5442 | 602.00 MiB |
+| 25,000 | 80.00% | ~6,233 | 2.0118 | 459.29 MiB |
+| 20,000 | 100.00% | ~7,358 | unstable | 367.43 MiB |
+| 16,384 | 122.07% | ~8,450 | overloaded | 301.00 MiB |
 
-This TIP chooses 131,072 cells per bucket. It keeps the fully populated slot+value footprint at
-256 MiB while leaving enough slack that the common path is still near one probe at 20k TPS.
+This TIP chooses 301 time buckets and 131,072 cells per bucket. The bucket count is the minimum
+that preserves the cheap expiry proof for a 300 second window, and the cell count keeps the
+per-`valid_before` load at 15.26% with an average accepted path of about 1.085 probes at 20k TPS.
 
 Smaller tables reduce the maximum footprint but increase average reads and tail risk. In
-particular, 65,536 cells per bucket doubles load to 30.52%, and 32,768 cells per bucket pushes load
-above 60%, where probe length and probe-exhaustion risk become much more sensitive to traffic
-bursts or adversarial hash selection.
+particular, 65,536 cells per bucket would halve the footprint to 1.18 GiB but double load to
+30.52%, and 32,768 cells per bucket pushes load above 60%, where probe length and probe-exhaustion
+risk become much more sensitive to traffic bursts or adversarial hash selection.
 
 Larger tables reduce collisions but mostly buy marginal latency improvement at the cost of much
 larger bounded state. The 16,777,216-cell parameter explored in implementation experiments has
-negligible collisions but a 32 GiB slot+value full-table footprint.
+negligible collisions but a 301 GiB slot+value full-table footprint with a 5-minute window.
 
 ## Hardfork Migration
 
@@ -322,24 +363,28 @@ At the activation block:
    Inclusion tracking MUST stop watching `expiringNonceSeen[H]`; it MUST remove a pooled
    transaction when a canonical state update writes `V || H[8..32]` to one of that transaction's
    TIP-1077 direct probe-path slots.
+6. Expiry-window validation MUST switch from `block.timestamp + 30` to `block.timestamp + 300`.
+   Transactions with `valid_before` more than 30 seconds but no more than 300 seconds in the
+   future are valid only in blocks at or after activation.
 
 To preserve replay protection across the hardfork boundary, implementations MUST perform a
 temporary dual replay check:
 
 ```text
 activation_timestamp = timestamp of the first block executing TIP-1077
-migration_cutoff     = activation_timestamp + EXPIRING_NONCE_MAX_EXPIRY_SECS
+old_seen_cutoff      = activation_timestamp + PRE_TIP_1077_MAX_EXPIRY_SECS
 
-if block.timestamp <= migration_cutoff:
+if block.timestamp <= old_seen_cutoff:
     reject if old_expiringNonceSeen[H] > block.timestamp
 
 always:
     check and mark the TIP-1077 time-wheel cell
 ```
 
-After `migration_cutoff`, every transaction recorded only in the old ring layout must have expired
-under the TIP-1009 validity window, so the old seen mapping is no longer needed for replay
-validation.
+The old ring only contains transactions accepted under TIP-1009's 30 second maximum expiry, so the
+dual-check cutoff uses `PRE_TIP_1077_MAX_EXPIRY_SECS` rather than the new 300 second window. After
+`old_seen_cutoff`, every transaction recorded only in the old ring layout must have expired, so the
+old seen mapping is no longer needed for replay validation.
 
 The hardfork does not need to enumerate or delete old ring state. The old slots become orphaned
 reserved state. A later state-cleanup hardfork MAY clear them, but replay safety does not depend on
@@ -352,11 +397,12 @@ that cleanup.
 The ring has a small bounded footprint and was simple to reason about at lower TPS. A 300,000-entry
 ring supports roughly 10k TPS over a 30 second window.
 
-At 20k TPS, the ring must grow to at least 600,000 live entries. Because the design stores both
-`ring[index] -> hash` and `seen[hash] -> expiry`, that is roughly 1.2 million storage words before
-database overhead. The larger issue is not only size: every accepted transaction still depends on a
-global insertion pointer and performs multiple replay and eviction storage operations. A pointer
-that lands on a still-live entry can also create global backpressure until time advances.
+At 20k TPS over a 5-minute window, the ring must grow to at least 6,000,000 live entries. Because
+the design stores both `ring[index] -> hash` and `seen[hash] -> expiry`, that is roughly 12 million
+storage words before database overhead. The larger issue is not only size: every accepted
+transaction still depends on a global insertion pointer and performs multiple replay and eviction
+storage operations. A pointer that lands on a still-live entry can also create global backpressure
+until time advances.
 
 ### Plain Mapping With Cleanup
 
@@ -389,7 +435,7 @@ one future cleanup item. Cleanup becomes a second write-heavy transaction stream
 of magnitude as user traffic.
 
 Access-key pruning has low volume and long TTLs. Expiring nonce replay state has high volume and a
-30 second TTL. The time wheel handles that by reusing cells without explicit deletion.
+5-minute TTL. The time wheel handles that by reusing cells without explicit deletion.
 
 ### Hash Modulo Fixed Table
 
@@ -400,8 +446,8 @@ index = replay_hash % capacity
 ```
 
 does not provide enough capacity without probing. With one slot per index, two different live
-transactions that map to the same index cannot both be accepted. At 20k TPS, the live window
-contains about 600,000 records, so a 300,000-slot table is overloaded.
+transactions that map to the same index cannot both be accepted. At 20k TPS, the 5-minute live
+window contains about 6,000,000 records, so a 300,000-slot table is overloaded.
 
 Adding probing makes the design closer to the time wheel, but without the cheap time-bucket proof.
 The implementation must read occupied cells and compare expiries to determine whether they are
@@ -411,8 +457,8 @@ expiry inside the selected bucket.
 ### More Time Buckets With One Cell Each
 
 Increasing the number of time buckets does not increase active throughput when each bucket has one
-cell. Only 30 `valid_before` seconds are live at once, so one cell per bucket allows at most about
-30 live expiring nonce transactions before collisions force rejection.
+cell. Only 300 `valid_before` seconds are live at once, so one cell per bucket allows at most about
+300 live expiring nonce transactions before collisions force rejection.
 
 Bucket count provides expiry separation. Bucket capacity provides throughput within one expiry
 second. Both are required.
@@ -437,9 +483,9 @@ derivable with integer addition.
 A larger time wheel reduces collisions and makes first-cell prewarming more reliable. The
 16,777,216-cell-per-bucket design has an expected first-cell collision rate near zero at 20k TPS.
 
-Its cost is a much larger bounded state footprint: 32 GiB when counted as slot+value pairs. It also
-creates a long first-touch period where most transactions write previously empty cells. This TIP
-chooses a smaller 256 MiB slot+value footprint and accepts a modest average probe rate instead.
+Its cost is a much larger bounded state footprint: 301 GiB when counted as slot+value pairs. It
+also creates a long first-touch period where most transactions write previously empty cells. This
+TIP chooses a smaller 2.35 GiB slot+value footprint and accepts a modest average probe rate instead.
 
 # Observability
 
@@ -464,7 +510,7 @@ Nodes SHOULD expose metrics for:
 2. **Hardfork replay continuity.** A transaction included before activation and still live after
    activation MUST be rejected by the migration dual-check.
 3. **Expiry bounds.** Transactions with `valid_before <= block.timestamp` or
-   `valid_before > block.timestamp + 30` MUST be rejected.
+   `valid_before > block.timestamp + 300` MUST be rejected.
 4. **Bucket expiry proof.** Within a bucket, `stored_valid_before != tx.valid_before` MUST imply the
    stored record is not live.
 5. **Collision handling.** A live collision with a different fingerprint MUST probe the next

--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -13,8 +13,8 @@ protocolVersion: TBD
 ## Abstract
 
 This TIP replaces TIP-1009's expiring nonce circular buffer with a fixed time-wheel replay table.
-`valid_before` selects one of 32 reusable time buckets, and the transaction replay hash selects a
-deterministic probe path inside that bucket.
+`valid_before` selects one of 32 reusable time buckets, and the sender-scoped transaction replay
+hash directly selects a deterministic probe path inside that bucket.
 
 The table is sized at 131,072 cells per bucket, for 4,194,304 total cells. A fully populated table
 is 128 MiB of cell values, or 256 MiB when counted as `(storage slot, storage value)` pairs.
@@ -29,7 +29,9 @@ depends on how many expiring nonce transactions came before it in the block.
 
 The time wheel keeps replay state bounded without a global append pointer. The common path is a
 read and write of one replay-table cell derived from transaction contents, so the builder can
-prewarm the first cell directly from `(replay_hash, valid_before)`.
+prewarm the first cell directly from `(replay_hash, valid_before)`. Replay cells use a reserved
+direct storage range rather than Solidity mapping layout, so probing a cell does not require a
+mapping-slot hash.
 
 ## Assumptions
 
@@ -73,17 +75,29 @@ EXPIRING_NONCE_BUCKET_COUNT    = 32
 EXPIRING_NONCE_BUCKET_CAPACITY = 131_072
 EXPIRING_NONCE_MAX_PROBES      = 32
 
-EXPIRING_NONCE_CELL_DOMAIN        = "tempo-expiring-nonce-cell"
-EXPIRING_NONCE_FINGERPRINT_DOMAIN = "tempo-expiring-nonce-fingerprint"
-EXPIRING_NONCE_FINGERPRINT_BITS   = 192
+EXPIRING_NONCE_CELL_COUNT      = 4_194_304
+EXPIRING_NONCE_CELL_BASE_SLOT  = 0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa2400000
+EXPIRING_NONCE_CELL_END_SLOT   = 0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa27fffff
+EXPIRING_NONCE_CELL_SLOT_DOMAIN = "tempo.expiringNonceCells.v1"
+EXPIRING_NONCE_FINGERPRINT_BITS = 192
 ```
 
 `EXPIRING_NONCE_BUCKET_COUNT` MUST be greater than `EXPIRING_NONCE_MAX_EXPIRY_SECS`.
 `EXPIRING_NONCE_BUCKET_CAPACITY` MUST be a power of two.
+`EXPIRING_NONCE_CELL_COUNT` MUST equal
+`EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY`.
+
+`EXPIRING_NONCE_CELL_BASE_SLOT` is the 4,194,304-slot-aligned value of
+`keccak256(EXPIRING_NONCE_CELL_SLOT_DOMAIN)`, with the low 22 bits cleared.
+`EXPIRING_NONCE_CELL_END_SLOT` is
+`EXPIRING_NONCE_CELL_BASE_SLOT + EXPIRING_NONCE_CELL_COUNT - 1`.
+The domain documents how the range was selected; implementations MUST use the fixed constants and
+MUST NOT compute this hash while processing transactions.
 
 ## Storage Layout
 
-The Nonce precompile keeps the existing 2D nonce mapping and adds a fresh replay-cell mapping:
+The Nonce precompile keeps the existing 2D nonce mapping and reserves a direct replay-cell storage
+range:
 
 ```solidity
 contract Nonce {
@@ -91,10 +105,21 @@ contract Nonce {
 
     // Slots 1, 2, and 3 are reserved for the pre-TIP-1077 expiring nonce
     // seen mapping, ring mapping, and ring pointer.
-
-    mapping(uint32 => bytes32) public expiringNonceCells;                  // slot 4
 }
 ```
+
+Replay cells are not stored in a Solidity-style mapping. For `cell_id` in
+`[0, EXPIRING_NONCE_CELL_COUNT)`, the corresponding storage slot is:
+
+```text
+cell_slot = EXPIRING_NONCE_CELL_BASE_SLOT + cell_id
+```
+
+The inclusive slot range
+`[EXPIRING_NONCE_CELL_BASE_SLOT, EXPIRING_NONCE_CELL_END_SLOT]` is reserved forever for expiring
+nonce replay cells. Future Nonce precompile fields MUST NOT be assigned inside this range.
+Mapping-derived slots are assumed collision-resistant under the same Keccak preimage assumptions as
+Solidity mapping layout.
 
 Each replay cell stores:
 
@@ -107,7 +132,7 @@ where:
 ```text
 stored_valid_before = high 64 bits of cell
 stored_fingerprint  = low 192 bits of cell
-fingerprint         = low_192_bits(keccak256(FINGERPRINT_DOMAIN || replay_hash))
+fingerprint         = low 192 bits of H
 ```
 
 A zero storage word has `stored_valid_before == 0` and is reusable.
@@ -126,6 +151,9 @@ V = tx.valid_before
 T = block.timestamp
 ```
 
+`H` MUST be the canonical protocol-computed replay hash, `keccak256(encode_for_signing || sender)`.
+It is not user-provided input.
+
 The transaction first chooses its time bucket:
 
 ```text
@@ -135,9 +163,8 @@ bucket = V % EXPIRING_NONCE_BUCKET_COUNT
 It then chooses a deterministic probe path inside that bucket:
 
 ```text
-seed = keccak256(EXPIRING_NONCE_CELL_DOMAIN || H)
-home = uint32_be(seed[0..4]) % EXPIRING_NONCE_BUCKET_CAPACITY
-step = (uint32_be(seed[4..8]) | 1) % EXPIRING_NONCE_BUCKET_CAPACITY
+home = uint32_be(H[0..4]) % EXPIRING_NONCE_BUCKET_CAPACITY
+step = (uint32_be(H[4..8]) | 1) % EXPIRING_NONCE_BUCKET_CAPACITY
 ```
 
 For probe `i`:
@@ -145,10 +172,13 @@ For probe `i`:
 ```text
 position_i = (home + i * step) % EXPIRING_NONCE_BUCKET_CAPACITY
 cell_id_i  = bucket * EXPIRING_NONCE_BUCKET_CAPACITY + position_i
+slot_i     = EXPIRING_NONCE_CELL_BASE_SLOT + cell_id_i
 ```
 
 `step` is forced odd so that, with power-of-two bucket capacity, the probe path can cycle through
 the bucket instead of being trapped in a smaller divisor-sized subset.
+Since `EXPIRING_NONCE_BUCKET_CAPACITY` is a power of two, implementations MAY use bit masks instead
+of modulo operations for `home`, `step`, and `position_i`.
 
 ## Replay Algorithm
 
@@ -164,16 +194,17 @@ T < V <= T + EXPIRING_NONCE_MAX_EXPIRY_SECS
 Then the Nonce precompile executes:
 
 ```text
-fingerprint = low_192_bits(keccak256(FINGERPRINT_DOMAIN || H))
+fingerprint = H[8..32]
 
 for i in 0..EXPIRING_NONCE_MAX_PROBES:
     cell_id = cell_id_i
-    word = expiringNonceCells[cell_id]
+    slot = EXPIRING_NONCE_CELL_BASE_SLOT + cell_id
+    word = sload(slot)
     stored_v = high_64_bits(word)
     stored_f = low_192_bits(word)
 
     if stored_v != V:
-        expiringNonceCells[cell_id] = V || fingerprint
+        sstore(slot, V || fingerprint)
         accept
 
     if stored_f == fingerprint:
@@ -213,6 +244,19 @@ equivalent dynamic metering mechanism in the precompile storage layer. With the 
 the 20k TPS sizing assumption, the expected accepted transaction reads about 1.085 cells.
 
 No expiring nonce insertion or later overwrite mints or consumes TIP-1060 storage credits.
+
+The time-wheel lookup performs no Keccak beyond the canonical replay hash `H`. If `H` has already
+been computed by transaction validation or pool deduplication, deriving `bucket`, `home`, `step`,
+`fingerprint`, `cell_id`, and `slot` requires only slicing and arithmetic:
+
+```text
+steady-state lookup keccaks after H = 0
+steady-state lookup keccaks total   = 1, if H must be computed
+```
+
+During the temporary hardfork migration dual-check, implementations still perform the old
+`expiringNonceSeen[H]` mapping lookup until `migration_cutoff`; that compatibility check adds one
+old mapping-slot hash during the migration window only.
 
 ## Parameter Selection
 
@@ -269,14 +313,15 @@ slot 3: expiringNonceRingPtr
 
 At the activation block:
 
-1. New expiring nonce insertions MUST use `expiringNonceCells` at slot 4.
+1. New expiring nonce insertions MUST use the direct replay-cell slot range
+   `[EXPIRING_NONCE_CELL_BASE_SLOT, EXPIRING_NONCE_CELL_END_SLOT]`.
 2. The old ring pointer, ring mapping, and seen mapping MUST NOT be updated.
 3. Slots 1, 2, and 3 MUST remain reserved.
 4. Payload-builder prewarming MUST switch to the time-wheel first-cell slot.
 5. Transaction pool deduplication MUST continue to key expiring nonce transactions by `H`.
    Inclusion tracking MUST stop watching `expiringNonceSeen[H]`; it MUST remove a pooled
-   transaction when a canonical state update writes `V || fingerprint(H)` to one of that
-   transaction's TIP-1077 probe-path cells.
+   transaction when a canonical state update writes `V || H[8..32]` to one of that transaction's
+   TIP-1077 direct probe-path slots.
 
 To preserve replay protection across the hardfork boundary, implementations MUST perform a
 temporary dual replay check:
@@ -372,6 +417,21 @@ cell. Only 30 `valid_before` seconds are live at once, so one cell per bucket al
 Bucket count provides expiry separation. Bucket capacity provides throughput within one expiry
 second. Both are required.
 
+### Solidity-Style Replay Cell Mapping
+
+The time wheel could store cells in a flat Solidity-style mapping:
+
+```text
+expiringNonceCells[cell_id] = valid_before || fingerprint
+```
+
+This keeps the storage layout familiar, but every probed cell requires computing
+`keccak256(cell_id || mapping_slot)` before the `SLOAD`. At the chosen capacity, the expected
+accepted transaction reads about 1.085 cells, so mapping layout would add about 1.085 Keccak
+computations per accepted transaction on average and up to 32 in the worst probe path. The direct
+slot range preserves the same bounded table and probe behavior while making each probe slot
+derivable with integer addition.
+
 ### Larger Time Wheel
 
 A larger time wheel reduces collisions and makes first-cell prewarming more reliable. The
@@ -412,9 +472,11 @@ Nodes SHOULD expose metrics for:
 6. **Probe exhaustion.** If all probed cells contain different live fingerprints for the same
    `valid_before`, the transaction MUST be rejected with `ExpiringNonceSetFull`.
 7. **Bounded state.** New replay state MUST be limited to
-   `EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY` cells.
+   `EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY` cells in the reserved direct slot
+   range.
 8. **No explicit cleanup dependency.** Replay correctness MUST NOT depend on offchain pruning,
    MEV services, or TIP-1060 storage credits.
 9. **No nonce mutation.** Expiring nonce transactions MUST NOT increment protocol nonces or 2D
    nonces.
-10. **Storage layout hygiene.** Old ring slots 1, 2, and 3 MUST remain reserved after activation.
+10. **Storage layout hygiene.** Old ring slots 1, 2, and 3 MUST remain reserved after activation,
+    and future Nonce precompile fields MUST NOT overlap the direct replay-cell slot range.

--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -1,0 +1,421 @@
+---
+id: TIP-1077
+title: Expiring Nonce Time Wheel
+description: Replaces the expiring nonce ring pointer with a bounded time-wheel replay table sized for 20k TPS.
+authors: Brian Picciano, Tanishk Goyal
+status: Draft
+related: TIP-1000, TIP-1009, TIP-1060, TIP-1073
+protocolVersion: TBD
+---
+
+# TIP-1077: Expiring Nonce Time Wheel
+
+## Abstract
+
+This TIP replaces TIP-1009's expiring nonce circular buffer with a fixed time-wheel replay table.
+`valid_before` selects one of 32 reusable time buckets, and the transaction replay hash selects a
+deterministic probe path inside that bucket.
+
+The table is sized at 131,072 cells per bucket, for 4,194,304 total cells. A fully populated table
+is 128 MiB of cell values, or 256 MiB when counted as `(storage slot, storage value)` pairs.
+
+## Motivation
+
+The current expiring nonce ring design keeps replay state bounded, but every accepted transaction
+updates a global append structure. The common steady-state path reads and writes several storage
+locations: `seen[hash]`, `ring[ptr]`, `seen[old_hash]`, and the ring pointer. The global pointer
+also complicates payload-builder prewarming because the storage slot touched by a transaction
+depends on how many expiring nonce transactions came before it in the block.
+
+The time wheel keeps replay state bounded without a global append pointer. The common path is a
+read and write of one replay-table cell derived from transaction contents, so the builder can
+prewarm the first cell directly from `(replay_hash, valid_before)`.
+
+## Assumptions
+
+1. Expiring nonce transactions keep the TIP-1009 validity window:
+   `block.timestamp < valid_before <= block.timestamp + 30`.
+2. Block timestamps are monotonically nondecreasing across canonical blocks.
+3. Replay hashes are uniformly distributed enough that bucket positions are random for operational
+   sizing. Adversaries can grind transaction contents, so probe exhaustion remains a consensus
+   error rather than an impossible case.
+4. The target load for this parameter set is 20,000 expiring nonce transactions per second,
+   sustained over the 30 second validity window.
+5. Traffic is assumed to be roughly constant over the 30 valid `valid_before` seconds. A workload
+   that intentionally concentrates all transactions into one exact `valid_before` second is still
+   accepted probabilistically, but has higher collision pressure.
+6. Expiring nonce replay cells are bounded temporary protocol state. They do not pay TIP-1000
+   permanent new-slot pricing on first touch and do not mint or consume TIP-1060 storage credits.
+
+If the target TPS assumption is exceeded for long periods, collision frequency and probe-exhausted
+rejections increase. A future TIP can raise `EXPIRING_NONCE_BUCKET_CAPACITY` without changing the
+replay algorithm.
+
+## Threat Model
+
+Users and relayers are untrusted. They may replay old signed transactions, submit many independent
+expiring nonce transactions with the same `valid_before`, or grind transaction contents to seek
+cell collisions.
+
+Builders and validators are untrusted for transaction ordering but trusted to execute the canonical
+state transition rules. A block containing a replay, an expired expiring nonce transaction, or a
+transaction whose probe path is exhausted is invalid.
+
+Offchain cleanup services are not trusted for replay safety. This TIP does not rely on any MEV,
+protocol-service, or permissionless pruning process to keep expiring nonce state bounded.
+
+---
+
+# Specification
+
+## Constants
+
+```text
+EXPIRING_NONCE_MAX_EXPIRY_SECS = 30
+EXPIRING_NONCE_BUCKET_COUNT    = 32
+EXPIRING_NONCE_BUCKET_CAPACITY = 131_072
+EXPIRING_NONCE_MAX_PROBES      = 32
+
+EXPIRING_NONCE_CELL_DOMAIN        = "tempo-expiring-nonce-cell"
+EXPIRING_NONCE_FINGERPRINT_DOMAIN = "tempo-expiring-nonce-fingerprint"
+EXPIRING_NONCE_FINGERPRINT_BITS   = 192
+```
+
+`EXPIRING_NONCE_BUCKET_COUNT` MUST be greater than `EXPIRING_NONCE_MAX_EXPIRY_SECS`.
+`EXPIRING_NONCE_BUCKET_CAPACITY` MUST be a power of two.
+
+## Storage Layout
+
+The Nonce precompile keeps the existing 2D nonce mapping and adds a fresh replay-cell mapping:
+
+```solidity
+contract Nonce {
+    mapping(address => mapping(uint256 => uint64)) public nonces;          // slot 0
+
+    // Slots 1, 2, and 3 are reserved for the pre-TIP-1077 expiring nonce
+    // seen mapping, ring mapping, and ring pointer.
+
+    mapping(uint32 => bytes32) public expiringNonceCells;                  // slot 4
+}
+```
+
+Each replay cell stores:
+
+```text
+cell = valid_before_u64 || replay_fingerprint_192
+```
+
+where:
+
+```text
+stored_valid_before = high 64 bits of cell
+stored_fingerprint  = low 192 bits of cell
+fingerprint         = low_192_bits(keccak256(FINGERPRINT_DOMAIN || replay_hash))
+```
+
+A zero storage word has `stored_valid_before == 0` and is reusable.
+
+Slots 1, 2, and 3 MUST remain reserved forever unless a later hardfork explicitly migrates or
+clears the old ring state. Reusing those slots for unrelated fields risks reading stale pre-fork
+data.
+
+## Cell Selection
+
+Let:
+
+```text
+H = sender-scoped expiring nonce replay hash
+V = tx.valid_before
+T = block.timestamp
+```
+
+The transaction first chooses its time bucket:
+
+```text
+bucket = V % EXPIRING_NONCE_BUCKET_COUNT
+```
+
+It then chooses a deterministic probe path inside that bucket:
+
+```text
+seed = keccak256(EXPIRING_NONCE_CELL_DOMAIN || H)
+home = uint32_be(seed[0..4]) % EXPIRING_NONCE_BUCKET_CAPACITY
+step = (uint32_be(seed[4..8]) | 1) % EXPIRING_NONCE_BUCKET_CAPACITY
+```
+
+For probe `i`:
+
+```text
+position_i = (home + i * step) % EXPIRING_NONCE_BUCKET_CAPACITY
+cell_id_i  = bucket * EXPIRING_NONCE_BUCKET_CAPACITY + position_i
+```
+
+`step` is forced odd so that, with power-of-two bucket capacity, the probe path can cycle through
+the bucket instead of being trapped in a smaller divisor-sized subset.
+
+## Replay Algorithm
+
+An expiring nonce transaction MUST satisfy the existing TIP-1009 transaction constraints:
+
+```text
+tx.nonce_key == TEMPO_EXPIRING_NONCE_KEY
+tx.nonce == 0
+V is present
+T < V <= T + EXPIRING_NONCE_MAX_EXPIRY_SECS
+```
+
+Then the Nonce precompile executes:
+
+```text
+fingerprint = low_192_bits(keccak256(FINGERPRINT_DOMAIN || H))
+
+for i in 0..EXPIRING_NONCE_MAX_PROBES:
+    cell_id = cell_id_i
+    word = expiringNonceCells[cell_id]
+    stored_v = high_64_bits(word)
+    stored_f = low_192_bits(word)
+
+    if stored_v != V:
+        expiringNonceCells[cell_id] = V || fingerprint
+        accept
+
+    if stored_f == fingerprint:
+        reject ExpiringNonceReplay
+
+    continue
+
+reject ExpiringNonceSetFull
+```
+
+`stored_v != V` is safe to overwrite because the bucket count is larger than the expiry window. Two
+different `valid_before` values in the same bucket differ by at least 32 seconds, while expiring
+nonce transactions are live for at most 30 seconds.
+
+`ExpiringNonceSetFull` means the transaction's own deterministic probe path is full of different
+live fingerprints for the same `valid_before`. Under the time-wheel design this is local
+congestion, not global table exhaustion.
+
+## Gas Pricing
+
+The common first-cell path is priced as one cold read and one reset-price write:
+
+```text
+EXPIRING_NONCE_BASE_GAS = COLD_SLOAD_COST + WARM_SSTORE_RESET
+                        = 2_100 + 2_900
+                        = 5_000
+```
+
+This charge intentionally does not apply TIP-1000 permanent new-slot pricing to first-touch replay
+cells. Expiring nonce cells are bounded temporary protocol state, not user-created permanent state.
+The maximum table footprint is capped by `EXPIRING_NONCE_BUCKET_COUNT *
+EXPIRING_NONCE_BUCKET_CAPACITY`.
+
+Implementations MUST ensure collision-heavy probe paths cannot create unbounded uncharged work.
+They MAY either charge `COLD_SLOAD_COST` for each additional probed cell beyond the first, or use an
+equivalent dynamic metering mechanism in the precompile storage layer. With the chosen capacity and
+the 20k TPS sizing assumption, the expected accepted transaction reads about 1.085 cells.
+
+No expiring nonce insertion or later overwrite mints or consumes TIP-1060 storage credits.
+
+## Parameter Selection
+
+At 20,000 expiring nonce transactions per second and a 30 second validity window, the live replay
+set is:
+
+```text
+20_000 * 30 = 600_000 records
+```
+
+With constant load across the 30 valid `valid_before` seconds, each exact `valid_before` bucket
+receives about 20,000 records. The table below models random hash placement inside one bucket.
+
+`Slot+value bloat` counts the full logical table as `(storage slot, storage value)` pairs:
+
+```text
+slot+value bytes = 32 buckets * cells_per_bucket * 64
+```
+
+| Cells per bucket | Load at 20k TPS | First-cell collisions per 20k txs | Avg probes per tx | Max slot+value bloat |
+| ---: | ---: | ---: | ---: | ---: |
+| 16,777,216 | 0.12% | ~12 | 1.0006 | 32.00 GiB |
+| 1,048,576 | 1.91% | ~190 | 1.0097 | 2.00 GiB |
+| 524,288 | 3.81% | ~377 | 1.0196 | 1.00 GiB |
+| 262,144 | 7.63% | ~744 | 1.0402 | 512.00 MiB |
+| 131,072 | 15.26% | ~1,451 | 1.0851 | 256.00 MiB |
+| 65,536 | 30.52% | ~2,764 | 1.1931 | 128.00 MiB |
+| 32,768 | 61.04% | ~5,030 | 1.5442 | 64.00 MiB |
+| 25,000 | 80.00% | ~6,233 | 2.0118 | 48.83 MiB |
+| 20,000 | 100.00% | ~7,358 | unstable | 39.06 MiB |
+| 16,384 | 122.07% | ~8,450 | overloaded | 32.00 MiB |
+
+This TIP chooses 131,072 cells per bucket. It keeps the fully populated slot+value footprint at
+256 MiB while leaving enough slack that the common path is still near one probe at 20k TPS.
+
+Smaller tables reduce the maximum footprint but increase average reads and tail risk. In
+particular, 65,536 cells per bucket doubles load to 30.52%, and 32,768 cells per bucket pushes load
+above 60%, where probe length and probe-exhaustion risk become much more sensitive to traffic
+bursts or adversarial hash selection.
+
+Larger tables reduce collisions but mostly buy marginal latency improvement at the cost of much
+larger bounded state. The 16,777,216-cell parameter explored in implementation experiments has
+negligible collisions but a 32 GiB slot+value full-table footprint.
+
+## Hardfork Migration
+
+Before this TIP activates, expiring nonce replay state is stored in the TIP-1009 ring layout:
+
+```text
+slot 1: expiringNonceSeen[hash] -> expiry
+slot 2: expiringNonceRing[index] -> hash
+slot 3: expiringNonceRingPtr
+```
+
+At the activation block:
+
+1. New expiring nonce insertions MUST use `expiringNonceCells` at slot 4.
+2. The old ring pointer, ring mapping, and seen mapping MUST NOT be updated.
+3. Slots 1, 2, and 3 MUST remain reserved.
+4. Payload-builder prewarming MUST switch to the time-wheel first-cell slot.
+5. Transaction pool replay tracking MUST switch to sender-scoped replay hashes and/or time-wheel
+   cell matches instead of detecting inclusion by `expiringNonceSeen[hash]` storage writes.
+
+To preserve replay protection across the hardfork boundary, implementations MUST perform a
+temporary dual replay check:
+
+```text
+activation_timestamp = timestamp of the first block executing TIP-1077
+migration_cutoff     = activation_timestamp + EXPIRING_NONCE_MAX_EXPIRY_SECS
+
+if block.timestamp <= migration_cutoff:
+    reject if old_expiringNonceSeen[H] > block.timestamp
+
+always:
+    check and mark the TIP-1077 time-wheel cell
+```
+
+After `migration_cutoff`, every transaction recorded only in the old ring layout must have expired
+under the TIP-1009 validity window, so the old seen mapping is no longer needed for replay
+validation.
+
+The hardfork does not need to enumerate or delete old ring state. The old slots become orphaned
+reserved state. A later state-cleanup hardfork MAY clear them, but replay safety does not depend on
+that cleanup.
+
+## Alternatives Considered
+
+### Keep The Circular Ring
+
+The ring has a small bounded footprint and was simple to reason about at lower TPS. A 300,000-entry
+ring supports roughly 10k TPS over a 30 second window.
+
+At 20k TPS, the ring must grow to at least 600,000 live entries. Because the design stores both
+`ring[index] -> hash` and `seen[hash] -> expiry`, that is roughly 1.2 million storage words before
+database overhead. The larger issue is not only size: every accepted transaction still depends on a
+global insertion pointer and performs multiple replay and eviction storage operations. A pointer
+that lands on a still-live entry can also create global backpressure until time advances.
+
+### Plain Mapping With Cleanup
+
+A plain mapping:
+
+```text
+expiringNonceSeen[hash] = expiry
+```
+
+is the simplest replay data structure. It removes the ring pointer and has a cheap replay lookup.
+
+It is not self-bounded. Solidity-style mappings are not enumerable, so expired entries require an
+external index, offchain block scanning, or a protocol cleanup service. At 20k TPS, cleanup must
+eventually delete 20,000 entries per second. If cleanup mints transferable storage credits, it
+creates gas-token-like incentives unless the original transaction prepaid the full future credit
+and cleanup execution cost. If cleanup is subsidized by the protocol, the cost is hidden rather
+than removed.
+
+This TIP rejects the plain mapping design because expiring nonce replay safety should not depend on
+a high-throughput cleanup market or service.
+
+### Plain Mapping With TIP-1073-Style Refunds
+
+The mapping design can be paired with prepaid cleanup budget and permissionless pruning, similar to
+temporary access-key state.
+
+That model is better than transferable credits because the refund is bounded and same-transaction.
+It is still a poor fit for expiring nonces because each expiring nonce transaction creates exactly
+one future cleanup item. Cleanup becomes a second write-heavy transaction stream at the same order
+of magnitude as user traffic.
+
+Access-key pruning has low volume and long TTLs. Expiring nonce replay state has high volume and a
+30 second TTL. The time wheel handles that by reusing cells without explicit deletion.
+
+### Hash Modulo Fixed Table
+
+A fixed table indexed by:
+
+```text
+index = replay_hash % capacity
+```
+
+does not provide enough capacity without probing. With one slot per index, two different live
+transactions that map to the same index cannot both be accepted. At 20k TPS, the live window
+contains about 600,000 records, so a 300,000-slot table is overloaded.
+
+Adding probing makes the design closer to the time wheel, but without the cheap time-bucket proof.
+The implementation must read occupied cells and compare expiries to determine whether they are
+reusable. The time wheel instead makes `stored_valid_before != current_valid_before` a proof of
+expiry inside the selected bucket.
+
+### More Time Buckets With One Cell Each
+
+Increasing the number of time buckets does not increase active throughput when each bucket has one
+cell. Only 30 `valid_before` seconds are live at once, so one cell per bucket allows at most about
+30 live expiring nonce transactions before collisions force rejection.
+
+Bucket count provides expiry separation. Bucket capacity provides throughput within one expiry
+second. Both are required.
+
+### Larger Time Wheel
+
+A larger time wheel reduces collisions and makes first-cell prewarming more reliable. The
+16,777,216-cell-per-bucket design has an expected first-cell collision rate near zero at 20k TPS.
+
+Its cost is a much larger bounded state footprint: 32 GiB when counted as slot+value pairs. It also
+creates a long first-touch period where most transactions write previously empty cells. This TIP
+chooses a smaller 256 MiB slot+value footprint and accepts a modest average probe rate instead.
+
+# Observability
+
+No new EVM events are required. Expiring nonce replay protection is a consensus validity rule, and
+emitting an event for every replay-cell write would add unnecessary receipt volume.
+
+Nodes SHOULD expose metrics for:
+
+| Metric | Purpose |
+| --- | --- |
+| `expiring_nonce_probe_count` | Distribution of probes per accepted transaction |
+| `expiring_nonce_first_cell_hit_total` | Common-path hit rate for builder prewarming |
+| `expiring_nonce_probe_exhausted_total` | Collision or attack pressure |
+| `expiring_nonce_replay_total` | Replay rejection rate |
+| `expiring_nonce_old_seen_replay_total` | Replays caught by the hardfork migration dual-check |
+| `expiring_nonce_cells_touched_total` | Approximate growth toward the bounded table footprint |
+
+# Invariants
+
+1. **No replay.** A sender-scoped expiring nonce replay hash with a live `valid_before` MUST NOT be
+   accepted twice.
+2. **Hardfork replay continuity.** A transaction included before activation and still live after
+   activation MUST be rejected by the migration dual-check.
+3. **Expiry bounds.** Transactions with `valid_before <= block.timestamp` or
+   `valid_before > block.timestamp + 30` MUST be rejected.
+4. **Bucket expiry proof.** Within a bucket, `stored_valid_before != tx.valid_before` MUST imply the
+   stored record is not live.
+5. **Collision handling.** A live collision with a different fingerprint MUST probe the next
+   deterministic cell, up to `EXPIRING_NONCE_MAX_PROBES`.
+6. **Probe exhaustion.** If all probed cells contain different live fingerprints for the same
+   `valid_before`, the transaction MUST be rejected with `ExpiringNonceSetFull`.
+7. **Bounded state.** New replay state MUST be limited to
+   `EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY` cells.
+8. **No explicit cleanup dependency.** Replay correctness MUST NOT depend on offchain pruning,
+   MEV services, or TIP-1060 storage credits.
+9. **No nonce mutation.** Expiring nonce transactions MUST NOT increment protocol nonces or 2D
+   nonces.
+10. **Storage layout hygiene.** Old ring slots 1, 2, and 3 MUST remain reserved after activation.

--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -61,9 +61,6 @@ Builders and validators are untrusted for transaction ordering but trusted to ex
 state transition rules. A block containing a replay, an expired expiring nonce transaction, or a
 transaction whose probe path is exhausted is invalid.
 
-Offchain cleanup services are not trusted for replay safety. This TIP does not rely on any MEV,
-protocol-service, or permissionless pruning process to keep expiring nonce state bounded.
-
 ---
 
 # Specification
@@ -276,8 +273,10 @@ At the activation block:
 2. The old ring pointer, ring mapping, and seen mapping MUST NOT be updated.
 3. Slots 1, 2, and 3 MUST remain reserved.
 4. Payload-builder prewarming MUST switch to the time-wheel first-cell slot.
-5. Transaction pool replay tracking MUST switch to sender-scoped replay hashes and/or time-wheel
-   cell matches instead of detecting inclusion by `expiringNonceSeen[hash]` storage writes.
+5. Transaction pool deduplication MUST continue to key expiring nonce transactions by `H`.
+   Inclusion tracking MUST stop watching `expiringNonceSeen[H]`; it MUST remove a pooled
+   transaction when a canonical state update writes `V || fingerprint(H)` to one of that
+   transaction's TIP-1077 probe-path cells.
 
 To preserve replay protection across the hardfork boundary, implementations MUST perform a
 temporary dual replay check:

--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -236,7 +236,10 @@ congestion, not global table exhaustion.
 
 ## Gas Pricing
 
-The common first-cell path is priced as one cold read and one reset-price write:
+Expiring nonce bookkeeping is charged as explicit AA intrinsic regular gas, not by relying on
+dynamic metering inside the precompile storage provider.
+
+The common first-cell path is one cold read and one reset-price write:
 
 ```text
 EXPIRING_NONCE_BASE_GAS = COLD_SLOAD_COST + WARM_SSTORE_RESET
@@ -244,15 +247,34 @@ EXPIRING_NONCE_BASE_GAS = COLD_SLOAD_COST + WARM_SSTORE_RESET
                         = 5_000
 ```
 
+For an accepted transaction, let `probes` be the number of replay cells read before the transaction
+is accepted. Implementations MUST charge:
+
+```text
+EXPIRING_NONCE_GAS(probes) = EXPIRING_NONCE_BASE_GAS
+                           + (probes - 1) * COLD_SLOAD_COST
+
+                           = probes * 2_100 + 2_900
+```
+
+Examples:
+
+| Probe count | Expiring nonce gas |
+| ---: | ---: |
+| 1 | 5,000 |
+| 2 | 7,100 |
+| 32 | 70,100 |
+
 This charge intentionally does not apply TIP-1000 permanent new-slot pricing to first-touch replay
 cells. Expiring nonce cells are bounded temporary protocol state, not user-created permanent state.
 The maximum table footprint is capped by `EXPIRING_NONCE_BUCKET_COUNT *
 EXPIRING_NONCE_BUCKET_CAPACITY`.
 
-Implementations MUST ensure collision-heavy probe paths cannot create unbounded uncharged work.
-They MAY either charge `COLD_SLOAD_COST` for each additional probed cell beyond the first, or use an
-equivalent dynamic metering mechanism in the precompile storage layer. With the chosen capacity and
-the 20k TPS sizing assumption, the expected accepted transaction reads about 1.085 cells.
+The replay insertion function MUST return the accepted probe count, and the EVM handler MUST charge
+the formula above explicitly as regular gas while keeping replay-cell writes exempt from
+TIP-1000/TIP-1060 state accounting. With the chosen capacity and the 20k TPS sizing assumption, the
+expected accepted transaction reads about 1.085 cells and pays about 5,179 gas for TIP-1077 replay
+bookkeeping.
 
 No expiring nonce insertion or later overwrite mints or consumes TIP-1060 storage credits.
 
@@ -267,7 +289,13 @@ steady-state lookup keccaks total   = 1, if H must be computed
 
 During the temporary hardfork migration dual-check, implementations still perform the old
 `expiringNonceSeen[H]` mapping lookup until `old_seen_cutoff`; that compatibility check adds one
-old mapping-slot hash during the migration window only.
+old mapping-slot hash and one extra cold read during the migration window only. Transactions
+accepted during that window therefore pay:
+
+```text
+EXPIRING_NONCE_MIGRATION_GAS(probes) = EXPIRING_NONCE_GAS(probes) + COLD_SLOAD_COST
+                                     = EXPIRING_NONCE_GAS(probes) + 2_100
+```
 
 ## Parameter Selection
 

--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -387,13 +387,17 @@ At the activation block:
 2. The old ring pointer, ring mapping, and seen mapping MUST NOT be updated.
 3. Slots 1, 2, and 3 MUST remain reserved.
 4. Payload-builder prewarming MUST switch to the time-wheel first-cell slot.
-5. Transaction pool deduplication MUST continue to key expiring nonce transactions by `H`.
-   Inclusion tracking MUST stop watching `expiringNonceSeen[H]`; it MUST remove a pooled
-   transaction when a canonical state update writes `V || H[8..32]` to one of that transaction's
-   TIP-1077 direct probe-path slots.
-6. Expiry-window validation MUST switch from `block.timestamp + 30` to `block.timestamp + 300`.
+5. Expiry-window validation MUST switch from `block.timestamp + 30` to `block.timestamp + 300`.
    Transactions with `valid_before` more than 30 seconds but no more than 300 seconds in the
    future are valid only in blocks at or after activation.
+
+The transaction pool can keep deduplicating expiring nonce transactions by `H`. Today it also uses
+the unique `expiringNonceSeen[H]` slot to notice when a pooled transaction was included. With
+TIP-1077 there is no unique per-transaction slot: each transaction has a probe path through shared
+replay cells, and another transaction may write a different fingerprint into one of those cells. If
+the pool keeps inclusion tracking from state updates, it should watch the probe-path cells and
+remove a transaction only when the written word is that transaction's exact `V || H[8..32]` value,
+not merely because a watched cell became non-zero.
 
 To preserve replay protection across the hardfork boundary, implementations MUST perform a
 temporary dual replay check:

--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -15,7 +15,8 @@ protocolVersion: TBD
 This TIP replaces TIP-1009's expiring nonce circular buffer with a fixed time-wheel replay table
 and increases the maximum expiring nonce validity window from 30 seconds to 5 minutes.
 `valid_before` selects one of 301 reusable time buckets, and the sender-scoped transaction replay
-hash directly selects a deterministic probe path inside that bucket.
+hash directly selects a deterministic probe path inside that bucket. Each replay cell packs up to
+three live 64-bit replay fingerprints for the selected `valid_before`.
 
 The table is sized at 131,072 cells per bucket, for 39,452,672 total cells. A fully populated table
 is 1.18 GiB of cell values, or 2.35 GiB when counted as `(storage slot, storage value)` pairs.
@@ -62,11 +63,44 @@ replay algorithm.
 
 Users and relayers are untrusted. They may replay old signed transactions, submit many independent
 expiring nonce transactions with the same `valid_before`, or grind transaction contents to seek
-cell collisions.
+full-cell or fingerprint collisions. Packed 64-bit fingerprints trade lower probe pressure for
+higher false-replay collision probability than a 192-bit fingerprint.
 
 Builders and validators are untrusted for transaction ordering but trusted to execute the canonical
 state transition rules. A block containing a replay, an expired expiring nonce transaction, or a
 transaction whose probe path is exhausted is invalid.
+
+### Known Censorship Vectors
+
+The current design leaves three censorship vectors. All of these vectors are
+mitigated by the fact that users can trivially switch to other nonce methods,
+like protocol or 2D nonces.
+
+1. **Probe-path exhaustion:** an attacker can submit individual transactions that occupy all cells
+   on a victim's deterministic probe path for the same `valid_before`, causing
+   `ExpiringNonceSetFull` until the victim transaction expires.
+
+    While this attack is fairly trivial, it requires the attacker to generate
+    and submit 12 real transactions prior to the victim's single transaction,
+    making the attack not economically sensible.
+
+2. **Single-target false replay:** an attacker can grind a transaction whose `position_0` and
+   fingerprint match a particular visible victim transaction. This is roughly an 82-bit target, and
+   inclusion of the attacker transaction first causes the victim to be rejected as replay.
+
+    This attack requires significant mining resources to be even be considered,
+    and even then is not really feasible. At 1 EH/s there is a ~0.012% chance of
+    finding a collision for a particular transaction within a 5 minute window.
+
+3. **Pool-wide false replay:** an attacker can target `position_0` plus
+   fingerprint for any visible transaction in the pool. This birthday-style
+   attack scales down the target space to roughly 66.7-bits, so broad random
+   censorship (griefing) is easier than censoring one specific transaction.
+
+   This attack requires fewer resources than the previous, but it cannot target
+   particular transactions and is therefore only viable for griefing. At 1 EH/s
+   the attacker will land ~2.48 transactions per 5 minute window from a pool of
+   20k transactions, rendering the attack far more expensive than it is useful.
 
 ---
 
@@ -80,13 +114,14 @@ EXPIRING_NONCE_MAX_EXPIRY_SECS = 300
 EXPIRING_NONCE_BUCKET_COUNT    = 301
 EXPIRING_NONCE_BUCKET_CAPACITY = 131_072
 EXPIRING_NONCE_POSITION_BITS   = 17
-EXPIRING_NONCE_MAX_PROBES      = 5
+EXPIRING_NONCE_MAX_PROBES      = 4
 
 EXPIRING_NONCE_CELL_COUNT      = 39_452_672
 EXPIRING_NONCE_CELL_BASE_SLOT  = 0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa2400000
 EXPIRING_NONCE_CELL_END_SLOT   = 0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa499ffff
 EXPIRING_NONCE_CELL_SLOT_DOMAIN = "tempo.expiringNonceCells.v1"
-EXPIRING_NONCE_FINGERPRINT_BITS = 192
+EXPIRING_NONCE_FINGERPRINT_BITS = 64
+EXPIRING_NONCE_PACKED_SLOTS     = 3
 ```
 
 `EXPIRING_NONCE_MAX_EXPIRY_SECS` increases TIP-1009's maximum expiry from 30 seconds to
@@ -96,7 +131,8 @@ old ring entries.
 `EXPIRING_NONCE_BUCKET_COUNT` MUST be greater than `EXPIRING_NONCE_MAX_EXPIRY_SECS`.
 `EXPIRING_NONCE_BUCKET_CAPACITY` MUST be a power of two.
 `EXPIRING_NONCE_POSITION_BITS` MUST equal `log2(EXPIRING_NONCE_BUCKET_CAPACITY)`.
-`EXPIRING_NONCE_POSITION_BITS * EXPIRING_NONCE_MAX_PROBES` MUST be less than or equal to 256.
+`EXPIRING_NONCE_POSITION_BITS * EXPIRING_NONCE_MAX_PROBES` MUST be less than or equal to 128.
+`EXPIRING_NONCE_PACKED_SLOTS * EXPIRING_NONCE_FINGERPRINT_BITS` MUST equal 192.
 `EXPIRING_NONCE_CELL_COUNT` MUST equal
 `EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY`.
 
@@ -104,6 +140,7 @@ old ring entries.
 `keccak256(EXPIRING_NONCE_CELL_SLOT_DOMAIN)` by clearing the low 22 bits.
 `EXPIRING_NONCE_CELL_END_SLOT` is
 `EXPIRING_NONCE_CELL_BASE_SLOT + EXPIRING_NONCE_CELL_COUNT - 1`.
+
 The domain documents how the range was selected; implementations MUST use the fixed constants and
 MUST NOT compute this hash while processing transactions.
 
@@ -121,6 +158,10 @@ contract Nonce {
 }
 ```
 
+Slots 1, 2, and 3 MUST remain reserved forever unless a later hardfork explicitly migrates or
+clears the old ring state. Reusing those slots for unrelated fields risks reading stale pre-fork
+data.
+
 Replay cells are not stored in a Solidity-style mapping. For `cell_id` in
 `[0, EXPIRING_NONCE_CELL_COUNT)`, the corresponding storage slot is:
 
@@ -137,22 +178,42 @@ Solidity mapping layout.
 Each replay cell stores:
 
 ```text
-cell = valid_before_u64 || replay_fingerprint_192
+cell = valid_before_u64 || fingerprint_slot_0 || fingerprint_slot_1 || fingerprint_slot_2
 ```
 
 where:
 
 ```text
 stored_valid_before = high 64 bits of cell
-stored_fingerprint  = low 192 bits of cell
-fingerprint         = low 192 bits of H
+fingerprint_slot_j  = one 64-bit lane in the low 192 bits of cell
+fingerprint         = nonzero 64-bit value derived from H
 ```
 
-A zero storage word has `stored_valid_before == 0` and is reusable.
+The fingerprint slots are encoded left-to-right after `valid_before_u64`. `fingerprint_slot_0`
+occupies the high 64 bits of the low 192-bit payload, `fingerprint_slot_1` occupies the middle
+64 bits, and `fingerprint_slot_2` occupies the low 64 bits.
 
-Slots 1, 2, and 3 MUST remain reserved forever unless a later hardfork explicitly migrates or
-clears the old ring state. Reusing those slots for unrelated fields risks reading stale pre-fork
-data.
+A zero storage word has `stored_valid_before == 0` and all fingerprint slots empty. Within a cell
+whose `stored_valid_before` equals the transaction's `valid_before`, a fingerprint slot equal to
+zero is empty. If `stored_valid_before` does not equal the transaction's `valid_before`, all three
+fingerprint slots are treated as empty, even if the stored low 192 bits are nonzero.
+
+The replay fingerprint is derived from bytes that do not overlap the probe-position chunks:
+
+```text
+primary_fingerprint  = uint64_be(H[24..32])
+fallback_fingerprint = uint64_be(H[16..24])
+
+if primary_fingerprint != 0:
+    fingerprint = primary_fingerprint
+else if fallback_fingerprint != 0:
+    fingerprint = fallback_fingerprint
+else:
+    fingerprint = 1
+```
+
+The zero value is reserved as the empty-slot marker. The fallback path is reached with probability
+`2^-64`, and the final `fingerprint = 1` case is reached with probability `2^-128`.
 
 ## Cell Selection
 
@@ -182,9 +243,9 @@ cell_id_i  = bucket * EXPIRING_NONCE_BUCKET_CAPACITY + position_i
 slot_i     = EXPIRING_NONCE_CELL_BASE_SLOT + cell_id_i
 ```
 
-With the chosen constants, the five probe positions are `H[0..17]`, `H[17..34]`, `H[34..51]`,
-`H[51..68]`, and `H[68..85]`. Since `EXPIRING_NONCE_BUCKET_CAPACITY` is `2^17`, each 17-bit chunk
-selects one cell in the bucket without modulo bias or rejection sampling.
+With the chosen constants, the four probe positions are `H[0..17]`, `H[17..34]`, `H[34..51]`,
+and `H[51..68]`. Since `EXPIRING_NONCE_BUCKET_CAPACITY` is `2^17`, each 17-bit chunk selects one
+cell in the bucket without modulo bias or rejection sampling.
 
 ## Replay Algorithm
 
@@ -201,21 +262,28 @@ T < V <= T + EXPIRING_NONCE_MAX_EXPIRY_SECS
 Then the Nonce precompile executes:
 
 ```text
-fingerprint = H[8..32]
+fingerprint = nonzero_fingerprint64(H)
 
 for i in 0..EXPIRING_NONCE_MAX_PROBES:
     cell_id = cell_id_i
     slot = EXPIRING_NONCE_CELL_BASE_SLOT + cell_id
     word = sload(slot)
     stored_v = high_64_bits(word)
-    stored_f = low_192_bits(word)
+    slots = low_192_bits(word) split into three 64-bit fingerprint slots
 
     if stored_v != V:
-        sstore(slot, V || fingerprint)
+        sstore(slot, V || fingerprint || 0 || 0)
         accept
 
-    if stored_f == fingerprint:
-        reject ExpiringNonceReplay
+    for slot_fingerprint in slots:
+        if slot_fingerprint == fingerprint:
+            reject ExpiringNonceReplay
+
+    for slot_index in 0..EXPIRING_NONCE_PACKED_SLOTS:
+        if slots[slot_index] == 0:
+            slots[slot_index] = fingerprint
+            sstore(slot, V || slots[0] || slots[1] || slots[2])
+            accept
 
     continue
 
@@ -226,62 +294,42 @@ reject ExpiringNonceSetFull
 different `valid_before` values in the same bucket differ by at least 301 seconds, while expiring
 nonce transactions are live for at most 300 seconds.
 
-`ExpiringNonceSetFull` means the transaction's own deterministic probe path is full of different
-live fingerprints for the same `valid_before`. Under the time-wheel design this is local
-congestion, not global table exhaustion.
+`ExpiringNonceSetFull` means every cell in the transaction's deterministic probe path has the same
+live `valid_before` and all three fingerprint slots occupied by different nonzero fingerprints.
+Under the time-wheel design this is local congestion, not global table exhaustion.
 
 ## Gas Pricing
 
-Expiring nonce bookkeeping is charged as explicit AA intrinsic regular gas, not by relying on
-dynamic metering inside the precompile storage provider.
+Expiring nonce bookkeeping is charged as a static AA intrinsic regular gas surcharge, not by
+relying on dynamic metering inside the precompile storage provider.
 
-The common first-cell path is one cold read and one reset-price write:
+This follows the TIP-1009 implementation pattern: expiring nonce gas is added to
+AA intrinsic gas during initial transaction validation and deducted up front,
+before the replay table is touched. By charging a static amount we avoid
+uncertainty in the pre-execution transaction validity checks.
 
-```text
-EXPIRING_NONCE_BASE_GAS = COLD_SLOAD_COST + WARM_SSTORE_RESET
-                        = 2_100 + 2_900
-                        = 5_000
-```
-
-For an accepted transaction, let `probes` be the number of replay cells read before the transaction
-is accepted. Implementations MUST charge:
+The static surcharge covers the worst-case four-probe path plus one reset-price write:
 
 ```text
-EXPIRING_NONCE_GAS(probes) = EXPIRING_NONCE_BASE_GAS
-                           + (probes - 1) * COLD_SLOAD_COST
+EXPIRING_NONCE_GAS = EXPIRING_NONCE_MAX_PROBES * COLD_SLOAD_COST
+                   + WARM_SSTORE_RESET
 
-                           = probes * 2_100 + 2_900
+                   = 4 * 2_100 + 2_900
+                   = 11_300
 ```
-
-Examples:
-
-| Probe count | Expiring nonce gas |
-| ---: | ---: |
-| 1 | 5,000 |
-| 2 | 7,100 |
-| 5 | 13,400 |
 
 This charge intentionally does not apply TIP-1000 permanent new-slot pricing to first-touch replay
 cells. Expiring nonce cells are bounded temporary protocol state, not user-created permanent state.
 The maximum table footprint is capped by `EXPIRING_NONCE_BUCKET_COUNT *
 EXPIRING_NONCE_BUCKET_CAPACITY`.
 
-The replay insertion function MUST return the accepted probe count, and the EVM handler MUST charge
-the formula above explicitly as regular gas while keeping replay-cell writes exempt from
-TIP-1000/TIP-1060 state accounting. With the chosen capacity and the 20k TPS sizing assumption, the
-expected accepted transaction reads about 1.085 cells and pays about 5,179 gas for TIP-1077 replay
-bookkeeping.
+Every expiring nonce transaction pays `EXPIRING_NONCE_GAS` as intrinsic regular gas regardless of how many
+cells are actually read. Implementations MUST include `EXPIRING_NONCE_GAS` in the transaction's
+initial AA gas calculation and MUST reject the transaction before execution if the gas limit is
+below the resulting intrinsic gas. Implementations MUST NOT add a second dynamic replay-table gas
+charge during `check_and_mark_expiring_nonce`.
 
 No expiring nonce insertion or later overwrite mints or consumes TIP-1060 storage credits.
-
-The time-wheel lookup performs no Keccak beyond the canonical replay hash `H`. If `H` has already
-been computed by transaction validation or pool deduplication, deriving `bucket`, `position_i`,
-`fingerprint`, `cell_id`, and `slot` requires only slicing and arithmetic:
-
-```text
-steady-state lookup keccaks after H = 0
-steady-state lookup keccaks total   = 1, if H must be computed
-```
 
 During the temporary hardfork migration dual-check, implementations still perform the old
 `expiringNonceSeen[H]` mapping lookup until `old_seen_cutoff`; that compatibility check adds one
@@ -289,49 +337,27 @@ old mapping-slot hash and one extra cold read during the migration window only. 
 accepted during that window therefore pay:
 
 ```text
-EXPIRING_NONCE_MIGRATION_GAS(probes) = EXPIRING_NONCE_GAS(probes) + COLD_SLOAD_COST
-                                     = EXPIRING_NONCE_GAS(probes) + 2_100
+EXPIRING_NONCE_MIGRATION_GAS = EXPIRING_NONCE_GAS + COLD_SLOAD_COST
+                             = 11_300 + 2_100
+                             = 13_400
 ```
 
 ## Parameter Selection
 
-At 20,000 expiring nonce transactions per second and a 5-minute validity window, the live replay
-set is:
-
-```text
-20_000 * 300 = 6_000_000 records
-```
-
-The time wheel does not size one bucket for all 6 million live records. With constant load across
-the 300 valid `valid_before` seconds, each exact `valid_before` bucket receives about 20,000
-records:
-
-```text
-6_000_000 / 300 = 20_000 records per live bucket
-```
-
-The bucket count must be greater than the maximum expiry window so that two different
-`valid_before` values in the same bucket cannot both be live:
-
-```text
-minimum bucket count = EXPIRING_NONCE_MAX_EXPIRY_SECS + 1
-                     = 300 + 1
-                     = 301
-```
-
 The wheel has two independent dimensions:
 
 - `EXPIRING_NONCE_BUCKET_COUNT` separates expiry seconds. It only needs to be greater than the
-  maximum expiry window, so 301 buckets covers a 300 second window.
-- `EXPIRING_NONCE_BUCKET_CAPACITY` controls collision probability within one exact
-  `valid_before` second.
+  maximum expiry window so that two different `valid_before` values in the same
+  bucket cannot both be live. So 301 buckets covers a 300 second window.
 
-Rounding the time-bucket count from 301 to 512 would not reduce same-second collisions: each exact
-`valid_before` second would still use one bucket with 131,072 cells. It would only reserve 211
-additional time buckets, increasing the 131,072-cell full-table footprint from 2.35 GiB to
-4.00 GiB.
+- `EXPIRING_NONCE_BUCKET_CAPACITY` controls how many packed cells are available within one exact
+  `valid_before` second. Each cell has three 64-bit fingerprint slots.
 
-The table below models random hash placement inside one bucket.
+The table below models random hash placement inside one bucket with three packed fingerprint slots
+per cell and `EXPIRING_NONCE_MAX_PROBES = 4`. "First-probe misses" means the first selected cell
+already has all three fingerprint slots occupied for the same `valid_before`. "Random false
+replays" estimates accidental rejection of a distinct transaction due to a 64-bit fingerprint match
+with an occupied slot on its probe path.
 
 `Slot+value bloat` counts the full logical table as `(storage slot, storage value)` pairs:
 
@@ -339,32 +365,37 @@ The table below models random hash placement inside one bucket.
 slot+value bytes = 301 buckets * cells_per_bucket * 64
 ```
 
-| Cells per bucket | Load at 20k TPS | First-probe misses per 20k txs | Avg reads per attempted tx | Probe-exhausted txs per 20k | Max slot+value bloat |
-| ---: | ---: | ---: | ---: | ---: | ---: |
-| 16,777,216 | 0.12% | ~12 | 1.0006 | ~0 | 301.00 GiB |
-| 1,048,576 | 1.91% | ~191 | 1.0097 | ~0 | 18.81 GiB |
-| 524,288 | 3.81% | ~381 | 1.0196 | ~0 | 9.41 GiB |
-| 262,144 | 7.63% | ~763 | 1.0402 | ~0.009 | 4.70 GiB |
-| 131,072 | 15.26% | ~1,526 | 1.0850 | ~0.28 | 2.35 GiB |
-| 65,536 | 30.52% | ~3,052 | 1.1925 | ~8.8 | 1.18 GiB |
-| 32,768 | 61.04% | ~6,103 | 1.5139 | ~282 | 602.00 MiB |
-| 25,000 | 80.00% | ~8,000 | 1.8232 | ~1,092 | 459.29 MiB |
-| 20,000 | 100.00% | ~10,000 | 2.2832 | ~3,333 | 367.43 MiB |
-| 16,384 | 122.07% | overloaded | overloaded | overloaded | 301.00 MiB |
+| Cells per bucket | Slot load at 20k TPS | First-probe misses per 20k txs | Avg reads per attempted tx | Probe-exhausted txs per 20k | Random false replays per 20k | Max slot+value bloat |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 16,777,216 | 0.04% | ~1.41e-6 | 1.000000 | ~9.74e-36 | ~6.46e-19 | 301.00 GiB |
+| 1,048,576 | 0.64% | ~0.00571 | 1.000000 | ~2.61e-21 | ~1.03e-17 | 18.81 GiB |
+| 524,288 | 1.27% | ~0.0452 | 1.000002 | ~1.01e-17 | ~2.07e-17 | 9.41 GiB |
+| 262,144 | 2.54% | ~0.353 | 1.000018 | ~3.73e-14 | ~4.14e-17 | 4.70 GiB |
+| 131,072 | 5.09% | ~2.7 | 1.000135 | ~1.24e-10 | ~8.27e-17 | 2.35 GiB |
+| 65,536 | 10.17% | ~19.8 | 1.000991 | ~3.36e-7 | ~1.66e-16 | 1.18 GiB |
+| 32,768 | 20.35% | ~134 | 1.006782 | ~6.33e-4 | ~3.34e-16 | 602.00 MiB |
+| 25,000 | 26.67% | ~273 | 1.014047 | ~0.0104 | ~4.43e-16 | 459.29 MiB |
+| 20,000 | 33.33% | ~483 | 1.025429 | ~0.0965 | ~5.64e-16 | 367.43 MiB |
+| 16,384 | 40.69% | ~793 | 1.043170 | ~0.665 | ~7.07e-16 | 301.00 MiB |
 
-This TIP chooses 301 time buckets and 131,072 cells per bucket. The bucket count is the minimum
-that preserves the cheap expiry proof for a 300 second window, and the cell count keeps the
-per-`valid_before` load at 15.26% with about 1.085 replay-cell reads per attempted transaction at
-20k TPS.
+At the chosen 131,072-cell capacity, varying `EXPIRING_NONCE_MAX_PROBES` gives:
 
-Smaller tables reduce the maximum footprint but increase average reads and tail risk. In
-particular, 65,536 cells per bucket would halve the footprint to 1.18 GiB but double load to
-30.52%, and 32,768 cells per bucket pushes load above 60%, where probe length and probe-exhaustion
-risk become much more sensitive to traffic bursts or adversarial hash selection.
+| Max probes | First-probe misses per 20k txs | Avg reads per attempted tx | Probe-exhausted txs per 20k | Random false replays per 20k |
+| ---: | ---: | ---: | ---: | ---: |
+| 1 | ~2.7 | 1.000000 | ~2.7 | ~8.27e-17 |
+| 2 | ~2.7 | 1.000135 | ~8.21e-4 | ~8.27e-17 |
+| 3 | ~2.7 | 1.000135 | ~3.04e-7 | ~8.27e-17 |
+| 4 | ~2.7 | 1.000135 | ~1.24e-10 | ~8.27e-17 |
+| 5 | ~2.7 | 1.000135 | ~5.33e-14 | ~8.27e-17 |
 
-Larger tables reduce collisions but mostly buy marginal latency improvement at the cost of much
-larger bounded state. The 16,777,216-cell parameter explored in implementation experiments has
-negligible collisions but a 301 GiB slot+value full-table footprint with a 5-minute window.
+This TIP chooses 301 time buckets, 131,072 cells per bucket, and a max probes of 4.
+
+The bucket count is the minimum that preserves the cheap expiry proof for a 300 second window.
+
+The packed cell count keeps the per-`valid_before` slot load at 5.09% with about
+1.000135 replay-cell reads per attempted transaction at 20k TPS.
+
+The max probes provides negligible chance of probe exhaustion at 20k TPS.
 
 ## Hardfork Migration
 
@@ -390,10 +421,11 @@ At the activation block:
 The transaction pool can keep deduplicating expiring nonce transactions by `H`. Today it also uses
 the unique `expiringNonceSeen[H]` slot to notice when a pooled transaction was included. With
 TIP-1077 there is no unique per-transaction slot: each transaction has a probe path through shared
-replay cells, and another transaction may write a different fingerprint into one of those cells. If
-the pool keeps inclusion tracking from state updates, it should watch the probe-path cells and
-remove a transaction only when the written word is that transaction's exact `V || H[8..32]` value,
-not merely because a watched cell became non-zero.
+replay cells, and another transaction may write another packed fingerprint into one of those cells.
+If the pool keeps inclusion tracking from state updates, it should watch the probe-path cells and
+remove a transaction only when the updated word has that transaction's `valid_before` and contains
+that transaction's derived 64-bit fingerprint in one of the three packed slots, not merely because a
+watched cell became non-zero.
 
 To preserve replay protection across the hardfork boundary, implementations MUST perform a
 temporary dual replay check:
@@ -496,24 +528,26 @@ second. Both are required.
 The time wheel could store cells in a flat Solidity-style mapping:
 
 ```text
-expiringNonceCells[cell_id] = valid_before || fingerprint
+expiringNonceCells[cell_id] =
+    valid_before || fingerprint_slot_0 || fingerprint_slot_1 || fingerprint_slot_2
 ```
 
 This keeps the storage layout familiar, but every probed cell requires computing
 `keccak256(cell_id || mapping_slot)` before the `SLOAD`. At the chosen capacity, the expected
-accepted transaction reads about 1.085 cells, so mapping layout would add about 1.085 Keccak
-computations per accepted transaction on average and up to 5 in the worst probe path. The direct
+accepted transaction reads about 1.000135 cells, so mapping layout would add about 1.000135 Keccak
+computations per accepted transaction on average and up to 4 in the worst probe path. The direct
 slot range preserves the same bounded table and probe behavior while making each probe slot
 derivable with integer addition.
 
 ### Larger Time Wheel
 
 A larger time wheel reduces collisions and makes first-cell prewarming more reliable. The
-16,777,216-cell-per-bucket design has an expected first-cell collision rate near zero at 20k TPS.
+16,777,216-cell-per-bucket design has an expected first-cell miss rate near zero at 20k TPS.
 
 Its cost is a much larger bounded state footprint: 301 GiB when counted as slot+value pairs. It
 also creates a long first-touch period where most transactions write previously empty cells. This
-TIP chooses a smaller 2.35 GiB slot+value footprint and accepts a modest average probe rate instead.
+TIP chooses a smaller 2.35 GiB slot+value footprint and relies on packed fingerprint slots to keep
+the average probe rate near one read.
 
 # Observability
 
@@ -541,16 +575,18 @@ Nodes SHOULD expose metrics for:
    `valid_before > block.timestamp + 300` MUST be rejected.
 4. **Bucket expiry proof.** Within a bucket, `stored_valid_before != tx.valid_before` MUST imply the
    stored record is not live.
-5. **Collision handling.** A live collision with a different fingerprint MUST probe the next
-   deterministic cell, up to `EXPIRING_NONCE_MAX_PROBES`.
-6. **Probe exhaustion.** If all probed cells contain different live fingerprints for the same
+5. **Packed insertion.** A cell with the transaction's `valid_before`, no matching fingerprint, and
+   at least one empty fingerprint slot MUST store the transaction's fingerprint in that cell.
+6. **Collision handling.** A live collision with a full cell of different fingerprints MUST probe
+   the next deterministic cell, up to `EXPIRING_NONCE_MAX_PROBES`.
+7. **Probe exhaustion.** If all probed cells contain three different live fingerprints for the same
    `valid_before`, the transaction MUST be rejected with `ExpiringNonceSetFull`.
-7. **Bounded state.** New replay state MUST be limited to
+8. **Bounded state.** New replay state MUST be limited to
    `EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY` cells in the reserved direct slot
    range.
-8. **No explicit cleanup dependency.** Replay correctness MUST NOT depend on offchain pruning,
+9. **No explicit cleanup dependency.** Replay correctness MUST NOT depend on offchain pruning,
    MEV services, or TIP-1060 storage credits.
-9. **No nonce mutation.** Expiring nonce transactions MUST NOT increment protocol nonces or 2D
+10. **No nonce mutation.** Expiring nonce transactions MUST NOT increment protocol nonces or 2D
    nonces.
-10. **Storage layout hygiene.** Old ring slots 1, 2, and 3 MUST remain reserved after activation,
+11. **Storage layout hygiene.** Old ring slots 1, 2, and 3 MUST remain reserved after activation,
     and future Nonce precompile fields MUST NOT overlap the direct replay-cell slot range.


### PR DESCRIPTION
Adds TIP-1077 for replacing the expiring nonce ring with a time-wheel replay table sized at 131,072 cells per bucket.

Documents the 256 MiB slot+value footprint, parameter tradeoffs, hardfork migration from the ring layout, and alternatives considered for cleanup and fixed-table designs.
