### PR TITLE
perf(precompiles): allocation-free EvmInternals account access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,8 +393,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
+source = "git+https://github.com/mattsse/evm?branch=matt%2Fevm-internals-with-account#3acd666305c2664c8a578991163ae38477b4a4a1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -399,6 +399,10 @@ vergen-git2 = "9.1.0"
 # reth-trie-sparse = { path = "../reth/crates/trie/sparse" }
 
 [patch.crates-io]
+# Benchmarking allocation-free EvmInternals::with_account_mut API.
+# Tracks https://github.com/mattsse/evm/tree/matt/evm-internals-with-account
+alloy-evm = { git = "https://github.com/mattsse/evm", branch = "matt/evm-internals-with-account" }
+
 # Commonware at HEAD after PR #3588 was merged
 commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -113,12 +113,14 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
         // Track state gas for code deposit
         self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
 
-        let was_empty = {
-            let mut account = self.internals.load_account_mut(address)?;
-            let was_empty = account.data.account().info.is_empty();
-            account.set_code_and_hash_slow(code);
-            was_empty
-        };
+        let was_empty = self
+            .internals
+            .with_account_mut(address, |account| {
+                let was_empty = account.account().info.is_empty();
+                account.set_code_and_hash_slow(code);
+                was_empty
+            })?
+            .data;
 
         // TIP-1016: charge TIP20 deployments as CREATE.
         if self.amsterdam_eip8037_enabled && was_empty {
@@ -183,11 +185,16 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
             false
         };
 
-        let result = self.internals.load_account_mut(address)?.sstore(
-            key,
-            value,
-            insufficient_gas_for_cold_load,
-        )?;
+        let result = self
+            .internals
+            .try_with_account_mut(address, |account| {
+                Ok::<_, TempoPrecompileError>(account.sstore(
+                    key,
+                    value,
+                    insufficient_gas_for_cold_load,
+                )?)
+            })?
+            .data;
 
         if !self.spec.is_t4() {
             self.deduct_gas(self.gas_params.sstore_static_gas())?;
@@ -249,15 +256,13 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
             false
         };
 
-        let value;
-        let is_cold;
-        {
-            let mut account = self.internals.load_account_mut(address)?;
-            let val = account.sload(key, insufficient_gas_for_cold_load)?;
-
-            value = val.present_value;
-            is_cold = val.is_cold;
-        };
+        let (value, is_cold) = self
+            .internals
+            .try_with_account_mut(address, |account| {
+                let val = account.sload(key, insufficient_gas_for_cold_load)?;
+                Ok::<_, TempoPrecompileError>((val.present_value, val.is_cold))
+            })?
+            .data;
 
         if !self.spec.is_t4() {
             self.deduct_gas(self.gas_params.warm_storage_read_cost())?;


### PR DESCRIPTION
Benchmarks the allocation-free account access API added in alloy-evm (mattsse/evm#matt/evm-internals-with-account).

Loading a journaled account through `EvmInternals` previously boxed the journal's GAT-typed account on every access — one heap allocation per `sload`/`sstore`/`set_code`. The new `with_account_mut` / `try_with_account_mut` visitor methods pass the account to a closure as a stack `&mut dyn JournaledAccountTr` instead, so no allocation is needed.

This PR patches `alloy-evm` to that branch and migrates the hot storage paths in `EvmPrecompileStorageProvider` (`sload`, `sstore`, `set_code`) to the visitor API. `with_account_info` is left on the boxed API for now because its gas accounting needs the cold-load flag in between loading the account and loading its code, which the visitor doesn't expose.

Draft for benchmarking only — the `alloy-evm` git patch must be replaced with a released version before merge.

ref #5132