### PR TITLE
Remove stale TIP-1059 and TIP-1065 T6 references

### DIFF
--- a/crates/contracts/CHANGELOG.md
+++ b/crates/contracts/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - Added T6 admin access key support for account keychain authorization and SDK transaction builders. (by @DerekCofausper, [#4650](https://github.com/tempoxyz/tempo/pull/4650))
 - Reject channel reserve payment-lane calls with malformed Tempo signature encodings. (by @DerekCofausper, [#4650](https://github.com/tempoxyz/tempo/pull/4650))
-- Added TIP-1059 discounted gas pricing for pure payment transfers that fit within the SSTORE_SET gas cap. Introduced `is_discounted_payment_call` helper, `TEMPO_T6_DISCOUNTED_PAYMENT_GAS_PRICE` constant, and applied the discounted effective gas price in both EVM execution and RPC receipt conversion when T6 is active. (by @DerekCofausper, [#4650](https://github.com/tempoxyz/tempo/pull/4650))
 - Added the T6 `SignatureVerifier.verifyKeychain` and `SignatureVerifier.verifyKeychainAdmin` selectors for checking account-bound active and admin keychain signatures. (by @DerekCofausper, [#4650](https://github.com/tempoxyz/tempo/pull/4650))
 
 ## `tempo-contracts@1.7.3`
@@ -39,4 +38,3 @@
 - Improved gas cap revert detection in BlockGasLimits invariant tests. (by @0xrusowsky, [#3495](https://github.com/tempoxyz/tempo/pull/3495))
 - Invariants: fix active order check (by @0xrusowsky, [#3495](https://github.com/tempoxyz/tempo/pull/3495))
 - Added TIP-1022 virtual address support: address registry precompile for registering master addresses with deterministic master IDs, TIP-20 recipient resolution that forwards transfers/mints to registered masters, and TIP-403 policy rejection of virtual addresses. (by @0xrusowsky, [#3495](https://github.com/tempoxyz/tempo/pull/3495))
-

--- a/crates/node/tests/it/gas/tip20_transfers.rs
+++ b/crates/node/tests/it/gas/tip20_transfers.rs
@@ -639,7 +639,7 @@ async fn test_tip20_transfer_gas_snapshots(hardfork: TempoHardfork) -> eyre::Res
     Ok(())
 }
 
-/// T6 TIP20 balance storage changes must not leak into pre-activation hardfork gas accounting.
+/// Current TIP20 balance storage must not leak into pre-activation hardfork gas accounting.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tip20_transfer_with_memo_t0_gas_snapshot() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();

--- a/tips/tip-1059.md
+++ b/tips/tip-1059.md
@@ -3,7 +3,7 @@ id: TIP-1059
 title: Discounted Pure Payment Transfers
 description: Lets simple TIP-20 payment and redemption operations settle at a lower gas price.
 authors: Mallesh Pai
-status: Approved
+status: Withdrawn
 related: TIP-1010, TIP-1016
 protocolVersion: T6
 ---

--- a/tips/tip-1065.md
+++ b/tips/tip-1065.md
@@ -3,7 +3,7 @@ id: TIP-1065
 title: Repurpose TIP-20 Balance slots into User State
 description: Turn TIP-20 balance slots into packed user state with balance, and cache fields.
 authors: @0xrusowsky, Arsenii Kulikov (@klkvr)
-status: Draft
+status: Withdrawn
 related: TIP-20, TIP-1000
 protocolVersion: T6
 ---


### PR DESCRIPTION
## Summary
- mark TIP-1059 and TIP-1065 as withdrawn while preserving their existing specifications
- drop the TIP-1059 discounted gas changelog entry
- update the stale TIP-20 gas-test comment

## Tests
- git diff --check
- git diff origin/main -- tips/tip-1059.md tips/tip-1065.md

Prompted by: @0xrusowsky