### PR TITLE
feat(precompiles): storage delta helpers

### DIFF
--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -483,6 +483,13 @@ mod tests {
         state: &EvmState,
         hardfork: TempoHardfork,
     ) {
+        let mut original_values = BTreeMap::<(Address, U256), U256>::new();
+        for (address, account) in state {
+            for (slot, storage_slot) in &account.storage {
+                original_values.insert((*address, *slot), storage_slot.original_value());
+            }
+        }
+
         let mut first_loads = BTreeMap::<(Address, U256), U256>::new();
         let mut reconstructed = BTreeMap::<(Address, U256), U256>::new();
 
@@ -507,6 +514,46 @@ mod tests {
                         reconstructed.contains_key(&key),
                         "SSTORE without prior SLOAD for {address:?}:{slot:?} on {hardfork:?}",
                     );
+                    reconstructed.insert(key, value);
+                }
+                StorageAction::Sinc(address, slot, delta) => {
+                    let key = (address, slot);
+                    let current = match reconstructed.get(&key) {
+                        Some(current) => *current,
+                        None => {
+                            let original = *original_values.get(&key).unwrap_or_else(|| {
+                                panic!(
+                                    "SINC without prior SLOAD for unknown EVM output storage cell {address:?}:{slot:?} on {hardfork:?}",
+                                )
+                            });
+                            first_loads.insert(key, original);
+                            reconstructed.insert(key, original);
+                            original
+                        }
+                    };
+                    let value = current.checked_add(delta).unwrap_or_else(|| {
+                        panic!("SINC overflow for {address:?}:{slot:?} on {hardfork:?}")
+                    });
+                    reconstructed.insert(key, value);
+                }
+                StorageAction::Sdec(address, slot, delta) => {
+                    let key = (address, slot);
+                    let current = match reconstructed.get(&key) {
+                        Some(current) => *current,
+                        None => {
+                            let original = *original_values.get(&key).unwrap_or_else(|| {
+                                panic!(
+                                    "SDEC without prior SLOAD for unknown EVM output storage cell {address:?}:{slot:?} on {hardfork:?}",
+                                )
+                            });
+                            first_loads.insert(key, original);
+                            reconstructed.insert(key, original);
+                            original
+                        }
+                    };
+                    let value = current.checked_sub(delta).unwrap_or_else(|| {
+                        panic!("SDEC underflow for {address:?}:{slot:?} on {hardfork:?}")
+                    });
                     reconstructed.insert(key, value);
                 }
             }
@@ -683,7 +730,6 @@ mod tests {
 
             let sender_after_fee = starting_balance - max_fee_spending;
             let sender_after_transfer = sender_after_fee - transfer_amount;
-            let sender_after_refund = sender_after_transfer + refund_amount;
 
             let actions = evm
                 .take_actions()
@@ -705,14 +751,10 @@ mod tests {
                     ),
                     // SLOAD paused: fee escrow respects token pause state.
                     StorageAction::Sload(PATH_USD_ADDRESS, tip20_slots::PAUSED, U256::ZERO),
-                    // SLOAD balances[sender]: read sender balance before fee escrow debit.
-                    StorageAction::Sload(PATH_USD_ADDRESS, sender_balance_slot, starting_balance),
-                    // SSTORE balances[sender]: debit max fee escrow.
-                    StorageAction::Sstore(PATH_USD_ADDRESS, sender_balance_slot, sender_after_fee),
-                    // SLOAD balances[FeeManager]: read fee escrow custody balance.
-                    StorageAction::Sload(PATH_USD_ADDRESS, fee_manager_balance_slot, U256::ZERO),
-                    // SSTORE balances[FeeManager]: credit max fee escrow.
-                    StorageAction::Sstore(
+                    // SDEC balances[sender]: debit max fee escrow.
+                    StorageAction::Sdec(PATH_USD_ADDRESS, sender_balance_slot, max_fee_spending),
+                    // SINC balances[FeeManager]: credit max fee escrow.
+                    StorageAction::Sinc(
                         PATH_USD_ADDRESS,
                         fee_manager_balance_slot,
                         max_fee_spending,
@@ -731,58 +773,24 @@ mod tests {
                         receive_policy_config_slot,
                         U256::ZERO,
                     ),
-                    // SLOAD balances[sender]: read post-escrow balance before user transfer debit.
-                    StorageAction::Sload(PATH_USD_ADDRESS, sender_balance_slot, sender_after_fee),
-                    // SSTORE balances[sender]: debit user transfer.
-                    StorageAction::Sstore(
-                        PATH_USD_ADDRESS,
-                        sender_balance_slot,
-                        sender_after_transfer,
-                    ),
-                    // SLOAD balances[recipient]: read recipient balance before transfer credit.
-                    StorageAction::Sload(PATH_USD_ADDRESS, recipient_balance_slot, U256::ZERO),
-                    // SSTORE balances[recipient]: credit user transfer.
-                    StorageAction::Sstore(
-                        PATH_USD_ADDRESS,
-                        recipient_balance_slot,
-                        transfer_amount,
-                    ),
+                    // SDEC balances[sender]: debit user transfer.
+                    StorageAction::Sdec(PATH_USD_ADDRESS, sender_balance_slot, transfer_amount),
+                    // SINC balances[recipient]: credit user transfer.
+                    StorageAction::Sinc(PATH_USD_ADDRESS, recipient_balance_slot, transfer_amount),
                     // SLOAD storageCredits[PATH_USD]: TIP-1060 tracks the user transfer credit.
                     StorageAction::Sload(
                         STORAGE_CREDITS_ADDRESS,
                         path_usd_storage_credit_slot,
                         U256::ZERO,
                     ),
-                    // SLOAD balances[FeeManager]: read escrow custody before refunding unused fee.
-                    StorageAction::Sload(
-                        PATH_USD_ADDRESS,
-                        fee_manager_balance_slot,
-                        max_fee_spending,
-                    ),
-                    // SSTORE balances[FeeManager]: leave actual spent fee in FeeManager custody.
-                    StorageAction::Sstore(
-                        PATH_USD_ADDRESS,
-                        fee_manager_balance_slot,
-                        actual_spending,
-                    ),
-                    // SLOAD balances[sender]: read sender before crediting unused fee refund.
-                    StorageAction::Sload(
-                        PATH_USD_ADDRESS,
-                        sender_balance_slot,
-                        sender_after_transfer,
-                    ),
-                    // SSTORE balances[sender]: refund unused fee.
-                    StorageAction::Sstore(
-                        PATH_USD_ADDRESS,
-                        sender_balance_slot,
-                        sender_after_refund,
-                    ),
+                    // SDEC balances[FeeManager]: refund unused fee from escrow.
+                    StorageAction::Sdec(PATH_USD_ADDRESS, fee_manager_balance_slot, refund_amount),
+                    // SINC balances[sender]: credit unused fee refund.
+                    StorageAction::Sinc(PATH_USD_ADDRESS, sender_balance_slot, refund_amount),
                     // SLOAD validatorTokens[beneficiary]: post-tx fee route uses default PATH_USD.
                     StorageAction::Sload(TIP_FEE_MANAGER_ADDRESS, validator_token_slot, U256::ZERO),
-                    // SLOAD collectedFees[beneficiary][PATH_USD]: read current validator accrual.
-                    StorageAction::Sload(TIP_FEE_MANAGER_ADDRESS, collected_fees_slot, U256::ZERO),
-                    // SSTORE collectedFees[beneficiary][PATH_USD]: accrue actual PATH_USD spending.
-                    StorageAction::Sstore(
+                    // SINC collectedFees[beneficiary][PATH_USD]: accrue actual PATH_USD spending.
+                    StorageAction::Sinc(
                         TIP_FEE_MANAGER_ADDRESS,
                         collected_fees_slot,
                         actual_spending,
@@ -828,14 +836,10 @@ mod tests {
                         tip20_slots::GLOBAL_REWARD_PER_TOKEN,
                         U256::ZERO,
                     ),
-                    // SLOAD balances[sender]: read fee payer balance for debit.
-                    StorageAction::Sload(PATH_USD_ADDRESS, sender_balance_slot, starting_balance),
-                    // SSTORE balances[sender]: debit max fee escrow.
-                    StorageAction::Sstore(PATH_USD_ADDRESS, sender_balance_slot, sender_after_fee),
-                    // SLOAD balances[FeeManager]: read fee escrow custody balance.
-                    StorageAction::Sload(PATH_USD_ADDRESS, fee_manager_balance_slot, U256::ZERO),
-                    // SSTORE balances[FeeManager]: credit max fee escrow.
-                    StorageAction::Sstore(
+                    // SDEC balances[sender]: debit max fee escrow.
+                    StorageAction::Sdec(PATH_USD_ADDRESS, sender_balance_slot, max_fee_spending),
+                    // SINC balances[FeeManager]: credit max fee escrow.
+                    StorageAction::Sinc(
                         PATH_USD_ADDRESS,
                         fee_manager_balance_slot,
                         max_fee_spending,
@@ -904,14 +908,8 @@ mod tests {
                         sender_balance_slot,
                         sender_after_transfer,
                     ),
-                    // SLOAD balances[recipient]: read recipient balance before transfer credit.
-                    StorageAction::Sload(PATH_USD_ADDRESS, recipient_balance_slot, U256::ZERO),
-                    // SSTORE balances[recipient]: credit user transfer.
-                    StorageAction::Sstore(
-                        PATH_USD_ADDRESS,
-                        recipient_balance_slot,
-                        transfer_amount,
-                    ),
+                    // SINC balances[recipient]: credit user transfer.
+                    StorageAction::Sinc(PATH_USD_ADDRESS, recipient_balance_slot, transfer_amount),
                     // SLOAD userRewardInfo[sender].rewardRecipient: sender is opted out before fee refund.
                     StorageAction::Sload(
                         PATH_USD_ADDRESS,
@@ -936,36 +934,14 @@ mod tests {
                         tip20_slots::GLOBAL_REWARD_PER_TOKEN,
                         U256::ZERO,
                     ),
-                    // SLOAD balances[FeeManager]: read escrow custody before refunding unused fee.
-                    StorageAction::Sload(
-                        PATH_USD_ADDRESS,
-                        fee_manager_balance_slot,
-                        max_fee_spending,
-                    ),
-                    // SSTORE balances[FeeManager]: leave actual spent fee in FeeManager custody.
-                    StorageAction::Sstore(
-                        PATH_USD_ADDRESS,
-                        fee_manager_balance_slot,
-                        actual_spending,
-                    ),
-                    // SLOAD balances[sender]: read sender before crediting unused fee refund.
-                    StorageAction::Sload(
-                        PATH_USD_ADDRESS,
-                        sender_balance_slot,
-                        sender_after_transfer,
-                    ),
-                    // SSTORE balances[sender]: refund unused fee.
-                    StorageAction::Sstore(
-                        PATH_USD_ADDRESS,
-                        sender_balance_slot,
-                        sender_after_refund,
-                    ),
+                    // SDEC balances[FeeManager]: refund unused fee from escrow.
+                    StorageAction::Sdec(PATH_USD_ADDRESS, fee_manager_balance_slot, refund_amount),
+                    // SINC balances[sender]: credit unused fee refund.
+                    StorageAction::Sinc(PATH_USD_ADDRESS, sender_balance_slot, refund_amount),
                     // SLOAD validatorTokens[beneficiary]: post-tx fee route uses default PATH_USD.
                     StorageAction::Sload(TIP_FEE_MANAGER_ADDRESS, validator_token_slot, U256::ZERO),
-                    // SLOAD collectedFees[beneficiary][PATH_USD]: read current validator accrual.
-                    StorageAction::Sload(TIP_FEE_MANAGER_ADDRESS, collected_fees_slot, U256::ZERO),
-                    // SSTORE collectedFees[beneficiary][PATH_USD]: accrue actual PATH_USD spending.
-                    StorageAction::Sstore(
+                    // SINC collectedFees[beneficiary][PATH_USD]: accrue actual PATH_USD spending.
+                    StorageAction::Sinc(
                         TIP_FEE_MANAGER_ADDRESS,
                         collected_fees_slot,
                         actual_spending,

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -804,8 +804,6 @@ mod tests {
                     ),
                     // SLOAD paused: fee escrow respects token pause state.
                     StorageAction::Sload(PATH_USD_ADDRESS, tip20_slots::PAUSED, U256::ZERO),
-                    // SLOAD balances[sender]: read sender balance before fee escrow debit.
-                    StorageAction::Sload(PATH_USD_ADDRESS, sender_balance_slot, starting_balance),
                     // SLOAD userRewardInfo[sender].rewardRecipient: fee payer is opted out.
                     StorageAction::Sload(
                         PATH_USD_ADDRESS,
@@ -830,6 +828,8 @@ mod tests {
                         tip20_slots::GLOBAL_REWARD_PER_TOKEN,
                         U256::ZERO,
                     ),
+                    // SLOAD balances[sender]: read fee payer balance for debit.
+                    StorageAction::Sload(PATH_USD_ADDRESS, sender_balance_slot, starting_balance),
                     // SSTORE balances[sender]: debit max fee escrow.
                     StorageAction::Sstore(PATH_USD_ADDRESS, sender_balance_slot, sender_after_fee),
                     // SLOAD balances[FeeManager]: read fee escrow custody balance.

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -75,6 +75,10 @@ pub enum TempoPrecompileError {
     #[error("Panic({0:?})")]
     Panic(PanicKind),
 
+    /// Internal storage delta underflow that carries the observed slot value for error mapping.
+    #[error("Storage delta underflow: current={0}")]
+    StorageDeltaUnderflow(U256),
+
     /// Error from validator config
     #[error("Validator config error: {0:?}")]
     ValidatorConfigError(ValidatorConfigError),
@@ -163,7 +167,7 @@ impl TempoPrecompileError {
             Self::ReceivePolicyGuardError(e) => e.selector(),
             Self::TIP1060StorageCreditsError(e) => e.selector(),
             Self::UnknownFunctionSelector(selector) => *selector,
-            Self::Panic(_) => Panic::SELECTOR,
+            Self::Panic(_) | Self::StorageDeltaUnderflow(_) => Panic::SELECTOR,
             Self::OutOfGas | Self::Fatal(_) => [0, 0, 0, 0],
         }
         .into()
@@ -173,7 +177,9 @@ impl TempoPrecompileError {
     /// rather than swallowed, because state may be inconsistent.
     pub fn is_system_error(&self) -> bool {
         match self {
-            Self::OutOfGas | Self::Fatal(_) | Self::Panic(_) => true,
+            Self::OutOfGas | Self::Fatal(_) | Self::Panic(_) | Self::StorageDeltaUnderflow(_) => {
+                true
+            }
             Self::StablecoinDEX(_)
             | Self::TIP20(_)
             | Self::TIP20ChannelReserveError(_)
@@ -197,6 +203,11 @@ impl TempoPrecompileError {
     /// Creates an arithmetic under/overflow panic error.
     pub fn under_overflow() -> Self {
         Self::Panic(PanicKind::UnderOverflow)
+    }
+
+    /// Creates a storage delta underflow that carries the current slot value.
+    pub fn storage_delta_underflow(current: U256) -> Self {
+        Self::StorageDeltaUnderflow(current)
     }
 
     /// Creates an enum conversion error panic (Solidity Panic `0x21`).
@@ -229,6 +240,13 @@ impl TempoPrecompileError {
             Self::Panic(kind) => {
                 let panic = Panic {
                     code: U256::from(kind as u32),
+                };
+
+                panic.abi_encode().into()
+            }
+            Self::StorageDeltaUnderflow(_) => {
+                let panic = Panic {
+                    code: U256::from(PanicKind::UnderOverflow as u32),
                 };
 
                 panic.abi_encode().into()

--- a/crates/precompiles/src/storage/actions.rs
+++ b/crates/precompiles/src/storage/actions.rs
@@ -11,6 +11,10 @@ pub enum StorageAction {
     Sload(Address, U256, U256),
     /// Records an SSTORE opcode.
     Sstore(Address, U256, U256),
+    /// Records an increment of a storage slot by delta.
+    Sinc(Address, U256, U256),
+    /// Records a decrement of a storage slot by delta.
+    Sdec(Address, U256, U256),
 }
 
 /// Buffer for recording EVM [storage actions](StorageAction).

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -110,6 +110,97 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
         }
         Ok(())
     }
+
+    #[inline]
+    fn sload_inner(
+        &mut self,
+        address: Address,
+        key: U256,
+        record: bool,
+    ) -> Result<U256, TempoPrecompileError> {
+        let additional_cost = self.gas_params.cold_storage_additional_cost();
+
+        // T4+: pre-charge static gas to avoid cheap useless work.
+        let insufficient_gas_for_cold_load = if self.spec.is_t4() {
+            self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
+            self.gas_tracker.remaining() < additional_cost
+        } else {
+            false
+        };
+
+        let value;
+        let is_cold;
+        {
+            let mut account = self.internals.load_account_mut(address)?;
+            let val = account.sload(key, insufficient_gas_for_cold_load)?;
+
+            value = val.present_value;
+            is_cold = val.is_cold;
+        };
+        if record {
+            self.actions
+                .record(StorageAction::Sload(address, key, value));
+        }
+
+        if !self.spec.is_t4() {
+            self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
+        }
+
+        // dynamic gas
+        if is_cold {
+            self.deduct_gas(additional_cost)?;
+        }
+
+        Ok(value)
+    }
+
+    #[inline]
+    fn sstore_inner(
+        &mut self,
+        address: Address,
+        key: U256,
+        value: U256,
+        action: StorageAction,
+    ) -> Result<(), TempoPrecompileError> {
+        // T4+: pre-charge static gas before loading storage to avoid cheap useless work.
+        let insufficient_gas_for_cold_load = if self.spec.is_t4() {
+            self.deduct_gas(self.gas_params.sstore_static_gas())?;
+            self.gas_tracker.remaining() < self.gas_params.cold_storage_additional_cost()
+        } else {
+            false
+        };
+
+        let result = self.internals.load_account_mut(address)?.sstore(
+            key,
+            value,
+            insufficient_gas_for_cold_load,
+        )?;
+        self.actions.record(action);
+
+        if !self.spec.is_t4() {
+            self.deduct_gas(self.gas_params.sstore_static_gas())?;
+        }
+
+        // TIP-1060 (T7+): run the storage credits policy so precompile-driven storage
+        // writes honor the same accounting as the opcode-level SSTORE hook.
+        if self.tip1060_storage_credits_enabled {
+            sstore_storage_credits(self, address, &result)?
+        }
+
+        // dynamic gas
+        self.deduct_gas(
+            self.gas_params
+                .sstore_dynamic_gas(true, &result.data, result.is_cold),
+        )?;
+
+        // Track state gas (cold SSTORE zero->non-zero only)
+        self.deduct_state_gas(self.gas_params.sstore_state_gas(&result.data))?;
+
+        // refund gas.
+        self.refund_gas(self.gas_params.sstore_refund(true, &result.data));
+
+        Ok(())
+    }
 }
 
 impl crate::tip1060_storage_credits::StorageCreditsBackend for EvmPrecompileStorageProvider<'_> {
@@ -259,45 +350,52 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
         key: U256,
         value: U256,
     ) -> Result<(), TempoPrecompileError> {
-        // T4+: pre-charge static gas before loading storage to avoid cheap useless work.
-        let insufficient_gas_for_cold_load = if self.spec.is_t4() {
-            self.deduct_gas(self.gas_params.sstore_static_gas())?;
-            self.gas_tracker.remaining() < self.gas_params.cold_storage_additional_cost()
-        } else {
-            false
-        };
-
-        let result = self.internals.load_account_mut(address)?.sstore(
+        self.sstore_inner(
+            address,
             key,
             value,
-            insufficient_gas_for_cold_load,
-        )?;
-        self.actions
-            .record(StorageAction::Sstore(address, key, value));
+            StorageAction::Sstore(address, key, value),
+        )
+    }
 
-        if !self.spec.is_t4() {
-            self.deduct_gas(self.gas_params.sstore_static_gas())?;
-        }
+    #[inline]
+    fn sinc(
+        &mut self,
+        address: Address,
+        key: U256,
+        delta: U256,
+    ) -> Result<(), TempoPrecompileError> {
+        let current = self.sload_inner(address, key, false)?;
+        let value = current
+            .checked_add(delta)
+            .ok_or_else(TempoPrecompileError::under_overflow)?;
 
-        // TIP-1060 (T7+): run the storage credits policy so precompile-driven storage
-        // writes honor the same accounting as the opcode-level SSTORE hook.
-        if self.tip1060_storage_credits_enabled {
-            sstore_storage_credits(self, address, &result)?
-        }
+        self.sstore_inner(
+            address,
+            key,
+            value,
+            StorageAction::Sinc(address, key, delta),
+        )
+    }
 
-        // dynamic gas
-        self.deduct_gas(
-            self.gas_params
-                .sstore_dynamic_gas(true, &result.data, result.is_cold),
-        )?;
+    #[inline]
+    fn sdec(
+        &mut self,
+        address: Address,
+        key: U256,
+        delta: U256,
+    ) -> Result<(), TempoPrecompileError> {
+        let current = self.sload_inner(address, key, false)?;
+        let value = current
+            .checked_sub(delta)
+            .ok_or_else(|| TempoPrecompileError::storage_delta_underflow(current))?;
 
-        // Track state gas (cold SSTORE zero->non-zero only)
-        self.deduct_state_gas(self.gas_params.sstore_state_gas(&result.data))?;
-
-        // refund gas.
-        self.refund_gas(self.gas_params.sstore_refund(true, &result.data));
-
-        Ok(())
+        self.sstore_inner(
+            address,
+            key,
+            value,
+            StorageAction::Sdec(address, key, delta),
+        )
     }
 
     #[inline]
@@ -331,38 +429,7 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
 
     #[inline]
     fn sload(&mut self, address: Address, key: U256) -> Result<U256, TempoPrecompileError> {
-        let additional_cost = self.gas_params.cold_storage_additional_cost();
-
-        // T4+: pre-charge static gas to avoid cheap useless work.
-        let insufficient_gas_for_cold_load = if self.spec.is_t4() {
-            self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
-            self.gas_tracker.remaining() < additional_cost
-        } else {
-            false
-        };
-
-        let value;
-        let is_cold;
-        {
-            let mut account = self.internals.load_account_mut(address)?;
-            let val = account.sload(key, insufficient_gas_for_cold_load)?;
-
-            value = val.present_value;
-            is_cold = val.is_cold;
-        };
-        self.actions
-            .record(StorageAction::Sload(address, key, value));
-
-        if !self.spec.is_t4() {
-            self.deduct_gas(self.gas_params.warm_storage_read_cost())?;
-        }
-
-        // dynamic gas
-        if is_cold {
-            self.deduct_gas(additional_cost)?;
-        }
-
-        Ok(value)
+        self.sload_inner(address, key, true)
     }
 
     #[inline]
@@ -609,6 +676,8 @@ mod tests {
         let _ = provider.sload(addr, k1)?;
         provider.sstore(addr, k1, v1_new)?;
         let _ = provider.sload(addr, k2)?;
+        provider.sinc(addr, k1, U256::from(4))?;
+        provider.sdec(addr, k2, U256::from(5))?;
 
         assert_eq!(
             provider.take_actions(),
@@ -618,6 +687,8 @@ mod tests {
                 StorageAction::Sload(addr, k1, v1),
                 StorageAction::Sstore(addr, k1, v1_new),
                 StorageAction::Sload(addr, k2, v2),
+                StorageAction::Sinc(addr, k1, U256::from(4)),
+                StorageAction::Sdec(addr, k2, U256::from(5)),
             ])
         );
 

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -73,6 +73,30 @@ pub trait PrecompileStorageProvider {
     /// Performs an SSTORE operation (persistent storage write).
     fn sstore(&mut self, address: Address, key: U256, value: U256) -> Result<()>;
 
+    /// Increments a persistent storage slot by `delta`.
+    ///
+    /// Intentionally returns no post-increment value, preserving `sinc` as a semantic
+    /// storage delta rather than an observation point that callers can branch on.
+    fn sinc(&mut self, address: Address, key: U256, delta: U256) -> Result<()> {
+        let value = self
+            .sload(address, key)?
+            .checked_add(delta)
+            .ok_or_else(TempoPrecompileError::under_overflow)?;
+        self.sstore(address, key, value)
+    }
+
+    /// Decrements a persistent storage slot by `delta`.
+    ///
+    /// Intentionally returns no post-decrement value, preserving `sdec` as a semantic
+    /// storage delta rather than an observation point that callers can branch on.
+    fn sdec(&mut self, address: Address, key: U256, delta: U256) -> Result<()> {
+        let current = self.sload(address, key)?;
+        let value = current
+            .checked_sub(delta)
+            .ok_or_else(|| TempoPrecompileError::storage_delta_underflow(current))?;
+        self.sstore(address, key, value)
+    }
+
     /// Performs a TSTORE operation (transient storage write).
     fn tstore(&mut self, address: Address, key: U256, value: U256) -> Result<()>;
 
@@ -179,6 +203,30 @@ pub trait StorageOps {
     fn store(&mut self, slot: U256, value: U256) -> Result<()>;
     /// Loads a value from the provided slot.
     fn load(&self, slot: U256) -> Result<U256>;
+
+    /// Increments a value at the provided slot by `delta`.
+    ///
+    /// Intentionally returns no post-increment value, preserving `sinc` as a semantic
+    /// storage delta rather than an observation point that callers can branch on.
+    fn sinc(&mut self, slot: U256, delta: U256) -> Result<()> {
+        let value = self
+            .load(slot)?
+            .checked_add(delta)
+            .ok_or_else(TempoPrecompileError::under_overflow)?;
+        self.store(slot, value)
+    }
+
+    /// Decrements a value at the provided slot by `delta`.
+    ///
+    /// Intentionally returns no post-decrement value, preserving `sdec` as a semantic
+    /// storage delta rather than an observation point that callers can branch on.
+    fn sdec(&mut self, slot: U256, delta: U256) -> Result<()> {
+        let current = self.load(slot)?;
+        let value = current
+            .checked_sub(delta)
+            .ok_or_else(|| TempoPrecompileError::storage_delta_underflow(current))?;
+        self.store(slot, value)
+    }
 }
 
 /// Trait providing access to a contract's address.

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -157,6 +157,16 @@ impl StorageCtx {
         Self::try_with_storage(|s| s.sstore(address, key, value))
     }
 
+    /// Increments a persistent storage slot by `delta`.
+    pub fn sinc(&mut self, address: Address, key: U256, delta: U256) -> Result<()> {
+        Self::try_with_storage(|s| s.sinc(address, key, delta))
+    }
+
+    /// Decrements a persistent storage slot by `delta`.
+    pub fn sdec(&mut self, address: Address, key: U256, delta: U256) -> Result<()> {
+        Self::try_with_storage(|s| s.sdec(address, key, delta))
+    }
+
     /// Performs a TSTORE operation (transient storage write).
     pub fn tstore(&mut self, address: Address, key: U256, value: U256) -> Result<()> {
         Self::try_with_storage(|s| s.tstore(address, key, value))

--- a/crates/precompiles/src/storage/types/slot.rs
+++ b/crates/precompiles/src/storage/types/slot.rs
@@ -124,6 +124,16 @@ impl<T> StorageOps for Slot<T> {
         let mut storage = StorageCtx;
         storage.sstore(self.address, slot, value)
     }
+
+    fn sinc(&mut self, slot: U256, delta: U256) -> Result<()> {
+        let mut storage = StorageCtx;
+        storage.sinc(self.address, slot, delta)
+    }
+
+    fn sdec(&mut self, slot: U256, delta: U256) -> Result<()> {
+        let mut storage = StorageCtx;
+        storage.sdec(self.address, slot, delta)
+    }
 }
 
 /// Wrapper that routes storage operations through transient storage (TLOAD/TSTORE).

--- a/crates/precompiles/src/storage/types/slot.rs
+++ b/crates/precompiles/src/storage/types/slot.rs
@@ -136,6 +136,20 @@ impl<T> StorageOps for Slot<T> {
     }
 }
 
+impl Slot<U256> {
+    /// Increments this slot by `delta`.
+    #[inline]
+    pub fn sinc(&mut self, delta: U256) -> Result<()> {
+        <Self as StorageOps>::sinc(self, self.slot, delta)
+    }
+
+    /// Decrements this slot by `delta`.
+    #[inline]
+    pub fn sdec(&mut self, delta: U256) -> Result<()> {
+        <Self as StorageOps>::sdec(self, self.slot, delta)
+    }
+}
+
 /// Wrapper that routes storage operations through transient storage (TLOAD/TSTORE).
 ///
 /// Created via `Slot::transient()` and used by `t_read()`, `t_write()`, `t_delete()`.
@@ -340,6 +354,23 @@ mod tests {
         let raw = storage.sload(address, slot_num)?;
         assert_eq!(raw, test_value);
         Ok(())
+    }
+
+    #[test]
+    fn test_u256_slot_sinc_sdec() -> eyre::Result<()> {
+        let (mut storage, address) = setup_storage();
+
+        StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
+            let mut slot = Slot::<U256>::new(U256::from(7), address);
+
+            slot.sinc(U256::from(10))?;
+            assert_eq!(slot.read()?, U256::from(10));
+
+            slot.sdec(U256::from(3))?;
+            assert_eq!(slot.read()?, U256::from(7));
+
+            Ok(())
+        })
     }
 
     #[test]

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1294,13 +1294,6 @@ impl TIP20Token {
         // This ensures that a transaction which pauses the token can still complete successfully and receive its fee refund.
         // Apart from this specific refund transfer, no other token transfers can occur after a pause event.
         self.check_not_paused()?;
-        let from_balance = self.get_balance(from)?;
-        if amount > from_balance {
-            return Err(
-                TIP20Error::insufficient_balance(from_balance, amount, self.address).into(),
-            );
-        }
-
         self.check_and_update_spending_limit(from, amount)?;
 
         // Update rewards for the sender and get their reward recipient

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1165,6 +1165,13 @@ impl TIP20Token {
     /// For virtual recipients the event address is the virtual alias; the balance update always
     /// targets `to.target` (the resolved master).
     pub(crate) fn _transfer(&mut self, from: Address, to: &Recipient, amount: U256) -> Result<()> {
+        let from_balance = self.get_balance(from)?;
+        if amount > from_balance {
+            return Err(
+                TIP20Error::insufficient_balance(from_balance, amount, self.address).into(),
+            );
+        }
+
         self.handle_rewards_on_transfer(from, to.target, amount)?;
 
         // Adjust balances

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     address_registry::AddressRegistry,
     error::{Result, TempoPrecompileError},
     receive_policy_guard::{InboundKind, ReceivePolicyGuard, RecoveryMode},
-    storage::{Handler, Mapping, StorageOps},
+    storage::{Handler, Mapping},
     tip20::{rewards::UserRewardInfo, roles::DEFAULT_ADMIN_ROLE},
     tip20_factory::TIP20Factory,
     tip403_registry::{AuthRole, ITIP403Registry, TIP403Registry},
@@ -999,9 +999,7 @@ impl TIP20Token {
     }
 
     fn increment_balance(&mut self, account: Address, amount: U256) -> Result<()> {
-        let balance = self.balances.at_mut(&account);
-        let slot = balance.slot();
-        balance.sinc(slot, amount).map_err(|err| {
+        self.balances[account].sinc(amount).map_err(|err| {
             if err == TempoPrecompileError::under_overflow() {
                 TIP20Error::supply_cap_exceeded().into()
             } else {
@@ -1011,14 +1009,14 @@ impl TIP20Token {
     }
 
     fn decrement_balance(&mut self, account: Address, amount: U256) -> Result<()> {
-        let balance = self.balances.at_mut(&account);
-        let slot = balance.slot();
-        balance.sdec(slot, amount).map_err(|err| match err {
-            TempoPrecompileError::StorageDeltaUnderflow(current) => {
-                TIP20Error::insufficient_balance(current, amount, self.address).into()
-            }
-            err => err,
-        })
+        self.balances[account]
+            .sdec(amount)
+            .map_err(|err| match err {
+                TempoPrecompileError::StorageDeltaUnderflow(current) => {
+                    TIP20Error::insufficient_balance(current, amount, self.address).into()
+                }
+                err => err,
+            })
     }
 
     fn get_allowance(&self, owner: Address, spender: Address) -> Result<U256> {

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     address_registry::AddressRegistry,
     error::{Result, TempoPrecompileError},
     receive_policy_guard::{InboundKind, ReceivePolicyGuard, RecoveryMode},
-    storage::{Handler, Mapping},
+    storage::{Handler, Mapping, StorageOps},
     tip20::{rewards::UserRewardInfo, roles::DEFAULT_ADMIN_ROLE},
     tip20_factory::TIP20Factory,
     tip403_registry::{AuthRole, ITIP403Registry, TIP403Registry},
@@ -540,11 +540,7 @@ impl TIP20Token {
         self.handle_rewards_on_mint(to.target, amount)?;
 
         self.set_total_supply(new_supply)?;
-        let to_balance = self.get_balance(to.target)?;
-        let new_to_balance = to_balance
-            .checked_add(amount)
-            .ok_or(TempoPrecompileError::under_overflow())?;
-        self.set_balance(to.target, new_to_balance)?;
+        self.increment_balance(to.target, amount)?;
 
         self.emit_event(to.build_transfer_event(Address::ZERO, amount))
     }
@@ -1002,6 +998,29 @@ impl TIP20Token {
         self.balances[account].write(amount)
     }
 
+    fn increment_balance(&mut self, account: Address, amount: U256) -> Result<()> {
+        let balance = self.balances.at_mut(&account);
+        let slot = balance.slot();
+        balance.sinc(slot, amount).map_err(|err| {
+            if err == TempoPrecompileError::under_overflow() {
+                TIP20Error::supply_cap_exceeded().into()
+            } else {
+                err
+            }
+        })
+    }
+
+    fn decrement_balance(&mut self, account: Address, amount: U256) -> Result<()> {
+        let balance = self.balances.at_mut(&account);
+        let slot = balance.slot();
+        balance.sdec(slot, amount).map_err(|err| match err {
+            TempoPrecompileError::StorageDeltaUnderflow(current) => {
+                TIP20Error::insufficient_balance(current, amount, self.address).into()
+            }
+            err => err,
+        })
+    }
+
     fn get_allowance(&self, owner: Address, spender: Address) -> Result<U256> {
         self.allowances[owner][spender].read()
     }
@@ -1148,29 +1167,13 @@ impl TIP20Token {
     /// For virtual recipients the event address is the virtual alias; the balance update always
     /// targets `to.target` (the resolved master).
     pub(crate) fn _transfer(&mut self, from: Address, to: &Recipient, amount: U256) -> Result<()> {
-        let from_balance = self.get_balance(from)?;
-        if amount > from_balance {
-            return Err(
-                TIP20Error::insufficient_balance(from_balance, amount, self.address).into(),
-            );
-        }
-
         self.handle_rewards_on_transfer(from, to.target, amount)?;
 
         // Adjust balances
-        let new_from_balance = from_balance
-            .checked_sub(amount)
-            .ok_or(TempoPrecompileError::under_overflow())?;
-
-        self.set_balance(from, new_from_balance)?;
+        self.decrement_balance(from, amount)?;
 
         if to.target != Address::ZERO {
-            let to_balance = self.get_balance(to.target)?;
-            let new_to_balance = to_balance
-                .checked_add(amount)
-                .ok_or(TempoPrecompileError::under_overflow())?;
-
-            self.set_balance(to.target, new_to_balance)?;
+            self.increment_balance(to.target, amount)?;
         }
 
         self.emit_event(to.build_transfer_event(from, amount))
@@ -1295,22 +1298,10 @@ impl TIP20Token {
             )?;
         }
 
-        let new_from_balance =
-            from_balance
-                .checked_sub(amount)
-                .ok_or(TIP20Error::insufficient_balance(
-                    from_balance,
-                    amount,
-                    self.address,
-                ))?;
+        self.decrement_balance(from, amount)?;
+        self.increment_balance(TIP_FEE_MANAGER_ADDRESS, amount)?;
 
-        self.set_balance(from, new_from_balance)?;
-
-        let to_balance = self.get_balance(TIP_FEE_MANAGER_ADDRESS)?;
-        let new_to_balance = to_balance
-            .checked_add(amount)
-            .ok_or(TIP20Error::supply_cap_exceeded())?;
-        self.set_balance(TIP_FEE_MANAGER_ADDRESS, new_to_balance)
+        Ok(())
     }
 
     /// Refunds unused fee tokens from the fee manager back to `to` and emits a transfer event for
@@ -1353,23 +1344,10 @@ impl TIP20Token {
             )?;
         }
 
-        let from_balance = self.get_balance(TIP_FEE_MANAGER_ADDRESS)?;
-        let new_from_balance =
-            from_balance
-                .checked_sub(refund)
-                .ok_or(TIP20Error::insufficient_balance(
-                    from_balance,
-                    refund,
-                    self.address,
-                ))?;
+        self.decrement_balance(TIP_FEE_MANAGER_ADDRESS, refund)?;
+        self.increment_balance(to, refund)?;
 
-        self.set_balance(TIP_FEE_MANAGER_ADDRESS, new_from_balance)?;
-
-        let to_balance = self.get_balance(to)?;
-        let new_to_balance = to_balance
-            .checked_add(refund)
-            .ok_or(TIP20Error::supply_cap_exceeded())?;
-        self.set_balance(to, new_to_balance)
+        Ok(())
     }
 }
 
@@ -2312,6 +2290,30 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_transfer_fee_pre_tx_fee_manager_overflow() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let admin = Address::random();
+        let user = Address::random();
+        let fee_amount = U256::ONE;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::create("Test", "TST", admin)
+                .with_issuer(admin)
+                .with_mint(user, fee_amount)
+                .apply()?;
+            token.set_balance(TIP_FEE_MANAGER_ADDRESS, U256::MAX)?;
+
+            assert_eq!(
+                token.transfer_fee_pre_tx(user, fee_amount),
+                Err(TempoPrecompileError::TIP20(
+                    TIP20Error::supply_cap_exceeded()
+                ))
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_transfer_fee_pre_tx_paused() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         let admin = Address::random();
@@ -2365,6 +2367,55 @@ pub(crate) mod tests {
                 &TIP20Event::transfer(user, TIP_FEE_MANAGER_ADDRESS, gas_used).into_log_data()
             );
 
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_fee_post_tx_insufficient_fee_manager_balance() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let admin = Address::random();
+        let user = Address::random();
+        let initial_fee = U256::from(10);
+        let refund_amount = U256::from(30);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::create("Test", "TST", admin)
+                .with_issuer(admin)
+                .with_mint(TIP_FEE_MANAGER_ADDRESS, initial_fee)
+                .apply()?;
+
+            assert_eq!(
+                token.transfer_fee_post_tx(user, refund_amount, U256::ZERO),
+                Err(TempoPrecompileError::TIP20(
+                    TIP20Error::insufficient_balance(initial_fee, refund_amount, token.address)
+                ))
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_fee_post_tx_recipient_overflow() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let admin = Address::random();
+        let user = Address::random();
+        let refund_amount = U256::ONE;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::create("Test", "TST", admin)
+                .with_issuer(admin)
+                .apply()?;
+            token.set_balance(TIP_FEE_MANAGER_ADDRESS, refund_amount)?;
+            token.set_balance(user, U256::MAX)?;
+
+            assert_eq!(
+                token.transfer_fee_post_tx(user, refund_amount, U256::ZERO),
+                Err(TempoPrecompileError::TIP20(
+                    TIP20Error::supply_cap_exceeded()
+                ))
+            );
             Ok(())
         })
     }

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1165,17 +1165,32 @@ impl TIP20Token {
     /// For virtual recipients the event address is the virtual alias; the balance update always
     /// targets `to.target` (the resolved master).
     pub(crate) fn _transfer(&mut self, from: Address, to: &Recipient, amount: U256) -> Result<()> {
-        let from_balance = self.get_balance(from)?;
-        if amount > from_balance {
-            return Err(
-                TIP20Error::insufficient_balance(from_balance, amount, self.address).into(),
-            );
-        }
+        let from_balance = if !self.storage.spec().is_t8() {
+            let from_balance = self.get_balance(from)?;
+            if amount > from_balance {
+                return Err(
+                    TIP20Error::insufficient_balance(from_balance, amount, self.address).into(),
+                );
+            }
+            Some(from_balance)
+        } else {
+            None
+        };
 
         self.handle_rewards_on_transfer(from, to.target, amount)?;
 
         // Adjust balances
-        self.decrement_balance(from, amount)?;
+        if let Some(from_balance) = from_balance {
+            // pre-T8 path
+            let new_from_balance = from_balance
+                .checked_sub(amount)
+                .ok_or(TempoPrecompileError::under_overflow())?;
+
+            self.set_balance(from, new_from_balance)?;
+        } else {
+            // post-T8 path
+            self.decrement_balance(from, amount)?;
+        }
 
         if to.target != Address::ZERO {
             self.increment_balance(to.target, amount)?;

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1180,6 +1180,9 @@ impl TIP20Token {
         self.handle_rewards_on_transfer(from, to.target, amount)?;
 
         // Adjust balances
+        //
+        // We can't just use `decrement_balance` in both pre- and post-T8 codepaths, because `decrement_balance`
+        // charges gas for balance SLOAD that we already do above for pre-T8.
         if let Some(from_balance) = from_balance {
             // pre-T8 path
             let new_from_balance = from_balance

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -7,7 +7,7 @@ pub mod dispatch;
 
 use crate::{
     error::{Result, TempoPrecompileError},
-    storage::{Handler, Mapping},
+    storage::{Handler, Mapping, StorageOps},
     tip_fee_manager::amm::{FeeRoute, Pool, compute_amount_out},
     tip20::{ITIP20, TIP20Token, validate_usd_currency},
     tip20_factory::TIP20Factory,
@@ -275,12 +275,9 @@ impl TipFeeManager {
             return Ok(());
         }
 
-        let collected_fees = self.collected_fees[validator][token].read()?;
-        self.collected_fees[validator][token].write(
-            collected_fees
-                .checked_add(amount)
-                .ok_or(TempoPrecompileError::under_overflow())?,
-        )?;
+        let collected_fees = self.collected_fees.at_mut(&validator).at_mut(&token);
+        let slot = collected_fees.slot();
+        collected_fees.sinc(slot, amount)?;
 
         Ok(())
     }

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -7,7 +7,7 @@ pub mod dispatch;
 
 use crate::{
     error::{Result, TempoPrecompileError},
-    storage::{Handler, Mapping, StorageOps},
+    storage::{Handler, Mapping},
     tip_fee_manager::amm::{FeeRoute, Pool, compute_amount_out},
     tip20::{ITIP20, TIP20Token, validate_usd_currency},
     tip20_factory::TIP20Factory,
@@ -275,9 +275,7 @@ impl TipFeeManager {
             return Ok(());
         }
 
-        let collected_fees = self.collected_fees.at_mut(&validator).at_mut(&token);
-        let slot = collected_fees.slot();
-        collected_fees.sinc(slot, amount)?;
+        self.collected_fees[validator][token].sinc(amount)?;
 
         Ok(())
     }


### PR DESCRIPTION
Adds semantic `sinc`/`sdec` storage helpers and uses them for TIP-20 balance deltas and fee-manager accruals. The helpers intentionally return no post-delta value so callers cannot branch on intermediate delta results.

They will be used for parallel execution in builder prewarming that outputs storage actions which can then be applied in serial builder loop.