### PR TITLE
perf(txpool): cache recovered fee payer on pooled transactions

### DIFF
--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -335,31 +335,30 @@ where
                 && let Some(ref mut provider) = state_provider
             {
                 let fee_token = tx.transaction.effective_fee_token();
-                let Ok(fee_payer) = tx.transaction.fee_payer() else {
-                    continue;
-                };
-
-                if updates
-                    .fee_balance_changes
-                    .get(&fee_token)
-                    .is_some_and(|accounts| accounts.contains(&fee_payer))
-                {
-                    let balance = match fee_balance_cache.entry((fee_token, fee_payer)) {
-                        Entry::Occupied(entry) => *entry.get(),
-                        Entry::Vacant(entry) => {
-                            let Ok(balance) =
-                                provider.get_token_balance(fee_token, fee_payer, spec)
-                            else {
-                                continue;
-                            };
-                            *entry.insert(balance)
-                        }
+                // only resolve the fee payer if the fee token saw balance changes
+                if let Some(accounts) = updates.fee_balance_changes.get(&fee_token) {
+                    let Ok(fee_payer) = tx.transaction.fee_payer() else {
+                        continue;
                     };
 
-                    if balance < tx.transaction.fee_token_cost() {
-                        to_remove.push(*tx.hash());
-                        insolvent_fee_payer_count += 1;
-                        continue;
+                    if accounts.contains(&fee_payer) {
+                        let balance = match fee_balance_cache.entry((fee_token, fee_payer)) {
+                            Entry::Occupied(entry) => *entry.get(),
+                            Entry::Vacant(entry) => {
+                                let Ok(balance) =
+                                    provider.get_token_balance(fee_token, fee_payer, spec)
+                                else {
+                                    continue;
+                                };
+                                *entry.insert(balance)
+                            }
+                        };
+
+                        if balance < tx.transaction.fee_token_cost() {
+                            to_remove.push(*tx.hash());
+                            insolvent_fee_payer_count += 1;
+                            continue;
+                        }
                     }
                 }
             }

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -74,6 +74,11 @@ pub struct TempoPooledTransaction {
     /// Stores `(fee_token, balance_slot)` so the payload builder's state-aware iterator
     /// can check if the fee payer's balance was modified without recomputing the keccak.
     fee_balance_slot: OnceLock<Option<(Address, U256)>>,
+    /// Cached fee payer of this transaction.
+    ///
+    /// Recovering the fee payer of a fee payer signed transaction requires a signature
+    /// recovery, this caches the result. `None` if recovery failed.
+    fee_payer: OnceLock<Option<Address>>,
 }
 
 impl TempoPooledTransaction {
@@ -109,6 +114,7 @@ impl TempoPooledTransaction {
             key_authorization_signer_subject: OnceLock::new(),
             key_authorization_target_subject: OnceLock::new(),
             fee_balance_slot: OnceLock::new(),
+            fee_payer: OnceLock::new(),
         }
     }
 
@@ -124,8 +130,13 @@ impl TempoPooledTransaction {
     }
 
     /// Resolves the transaction fee payer.
+    ///
+    /// The recovered fee payer is cached, so repeated calls only pay for the
+    /// signature recovery once.
     pub fn fee_payer(&self) -> Result<Address, RecoveryError> {
-        self.inner().fee_payer(self.inner().signer())
+        self.fee_payer
+            .get_or_init(|| self.inner().fee_payer(self.inner().signer()).ok())
+            .ok_or_else(RecoveryError::new)
     }
 
     /// Returns true if this is an AA transaction


### PR DESCRIPTION
In the 50k TPS profile, `evict_invalidated_transactions_from` accounts for ~11% of the txpool maintenance thread, and a sizable share of that is `fee_payer()` calls: resolving the fee payer of a fee payer signed transaction requires a signature recovery, and the per-block maintenance scan resolves it up to four times per pooled transaction (fee balance, blacklist, whitelist, and user token checks). The recovered fee payer is now cached on `TempoPooledTransaction` alongside the other recovered metadata, so each transaction pays for recovery at most once over its pool lifetime.

The fee payer balance check now also looks up the fee token in the balance change set before resolving the fee payer, so transactions whose fee token saw no balance changes skip the recovery entirely.