### PR TITLE
test(amm): keep required liquidity burn check priced

### DIFF
--- a/crates/node/tests/it/tip_fee_amm.rs
+++ b/crates/node/tests/it/tip_fee_amm.rs
@@ -839,6 +839,7 @@ async fn test_cant_burn_required_liquidity() -> eyre::Result<()> {
             alice,
         )
         .max_fee_per_gas(TEMPO_T1_BASE_FEE as u128 * 100)
+        .max_priority_fee_per_gas(TEMPO_T1_BASE_FEE as u128 * 99)
         .gas(1000000)
         .send()
         .await?


### PR DESCRIPTION
## Summary
- Set an explicit priority fee on `test_cant_burn_required_liquidity` burn tx.
- Keeps the fee-swap reservation large enough under TIP-1067 dynamic base fees so the test continues to assert the intended invariant.

## Why
The mutation coverage job failed in `coverage` with `tip_fee_amm::test_cant_burn_required_liquidity`: the burn receipt succeeded when the test expected it to fail. Under dynamic base fees, `max_fee_per_gas` alone can leave the tx with a lower effective gas price than the test assumed.

## Verification
- `cargo test -p tempo-node --test it tip_fee_amm::test_cant_burn_required_liquidity -- --nocapture`
- `cargo +nightly fmt --check`