### PR TITLE
docs(tips): add tooling prompt to TIP template

### DIFF
--- a/tips/tip_template.md
+++ b/tips/tip_template.md
@@ -39,6 +39,10 @@ For features that do not introduce a precompile, this section should define the 
 
 Where a feature involves multiple processes, state diagrams / flowcharts should be considered when helpful.
 
+# Tooling
+
+Describe any tooling impact for this TIP. Include new or changed commands, SDK or library interfaces, test helpers, fixtures, machine-readable outputs, debugging or recovery workflows, and integration guidance needed by implementers, operators, support teams, or users. If no tooling changes are required, write `N/A` and explain why existing tooling is sufficient.
+
 # Observability
 
 Describe the events needed to monitor and debug this TIP in production. List each event that MUST be emitted, its fields, and the operational question it answers. If no new events are required, write `N/A` and explain why existing observability is sufficient.


### PR DESCRIPTION
Adds a tooling section to the TIP template so proposals capture command, SDK, helper, fixture, machine-readable output, and recovery workflow impact.

This mirrors the existing observability prompt and gives authors an explicit `N/A` path when current tooling is sufficient.