### PR TITLE
ci: run Test/RPC Tests for v1.9.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12818,7 +12818,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -12966,7 +12966,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13027,7 +13027,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13056,7 +13056,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13070,7 +13070,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13121,7 +13121,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13165,7 +13165,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13184,7 +13184,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "eyre",
  "indenter",
@@ -13192,7 +13192,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13205,7 +13205,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13273,7 +13273,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -13311,7 +13311,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13330,7 +13330,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13362,7 +13362,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13410,7 +13410,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13444,7 +13444,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "alloy",
  "clap",
@@ -13469,7 +13469,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "eyre",
  "jiff",
@@ -13478,7 +13478,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13517,7 +13517,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13529,7 +13529,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.8.1"
+version = "1.9.0"
 edition = "2024"
 rust-version = "1.93.0"
 authors = ["Tempo Contributors"]


### PR DESCRIPTION
Draft PR to trigger `Test` and `RPC Tests` (which only run on `pull_request`/`push:main`/`merge_group`) against the `release/v1.9.0` commit `948196c`.

**Do not merge** — this is purely to get a green CI record on the release branch for the v1.9.0 release validation. The main-branch version sync happens post-publish per the release process.

Diff is just the version bump (`Cargo.toml` + `Cargo.lock`) from #5608.