### PR TITLE
docs(tip-1060): add storage credit budget

### DIFF
--- a/tips/tip-1060.md
+++ b/tips/tip-1060.md
@@ -12,7 +12,7 @@ protocolVersion: T7
 
 ## Abstract
 
-This TIP introduces *storage credits*: a per-account counter that increments whenever the account deletes one of its own storage slots and that can later offset most of the TIP-1000 storage creation cost (250,000 gas per zero-to-nonzero SSTORE) when the same account creates a new slot. A single credit has a *storage credit value* of 230,000 gas; the remaining 20,000 gas of the TIP-1000 creation cost is always charged, so using one credit to create a slot costs 20,000 gas rather than nothing. Each account chooses, via a new precompile, one of three storage creation modes: `Refund` (pay the full TIP-1000 cost upfront; at end-of-transaction, each refund-eligible creation is matched against the account's then-current credit balance to grant a 230,000-gas refund per credit consumed), `Preserve` (always pay the full cost, never consume credits), or `Direct` (when a credit is available, consume it synchronously so only the 20,000-gas residual is charged instead of the full 250,000-gas cost). The selected mode is held in transient storage: it defaults to `Refund` at the start of every transaction and must be re-selected within a transaction to use `Preserve` or `Direct`. Only the credit balance is persistent.
+This TIP introduces *storage credits*: a per-account counter that increments whenever the account deletes one of its own storage slots and that can later offset most of the TIP-1000 storage creation cost (250,000 gas per zero-to-nonzero SSTORE) when the same account creates a new slot. A single credit has a *storage credit value* of 230,000 gas; the remaining 20,000 gas of the TIP-1000 creation cost is always charged, so using one credit to create a slot costs 20,000 gas rather than nothing. Each account chooses, via a new precompile, one of three storage creation modes: `Refund` (pay the full TIP-1000 cost upfront; at end-of-transaction, each refund-eligible creation is matched against the account's then-current credit balance to grant a 230,000-gas refund per credit consumed), `Preserve` (always pay the full cost, never consume credits), or `Direct` (when a credit is available, consume it synchronously so only the 20,000-gas residual is charged instead of the full 250,000-gas cost). `Direct` mode also has a transaction-local direct-spend budget that caps how many credits may be consumed synchronously. Calling `setBudget(budget)` selects `Direct` mode with that budget; when the budget reaches zero, the protocol automatically switches the account to `Preserve`. `Direct` is useful for contracts that maintain their own per-user credit attribution and want to offer targeted refunds to the users whose operations are known to have reserved credits. The selected mode, Direct budget, and pending refund count are held in transient storage and default to `Refund`, zero, and zero at the start of every transaction. Only the credit balance is persistent.
 
 This TIP also removes the pre-existing storage-clearing gas refund (the gas refund granted when a nonzero storage slot is set to zero), replacing it with the storage credit minted on deletion. After this TIP, storage credit settlement is the only mechanism by which storage operations affect the transaction's gas refund counter, and the standard EVM refund cap (one fifth of gas used) no longer applies.
 
@@ -36,10 +36,11 @@ TIP-1000 makes net-new storage creation expensive to protect Tempo from state gr
 - **Storage deletion**: A storage slot transition from nonzero to zero in storage owned by some account.
 - **TIP-1000 storage creation cost**: The 250,000-gas state-creation component charged by TIP-1000 on every zero-to-nonzero SSTORE, separate from the EIP-2929 access cost (2,100 gas cold, 100 gas warm) and any other base SSTORE gas. References elsewhere in this TIP to "the TIP-1000 storage creation cost", "the TIP-1000 creation cost", or "the TIP-1000 storage creation component" all denote this same 250,000-gas component. Storage credits offset only part of this component (see *Storage credit value*); the EIP-2929 and base SSTORE gas remain payable in full.
 - **Storage credit value**: The fixed amount, 230,000 gas, that a single storage credit offsets from the TIP-1000 storage creation cost. Because the credit (230,000) is less than the full TIP-1000 creation cost (250,000), a 20,000-gas residual of that component is always charged even when a credit is applied. Consuming one credit to create a slot therefore costs 20,000 gas of the TIP-1000 component rather than the full 250,000 gas.
-- **Storage creation mode**: A per-account selection of one of the three modes below (`Refund`, `Preserve`, or `Direct`), held in transient storage. It is *not* persisted across transactions: it defaults to `Refund` at the start of every transaction, is cleared at end-of-transaction, and is journaled with EVM scopes (so a `setMode` write reverts with the call frame that made it, per EIP-1153 transient storage semantics).
+- **Storage creation mode**: A per-account selection of one of the three modes below (`Refund`, `Preserve`, or `Direct`), held in transient storage. It is *not* persisted across transactions: it defaults to `Refund` at the start of every transaction, is cleared at end-of-transaction, and is journaled with EVM scopes (so a `setMode` or `setBudget` write reverts with the call frame that made it, per EIP-1153 transient storage semantics).
+- **Direct-spend budget**: A per-account transaction-local `uint64` counter associated with `Direct` mode. It caps how many credits may be consumed synchronously by `Direct`-mode storage creations after an explicit `setBudget` call. The budget defaults to zero at the start of every transaction and is ignored unless the account is in `Direct` mode. Calling `setMode(Direct)` sets the budget to `type(uint64).max`, which is treated as effectively unlimited. When a storage credit is consumed in `Direct` mode, the budget is decremented by one unless it is already `type(uint64).max`. If the budget reaches zero after a `Direct`-mode consumption, the protocol automatically switches the account to `Preserve` mode.
 - **Refund-credit mode**: The default storage creation mode. Each storage creation pays the full TIP-1000 creation cost upfront and increments a transaction-local *pending refund-eligible creation* counter for the storage-owning account. At end-of-transaction, the protocol matches each pending refund-eligible creation against the account's storage credit balance (as it stands at end-of-transaction, after all in-transaction deletions and mode changes) and credits a refund of one storage credit value (230,000 gas) per credit consumed.
 - **Preserve-credit mode**: A storage creation mode in which storage creation always pays the full TIP-1000 creation cost and leaves the storage credit balance unchanged.
-- **Direct-credit mode**: A storage creation mode in which, if a storage credit is available, one credit is consumed and one storage credit value (230,000 gas) is deducted from the TIP-1000 storage creation cost, leaving the 20,000-gas residual to be charged.
+- **Direct-credit mode**: A storage creation mode in which, if a storage credit is available and the account's Direct budget is nonzero, one credit is consumed, the budget is decremented by one, and one storage credit value (230,000 gas) is deducted from the TIP-1000 storage creation cost, leaving the 20,000-gas residual to be charged.
 - **Pending refund-eligible creation**: A `Refund`-mode storage creation that has not yet been redeemed for a refund. Counted per account, transaction-local, journaled with EVM scopes, and reset to zero at the start of each transaction.
 - **Storage Credits precompile**: The protocol precompile, defined below, through which accounts read their balance and set their storage creation mode.
 
@@ -68,20 +69,27 @@ Reserved bits MUST be written as zero by this TIP. Future TIPs MAY assign reserv
 
 Each account's `storage_credit_state` word is the only persistent slot this TIP introduces, and it is first written when the account mints its first storage credit, i.e., when it deletes one of its own nonzero storage slots. Writes whose storage owner is `STORAGE_CREDITS_ADDRESS`, including the first nonzero write that creates an account's `storage_credit_state` slot, MUST be journaled as ordinary protocol state but MUST NOT incur the 250,000-gas TIP-1000-mandated storage creation cost. Implementations MUST only charge ordinary protocol gas for the backing state write, such as the non-creating update/reset cost when a value changes. These writes also MUST NOT be treated as TIP-1060 storage-credit events: they MUST NOT themselves mint or consume storage credits and MUST NOT increment `pending_refund_eligible_creations`.
 
-This exemption is not a discount for arbitrary user storage. It waives only the extra 250,000-gas storage-creation component for the protocol metadata slot that tracks an account's credit balance. That slot is only ever created as a side effect of the account deleting one of its own pre-existing nonzero storage slots — storage for which the account already paid the full TIP-1000 creation cost. An account therefore cannot create a credit-balance slot without simultaneously removing a previously paid slot, so the exemption cannot be used to grow net state cheaply: minting requires pre-existing paid storage to delete, and mass creation of credit-balance slots is bounded by the cost already paid for the slots being deleted. Because the storage creation mode now lives in transient storage, `setMode` creates no persistent slot and contributes nothing to this footprint.
+This exemption is not a discount for arbitrary user storage. It waives only the extra 250,000-gas storage-creation component for the protocol metadata slot that tracks an account's credit balance. That slot is only ever created as a side effect of the account deleting one of its own pre-existing nonzero storage slots — storage for which the account already paid the full TIP-1000 creation cost. An account therefore cannot create a credit-balance slot without simultaneously removing a previously paid slot, so the exemption cannot be used to grow net state cheaply: minting requires pre-existing paid storage to delete, and mass creation of credit-balance slots is bounded by the cost already paid for the slots being deleted. Because the storage creation mode and Direct budget live in transient storage, `setMode` and `setBudget` create no persistent slot and contribute nothing to this footprint.
 
 ### Transaction-local (transient) state
 
-The protocol MUST maintain the following transaction-local state in transient storage. Neither mapping is persisted across transactions:
+The protocol MUST maintain the following transaction-local state in transient storage. The mapping is not persisted across transactions:
 
 ```text
-storage_creation_mode:             mapping(address account => uint8)   // 0=Refund, 1=Preserve, 2=Direct, 3=reserved
-pending_refund_eligible_creations: mapping(address account => uint64)
+storage_credit_transient_state:    mapping(address account => TransientState)
+
+struct TransientState {
+    uint64 budget;          // remaining direct-spend budget; default 0
+    uint8 mode;             // 0=Refund, 1=Preserve, 2=Direct, 3=reserved
+    uint64 pending_refunds; // pending refund-eligible creations; default 0
+}
 ```
 
-Both mappings are initialized to their zero/default value at the start of every transaction and discarded at end-of-transaction. `storage_creation_mode` therefore defaults to `Refund` (`0`) for every account at the start of each transaction. Both are journaled with EVM scopes — a write reverts with the call frame that made it under normal EVM revert semantics, exactly like EIP-1153 transient storage — and `pending_refund_eligible_creations` is consulted only by the end-of-transaction settlement procedure defined below.
+The mapping is initialized to its default values at the start of every transaction and discarded at end-of-transaction. `storage_credit_transient_state[account].mode` defaults to `Refund` (`0`), `storage_credit_transient_state[account].budget` defaults to zero, and `storage_credit_transient_state[account].pending_refunds` defaults to zero. All fields are journaled with EVM scopes — a write reverts with the call frame that made it under normal EVM revert semantics, exactly like EIP-1153 transient storage — and `pending_refunds` is consulted only by the end-of-transaction settlement procedure defined below.
 
 The `storage_creation_mode` value `3` is reserved; clients MUST treat it as invalid until a future hardfork assigns it semantics, and `setMode` MUST reject it (see the precompile behavior).
+
+For readability, the rest of this TIP refers to `storage_creation_mode[A]`, `storage_credit_budget[A]`, and `pending_refund_eligible_creations[A]` as aliases for `storage_credit_transient_state[A].mode`, `storage_credit_transient_state[A].budget`, and `storage_credit_transient_state[A].pending_refunds`.
 
 ## Storage Credit Minting
 
@@ -109,14 +117,17 @@ When account `A` changes one of `A`'s storage slots from zero to nonzero, the pr
 2. `storage_creation_mode[A] == Preserve`:
    - Leave `storage_credit_balance[A]` unchanged.
    - Charge the full TIP-1000-mandated storage creation cost.
-3. `storage_creation_mode[A] == Direct` and `storage_credit_balance[A] > 0`:
+3. `storage_creation_mode[A] == Direct` and `storage_credit_balance[A] > 0` and `storage_credit_budget[A] > 0`:
    - Decrement `storage_credit_balance[A]` by one immediately.
+   - Decrement `storage_credit_budget[A]` by one unless it is already `type(uint64).max`.
+   - If `storage_credit_budget[A]` is now zero, set `storage_creation_mode[A] := Preserve` and emit `ModeUpdated(A, Preserve)`.
    - Charge the normal zero-to-nonzero storage write cost, but reduce the TIP-1000 storage creation component by one storage credit value (230,000 gas), so only the 20,000-gas residual of that component is charged.
-4. `storage_creation_mode[A] == Direct` and `storage_credit_balance[A] == 0`:
+4. `storage_creation_mode[A] == Direct` and (`storage_credit_balance[A] == 0` or `storage_credit_budget[A] == 0`):
    - Leave `storage_credit_balance[A]` unchanged.
+   - If `storage_credit_budget[A] == 0`, set `storage_creation_mode[A] := Preserve` and emit `ModeUpdated(A, Preserve)`.
    - Charge the full TIP-1000-mandated storage creation cost.
 
-The synchronous parts (storage write, `Direct`-mode credit debit, `Refund`-mode pending counter increment, and any mode changes) MUST be atomic with the storage write that caused them. If the storage write reverts, all of the above MUST revert according to normal EVM revert semantics.
+The synchronous parts (storage write, `Direct`-mode credit debit, `Refund`-mode pending counter increment, Direct budget decrement, and any mode changes) MUST be atomic with the storage write that caused them. If the storage write reverts, all of the above MUST revert according to normal EVM revert semantics.
 
 ### End-of-Transaction Settlement
 
@@ -140,7 +151,7 @@ If a `Refund`-mode creation occurred in a call frame that reverted, the incremen
 
 `Refund` mode avoids that by always charging the full TIP-1000 creation cost upfront. When credits are available at the end-of-transaction settlement, the user receives a 230,000-gas refund per redeemed creation and pays the same net amount as `Direct` would (the 20,000-gas residual per creation), but the worst-case upfront gas is bounded by the always-charged amount.
 
-`Direct` mode is available for accounts whose callers explicitly accept the simulation-vs-inclusion risk, for example because they reserve their own per-user storage credits inside the contract and only select `Direct` mode when their accounting guarantees that a credit is reserved for the specific operation about to execute.
+`Direct` mode is available for accounts whose callers explicitly accept the simulation-vs-inclusion risk, for example because they reserve their own per-user storage credits inside the contract and only select `Direct` mode with a bounded Direct budget when their accounting guarantees that credits are reserved for the specific operation about to execute. The budget lets a contract cap protocol credit consumption for high-level operations whose number of underlying SSTORE creations varies with packing or data layout.
 
 ## Other Storage Transitions
 
@@ -171,7 +182,8 @@ pragma solidity ^0.8.13;
 /// @notice Per-account storage credit accounting. Each account earns a
 ///         credit when it deletes one of its own storage slots and can use
 ///         it to offset a later storage creation. Each account selects how
-///         credits are applied to its own storage creations via `setMode`.
+///         credits are applied to its own storage creations via `setMode`
+///         or `setBudget`.
 interface IStorageCredits {
     /// @notice Storage creation mode for an account. A single credit is worth
     ///         a 230,000-gas credit against the 250,000-gas TIP-1000 creation
@@ -223,6 +235,12 @@ interface IStorageCredits {
     /// @notice Read the storage creation mode for `account`.
     function modeOf(address account) external view returns (Mode);
 
+    /// @notice Read the calling account's remaining transaction-local Direct budget.
+    function creditBudget() external view returns (uint64);
+
+    /// @notice Read the remaining transaction-local Direct budget for `account`.
+    function creditBudgetOf(address account) external view returns (uint64);
+
     /// @notice Set the storage creation mode for the calling account.
     /// @dev Applies to every subsequent zero-to-nonzero write to
     ///      `msg.sender`'s storage until another `setMode` call from the
@@ -235,19 +253,29 @@ interface IStorageCredits {
     ///      propagated `msg.sender`.
     /// @param newMode New storage creation mode. MUST be a defined `Mode`.
     function setMode(Mode newMode) external;
+
+    /// @notice Switch the calling account to `Direct` mode with a remaining
+    ///         direct-spend budget.
+    /// @dev Sets the calling account's mode to `Direct` and initializes its
+    ///      remaining direct-spend budget to `creditBudget`.
+    /// @param creditBudget Maximum number of credits to spend directly after
+    ///                     this call in the current transaction.
+    function setBudget(uint64 creditBudget) external;
 }
 ```
 
 ### Behavior
 
-- `balance()` and `mode()` are equivalent to `balanceOf(msg.sender)` and `modeOf(msg.sender)`. All four read functions MUST NOT modify state.
+- `balance()` and `mode()` are equivalent to `balanceOf(msg.sender)` and `modeOf(msg.sender)`. `creditBudget()` is equivalent to `creditBudgetOf(msg.sender)`. All read functions MUST NOT modify state.
 - `balanceOf(account)` returns the `storage_credit_balance` field of `storage_credit_state[account]`.
-- `modeOf(account)` returns the current transient `storage_creation_mode` for `account` within the current transaction, which is `Refund` unless `account` has called `setMode` earlier in the same transaction (and that call has not been reverted).
+- `modeOf(account)` returns the current transient storage creation mode for `account` within the current transaction, which is `Refund` unless `account` has called `setMode` or `setBudget` earlier in the same transaction (and that call has not been reverted) or has been automatically moved from `Direct` to `Preserve` after exhausting its Direct budget.
+- `creditBudgetOf(account)` returns the current transient Direct budget for `account` within the current transaction. It is zero by default, `type(uint64).max` after a non-reverted `setMode(Direct)`, and the remaining budget after a non-reverted `setBudget` call and any subsequent `Direct`-mode consumption.
 - Every function of the precompile MUST revert with `OnlyDirectCall` if it is reached via `DELEGATECALL` or `CALLCODE`. Implementations MUST detect this the same way as other Tempo precompile guards: the call is non-direct whenever the executing-context address is not `STORAGE_CREDITS_ADDRESS` (equivalently, the precompile's own code is not the code being run). Only a direct `CALL` (or `STATICCALL` for the read-only functions) is permitted. This guarantees `msg.sender` is the actual calling account rather than a propagated ancestor, so a contract cannot use `DELEGATECALL` to the precompile to change a different account's mode.
 - `setMode(newMode)` is callable by any account, including EOAs (and EIP-7702 delegated accounts). It is unauthenticated in the sense that any account may set its own mode but only its own; the direct caller (`msg.sender`) is the account whose mode is written. Setting a mode on an account that never performs its own storage writes (such as a plain EOA) simply has no effect.
-- `setMode(newMode)` MUST revert with `InvalidMode` if `newMode` is the reserved value `3` (or any encoding outside `{0, 1, 2}`). Otherwise it MUST set the transient `storage_creation_mode[msg.sender] := newMode` and emit `ModeUpdated(msg.sender, newMode)`. The write targets transient storage only: it creates no persistent state, costs only an ordinary transient-storage write (EIP-1153 `TSTORE`-equivalent), MUST NOT incur a TIP-1000 storage creation charge, and MUST NOT mint storage credits, consume storage credits, or increment `pending_refund_eligible_creations`.
+- `setMode(newMode)` MUST revert with `InvalidMode` if `newMode` is the reserved value `3` (or any encoding outside `{0, 1, 2}`). Otherwise it MUST set the transient mode for `msg.sender` to `newMode`, set the transient Direct budget for `msg.sender` to `type(uint64).max` if `newMode == Direct` and zero otherwise, and emit `ModeUpdated(msg.sender, newMode)`. The writes target transient storage only: they create no persistent state, cost only ordinary transient-storage writes (EIP-1153 `TSTORE`-equivalent), MUST NOT incur a TIP-1000 storage creation charge, and MUST NOT mint storage credits, consume storage credits, or increment `pending_refund_eligible_creations`.
+- `setBudget(creditBudget)` MUST set the transient mode for `msg.sender` to `Direct`, set the transient Direct budget for `msg.sender` to `creditBudget`, and emit `ModeUpdated(msg.sender, Direct)`. It switches to `Direct` mode and caps the number of credits that may be spent directly by subsequent storage creations in the current transaction. If `creditBudget == 0`, the next storage creation follows the zero-budget branch, switches the account to `Preserve`, and pays the full TIP-1000 storage creation cost.
 - A contract that itself runs as the callee of a `DELEGATECALL` (i.e. library code executing in another account's context) may still call the precompile, because that is a direct `CALL` to the precompile from within that context: `msg.sender` is then the account whose code is executing and whose storage the mode governs. Only `DELEGATECALL`/`CALLCODE` *into the precompile itself* is rejected.
-- A mode write performed inside an execution scope that later reverts MUST itself revert, restoring the prior transient `storage_creation_mode` value for the same account.
+- A mode or budget write performed inside an execution scope that later reverts MUST itself revert, restoring the prior transient `storage_creation_mode` and `storage_credit_budget` values for the same account.
 
 ## Scope
 
@@ -257,7 +285,7 @@ This TIP applies to every account on Tempo. Storage credit minting, consumption,
 
 Every account defaults to `Refund` mode at the start of every transaction. This means an account that deletes a storage slot and later creates a storage slot will automatically pay the full storage creation cost upfront and receive an offsetting refund if a storage credit is available, unless that account has called `setMode(Preserve)` or `setMode(Direct)` earlier in the same transaction.
 
-Because the mode is held in transient storage, it is not persisted across transactions: an account that wants `Preserve` or `Direct` MUST call `setMode` within each transaction, before the storage creations the mode should affect. Absent such a call, the account is in `Refund` mode for that transaction.
+Because the mode and Direct budget are held in transient storage, they are not persisted across transactions: an account that wants `Preserve`, `Direct`, or a bounded Direct budget MUST call `setMode` or `setBudget` within each transaction, before the storage creations the mode or Direct budget should affect. Absent such a call, the account is in `Refund` mode; the Direct budget has no effect unless the account enters `Direct` mode.
 
 The default mode is intentionally refund-based rather than direct consumption: a caller must always provide enough gas for the full storage creation cost, so transactions do not unexpectedly fail when the storage credit balance changes between simulation and inclusion.
 
@@ -267,29 +295,30 @@ Existing contracts keep the default `Refund` mode and a zero balance until they 
 
 For an account that deletes a slot and later creates one, this is neutral-to-favorable: instead of the small immediate clearing refund it previously received, it earns a storage credit that redeems (in the default `Refund` mode) for a 230,000-gas refund at end-of-transaction settlement when it next creates a slot. The one downside is for a deletion that is *not* matched by a later creation in the same account: such an account no longer receives the immediate clearing refund it used to get, and instead holds a carried-forward credit that only yields gas savings if and when it later creates storage. Credits are non-expiring and account-keyed, so for slots that are cleared but never followed by a creation the loss is bounded by the former (small) clearing-refund amount. Removing the EVM refund cap is favorable in all cases.
 
-Gas estimation for storage creations in the default `Refund` mode is unchanged in upfront cost: the same zero-to-nonzero write always charges the full TIP-1000 storage creation cost and the required gas limit does not depend on the account's current credit balance. The effective cost is determined at end-of-transaction settlement and may be lower via a refund, including via credits minted by deletions earlier in the same transaction. Storage creations performed under `Direct` mode depend on whether a storage credit is available at the moment of the creation, so callers using `Direct` SHOULD assume the worst case (no credit available) when sizing gas limits or accept that the transaction may fail if the balance changes between simulation and inclusion. Because the mode is transient and resets to `Refund` each transaction, a contract that relies on `Preserve` or `Direct` MUST call `setMode` in every transaction in which it wants that behavior; a mode set in one transaction does not carry over to the next. `setMode` writes only transient storage, so it costs an ordinary transient-storage write (EIP-1153), creates no persistent state, and applies no 250,000-gas TIP-1000 storage creation component or storage-credit side effects.
+Gas estimation for storage creations in the default `Refund` mode is unchanged in upfront cost: the same zero-to-nonzero write always charges the full TIP-1000 storage creation cost and the required gas limit does not depend on the account's current credit balance. The effective cost is determined at end-of-transaction settlement and may be lower via a refund, including via credits minted by deletions earlier in the same transaction. Storage creations performed under `Direct` mode depend on whether a storage credit and Direct budget are available at the moment of the creation, so callers using `Direct` SHOULD assume the worst case (no credit or no Direct budget available) when sizing gas limits or accept that the transaction may fail if the balance changes between simulation and inclusion. Because the mode and Direct budget are transient and reset each transaction, a contract that relies on `Preserve`, `Direct`, or bounded Direct consumption MUST call `setMode` or `setBudget` in every transaction in which it wants that behavior; settings from one transaction do not carry over to the next. `setMode` and `setBudget` write only transient storage, so they cost ordinary transient-storage writes (EIP-1153), create no persistent state, and apply no 250,000-gas TIP-1000 storage creation component or storage-credit side effects.
 
-Traces and debug tooling SHOULD expose credit minting, synchronous `Direct` credit consumption, `Refund` pending counter increments, end-of-transaction settlement (per-account credits consumed and refund credited), and storage creation mode reads or writes so developers can explain gas differences. Smart contracts that perform storage churn may observe lower effective costs after this TIP, including for transactions that net to zero new storage. SSTORE semantics for accounts that do not churn storage remain unchanged.
+Traces and debug tooling SHOULD expose credit minting, synchronous `Direct` credit consumption, `Refund` pending counter increments, Direct budget reads and writes, end-of-transaction settlement (per-account credits consumed and refund credited), and storage creation mode reads or writes so developers can explain gas differences. Smart contracts that perform storage churn may observe lower effective costs after this TIP, including for transactions that net to zero new storage. SSTORE semantics for accounts that do not churn storage remain unchanged.
 
 ---
 
 # Invariants
 
 1. An account's storage credit balance increases only when that account deletes one of its own nonzero storage slots, and only if that deletion persists past the end of the enclosing transaction (i.e., is not unwound by any subsequent revert).
-2. An account's storage credit balance decreases only via: (a) a `Direct`-mode storage creation when `storage_credit_balance[A] > 0` (decrement of one per creation, synchronous); or (b) end-of-transaction settlement of `Refund`-mode pending refund-eligible creations. In `Preserve` mode the balance never decreases.
+2. An account's storage credit balance decreases only via: (a) a `Direct`-mode storage creation when `storage_credit_balance[A] > 0` and `storage_credit_budget[A] > 0` (decrement of one per creation, synchronous); or (b) end-of-transaction settlement of `Refund`-mode pending refund-eligible creations. In `Preserve` mode the balance never decreases.
 3. A storage credit can offset at most one storage creation, either by funding one 230,000-gas refund for a redeemed `Refund`-mode pending creation at settlement or by removing 230,000 gas (one storage credit value) from the TIP-1000 component of a single `Direct`-mode creation. In both cases the 20,000-gas residual of the TIP-1000 creation cost is still paid.
 4. Storage credits cannot be transferred between accounts.
-5. Storage credit minting, `Direct`-mode consumption, `Refund`-mode pending counter increments, mode changes, and any synchronous refund credits revert with the execution scope that caused them. End-of-transaction settlement reads only the journaled, non-reverted state.
-6. Writes owned by `STORAGE_CREDITS_ADDRESS` do not incur the TIP-1000 storage creation cost, including the first write that creates an account's persistent `storage_credit_state` (credit-balance) slot. Accordingly, they do not mint or consume storage credits and do not increment `pending_refund_eligible_creations`. The storage creation mode lives in transient storage, so `setMode` creates no persistent slot.
+5. Storage credit minting, `Direct`-mode consumption, `Refund`-mode pending counter increments, Direct budget decrements, mode changes, Direct budget changes, and any synchronous refund credits revert with the execution scope that caused them. End-of-transaction settlement reads only the journaled, non-reverted state.
+6. Writes owned by `STORAGE_CREDITS_ADDRESS` do not incur the TIP-1000 storage creation cost, including the first write that creates an account's persistent `storage_credit_state` (credit-balance) slot. Accordingly, they do not mint or consume storage credits and do not increment `pending_refund_eligible_creations`. The storage creation mode and budget live in transient storage, so `setMode` and `setBudget` create no persistent slot.
 7. A storage creation in `Direct` mode that consumed a storage credit cannot also receive a refund for the 230,000 gas offset from the TIP-1000 storage creation cost.
-8. The storage creation mode defaults to `Refund` for every account at the start of every transaction.
+8. The storage creation mode defaults to `Refund` and the Direct budget defaults to zero for every account at the start of every transaction.
 9. The persistent packed state word's reserved bits (`64..255`) remain zero, and the reserved `storage_creation_mode` encoding (`3`) remains unused, until assigned by a future TIP.
 10. The gas charged upfront for a `Refund`-mode zero-to-nonzero write does not depend on `storage_credit_balance[A]`, so a transaction's required gas limit is independent of the account's current credit balance. End-of-transaction settlement can only add to the transaction's refund counter and cannot cause the transaction to run out of gas.
 11. At end-of-transaction settlement, for each account `A` the number of credits consumed equals `min(pending_refund_eligible_creations[A], storage_credit_balance[A])` evaluated against the journaled, non-reverted end-of-transaction state, and exactly that many 230,000-gas refunds (one storage credit value per redeemed creation) are credited in full to the transaction's refund counter, with no refund cap applied.
 12. `pending_refund_eligible_creations` is transaction-local: it is zero at the start of every transaction and is not visible to or readable by EVM code in any subsequent transaction.
-13. `setMode(newMode)` from account `A` (any account, including an EOA) MUST set `storage_creation_mode[A]` to `newMode` if `newMode ∈ {Refund, Preserve, Direct}` and MUST revert with `InvalidMode` otherwise. It MUST NOT change `storage_creation_mode` for any account other than `A`.
-14. `setMode` MUST NOT change any account's `storage_credit_balance` and MUST NOT change `pending_refund_eligible_creations` for any account.
-15. The pre-existing nonzero-to-zero storage-clearing gas refund is removed. Deleting a storage slot mints one storage credit (Invariant 1) instead of crediting an immediate refund, and storage credit settlement is the only mechanism by which storage operations affect the transaction's gas refund counter.
-16. No refund cap applies. The storage credit settlement refund (`settled * 230_000` gas per account) is credited in full and is not limited to any fraction of the transaction's gas used.
-17. The storage creation mode is transaction-local transient state: it is `Refund` at the start of every transaction, is not persisted across transactions, and a mode set in one transaction is not visible to or readable by EVM code in any subsequent transaction. `setMode` writes no persistent state.
-18. Every function of the Storage Credits precompile MUST revert with `OnlyDirectCall` when reached via `DELEGATECALL` or `CALLCODE`. Consequently `setMode` only ever writes the mode of its direct caller (`msg.sender`), which is always the account whose storage the mode governs, and the precompile can never be used to read or modify state on behalf of a propagated, non-direct caller.
+13. A bounded `storage_credit_budget[A]` caps the number of subsequent storage creations from account `A` that can consume a credit in `Direct` mode. Once a `Direct`-mode consumption decrements the budget to zero, the protocol MUST set `storage_creation_mode[A] := Preserve` and emit `ModeUpdated(A, Preserve)`. `Refund`-mode eligibility is not budgeted.
+14. `setMode(newMode)` from account `A` (any account, including an EOA) MUST set `storage_creation_mode[A]` to `newMode` if `newMode ∈ {Refund, Preserve, Direct}` and MUST revert with `InvalidMode` otherwise. It MUST set `storage_credit_budget[A]` to `type(uint64).max` when `newMode == Direct` and zero otherwise. `setBudget(creditBudget)` from account `A` MUST set `storage_creation_mode[A]` to `Direct` and `storage_credit_budget[A]` to `creditBudget`. These functions MUST NOT change `storage_creation_mode` or `storage_credit_budget` for any account other than `A`.
+15. `setMode` and `setBudget` MUST NOT change any account's `storage_credit_balance` and MUST NOT change `pending_refund_eligible_creations` for any account.
+16. The pre-existing nonzero-to-zero storage-clearing gas refund is removed. Deleting a storage slot mints one storage credit (Invariant 1) instead of crediting an immediate refund, and storage credit settlement is the only mechanism by which storage operations affect the transaction's gas refund counter.
+17. No refund cap applies. The storage credit settlement refund (`settled * 230_000` gas per account) is credited in full and is not limited to any fraction of the transaction's gas used.
+18. The storage creation mode and Direct budget are transaction-local transient state: the mode is `Refund` and the Direct budget is zero at the start of every transaction, neither is persisted across transactions, and a setting from one transaction is not visible to or readable by EVM code in any subsequent transaction. `setMode` and `setBudget` write no persistent state.
+19. Every function of the Storage Credits precompile MUST revert with `OnlyDirectCall` when reached via `DELEGATECALL` or `CALLCODE`. Consequently `setMode` only ever writes the mode of its direct caller (`msg.sender`), which is always the account whose storage the mode governs, and the precompile can never be used to read or modify state on behalf of a propagated, non-direct caller.


### PR DESCRIPTION
## Summary
- add a transaction-local storage credit budget alongside the storage creation mode
- extend the Storage Credits precompile with budget reads and a two-argument setMode overload
- gate Direct consumption and Refund eligibility by the remaining budget so contracts can cap multi-slot operations

Stacked on #4016.