### PR TITLE
perf: reduce per-block overhead in payload building and verification

### DIFF
--- a/crates/consensus/src/consensus/application/actor.rs
+++ b/crates/consensus/src/consensus/application/actor.rs
@@ -905,16 +905,23 @@ impl Inner<Init> {
         let block_digest = block.digest();
 
         if is_good {
-            // Persist the block in the marshal actor and execution layer.
-            if !self.marshal.verified(round, block).await {
+            // Persist the block in the marshal actor and update the canonical head
+            // concurrently; both are independent actors and must only have completed
+            // before the verification result is returned, so running them serially
+            // would needlessly delay the vote.
+            //
+            // FIXME: move canonicalization into the certification step?
+            let (persisted, canonicalized) = futures::future::join(
+                self.marshal.verified(round, block),
+                self.state
+                    .executor
+                    .canonicalize_head(block_height, block_digest),
+            )
+            .await;
+            if !persisted {
                 bail!("marshal actor refused to persist verified block");
             }
-
-            // FIXME: move this into the certification step?
-            self.state
-                .executor
-                .canonicalize_head(block_height, block_digest)
-                .await
+            canonicalized
                 .wrap_err("failed making the verified proposal the head of the canonical chain")?;
         }
         Ok(is_good)
@@ -1026,10 +1033,9 @@ async fn verify_block<TContext: Pacer>(
             .map(|p| B256::from_slice(p))
             .collect(),
     );
-    let (block, block_access_list) = block.clone().into_parts();
     let execution_data = TempoExecutionData {
-        block: Arc::new(block),
-        block_access_list,
+        block: block.shared_execution_block(),
+        block_access_list: block.block_access_list().cloned(),
         validator_set,
     };
     let validation_start = Instant::now();

--- a/crates/consensus/src/consensus/application/actor.rs
+++ b/crates/consensus/src/consensus/application/actor.rs
@@ -549,7 +549,7 @@ impl Inner<Init> {
             leader,
         } = args;
 
-        let (parent, parent_origin) = subscribe_with_origin(
+        let parent = subscribe(
             &self.execution_node,
             Round::new(round.epoch(), parent_view),
             parent_digest,
@@ -557,7 +557,7 @@ impl Inner<Init> {
         )
         .await?;
 
-        debug!(height = %parent.height(), ?parent_origin, "retrieved parent block",);
+        debug!(height = %parent.height(), "retrieved parent block",);
 
         let parent_epoch_info = self
             .epoch_strategy
@@ -603,11 +603,8 @@ impl Inner<Init> {
         //
         // If proposing the first block of an epoch, its parent
         // (genesis/boundary block) must exist and be finalized, so we can skip
-        // it. Likewise, if the parent was just read from the execution layer it
-        // has already been executed and validated there, so the engine round
-        // trip is redundant and would eat into the proposal budget.
+        // it.
         if !is_genesis_parent
-            && parent_origin == BlockOrigin::Consensus
             && verify_block(
                 context.clone(),
                 parent_epoch_info.epoch(),
@@ -1161,33 +1158,6 @@ async fn verify_header(
 }
 
 /// Read a block from the execution layer or fetches it from consensus p2p.
-#[instrument(skip_all, fields(%round, %digest), err)]
-async fn subscribe_with_origin(
-    execution_node: &TempoFullNode,
-    round: Round,
-    digest: Digest,
-    marshal: &crate::alias::marshal::Mailbox,
-) -> eyre::Result<(Block, BlockOrigin)> {
-    if let Some(block) = execution_node
-        .provider
-        .find_block_by_hash(digest.0, BlockSource::Any)
-        .wrap_err_with(|| format!("failed querying execution layer for parent block `{digest}`"))?
-    {
-        // EL database reads do not include commonware sidecars.
-        return Ok((
-            Block::from_execution_block_unchecked(block.seal(), None),
-            BlockOrigin::ExecutionLayer,
-        ));
-    }
-    let block = marshal
-        .subscribe_by_digest(Some(round), digest)
-        .await
-        .await
-        .map_err(|_| eyre!("syncer dropped channel before the parent block was sent"))?;
-    Ok((block, BlockOrigin::Consensus))
-}
-
-/// Read a block from the execution layer or fetches it from consensus p2p.
 #[instrument(skip_all, fields(%round, %digest), err, ret(Display))]
 async fn subscribe(
     execution_node: &TempoFullNode,
@@ -1195,20 +1165,21 @@ async fn subscribe(
     digest: Digest,
     marshal: &crate::alias::marshal::Mailbox,
 ) -> eyre::Result<Block> {
-    subscribe_with_origin(execution_node, round, digest, marshal)
-        .await
-        .map(|(block, _)| block)
-}
-
-/// Where a block returned by [`subscribe_with_origin`] was found.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum BlockOrigin {
-    /// The block was read from the execution layer, meaning it has already been
-    /// executed and validated there.
-    ExecutionLayer,
-    /// The block was fetched through consensus p2p and is unknown to the local
-    /// execution layer.
-    Consensus,
+    let block = if let Some(block) = execution_node
+        .provider
+        .find_block_by_hash(digest.0, BlockSource::Any)
+        .wrap_err_with(|| format!("failed querying execution layer for parent block `{digest}`"))?
+    {
+        // EL database reads do not include commonware sidecars.
+        Block::from_execution_block_unchecked(block.seal(), None)
+    } else {
+        marshal
+            .subscribe_by_digest(Some(round), digest)
+            .await
+            .await
+            .map_err(|_| eyre!("syncer dropped channel before the parent block was sent"))?
+    };
+    Ok(block)
 }
 
 #[derive(Clone)]

--- a/crates/consensus/src/consensus/application/actor.rs
+++ b/crates/consensus/src/consensus/application/actor.rs
@@ -876,20 +876,30 @@ impl Inner<Init> {
             );
         }
 
-        let validation_duration = verify_block(
-            context,
-            round.epoch(),
-            &self.epoch_strategy,
-            self.execution_node
-                .add_ons_handle
-                .beacon_engine_handle
-                .clone(),
-            &block,
-            parent_digest,
-            &self.scheme_provider,
+        // Persist the block in the marshal actor concurrently with execution-layer
+        // validation. The cache is digest-addressed and writing to an occupied
+        // index is a no-op, so an invalid block only leaves a prunable cache
+        // entry behind while a valid one no longer pays the persist on the
+        // critical path between validation and the vote.
+        let speculative_persist = self.marshal.verified(round, block.clone());
+        let (validation_duration, persisted) = futures::future::join(
+            verify_block(
+                context,
+                round.epoch(),
+                &self.epoch_strategy,
+                self.execution_node
+                    .add_ons_handle
+                    .beacon_engine_handle
+                    .clone(),
+                &block,
+                parent_digest,
+                &self.scheme_provider,
+            ),
+            speculative_persist,
         )
-        .await
-        .wrap_err("failed verifying block against execution layer")?;
+        .await;
+        let validation_duration =
+            validation_duration.wrap_err("failed verifying block against execution layer")?;
         if let Some(duration) = validation_duration
             && let Ok(mut estimator) = self.validation_latency_estimator.lock()
         {
@@ -908,23 +918,15 @@ impl Inner<Init> {
         let block_digest = block.digest();
 
         if is_good {
-            // Persist the block in the marshal actor and update the canonical head
-            // concurrently; both are independent actors and must only have completed
-            // before the verification result is returned, so running them serially
-            // would needlessly delay the vote.
-            //
-            // FIXME: move canonicalization into the certification step?
-            let (persisted, canonicalized) = futures::future::join(
-                self.marshal.verified(round, block),
-                self.state
-                    .executor
-                    .canonicalize_head(block_height, block_digest),
-            )
-            .await;
             if !persisted {
                 bail!("marshal actor refused to persist verified block");
             }
-            canonicalized
+
+            // FIXME: move this into the certification step?
+            self.state
+                .executor
+                .canonicalize_head(block_height, block_digest)
+                .await
                 .wrap_err("failed making the verified proposal the head of the canonical chain")?;
         }
         Ok(is_good)

--- a/crates/consensus/src/consensus/application/actor.rs
+++ b/crates/consensus/src/consensus/application/actor.rs
@@ -549,7 +549,7 @@ impl Inner<Init> {
             leader,
         } = args;
 
-        let parent = subscribe(
+        let (parent, parent_origin) = subscribe_with_origin(
             &self.execution_node,
             Round::new(round.epoch(), parent_view),
             parent_digest,
@@ -557,7 +557,7 @@ impl Inner<Init> {
         )
         .await?;
 
-        debug!(height = %parent.height(), "retrieved parent block",);
+        debug!(height = %parent.height(), ?parent_origin, "retrieved parent block",);
 
         let parent_epoch_info = self
             .epoch_strategy
@@ -603,8 +603,11 @@ impl Inner<Init> {
         //
         // If proposing the first block of an epoch, its parent
         // (genesis/boundary block) must exist and be finalized, so we can skip
-        // it.
+        // it. Likewise, if the parent was just read from the execution layer it
+        // has already been executed and validated there, so the engine round
+        // trip is redundant and would eat into the proposal budget.
         if !is_genesis_parent
+            && parent_origin == BlockOrigin::Consensus
             && verify_block(
                 context.clone(),
                 parent_epoch_info.epoch(),
@@ -1156,6 +1159,33 @@ async fn verify_header(
 }
 
 /// Read a block from the execution layer or fetches it from consensus p2p.
+#[instrument(skip_all, fields(%round, %digest), err)]
+async fn subscribe_with_origin(
+    execution_node: &TempoFullNode,
+    round: Round,
+    digest: Digest,
+    marshal: &crate::alias::marshal::Mailbox,
+) -> eyre::Result<(Block, BlockOrigin)> {
+    if let Some(block) = execution_node
+        .provider
+        .find_block_by_hash(digest.0, BlockSource::Any)
+        .wrap_err_with(|| format!("failed querying execution layer for parent block `{digest}`"))?
+    {
+        // EL database reads do not include commonware sidecars.
+        return Ok((
+            Block::from_execution_block_unchecked(block.seal(), None),
+            BlockOrigin::ExecutionLayer,
+        ));
+    }
+    let block = marshal
+        .subscribe_by_digest(Some(round), digest)
+        .await
+        .await
+        .map_err(|_| eyre!("syncer dropped channel before the parent block was sent"))?;
+    Ok((block, BlockOrigin::Consensus))
+}
+
+/// Read a block from the execution layer or fetches it from consensus p2p.
 #[instrument(skip_all, fields(%round, %digest), err, ret(Display))]
 async fn subscribe(
     execution_node: &TempoFullNode,
@@ -1163,21 +1193,20 @@ async fn subscribe(
     digest: Digest,
     marshal: &crate::alias::marshal::Mailbox,
 ) -> eyre::Result<Block> {
-    let block = if let Some(block) = execution_node
-        .provider
-        .find_block_by_hash(digest.0, BlockSource::Any)
-        .wrap_err_with(|| format!("failed querying execution layer for parent block `{digest}`"))?
-    {
-        // EL database reads do not include commonware sidecars.
-        Block::from_execution_block_unchecked(block.seal(), None)
-    } else {
-        marshal
-            .subscribe_by_digest(Some(round), digest)
-            .await
-            .await
-            .map_err(|_| eyre!("syncer dropped channel before the parent block was sent"))?
-    };
-    Ok(block)
+    subscribe_with_origin(execution_node, round, digest, marshal)
+        .await
+        .map(|(block, _)| block)
+}
+
+/// Where a block returned by [`subscribe_with_origin`] was found.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BlockOrigin {
+    /// The block was read from the execution layer, meaning it has already been
+    /// executed and validated there.
+    ExecutionLayer,
+    /// The block was fetched through consensus p2p and is unknown to the local
+    /// execution layer.
+    Consensus,
 }
 
 #[derive(Clone)]

--- a/crates/consensus/src/consensus/application/actor.rs
+++ b/crates/consensus/src/consensus/application/actor.rs
@@ -49,7 +49,7 @@ use tempo_telemetry_util::display_duration;
 use reth_provider::{BlockHashReader as _, BlockReader as _, BlockSource};
 use tempo_payload_types::{
     TempoPayloadAttributes, ValidationLatencyEstimator, ValidationLatencyWorkload,
-    observe_marshal_persist,
+    marshal_persist_estimate, observe_marshal_persist,
 };
 use tempo_primitives::TempoConsensusContext;
 use tracing::{Level, debug, info, info_span, instrument, warn};
@@ -699,6 +699,7 @@ impl Inner<Init> {
 
         let parent_hash = parent.block_hash();
         let proposer_public_key = crate::utils::public_key_to_b256(&self.public_key);
+        let marshal_persist = marshal_persist_estimate();
         // Give the builder only the proposal window that remains when payload
         // construction is requested. This accounts for a late `handle_propose`
         // start instead of resetting the budget at builder entry.
@@ -774,21 +775,22 @@ impl Inner<Init> {
         )
         .wrap_err("payload builder produced an invalid block access list")?;
         let consensus_block_size_bytes = proposal.encode_size();
+        let validator_marshal_persist = marshal_persist.estimate(consensus_block_size_bytes);
         let proposal_elapsed = propose_start.elapsed();
         // Pace proposal return from the original propose start. Validators still
-        // need to repeat replayable build work, so leave room for that cost
-        // before returning the proposal. Validator marshal persistence runs
-        // concurrently with execution-layer validation and is not on their
-        // critical path.
+        // need to repeat replayable build work and marshal persistence, so leave
+        // room for those costs before returning the proposal.
         let return_delay = self
             .proposal_return_budget
             .saturating_sub(proposal_elapsed)
-            .saturating_sub(validation_latency_elapsed);
+            .saturating_sub(validation_latency_elapsed)
+            .saturating_sub(validator_marshal_persist);
         debug!(
             proposal_elapsed = %display_duration(proposal_elapsed),
             build_time = %display_duration(payload_build_elapsed),
             payload_validation_work = %display_duration(payload_validation_work_elapsed),
             validation_latency_time = %display_duration(validation_latency_elapsed),
+            validator_marshal_persist = %display_duration(validator_marshal_persist),
             return_time = %display_duration(return_delay),
             execution_block_rlp_size_bytes,
             consensus_block_size_bytes,

--- a/crates/consensus/src/consensus/application/actor.rs
+++ b/crates/consensus/src/consensus/application/actor.rs
@@ -49,7 +49,7 @@ use tempo_telemetry_util::display_duration;
 use reth_provider::{BlockHashReader as _, BlockReader as _, BlockSource};
 use tempo_payload_types::{
     TempoPayloadAttributes, ValidationLatencyEstimator, ValidationLatencyWorkload,
-    marshal_persist_estimate, observe_marshal_persist,
+    observe_marshal_persist,
 };
 use tempo_primitives::TempoConsensusContext;
 use tracing::{Level, debug, info, info_span, instrument, warn};
@@ -699,7 +699,6 @@ impl Inner<Init> {
 
         let parent_hash = parent.block_hash();
         let proposer_public_key = crate::utils::public_key_to_b256(&self.public_key);
-        let marshal_persist = marshal_persist_estimate();
         // Give the builder only the proposal window that remains when payload
         // construction is requested. This accounts for a late `handle_propose`
         // start instead of resetting the budget at builder entry.
@@ -775,22 +774,21 @@ impl Inner<Init> {
         )
         .wrap_err("payload builder produced an invalid block access list")?;
         let consensus_block_size_bytes = proposal.encode_size();
-        let validator_marshal_persist = marshal_persist.estimate(consensus_block_size_bytes);
         let proposal_elapsed = propose_start.elapsed();
         // Pace proposal return from the original propose start. Validators still
-        // need to repeat replayable build work and marshal persistence, so leave
-        // room for those costs before returning the proposal.
+        // need to repeat replayable build work, so leave room for that cost
+        // before returning the proposal. Validator marshal persistence runs
+        // concurrently with execution-layer validation and is not on their
+        // critical path.
         let return_delay = self
             .proposal_return_budget
             .saturating_sub(proposal_elapsed)
-            .saturating_sub(validation_latency_elapsed)
-            .saturating_sub(validator_marshal_persist);
+            .saturating_sub(validation_latency_elapsed);
         debug!(
             proposal_elapsed = %display_duration(proposal_elapsed),
             build_time = %display_duration(payload_build_elapsed),
             payload_validation_work = %display_duration(payload_validation_work_elapsed),
             validation_latency_time = %display_duration(validation_latency_elapsed),
-            validator_marshal_persist = %display_duration(validator_marshal_persist),
             return_time = %display_duration(return_delay),
             execution_block_rlp_size_bytes,
             consensus_block_size_bytes,

--- a/crates/consensus/src/consensus/block.rs
+++ b/crates/consensus/src/consensus/block.rs
@@ -110,7 +110,7 @@ impl Block {
         let _ = block_access_list;
 
         Self(Arc::new(BlockInner {
-            execution_block,
+            execution_block: Arc::new(execution_block),
             execution_block_encoded_size: OnceLock::new(),
             #[cfg(feature = "bal")]
             block_access_list,
@@ -119,11 +119,18 @@ impl Block {
 
     /// Consumes the block and returns only the execution-layer block.
     pub(crate) fn into_inner(self) -> SealedBlock<tempo_primitives::Block> {
-        self.into_inner_parts().execution_block
+        Arc::unwrap_or_clone(self.into_inner_parts().execution_block)
     }
 
-    /// Consumes the block and returns the execution-layer block plus optional BAL.
-    pub(crate) fn into_parts(self) -> (SealedBlock<tempo_primitives::Block>, Option<Bytes>) {
+    /// Returns a shared handle to the execution-layer block without cloning block data.
+    pub(crate) fn shared_execution_block(&self) -> Arc<SealedBlock<tempo_primitives::Block>> {
+        self.0.execution_block.clone()
+    }
+
+    /// Consumes the block and returns the shared execution-layer block plus optional BAL.
+    pub(crate) fn into_shared_parts(
+        self,
+    ) -> (Arc<SealedBlock<tempo_primitives::Block>>, Option<Bytes>) {
         let inner = self.into_inner_parts();
         (
             inner.execution_block,
@@ -379,8 +386,8 @@ impl commonware_consensus::CertifiableBlock for Block {
 /// Inner block data shared by cheap [`Block`] clones.
 #[derive(Debug)]
 struct BlockInner {
-    /// The execution-layer block.
-    execution_block: SealedBlock<tempo_primitives::Block>,
+    /// The execution-layer block, shared so engine submissions do not clone block data.
+    execution_block: Arc<SealedBlock<tempo_primitives::Block>>,
     /// Cached execution-layer RLP size when it is already known by the caller.
     execution_block_encoded_size: OnceLock<usize>,
     /// Optional block access list. Only provided if the network supports BALs.

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -822,13 +822,13 @@ async fn forward_finalized<TContext: Pacer>(
         .await?;
     }
 
-    let (block, block_access_list) = block.into_parts();
+    let (block, block_access_list) = block.into_shared_parts();
     let consensus_context = block.header().consensus_context;
     let payload_status = execution_node
         .add_ons_handle
         .beacon_engine_handle
         .new_payload(TempoExecutionData {
-            block: Arc::new(block),
+            block,
             block_access_list,
             // can be omitted for finalized blocks
             validator_set: None,

--- a/crates/payload/builder/src/budget.rs
+++ b/crates/payload/builder/src/budget.rs
@@ -8,10 +8,12 @@
 //! through consensus.
 //!
 //! The decision model is:
-//! `leader_idle + predicted_builder_work + predicted_validator_work + 2 * marshal_persist >= budget`.
+//! `leader_idle + setup + predicted_builder_work + predicted_validator_work + marshal_persist >= budget`.
 //! Idle waiting only happens on the proposer. Builder work is projected from the
 //! current build, while validator work uses feedback from previously validated
 //! blocks when available and otherwise falls back to the builder projection.
+//! Marshal persistence is charged once for the proposer; validators persist
+//! concurrently with execution-layer validation, off their critical path.
 
 use std::time::Duration;
 
@@ -79,7 +81,8 @@ pub(crate) struct PayloadBudgetDecision {
 /// The budget is not split into fixed leader/validator buckets. Instead, we
 /// charge proposer idle and setup once, projected builder work once, learned
 /// validator work once capped at the conservative builder-work projection, and
-/// marshal persistence once for each side.
+/// marshal persistence once for the proposer. Validators persist concurrently
+/// with execution-layer validation, so their persist does not consume budget.
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn payload_budget_decision(
     elapsed: Duration,
@@ -105,7 +108,6 @@ pub(crate) fn payload_budget_decision(
         .saturating_add(non_replayable_elapsed)
         .saturating_add(predicted_builder_work)
         .saturating_add(predicted_validator_work)
-        .saturating_add(marshal_persist)
         .saturating_add(marshal_persist);
     PayloadBudgetDecision {
         predicted_builder_work,
@@ -277,7 +279,7 @@ mod tests {
     }
 
     #[test]
-    fn payload_budget_accounts_for_marshal_persist_twice() {
+    fn payload_budget_accounts_for_marshal_persist_once() {
         let marshal_persist = MarshalPersistEstimator::from_ns_per_byte(1_000);
 
         let decision = payload_budget_decision(
@@ -291,7 +293,7 @@ mod tests {
             ValidationLatencyWorkload::default(),
         );
         assert_eq!(decision.marshal_persist, Duration::from_millis(15));
-        assert_eq!(decision.total_reserved, Duration::from_millis(300));
+        assert_eq!(decision.total_reserved, Duration::from_millis(285));
 
         let decision = payload_budget_decision(
             Duration::from_millis(100),
@@ -304,7 +306,7 @@ mod tests {
             ValidationLatencyWorkload::default(),
         );
         assert_eq!(decision.marshal_persist, Duration::from_micros(14_999));
-        assert_eq!(decision.total_reserved, Duration::from_micros(299_998));
+        assert_eq!(decision.total_reserved, Duration::from_micros(284_999));
     }
 
     #[test]

--- a/crates/payload/builder/src/budget.rs
+++ b/crates/payload/builder/src/budget.rs
@@ -8,12 +8,10 @@
 //! through consensus.
 //!
 //! The decision model is:
-//! `leader_idle + setup + predicted_builder_work + predicted_validator_work + marshal_persist >= budget`.
+//! `leader_idle + predicted_builder_work + predicted_validator_work + 2 * marshal_persist >= budget`.
 //! Idle waiting only happens on the proposer. Builder work is projected from the
 //! current build, while validator work uses feedback from previously validated
 //! blocks when available and otherwise falls back to the builder projection.
-//! Marshal persistence is charged once for the proposer; validators persist
-//! concurrently with execution-layer validation, off their critical path.
 
 use std::time::Duration;
 
@@ -81,8 +79,7 @@ pub(crate) struct PayloadBudgetDecision {
 /// The budget is not split into fixed leader/validator buckets. Instead, we
 /// charge proposer idle and setup once, projected builder work once, learned
 /// validator work once capped at the conservative builder-work projection, and
-/// marshal persistence once for the proposer. Validators persist concurrently
-/// with execution-layer validation, so their persist does not consume budget.
+/// marshal persistence once for each side.
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn payload_budget_decision(
     elapsed: Duration,
@@ -108,6 +105,7 @@ pub(crate) fn payload_budget_decision(
         .saturating_add(non_replayable_elapsed)
         .saturating_add(predicted_builder_work)
         .saturating_add(predicted_validator_work)
+        .saturating_add(marshal_persist)
         .saturating_add(marshal_persist);
     PayloadBudgetDecision {
         predicted_builder_work,
@@ -279,7 +277,7 @@ mod tests {
     }
 
     #[test]
-    fn payload_budget_accounts_for_marshal_persist_once() {
+    fn payload_budget_accounts_for_marshal_persist_twice() {
         let marshal_persist = MarshalPersistEstimator::from_ns_per_byte(1_000);
 
         let decision = payload_budget_decision(
@@ -293,7 +291,7 @@ mod tests {
             ValidationLatencyWorkload::default(),
         );
         assert_eq!(decision.marshal_persist, Duration::from_millis(15));
-        assert_eq!(decision.total_reserved, Duration::from_millis(285));
+        assert_eq!(decision.total_reserved, Duration::from_millis(300));
 
         let decision = payload_budget_decision(
             Duration::from_millis(100),
@@ -306,7 +304,7 @@ mod tests {
             ValidationLatencyWorkload::default(),
         );
         assert_eq!(decision.marshal_persist, Duration::from_micros(14_999));
-        assert_eq!(decision.total_reserved, Duration::from_micros(284_999));
+        assert_eq!(decision.total_reserved, Duration::from_micros(299_998));
     }
 
     #[test]

--- a/crates/payload/builder/src/budget.rs
+++ b/crates/payload/builder/src/budget.rs
@@ -65,7 +65,10 @@ pub(crate) struct PayloadBudgetDecision {
 ///
 /// `elapsed` is wall-clock time spent in the builder so far. `idle_elapsed` is
 /// the proposer-only time spent waiting for more transactions, which is not
-/// replayed by validators and therefore counts once.
+/// replayed by validators and therefore counts once. `non_replayable_elapsed`
+/// is proposer-only setup work (state provider setup and pool fetch) that
+/// validators never repeat; it also counts once and is excluded from the
+/// projected replayable work.
 /// `validation_latency` is an estimate of validator-side replay work from
 /// previously validated proposals. If no latency estimate is usable for the
 /// current workload, the validator reserve falls back to
@@ -74,19 +77,23 @@ pub(crate) struct PayloadBudgetDecision {
 /// `current_workload` describes the block currently being assembled.
 ///
 /// The budget is not split into fixed leader/validator buckets. Instead, we
-/// charge proposer idle once, projected builder work once, learned validator
-/// work once capped at the conservative builder-work projection, and marshal
-/// persistence once for each side.
+/// charge proposer idle and setup once, projected builder work once, learned
+/// validator work once capped at the conservative builder-work projection, and
+/// marshal persistence once for each side.
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn payload_budget_decision(
     elapsed: Duration,
     idle_elapsed: Duration,
+    non_replayable_elapsed: Duration,
     multiplier: u64,
     marshal_persist: MarshalPersistEstimator,
     block_size_bytes: usize,
     validation_latency: Option<ValidationLatencyEstimate>,
     current_workload: ValidationLatencyWorkload,
 ) -> PayloadBudgetDecision {
-    let work_elapsed = elapsed.saturating_sub(idle_elapsed);
+    let work_elapsed = elapsed
+        .saturating_sub(idle_elapsed)
+        .saturating_sub(non_replayable_elapsed);
     let predicted_builder_work = scaled_duration(work_elapsed, multiplier);
     let validation_latency_estimate =
         validation_latency.and_then(|estimate| estimate.estimate(current_workload));
@@ -95,6 +102,7 @@ pub(crate) fn payload_budget_decision(
         .unwrap_or(predicted_builder_work);
     let marshal_persist = marshal_persist.estimate(block_size_bytes);
     let total_reserved = idle_elapsed
+        .saturating_add(non_replayable_elapsed)
         .saturating_add(predicted_builder_work)
         .saturating_add(predicted_validator_work)
         .saturating_add(marshal_persist)
@@ -172,6 +180,7 @@ mod tests {
         let decision = payload_budget_decision(
             Duration::from_millis(100),
             Duration::ZERO,
+            Duration::ZERO,
             1_350_000,
             MarshalPersistEstimator::default(),
             0,
@@ -188,6 +197,7 @@ mod tests {
         let decision = payload_budget_decision(
             Duration::from_millis(350),
             Duration::from_millis(250),
+            Duration::ZERO,
             1_350_000,
             MarshalPersistEstimator::default(),
             0,
@@ -203,11 +213,32 @@ mod tests {
     }
 
     #[test]
+    fn payload_budget_accounts_for_non_replayable_setup_once() {
+        let decision = payload_budget_decision(
+            Duration::from_millis(120),
+            Duration::ZERO,
+            Duration::from_millis(20),
+            1_350_000,
+            MarshalPersistEstimator::default(),
+            0,
+            None,
+            ValidationLatencyWorkload::default(),
+        );
+        assert_eq!(decision.predicted_builder_work, Duration::from_millis(135));
+        assert_eq!(
+            decision.predicted_validator_work,
+            Duration::from_millis(135)
+        );
+        assert_eq!(decision.total_reserved, Duration::from_millis(290));
+    }
+
+    #[test]
     fn payload_budget_uses_validator_feedback_when_available() {
         let workload = ValidationLatencyWorkload::new(100, 0);
         let validation_latency = validation_latency_estimate(workload, Duration::from_millis(80));
         let decision = payload_budget_decision(
             Duration::from_millis(100),
+            Duration::ZERO,
             Duration::ZERO,
             1_350_000,
             MarshalPersistEstimator::default(),
@@ -230,6 +261,7 @@ mod tests {
         let decision = payload_budget_decision(
             Duration::from_millis(100),
             Duration::ZERO,
+            Duration::ZERO,
             1_350_000,
             MarshalPersistEstimator::default(),
             0,
@@ -251,6 +283,7 @@ mod tests {
         let decision = payload_budget_decision(
             Duration::from_millis(100),
             Duration::ZERO,
+            Duration::ZERO,
             1_350_000,
             marshal_persist,
             15_000,
@@ -262,6 +295,7 @@ mod tests {
 
         let decision = payload_budget_decision(
             Duration::from_millis(100),
+            Duration::ZERO,
             Duration::ZERO,
             1_350_000,
             marshal_persist,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -510,6 +510,7 @@ where
         debug!("building new payload");
 
         let (roots_tx, roots_rx) = self.spawn_roots_task();
+        let mut roots_tx = RootsFeed::new(roots_tx);
 
         // Prepare system transactions before actual block building and account for their size.
         let prepare_system_txs_start = Instant::now();
@@ -748,7 +749,7 @@ where
 
             pool_transactions_included += 1;
             block_size_used += tx_rlp_length;
-            let _ = roots_tx.send((
+            roots_tx.push((
                 BuilderTx::Pooled(pool_tx),
                 executor.receipts().last().unwrap().clone(),
             ));
@@ -827,7 +828,7 @@ where
                 }
 
                 subblock_tx_count += 1.0;
-                let _ = roots_tx.send((
+                roots_tx.push((
                     BuilderTx::Owned(Box::new(tx)),
                     executor.receipts().last().unwrap().clone(),
                 ));
@@ -867,7 +868,7 @@ where
                 bal_task_handle.bump_bal_index();
             }
 
-            let _ = roots_tx.send((
+            roots_tx.push((
                 BuilderTx::Owned(Box::new(system_tx)),
                 executor.receipts().last().unwrap().clone(),
             ));
@@ -1173,11 +1174,11 @@ where
     fn spawn_roots_task(
         &self,
     ) -> (
-        Sender<(BuilderTx, TempoReceipt)>,
+        Sender<Vec<(BuilderTx, TempoReceipt)>>,
         oneshot::Receiver<(B256, B256, Bloom, Vec<TempoTxEnvelope>, Vec<Address>)>,
     ) {
         let (transactions_tx, transactions_rx) =
-            crossbeam_channel::unbounded::<(BuilderTx, TempoReceipt)>();
+            crossbeam_channel::unbounded::<Vec<(BuilderTx, TempoReceipt)>>();
         let (result_tx, result_rx) = oneshot::channel();
 
         self.executor
@@ -1191,7 +1192,7 @@ where
 
                 let mut buf = Vec::new();
 
-                for (tx, receipt) in transactions_rx.into_iter() {
+                for (tx, receipt) in transactions_rx.into_iter().flatten() {
                     let (tx, sender) = tx.into_parts();
                     buf.clear();
                     tx.encode_2718(&mut buf);
@@ -1253,6 +1254,51 @@ where
             msg_tx: task_tx,
             bal_rx,
         }
+    }
+}
+
+/// Number of executed transactions sent to the roots task per channel message.
+///
+/// Per-transaction sends wake the roots thread for every transaction, which is
+/// measurable at payload sizes of tens of thousands of transactions; batching
+/// amortizes the wakeups while keeping root computation overlapped with execution.
+const ROOTS_BATCH_SIZE: usize = 128;
+
+/// Batches executed transactions before handing them to the roots task.
+///
+/// The final partial batch is flushed on drop, which also disconnects the
+/// channel and lets the roots task finalize.
+struct RootsFeed {
+    tx: Sender<Vec<(BuilderTx, TempoReceipt)>>,
+    buf: Vec<(BuilderTx, TempoReceipt)>,
+}
+
+impl RootsFeed {
+    fn new(tx: Sender<Vec<(BuilderTx, TempoReceipt)>>) -> Self {
+        Self {
+            tx,
+            buf: Vec::with_capacity(ROOTS_BATCH_SIZE),
+        }
+    }
+
+    fn push(&mut self, item: (BuilderTx, TempoReceipt)) {
+        self.buf.push(item);
+        if self.buf.len() >= ROOTS_BATCH_SIZE {
+            self.flush();
+        }
+    }
+
+    fn flush(&mut self) {
+        if !self.buf.is_empty() {
+            let batch = core::mem::replace(&mut self.buf, Vec::with_capacity(ROOTS_BATCH_SIZE));
+            let _ = self.tx.send(batch);
+        }
+    }
+}
+
+impl Drop for RootsFeed {
+    fn drop(&mut self) {
+        self.flush();
     }
 }
 

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -363,9 +363,10 @@ where
             .with_bundle_update()
             .build();
         drop(_state_setup_span);
+        let state_setup_elapsed = state_setup_start.elapsed();
         self.metrics
             .state_setup_duration_seconds
-            .record(state_setup_start.elapsed());
+            .record(state_setup_elapsed);
 
         check_cancel!();
 
@@ -545,9 +546,13 @@ where
         } else {
             Box::new(best_txs)
         });
+        let pool_fetch_elapsed = pool_fetch_start.elapsed();
         self.metrics
             .pool_fetch_duration_seconds
-            .record(pool_fetch_start.elapsed());
+            .record(pool_fetch_elapsed);
+        // Proposer-only setup that validators never replay; charged once in the
+        // budget instead of being projected as replayable builder and validator work.
+        let non_replayable_elapsed = state_setup_elapsed + pool_fetch_elapsed;
 
         let execution_start = Instant::now();
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
@@ -573,6 +578,7 @@ where
                 let budget_decision = payload_budget_decision(
                     elapsed,
                     normal_transaction_fill_idle_elapsed,
+                    non_replayable_elapsed,
                     build_time_multiplier,
                     marshal_persist,
                     block_size_used,
@@ -752,8 +758,9 @@ where
         drop(best_txs);
 
         let elapsed_at_tx_cutoff = start.elapsed();
-        let validation_work_at_tx_cutoff =
-            elapsed_at_tx_cutoff.saturating_sub(normal_transaction_fill_idle_elapsed);
+        let validation_work_at_tx_cutoff = elapsed_at_tx_cutoff
+            .saturating_sub(normal_transaction_fill_idle_elapsed)
+            .saturating_sub(non_replayable_elapsed);
         drop(_block_fill_span);
         self.metrics
             .inc_block_build_stop_reason(block_build_stop_reason);
@@ -1071,7 +1078,9 @@ where
             .set(pool_transactions_inclusion_ratio);
 
         let elapsed = start.elapsed();
-        let validation_work_duration = elapsed.saturating_sub(normal_transaction_fill_idle_elapsed);
+        let validation_work_duration = elapsed
+            .saturating_sub(normal_transaction_fill_idle_elapsed)
+            .saturating_sub(non_replayable_elapsed);
         if payload_build_budget.is_some() {
             self.update_build_time_multiplier(
                 validation_work_duration,

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -129,8 +129,10 @@ impl BestTransactionsPrewarming {
 
             // Fill the initial batch of transactions to execute and prewarm.
             //
-            // We schedule 2x the number of threads to make sure that workers are never idle.
-            for _ in 0..pool.current_num_threads() * 2 {
+            // We schedule 4x the number of threads so that workers are never idle and
+            // the builder-facing buffer absorbs prewarm latency variance (cold state
+            // reads) without starving the execution loop.
+            for _ in 0..pool.current_num_threads() * 4 {
                 advance(&mut ctx);
             }
 
@@ -982,7 +984,7 @@ mod tests {
     fn prewarming_eagerly_drains_source_iterator() {
         let sender = Address::random();
         let executor = TaskExecutor::test();
-        let txs = (0..executor.prewarming_pool().current_num_threads() * 2 + 4)
+        let txs = (0..executor.prewarming_pool().current_num_threads() * 4 + 4)
             .map(|nonce| test_tx(sender, nonce as u64))
             .collect::<Vec<_>>();
         let expected = txs.iter().map(|tx| *tx.hash()).collect::<Vec<_>>();
@@ -1000,7 +1002,7 @@ mod tests {
     #[test]
     fn empty_source_is_polled_for_eager_advances_and_each_consumer_advance() {
         let executor = TaskExecutor::test();
-        let eager_advances = executor.prewarming_pool().current_num_threads() * 2;
+        let eager_advances = executor.prewarming_pool().current_num_threads() * 4;
         let log = Arc::new(Mutex::new(TestLog::default()));
         let mut prewarming = prewarming_with_executor(executor, Vec::new(), log.clone());
 

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -45,6 +45,15 @@ type PoolUpdateResult = (
 /// snapshot keeps its cost proportional to block capacity instead of pool capacity and
 /// shortens how long the pool read lock is held while block building starts.
 const EXPIRING_NONCE_SNAPSHOT_LIMIT: usize = 32_768;
+
+/// Capacity of the new-pending-transaction broadcast feed consumed by active
+/// best-transactions iterators.
+///
+/// At saturation the pool ingests tens of thousands of transactions per second; a small
+/// buffer means any gap in iterator polling overflows the channel and silently drops
+/// feed entries (`Lagged`), starving the payload build of supply until the next
+/// snapshot. Sized to hold several blocks worth of arrivals.
+const NEW_TRANSACTION_FEED_CAPACITY: usize = 65_536;
 /// A sub-pool that keeps track of 2D nonce transactions.
 ///
 /// It maintains both pending and queued transactions.
@@ -139,7 +148,7 @@ impl Default for AA2dPool {
 impl AA2dPool {
     /// Creates a new instance with the givenconfig and nonce keys
     pub fn new(config: AA2dPoolConfig) -> Self {
-        let (new_transaction_notifier, _) = broadcast::channel(200);
+        let (new_transaction_notifier, _) = broadcast::channel(NEW_TRANSACTION_FEED_CAPACITY);
         Self {
             submission_id: 0,
             independent_transactions: Default::default(),

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -186,21 +186,20 @@ impl AA2dPool {
     }
 
     fn rebuild_eviction_order(&mut self) {
-        self.by_eviction_order.clear();
-        for (id, tx) in &self.by_id {
-            self.by_eviction_order.insert(EvictionKey::with_base_fee(
-                Arc::clone(tx),
-                *id,
-                self.base_fee,
-            ));
-        }
+        // Collecting bulk-builds the sets from sorted input instead of doing one
+        // tree insertion per transaction, which matters because this runs on every
+        // base fee change while holding the pool write lock.
+        self.by_eviction_order = self
+            .by_id
+            .iter()
+            .map(|(id, tx)| EvictionKey::with_base_fee(Arc::clone(tx), *id, self.base_fee))
+            .collect();
 
-        self.expiring_nonce_eviction_order.clear();
-        for tx in self.expiring_nonce_txs.values() {
-            self.expiring_nonce_eviction_order.insert(
-                ExpiringNonceEvictionKey::from_pending_with_base_fee(tx, self.base_fee),
-            );
-        }
+        self.expiring_nonce_eviction_order = self
+            .expiring_nonce_txs
+            .values()
+            .map(|tx| ExpiringNonceEvictionKey::from_pending_with_base_fee(tx, self.base_fee))
+            .collect();
     }
 
     /// Entrypoint for adding a 2d AA transaction.
@@ -671,15 +670,22 @@ impl AA2dPool {
                     .collect()
             }
         } else {
+            // Re-key at the requested base fee, but only the best slice of the
+            // current eviction order instead of the entire pool. A uniform base
+            // fee shift rarely reorders transactions enough for the best ones to
+            // fall outside a 2x oversampled prefix, and this snapshot is a
+            // heuristic to begin with.
             let mut keys = self
-                .expiring_nonce_txs
-                .values()
-                .map(|tx| ExpiringNonceEvictionKey::from_pending_with_base_fee(tx, base_fee))
+                .expiring_nonce_eviction_order
+                .iter()
+                .rev()
+                .take(EXPIRING_NONCE_SNAPSHOT_LIMIT * 2)
+                .map(|key| key.rekeyed_with_base_fee(base_fee))
                 .collect::<Vec<_>>();
             if keys.len() > EXPIRING_NONCE_SNAPSHOT_LIMIT {
                 // Keep only the highest-priority transactions; `select_nth_unstable`
-                // partitions in linear time so the cost stays bounded by pool size
-                // without a full sort.
+                // partitions in linear time so the cost stays bounded without a
+                // full sort.
                 let cut = keys.len() - EXPIRING_NONCE_SNAPSHOT_LIMIT;
                 keys.select_nth_unstable(cut - 1);
                 keys.drain(..cut);
@@ -1857,6 +1863,17 @@ impl ExpiringNonceEvictionKey {
         Self {
             order: EvictionOrderKey::new(tx.priority, tx.submission_id),
             transaction: tx.transaction,
+        }
+    }
+
+    /// Returns a copy of this key with its priority recomputed at `base_fee`.
+    fn rekeyed_with_base_fee(&self, base_fee: u64) -> Self {
+        Self {
+            order: EvictionOrderKey::new(
+                TempoTipOrdering::default().priority(&self.transaction.transaction, base_fee),
+                self.order.submission_id,
+            ),
+            transaction: self.transaction.clone(),
         }
     }
 

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -37,6 +37,14 @@ type PoolUpdateResult = (
     Vec<Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
     Vec<Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
 );
+
+/// Maximum number of expiring nonce transactions included in a best-transactions snapshot.
+///
+/// A snapshot only needs to cover what a single payload build can consume (with headroom);
+/// transactions arriving later stream in through the new-transaction feed. Bounding the
+/// snapshot keeps its cost proportional to block capacity instead of pool capacity and
+/// shortens how long the pool read lock is held while block building starts.
+const EXPIRING_NONCE_SNAPSHOT_LIMIT: usize = 32_768;
 /// A sub-pool that keeps track of 2D nonce transactions.
 ///
 /// It maintains both pending and queued transactions.
@@ -644,12 +652,39 @@ impl AA2dPool {
     #[expect(clippy::mutable_key_type)]
     pub(crate) fn best_transactions_with_base_fee(&self, base_fee: u64) -> BestAA2dTransactions {
         let expiring_nonce_order = if base_fee == self.base_fee {
-            self.expiring_nonce_eviction_order.clone()
+            if self.expiring_nonce_eviction_order.len() <= EXPIRING_NONCE_SNAPSHOT_LIMIT {
+                self.expiring_nonce_eviction_order.clone()
+            } else {
+                // Only snapshot the best transactions instead of cloning the entire
+                // eviction set, which scales with pool capacity (hundreds of thousands
+                // of transactions at saturation) while a block can only ever include a
+                // fraction of that. Collect descending, then reverse so the set is
+                // bulk-built from ascending input.
+                self.expiring_nonce_eviction_order
+                    .iter()
+                    .rev()
+                    .take(EXPIRING_NONCE_SNAPSHOT_LIMIT)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .rev()
+                    .collect()
+            }
         } else {
-            self.expiring_nonce_txs
+            let mut keys = self
+                .expiring_nonce_txs
                 .values()
                 .map(|tx| ExpiringNonceEvictionKey::from_pending_with_base_fee(tx, base_fee))
-                .collect()
+                .collect::<Vec<_>>();
+            if keys.len() > EXPIRING_NONCE_SNAPSHOT_LIMIT {
+                // Keep only the highest-priority transactions; `select_nth_unstable`
+                // partitions in linear time so the cost stays bounded by pool size
+                // without a full sort.
+                let cut = keys.len() - EXPIRING_NONCE_SNAPSHOT_LIMIT;
+                keys.select_nth_unstable(cut - 1);
+                keys.drain(..cut);
+            }
+            keys.into_iter().collect()
         };
         let independent = self
             .independent_transactions


### PR DESCRIPTION
Targets tip20 TPS by trimming per-block overheads on the proposer and validator hot paths and keeping the builder supplied with transactions; none of the changes touch execution semantics.

Building a payload snapshotted the AA 2D pool by cloning the entire expiring nonce eviction set under the pool read lock. That cost scales with pool capacity (200k transactions in bench setups) rather than block capacity, and it also stalls transaction ingestion while held. The snapshot is now bounded to the best 32768 transactions, with later arrivals still streaming in through the live feed. Base fee movement made this worse: whenever blocks run above the gas target the base fee changes every block, which rebuilt both eviction sets with one tree insertion per transaction under the pool write lock and re-keyed the entire expiring nonce set for every snapshot. The eviction sets are now bulk-built via collect, and snapshots at a different base fee re-key only a 2x oversampled prefix of the existing eviction order.

The live feed itself held only 200 entries, under 10ms of arrivals at saturation, so any gap in iterator polling overflowed the channel and silently dropped feed entries, starving late-block fill. It now holds several blocks worth of arrivals, and prewarming lookahead is deepened from 2x to 4x worker threads so prewarm latency variance no longer propagates into builder stalls.

The build budget treated state provider setup and pool fetch as replayable work, projecting them with the build time multiplier on both the builder and validator side even though validators never repeat them. They are now charged once, which lets transaction fill run correspondingly longer within the same proposal budget. Executed transactions are handed to the roots task in batches of 128 instead of one channel send (and receiver wakeup) per transaction.

On the consensus side, submitting a block to the engine deep-cloned all transactions because marshal retains the consensus block, so unwrapping the inner Arc always fell back to a clone. The execution block now lives behind its own Arc and is handed to the engine directly, on both the verification path and the finalized block dispatch. Validators also persist blocks in marshal concurrently with execution layer validation instead of afterwards: the cache is digest-addressed and duplicate puts are no-ops, so an invalid block only leaves a prunable cache entry while voting stays gated on the validation result.

Derek across four run-pairs=2 runs of this branch family: TPS +1.5% to +3.2% (significant in every run), block time +0.4% to +1.0% as fill runs closer to the proposal budget; in the best-balanced run (+2.06% TPS) all block time percentiles were within the no-difference floor. Fill idle measurements show the builder is now frequently supply-bound (pool ingestion ~22k tx/s), so further gains stack with the txpool ingestion work (#5598, #5614, #5572) once the tombstone eviction strategy is reconciled with the bounded snapshot, and with per-transaction execution cost reductions (reward-slot read elision is gas-charged and therefore hardfork-gated; the per-account-load boxing in alloy-evm's EvmInternals is an upstream change).