### PR TITLE
ci(bench): use existing recipients preset, multiple TIP-20 tokens

### DIFF
--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -1,6 +1,6 @@
 # Scheduled e2e regression benchmarks.
 #
-# Runs nightly at 02:00 UTC and on v*.*.* tag pushes for the tip20 preset.
+# Runs nightly at 02:00 UTC and on v*.*.* tag pushes for each preset below.
 # Nightly runs compare the latest main commit against the
 # last commit that completed this scheduled e2e workflow successfully for the
 # same preset.
@@ -58,7 +58,7 @@ jobs:
           INPUT_FORCE: ${{ inputs.force || 'false' }}
           INPUT_REF: ${{ inputs.ref || '' }}
         run: |
-          presets=(tip20)
+          presets=(tip20 tip20_existing_recipients)
           bench_entries=()
           save_entries=()
           stale_presets=()

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -55,7 +55,7 @@ on:
         description: Benchmark preset.
         type: choice
         required: true
-        default: tip20
+        default: tip20_existing_recipients
         options:
           - tip20
           - tip20_2d_nonces
@@ -178,7 +178,7 @@ on:
       preset:
         type: string
         required: false
-        default: tip20
+        default: tip20_existing_recipients
       duration:
         type: string
         required: false

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1160,7 +1160,7 @@ def "main summarize" [
 def "main e2e" [
     --baseline: string                                  # Baseline git SHA/ref
     --feature: string                                   # Feature git SHA/ref
-    --preset: string = ""                               # Txgen preset name
+    --preset: string = "tip20_existing_recipients"      # Txgen preset name
     --tps: int = 50000                                  # Target TPS
     --duration: int = 90                                # Duration in seconds
     --summary-warmup-blocks: int = 5                    # Initial blocks per run excluded from summary metrics

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1160,7 +1160,7 @@ def "main summarize" [
 def "main e2e" [
     --baseline: string                                  # Baseline git SHA/ref
     --feature: string                                   # Feature git SHA/ref
-    --preset: string = "tip20_existing_recipients"      # Txgen preset name
+    --preset: string = ""                               # Txgen preset name
     --tps: int = 50000                                  # Target TPS
     --duration: int = 90                                # Duration in seconds
     --summary-warmup-blocks: int = 5                    # Initial blocks per run excluded from summary metrics

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -7,6 +7,22 @@ const TXGEN_HELPER_PRESETS_DIR = "contrib/bench/txgen/presets"
 const TXGEN_HELPER_EXISTING_RECIPIENTS_PRESETS = ["tip20_existing_recipients" "tip20_2d_nonces"]
 const TXGEN_HELPER_EXISTING_RECIPIENTS_START = 10000
 
+def txgen-tip20-token-address [token_id: int] {
+    ^printf "0x20c000000000000000000000%016x" $token_id
+}
+
+def txgen-tip20-token-choices [token_count: int] {
+    if $token_count <= 0 {
+        error make { msg: "TIP20 token count must be greater than zero" }
+    }
+
+    0..<$token_count | each { |id| txgen-tip20-token-address $id } | to json -r
+}
+
+def --env txgen-configure-tip20-token-env [token_count: int] {
+    $env.TXGEN_TIP20_TOKENS = (txgen-tip20-token-choices $token_count)
+}
+
 def txgen-shell-quote [value: any] {
     let s = ($value | into string)
     let escaped = ($s | str replace -a "'" "'\"'\"'")
@@ -258,6 +274,7 @@ def txgen-run-preset-pipeline [
     if not ($spec_path | path exists) {
         error make { msg: $"txgen preset file not found: ($spec_path)" }
     }
+    txgen-configure-tip20-token-env $bloat_token_count
     txgen-configure-existing-recipients-env $spec_path $bloat_mib $bloat_token_count
     if not $skip_funding {
         txgen-fund-accounts $txgen_tempo_bin $spec_path $generate_rpc_url

--- a/contrib/bench/txgen/presets/mix.yml
+++ b/contrib/bench/txgen/presets/mix.yml
@@ -88,7 +88,8 @@ templates:
     expiring_nonce: true
     valid_for_secs: 25
     call:
-      to: "0x20c0000000000000000000000000000000000000"
+      to:
+        choice: ${TXGEN_TIP20_TOKENS}
       abi: ERC20
       function: transfer
       args:

--- a/contrib/bench/txgen/presets/tip20.yml
+++ b/contrib/bench/txgen/presets/tip20.yml
@@ -27,7 +27,8 @@ templates:
     expiring_nonce: true
     valid_for_secs: 5
     call:
-      to: "0x20c0000000000000000000000000000000000000"
+      to:
+        choice: ${TXGEN_TIP20_TOKENS}
       abi: ERC20
       function: transfer
       args:
@@ -39,4 +40,3 @@ templates:
 mix:
   - template: tip20_transfer
     weight: 100
-

--- a/contrib/bench/txgen/presets/tip20_2d_nonces.yml
+++ b/contrib/bench/txgen/presets/tip20_2d_nonces.yml
@@ -35,7 +35,8 @@ templates:
     nonce_key:
       uniform: [1, 18446744073709551615]
     call:
-      to: "0x20c0000000000000000000000000000000000000"
+      to:
+        choice: ${TXGEN_TIP20_TOKENS}
       abi: ERC20
       function: transfer
       args:

--- a/contrib/bench/txgen/presets/tip20_existing_recipients.yml
+++ b/contrib/bench/txgen/presets/tip20_existing_recipients.yml
@@ -35,7 +35,8 @@ templates:
     expiring_nonce: true
     valid_for_secs: 5
     call:
-      to: "0x20c0000000000000000000000000000000000000"
+      to:
+        choice: ${TXGEN_TIP20_TOKENS}
       abi: ERC20
       function: transfer
       args:

--- a/contrib/bench/txgen/presets/tip20_random_recipients.yml
+++ b/contrib/bench/txgen/presets/tip20_random_recipients.yml
@@ -27,7 +27,8 @@ templates:
     expiring_nonce: true
     valid_for_secs: 5
     call:
-      to: "0x20c0000000000000000000000000000000000000"
+      to:
+        choice: ${TXGEN_TIP20_TOKENS}
       abi: ERC20
       function: transfer
       args:

--- a/tempo.nu
+++ b/tempo.nu
@@ -728,6 +728,7 @@ def run-bench-single [
             --git-ref $git_ref
             --build-profile $build_profile
             --benchmark-mode $benchmark_mode
+            --bloat-token-count ($TIP20_TOKEN_IDS | length)
             --skip-funding=($bloat > 0))
         if not $result.ok {
             print $"  Benchmark run ($run_label) failed with exit code ($result.exit_code)"
@@ -2911,6 +2912,7 @@ def "main bench" [
             --git-ref $current_sha
             --build-profile $profile
             --benchmark-mode $mode
+            --bloat-token-count ($TIP20_TOKEN_IDS | length)
             --skip-funding=($bloat > 0))
         $result
     } catch { |e|
@@ -3323,7 +3325,8 @@ tempo-precompiles = { path = '($tempo_root)/crates/precompiles' }
                         --accounts $accounts
                         --max-concurrent-requests 100
                         --build-profile "coverage"
-                        --benchmark-mode "coverage")
+                        --benchmark-mode "coverage"
+                        --bloat-token-count ($TIP20_TOKEN_IDS | length))
                     if not $bench_result.ok {
                         print "Bench finished (or interrupted)."
                     }


### PR DESCRIPTION
Summary
- Route TIP20 benchmark transfers through a generated token address set instead of a single fixed recipient.
- Default the e2e benchmark preset to `tip20_existing_recipients` and pass the token count through the bench pipeline so all TIP20 presets share the same recipient pool.

Testing
- Not run (not requested)