### PR TITLE
refactor: make tempo eth api builder generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13209,6 +13209,7 @@ version = "1.8.2"
 dependencies = [
  "alloy",
  "alloy-eips",
+ "alloy-evm",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
@@ -13262,6 +13263,7 @@ dependencies = [
  "tempo-payload-types",
  "tempo-precompiles",
  "tempo-primitives",
+ "tempo-revm",
  "tempo-transaction-pool",
  "test-case",
  "thiserror 2.0.18",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -24,6 +24,7 @@ tempo-payload-builder.workspace = true
 tempo-payload-types.workspace = true
 tempo-precompiles.workspace = true
 tempo-primitives = { workspace = true, features = ["default"] }
+tempo-revm.workspace = true
 
 thiserror.workspace = true
 
@@ -49,6 +50,7 @@ reth-node-ethereum.workspace = true
 reth-storage-api.workspace = true
 
 alloy-serde.workspace = true
+alloy-evm.workspace = true
 alloy-eips.workspace = true
 alloy-rpc-types-admin.workspace = true
 alloy-rpc-types-eth.workspace = true
@@ -106,6 +108,7 @@ default = []
 bal = ["tempo-payload-builder/bal"]
 asm-keccak = [
 	"alloy/asm-keccak",
+	"alloy-evm/asm-keccak",
 	"alloy-primitives/asm-keccak",
 	"reth-node-core/asm-keccak",
 	"reth-node-ethereum/asm-keccak",

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -199,9 +199,10 @@ impl NodeTypes for TempoNode {
 
 #[derive(Debug)]
 pub struct TempoAddOns<N: FullNodeTypes<Types = TempoNode>> {
+    #[allow(clippy::type_complexity)]
     inner: RpcAddOns<
         NodeAdapter<N>,
-        TempoEthApiBuilder,
+        TempoEthApiBuilder<NodeAdapter<N>>,
         TempoEngineValidatorBuilder,
         NoopEngineApiBuilder,
         BasicEngineValidatorBuilder<TempoEngineValidatorBuilder>,
@@ -234,7 +235,7 @@ impl<N> NodeAddOns<NodeAdapter<N>> for TempoAddOns<N>
 where
     N: FullNodeTypes<Types = TempoNode>,
 {
-    type Handle = RpcHandle<NodeAdapter<N>, TempoEthApi<N>>;
+    type Handle = RpcHandle<NodeAdapter<N>, TempoEthApi<NodeAdapter<N>>>;
 
     async fn launch_add_ons(
         self,
@@ -281,7 +282,7 @@ impl<N> RethRpcAddOns<NodeAdapter<N>> for TempoAddOns<N>
 where
     N: FullNodeTypes<Types = TempoNode>,
 {
-    type EthApi = TempoEthApi<N>;
+    type EthApi = TempoEthApi<NodeAdapter<N>>;
 
     fn hooks_mut(&mut self) -> &mut RpcHooks<NodeAdapter<N>, Self::EthApi> {
         self.inner.hooks_mut()

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -16,33 +16,34 @@ pub use fork_schedule::{TempoForkScheduleApiServer, TempoForkScheduleRpc};
 use futures::{TryFutureExt, future::Either};
 pub use operator::{TempoOperatorApiServer, TempoOperatorRpc};
 use reth_errors::RethError;
-use reth_primitives_traits::{Recovered, TransactionMeta, WithEncoded, transaction::TxHashRef};
+use reth_primitives_traits::{
+    HeaderTy, Recovered, TransactionMeta, WithEncoded, transaction::TxHashRef,
+};
 use reth_rpc_eth_api::{FromEthApiError, IntoEthApiError, RpcTxReq};
-use reth_transaction_pool::{PoolPooledTx, TransactionOrigin};
+use reth_transaction_pool::{PoolPooledTx, PoolTransaction, TransactionOrigin, TransactionPool};
 pub use simulate::{TempoSimulate, TempoSimulateApiServer, TempoSimulateV1Response};
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 pub use tempo_alloy::rpc::TempoTransactionRequest;
-use tempo_chainspec::TempoChainSpec;
+use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork};
 use tempo_evm::TempoStateAccess;
 use tempo_precompiles::{NONCE_PRECOMPILE_ADDRESS, nonce::NonceManager};
 use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
 pub use token::{TempoToken, TempoTokenApiServer};
 
-use crate::{node::TempoNode, rpc::error::TempoEthApiError};
+use crate::rpc::error::TempoEthApiError;
 use alloy::primitives::{U256, uint};
+use alloy_evm::{EvmFactory, block::BlockExecutorFactory};
+use reth_chainspec::{EthereumHardforks, Hardforks};
 use reth_ethereum::tasks::{
     Runtime,
     pool::{BlockingTaskGuard, BlockingTaskPool},
 };
 use reth_evm::{
-    EvmEnvFor, TxEnvFor,
-    revm::{Database, context::result::EVMError},
+    ConfigureEvm, EvmEnvFor, TxEnvFor,
+    revm::{Database, context::result::EVMError, database_interface::bal::EvmDatabaseError},
 };
-use reth_node_api::{FullNodeComponents, FullNodeTypes, HeaderTy, PrimitivesTy};
-use reth_node_builder::{
-    NodeAdapter,
-    rpc::{EthApiBuilder, EthApiCtx},
-};
+use reth_node_api::{FullNodeComponents, FullNodeTypes, NodeTypes};
+use reth_node_builder::rpc::{EthApiBuilder, EthApiCtx};
 use reth_provider::{ChainSpecProvider, ProviderError};
 use reth_rpc::{DynRpcConverter, eth::EthApi};
 use reth_rpc_eth_api::{
@@ -50,7 +51,9 @@ use reth_rpc_eth_api::{
     helpers::{
         Call, EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, LoadBlock,
         LoadFee, LoadPendingBlock, LoadReceipt, LoadState, LoadTransaction, SpawnBlocking, Trace,
-        bal::GetBlockAccessList, estimate::EstimateCall, pending_block::PendingEnvBuilder,
+        bal::GetBlockAccessList,
+        estimate::EstimateCall,
+        pending_block::{BuildPendingEnv, PendingEnvBuilder},
         spec::SignersForRpc,
     },
     transaction::{ConvertReceiptInput, ReceiptConverter},
@@ -60,11 +63,12 @@ use reth_rpc_eth_types::{
     builder::config::PendingBlockKind, receipt::EthReceiptConverter,
 };
 use tempo_alloy::{TempoNetwork, rpc::TempoTransactionReceipt};
-use tempo_evm::TempoEvmConfig;
+use tempo_evm::{TempoBlockEnv, TempoHaltReason, TempoInvalidTransaction};
 use tempo_primitives::{
-    TEMPO_GAS_PRICE_SCALING_FACTOR, TempoPrimitives, TempoReceipt, TempoTxEnvelope,
+    TEMPO_GAS_PRICE_SCALING_FACTOR, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope,
     subblock::PartialValidatorKey,
 };
+use tempo_revm::TempoTxEnv;
 use tokio::sync::{Mutex, broadcast};
 
 /// Placeholder constant for `eth_getBalance` calls because the native token balance is N/A on
@@ -79,7 +83,58 @@ pub const NATIVE_BALANCE_PLACEHOLDER: U256 =
 /// being added to the channel to prevent DoS attacks.
 pub const SUBBLOCK_TX_CHANNEL_CAPACITY: usize = 10_000;
 
-/// Tempo `Eth` API implementation.
+/// Helper trait that groups the component bounds required by [`TempoEthApi`].
+///
+/// This trait has no methods. It exists so the generic Tempo RPC implementation
+/// and builder can name the required Tempo primitives, pooled transaction type,
+/// and EVM configuration in one place.
+pub trait TempoEthApiBounds:
+    RpcNodeCore<
+        Primitives = TempoPrimitives,
+        Pool: TransactionPool<Transaction: PoolTransaction<Pooled = TempoTxEnvelope>>,
+        Evm: ConfigureEvm<
+            Primitives = TempoPrimitives,
+            BlockExecutorFactory: BlockExecutorFactory<
+                EvmFactory: EvmFactory<
+                    Tx = TempoTxEnv,
+                    Spec = TempoHardfork,
+                    BlockEnv = TempoBlockEnv,
+                    HaltReason = TempoHaltReason,
+                    Error<EvmDatabaseError<ProviderError>> = EVMError<
+                        EvmDatabaseError<ProviderError>,
+                        TempoInvalidTransaction,
+                    >,
+                >,
+            >,
+        >,
+    >
+{
+}
+
+impl<N> TempoEthApiBounds for N where
+    N: RpcNodeCore<
+            Primitives = TempoPrimitives,
+            Pool: TransactionPool<Transaction: PoolTransaction<Pooled = TempoTxEnvelope>>,
+            Evm: ConfigureEvm<
+                Primitives = TempoPrimitives,
+                BlockExecutorFactory: BlockExecutorFactory<
+                    EvmFactory: EvmFactory<
+                        Tx = TempoTxEnv,
+                        Spec = TempoHardfork,
+                        BlockEnv = TempoBlockEnv,
+                        HaltReason = TempoHaltReason,
+                        Error<EvmDatabaseError<ProviderError>> = EVMError<
+                            EvmDatabaseError<ProviderError>,
+                            TempoInvalidTransaction,
+                        >,
+                    >,
+                >,
+            >,
+        >
+{
+}
+
+/// Generic Tempo `Eth` API implementation.
 ///
 /// This type provides the functionality for handling `eth_` related requests.
 ///
@@ -90,9 +145,12 @@ pub const SUBBLOCK_TX_CHANNEL_CAPACITY: usize = 10_000;
 /// This type implements the [`FullEthApi`](reth_rpc_eth_api::helpers::FullEthApi) by implemented
 /// all the `Eth` helper traits and prerequisite traits.
 #[derive(Debug, Clone)]
-pub struct TempoEthApi<N: FullNodeTypes<Types = TempoNode>> {
+pub struct TempoEthApi<N>
+where
+    N: TempoEthApiBounds,
+{
     /// Gateway to node's core components.
-    inner: EthApi<NodeAdapter<N>, DynRpcConverter<TempoEvmConfig, TempoNetwork>>,
+    inner: EthApi<N, DynRpcConverter<N::Evm, TempoNetwork>>,
 
     /// Channel for sending subblock transactions to the subblocks service.
     subblock_transactions_tx: broadcast::Sender<Recovered<TempoTxEnvelope>>,
@@ -105,10 +163,13 @@ pub struct TempoEthApi<N: FullNodeTypes<Types = TempoNode>> {
     validator_key: Option<B256>,
 }
 
-impl<N: FullNodeTypes<Types = TempoNode>> TempoEthApi<N> {
+impl<N> TempoEthApi<N>
+where
+    N: TempoEthApiBounds,
+{
     /// Creates a new `TempoEthApi`.
     pub fn new(
-        eth_api: EthApi<NodeAdapter<N>, DynRpcConverter<TempoEvmConfig, TempoNetwork>>,
+        eth_api: EthApi<N, DynRpcConverter<N::Evm, TempoNetwork>>,
         validator_key: Option<B256>,
     ) -> Self {
         Self {
@@ -133,22 +194,28 @@ impl<N: FullNodeTypes<Types = TempoNode>> TempoEthApi<N> {
     }
 }
 
-impl<N: FullNodeTypes<Types = TempoNode>> EthApiTypes for TempoEthApi<N> {
+impl<N> EthApiTypes for TempoEthApi<N>
+where
+    N: TempoEthApiBounds,
+{
     type Error = TempoEthApiError;
     type NetworkTypes = TempoNetwork;
-    type RpcConvert = DynRpcConverter<TempoEvmConfig, TempoNetwork>;
+    type RpcConvert = DynRpcConverter<N::Evm, TempoNetwork>;
 
     fn converter(&self) -> &Self::RpcConvert {
         self.inner.converter()
     }
 }
 
-impl<N: FullNodeTypes<Types = TempoNode>> RpcNodeCore for TempoEthApi<N> {
-    type Primitives = PrimitivesTy<N::Types>;
+impl<N> RpcNodeCore for TempoEthApi<N>
+where
+    N: TempoEthApiBounds,
+{
+    type Primitives = N::Primitives;
     type Provider = N::Provider;
-    type Pool = <NodeAdapter<N> as FullNodeComponents>::Pool;
-    type Evm = <NodeAdapter<N> as FullNodeComponents>::Evm;
-    type Network = <NodeAdapter<N> as FullNodeComponents>::Network;
+    type Pool = N::Pool;
+    type Evm = N::Evm;
+    type Network = N::Network;
 
     #[inline]
     fn pool(&self) -> &Self::Pool {
@@ -171,21 +238,30 @@ impl<N: FullNodeTypes<Types = TempoNode>> RpcNodeCore for TempoEthApi<N> {
     }
 }
 
-impl<N: FullNodeTypes<Types = TempoNode>> RpcNodeCoreExt for TempoEthApi<N> {
+impl<N> RpcNodeCoreExt for TempoEthApi<N>
+where
+    N: TempoEthApiBounds,
+{
     #[inline]
-    fn cache(&self) -> &EthStateCache<PrimitivesTy<N::Types>> {
+    fn cache(&self) -> &EthStateCache<N::Primitives> {
         self.inner.cache()
     }
 }
 
-impl<N: FullNodeTypes<Types = TempoNode>> EthApiSpec for TempoEthApi<N> {
+impl<N> EthApiSpec for TempoEthApi<N>
+where
+    N: TempoEthApiBounds,
+{
     #[inline]
     fn starting_block(&self) -> U256 {
         self.inner.starting_block()
     }
 }
 
-impl<N: FullNodeTypes<Types = TempoNode>> SpawnBlocking for TempoEthApi<N> {
+impl<N> SpawnBlocking for TempoEthApi<N>
+where
+    N: TempoEthApiBounds,
+{
     #[inline]
     fn io_task_spawner(&self) -> &Runtime {
         self.inner.task_spawner()
@@ -207,7 +283,10 @@ impl<N: FullNodeTypes<Types = TempoNode>> SpawnBlocking for TempoEthApi<N> {
     }
 }
 
-impl<N: FullNodeTypes<Types = TempoNode>> LoadPendingBlock for TempoEthApi<N> {
+impl<N> LoadPendingBlock for TempoEthApi<N>
+where
+    N: TempoEthApiBounds,
+{
     #[inline]
     fn pending_block(&self) -> &Mutex<Option<PendingBlock<Self::Primitives>>> {
         self.inner.pending_block()
@@ -220,24 +299,31 @@ impl<N: FullNodeTypes<Types = TempoNode>> LoadPendingBlock for TempoEthApi<N> {
 
     #[inline]
     fn pending_block_kind(&self) -> PendingBlockKind {
-        // don't build a local pending block because we can't build a block without consensus data (system transaction)
+        // Don't build a local pending block because the Tempo node can't build
+        // one without consensus data (system transaction).
         PendingBlockKind::None
     }
 }
 
-impl<N: FullNodeTypes<Types = TempoNode>> LoadFee for TempoEthApi<N> {
+impl<N> LoadFee for TempoEthApi<N>
+where
+    N: TempoEthApiBounds,
+{
     #[inline]
     fn gas_oracle(&self) -> &GasPriceOracle<Self::Provider> {
         self.inner.gas_oracle()
     }
 
     #[inline]
-    fn fee_history_cache(&self) -> &FeeHistoryCache<HeaderTy<N::Types>> {
+    fn fee_history_cache(&self) -> &FeeHistoryCache<HeaderTy<N::Primitives>> {
         self.inner.fee_history_cache()
     }
 }
 
-impl<N: FullNodeTypes<Types = TempoNode>> LoadState for TempoEthApi<N> {
+impl<N> LoadState for TempoEthApi<N>
+where
+    N: TempoEthApiBounds,
+{
     async fn next_available_nonce_for(
         &self,
         request: &RpcTxReq<Self::NetworkTypes>,
@@ -272,7 +358,10 @@ impl<N: FullNodeTypes<Types = TempoNode>> LoadState for TempoEthApi<N> {
     }
 }
 
-impl<N: FullNodeTypes<Types = TempoNode>> EthState for TempoEthApi<N> {
+impl<N> EthState for TempoEthApi<N>
+where
+    N: TempoEthApiBounds,
+{
     #[inline]
     async fn balance(
         &self,
@@ -288,15 +377,18 @@ impl<N: FullNodeTypes<Types = TempoNode>> EthState for TempoEthApi<N> {
     }
 }
 
-impl<N: FullNodeTypes<Types = TempoNode>> EthFees for TempoEthApi<N> {}
+impl<N> EthFees for TempoEthApi<N> where N: TempoEthApiBounds {}
 
-impl<N: FullNodeTypes<Types = TempoNode>> Trace for TempoEthApi<N> {}
+impl<N> Trace for TempoEthApi<N> where N: TempoEthApiBounds {}
 
-impl<N: FullNodeTypes<Types = TempoNode>> EthCall for TempoEthApi<N> {}
+impl<N> EthCall for TempoEthApi<N> where N: TempoEthApiBounds {}
 
-impl<N: FullNodeTypes<Types = TempoNode>> GetBlockAccessList for TempoEthApi<N> {}
+impl<N> GetBlockAccessList for TempoEthApi<N> where N: TempoEthApiBounds {}
 
-impl<N: FullNodeTypes<Types = TempoNode>> Call for TempoEthApi<N> {
+impl<N> Call for TempoEthApi<N>
+where
+    N: TempoEthApiBounds,
+{
     #[inline]
     fn call_gas_limit(&self) -> u64 {
         self.inner.gas_cap()
@@ -372,13 +464,16 @@ impl<N: FullNodeTypes<Types = TempoNode>> Call for TempoEthApi<N> {
     }
 }
 
-impl<N: FullNodeTypes<Types = TempoNode>> EstimateCall for TempoEthApi<N> {}
-impl<N: FullNodeTypes<Types = TempoNode>> LoadBlock for TempoEthApi<N> {}
-impl<N: FullNodeTypes<Types = TempoNode>> LoadReceipt for TempoEthApi<N> {}
-impl<N: FullNodeTypes<Types = TempoNode>> EthBlocks for TempoEthApi<N> {}
-impl<N: FullNodeTypes<Types = TempoNode>> LoadTransaction for TempoEthApi<N> {}
+impl<N> EstimateCall for TempoEthApi<N> where N: TempoEthApiBounds {}
+impl<N> LoadBlock for TempoEthApi<N> where N: TempoEthApiBounds {}
+impl<N> LoadReceipt for TempoEthApi<N> where N: TempoEthApiBounds {}
+impl<N> EthBlocks for TempoEthApi<N> where N: TempoEthApiBounds {}
+impl<N> LoadTransaction for TempoEthApi<N> where N: TempoEthApiBounds {}
 
-impl<N: FullNodeTypes<Types = TempoNode>> EthTransactions for TempoEthApi<N> {
+impl<N> EthTransactions for TempoEthApi<N>
+where
+    N: TempoEthApiBounds,
+{
     fn signers(&self) -> &SignersForRpc<Self::Provider, Self::NetworkTypes> {
         self.inner.signers()
     }
@@ -492,27 +587,48 @@ impl ReceiptConverter<TempoPrimitives> for TempoReceiptConverter {
     }
 }
 
-#[derive(Debug, Default)]
-pub struct TempoEthApiBuilder {
+#[derive(Debug)]
+pub struct TempoEthApiBuilder<N = ()> {
     /// Validator public key used to filter subblock transactions.
     pub validator_key: Option<B256>,
+    _marker: PhantomData<fn() -> N>,
 }
 
-impl TempoEthApiBuilder {
-    /// Creates a new builder with the given validator key.
-    pub fn new(validator_key: Option<B256>) -> Self {
-        Self { validator_key }
+impl<N> Default for TempoEthApiBuilder<N> {
+    fn default() -> Self {
+        Self {
+            validator_key: None,
+            _marker: PhantomData,
+        }
     }
 }
 
-impl<N> EthApiBuilder<NodeAdapter<N>> for TempoEthApiBuilder
+impl<N> TempoEthApiBuilder<N> {
+    /// Creates a new builder with the given validator key.
+    pub fn new(validator_key: Option<B256>) -> Self {
+        Self {
+            validator_key,
+            ..Self::default()
+        }
+    }
+}
+
+impl<N> EthApiBuilder<N> for TempoEthApiBuilder<N>
 where
-    N: FullNodeTypes<Types = TempoNode>,
+    N: FullNodeComponents<
+            Types: NodeTypes<ChainSpec = TempoChainSpec, Primitives = TempoPrimitives>,
+            Pool = <N as RpcNodeCore>::Pool,
+            Evm = <N as RpcNodeCore>::Evm,
+        > + FullNodeTypes<Provider = <N as RpcNodeCore>::Provider>
+        + TempoEthApiBounds,
+    <N as RpcNodeCore>::Provider: ChainSpecProvider<ChainSpec = TempoChainSpec>,
+    <<N as RpcNodeCore>::Evm as ConfigureEvm>::NextBlockEnvCtx: BuildPendingEnv<TempoHeader>,
+    <N::Types as NodeTypes>::ChainSpec: Hardforks + EthereumHardforks,
 {
     type EthApi = TempoEthApi<N>;
 
-    async fn build_eth_api(self, ctx: EthApiCtx<'_, NodeAdapter<N>>) -> eyre::Result<Self::EthApi> {
-        let chain_spec = ctx.components.provider.chain_spec();
+    async fn build_eth_api(self, ctx: EthApiCtx<'_, N>) -> eyre::Result<Self::EthApi> {
+        let chain_spec = FullNodeComponents::provider(ctx.components).chain_spec();
         let eth_api = ctx
             .eth_api_builder()
             .modify_gas_oracle_config(|config| config.default_suggested_fee = Some(U256::ZERO))

--- a/crates/node/src/rpc/simulate.rs
+++ b/crates/node/src/rpc/simulate.rs
@@ -4,6 +4,7 @@ use alloy_rpc_types_eth::simulate::SimulatedBlock;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_ethereum::evm::revm::database::StateProviderDatabase;
 use reth_node_api::FullNodeTypes;
+use reth_node_builder::NodeAdapter;
 use reth_primitives_traits::AlloyBlockHeader as _;
 use reth_provider::{BlockIdReader, ChainSpecProvider, HeaderProvider};
 use reth_rpc_eth_api::{
@@ -69,11 +70,11 @@ pub trait TempoSimulateApi {
 /// Implementation of `tempo_simulateV1`.
 #[derive(Debug, Clone)]
 pub struct TempoSimulate<N: FullNodeTypes<Types = TempoNode>> {
-    eth_api: TempoEthApi<N>,
+    eth_api: TempoEthApi<NodeAdapter<N>>,
 }
 
 impl<N: FullNodeTypes<Types = TempoNode>> TempoSimulate<N> {
-    pub fn new(eth_api: TempoEthApi<N>) -> Self {
+    pub fn new(eth_api: TempoEthApi<NodeAdapter<N>>) -> Self {
         Self { eth_api }
     }
 }


### PR DESCRIPTION
## Summary

- Make `TempoEthApi<N>` and `TempoEthApiBuilder<N>` generic over Tempo-compatible RPC node cores.
- Keep L1 wiring explicit with `TempoEthApi<NodeAdapter<N>>`.
- Add `TempoEthApiBounds` to group the required RPC component bounds.

## Why

Zones can reuse Tempo's `eth_` RPC behavior instead of copying the wrapper implementation.