### PR TITLE
Add jenpaff as tips codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,4 +21,4 @@ crates/primitives/ @klkvr @mattsse
 crates/revm/ @klkvr @mattsse @rakita @0xKitsune
 crates/telemetry-util/ @SuperFluffy
 crates/transaction-pool/ @0xKitsune @klkvr @mattsse
-tips/ @legion2002 @0xKitsune @danrobinson @dankrad @jenpaff
+tips/ @legion2002 @0xKitsune @danrobinson @dankrad @jenpaff @horsefacts @AlphaRUSH @samczsun

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,4 +21,4 @@ crates/primitives/ @klkvr @mattsse
 crates/revm/ @klkvr @mattsse @rakita @0xKitsune
 crates/telemetry-util/ @SuperFluffy
 crates/transaction-pool/ @0xKitsune @klkvr @mattsse
-tips/ @legion2002 @0xKitsune @danrobinson @dankrad @jenpaff @horsefacts @AlphaRUSH @samczsun
+tips/ @legion2002 @0xKitsune @danrobinson @dankrad @jenpaff @horsefacts @0xalpharush @samczsun

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,4 +21,4 @@ crates/primitives/ @klkvr @mattsse
 crates/revm/ @klkvr @mattsse @rakita @0xKitsune
 crates/telemetry-util/ @SuperFluffy
 crates/transaction-pool/ @0xKitsune @klkvr @mattsse
-tips/ @legion2002 @0xKitsune @danrobinson @dankrad
+tips/ @legion2002 @0xKitsune @danrobinson @dankrad @jenpaff


### PR DESCRIPTION
Adds @jenpaff as a CODEOWNER for `tips/` paths.

Prompted by: @jenpaff