### PR TITLE
feat(chainspec): add T8 wiring

### DIFF
--- a/crates/chainspec/src/genesis/dev.json
+++ b/crates/chainspec/src/genesis/dev.json
@@ -31,6 +31,7 @@
     "t5Time": 0,
     "t6Time": 0,
     "t7Time": 0,
+    "t8Time": 0,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -202,6 +202,8 @@ tempo_hardfork! (
         T6,
         /// T7 hardfork
         T7,
+        /// T8 hardfork
+        T8,
     }
 );
 
@@ -309,6 +311,7 @@ impl TempoHardfork {
             Self::T5 => None,
             Self::T6 => None,
             Self::T7 => None,
+            Self::T8 => None,
         }
     }
 
@@ -328,6 +331,7 @@ impl TempoHardfork {
             Self::T5 => Some(MAINNET_T5_TIMESTAMP),
             Self::T6 => None,
             Self::T7 => None,
+            Self::T8 => None,
         }
     }
 
@@ -347,6 +351,7 @@ impl TempoHardfork {
             Self::T5 => None,
             Self::T6 => None,
             Self::T7 => None,
+            Self::T8 => None,
         }
     }
 
@@ -366,6 +371,7 @@ impl TempoHardfork {
             Self::T5 => Some(MODERATO_T5_TIMESTAMP),
             Self::T6 => None,
             Self::T7 => None,
+            Self::T8 => None,
         }
     }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -67,6 +67,9 @@ pub struct TempoGenesisInfo {
     /// Activation timestamp for T7 hardfork.
     #[serde(skip_serializing_if = "Option::is_none")]
     t7_time: Option<u64>,
+    /// Activation timestamp for T8 hardfork.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    t8_time: Option<u64>,
 }
 
 impl TempoGenesisInfo {
@@ -98,6 +101,7 @@ impl TempoGenesisInfo {
             TempoHardfork::T5 => self.t5_time,
             TempoHardfork::T6 => self.t6_time,
             TempoHardfork::T7 => self.t7_time,
+            TempoHardfork::T8 => self.t8_time,
         }
     }
 }

--- a/crates/node/tests/assets/test-genesis.json
+++ b/crates/node/tests/assets/test-genesis.json
@@ -31,6 +31,7 @@
     "t5Time": 0,
     "t6Time": 0,
     "t7Time": 0,
+    "t8Time": 0,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -189,6 +189,10 @@ pub(crate) struct GenesisArgs {
     /// T7 hardfork activation time.
     #[arg(long, default_value = "0")]
     t7_time: u64,
+
+    /// T8 hardfork activation time.
+    #[arg(long, default_value = "0")]
+    t8_time: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -598,6 +602,9 @@ impl GenesisArgs {
         chain_config
             .extra_fields
             .insert_value("t7Time".to_string(), self.t7_time)?;
+        chain_config
+            .extra_fields
+            .insert_value("t8Time".to_string(), self.t8_time)?;
         let mut extra_data = Bytes::from_static(b"tempo-genesis");
 
         if let Some(consensus_config) = &consensus_config {


### PR DESCRIPTION
Adds T8 to the Tempo hardfork enum and wires `t8Time` through genesis parsing, dev/test genesis, and xtask generation.

This keeps hardfork plumbing separate from TIP-1075 behavior changes.

Validation:
- `cargo +nightly fmt`
- `cargo test -p tempo-chainspec hardfork`
- `cargo check -p tempo-xtask`
