### PR TITLE
perf(txpool): cache active hardfork as atomic in validator

### DIFF
--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -137,6 +137,20 @@ macro_rules! tempo_hardfork {
             }
 
             #[test]
+            fn test_variant_index_roundtrip() {
+                for fork in TempoHardfork::VARIANTS {
+                    assert_eq!(
+                        TempoHardfork::from_variant_index(fork.variant_index()),
+                        Some(*fork)
+                    );
+                }
+                assert_eq!(
+                    TempoHardfork::from_variant_index(TempoHardfork::VARIANTS.len() as u8),
+                    None
+                );
+            }
+
+            #[test]
             #[cfg(feature = "serde")]
             fn test_tempo_hardfork_serde() {
                 for fork in TempoHardfork::VARIANTS {
@@ -208,6 +222,25 @@ tempo_hardfork! (
 );
 
 impl TempoHardfork {
+    /// Returns the position of this hardfork in [`Self::VARIANTS`].
+    ///
+    /// Useful for storing the hardfork in an atomic, see [`Self::from_variant_index`].
+    pub const fn variant_index(&self) -> u8 {
+        *self as u8
+    }
+
+    /// Returns the hardfork at the given [`Self::VARIANTS`] position, see
+    /// [`Self::variant_index`].
+    ///
+    /// Returns `None` if the index is out of bounds.
+    pub const fn from_variant_index(index: u8) -> Option<Self> {
+        if (index as usize) < Self::VARIANTS.len() {
+            Some(Self::VARIANTS[index as usize])
+        } else {
+            None
+        }
+    }
+
     /// Returns the fixed general gas limit for T1+, or None for pre-T1.
     /// - Pre-T1: None
     /// - T1+: 30M gas (fixed)

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -29,10 +29,7 @@ use reth_transaction_pool::{
 };
 use revm::database::BundleAccount;
 use std::{sync::Arc, time::Instant};
-use tempo_chainspec::{
-    TempoChainSpec,
-    hardfork::{TempoHardfork, TempoHardforks},
-};
+use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork};
 use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS,
     account_keychain::AccountKeychain,
@@ -171,7 +168,7 @@ where
             .inner
             .fork_tracker()
             .tip_timestamp();
-        let spec = self.client().chain_spec().tempo_hardfork_at(tip_timestamp);
+        let spec = self.protocol_pool.validator().validator().active_hardfork();
 
         // Cache policy lookups per fee token to avoid redundant storage reads.
         // For compound policies (TIP-1015), the cache stores all sub-policy IDs
@@ -531,14 +528,7 @@ where
                     };
 
                     // Get the active Tempo hardfork for expiring nonce handling
-                    let tip_timestamp = self
-                        .protocol_pool
-                        .validator()
-                        .validator()
-                        .inner
-                        .fork_tracker()
-                        .tip_timestamp();
-                    let hardfork = self.client().chain_spec().tempo_hardfork_at(tip_timestamp);
+                    let hardfork = self.protocol_pool.validator().validator().active_hardfork();
 
                     let tx = Arc::new(tx);
                     let added =

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -26,6 +26,7 @@ use revm::{
     DatabaseRef,
     context::result::{EVMError, InvalidTransaction},
 };
+use std::sync::atomic::{AtomicU8, Ordering};
 use tempo_chainspec::{
     TempoChainSpec,
     hardfork::{TempoHardfork, TempoHardforks},
@@ -93,6 +94,12 @@ pub struct TempoTransactionValidator<Client> {
     pub(crate) amm_liquidity_cache: AmmLiquidityCache,
     /// Cached EVM environment from the latest tip block, updated on each `on_new_head_block`.
     cached_evm_env: RwLock<EvmEnv<TempoHardfork, TempoBlockEnv>>,
+    /// The Tempo hardfork active at the current tip, stored as an index into
+    /// [`TempoHardfork::VARIANTS`] and updated on each `on_new_head_block`.
+    ///
+    /// Cached here so hot paths can resolve the active hardfork with a single atomic load
+    /// instead of walking the chain spec's fork schedule.
+    active_hardfork: AtomicU8,
 }
 
 impl<Client> TempoTransactionValidator<Client>
@@ -119,13 +126,23 @@ where
                     .header(),
             )
             .expect("failed constructing EvmEnv from latest header");
+        let active_hardfork = AtomicU8::new(evm_env.cfg_env.spec.variant_index());
         Self {
             inner,
             aa_valid_after_max_secs,
             max_tempo_authorizations,
             amm_liquidity_cache,
             cached_evm_env: parking_lot::RwLock::new(evm_env),
+            active_hardfork,
         }
+    }
+
+    /// Returns the Tempo hardfork active at the current tip.
+    ///
+    /// Updated on each `on_new_head_block`.
+    pub fn active_hardfork(&self) -> TempoHardfork {
+        TempoHardfork::from_variant_index(self.active_hardfork.load(Ordering::Relaxed))
+            .expect("stored hardfork index is valid")
     }
 
     /// Obtains a clone of the shared [`AmmLiquidityCache`].
@@ -354,11 +371,8 @@ where
         mut state_provider: impl StateProvider,
         cached_reads: &mut CachedReads,
     ) -> TransactionValidationOutcome<TempoPooledTransaction> {
-        // Get the current hardfork based on tip timestamp
-        let spec = self
-            .inner
-            .chain_spec()
-            .tempo_hardfork_at(self.inner.fork_tracker().tip_timestamp());
+        // Get the hardfork active at the current tip
+        let spec = self.active_hardfork();
 
         // Reject system transactions, those are never allowed in the pool.
         if transaction.inner().is_system_tx() {
@@ -677,11 +691,14 @@ where
         self.inner.on_new_head_block(new_tip_block);
 
         // Cache the EVM environment for the new tip block.
-        *self.cached_evm_env.write() = self
+        let evm_env = self
             .inner
             .evm_config()
             .evm_env(new_tip_block.header())
             .expect("invalid block in on_new_head_block");
+        self.active_hardfork
+            .store(evm_env.cfg_env.spec.variant_index(), Ordering::Relaxed);
+        *self.cached_evm_env.write() = evm_env;
     }
 }
 


### PR DESCRIPTION
Resolving the active hardfork walked the chain spec's fork schedule and cloned the chain spec `Arc` once per validated transaction in `validate_one` and once per inserted AA 2D transaction in `add_validated_transaction`.

The validator now caches the active hardfork as an `AtomicU8` holding its `TempoHardfork::VARIANTS` index, updated in `on_new_head_block` where the EVM environment for the new tip is already constructed. The new `TempoHardfork::variant_index`/`from_variant_index` helpers handle the atomic round-trip.

Extracted from #5598.