### PR TITLE
perf(tx-pool): seed validation state cache from block post-state

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -541,6 +541,14 @@ where
             tempo_transaction_pool::maintain::maintain_tempo_pool(transaction_pool.clone()),
         );
 
+        // Spawn the validator state cache reseed task separately so building the seeded cache
+        // never competes with the latency-critical pool maintenance above.
+        ctx.task_executor().spawn_critical_os_thread(
+            "tempo-txpool-state-cache",
+            "txpool maintenance - state cache",
+            tempo_transaction_pool::maintain::maintain_state_cache(transaction_pool.clone()),
+        );
+
         info!(target: "reth::cli", "Transaction pool initialized");
         debug!(target: "reth::cli", "Spawned txpool maintenance task");
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -541,10 +541,8 @@ where
             tempo_transaction_pool::maintain::maintain_tempo_pool(transaction_pool.clone()),
         );
 
-        // Spawn the validator state cache reseed task separately so building the seeded cache
-        // never competes with the latency-critical pool maintenance above.
-        ctx.task_executor().spawn_critical_os_thread(
-            "tempo-txpool-state-cache",
+        // Reseed the validator state cache off the critical pool maintenance path.
+        ctx.task_executor().spawn_critical_task(
             "txpool maintenance - state cache",
             tempo_transaction_pool::maintain::maintain_state_cache(transaction_pool.clone()),
         );

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -617,8 +617,13 @@ where
                 let block_update_start = Instant::now();
 
                 let tip = &new;
-                let bundle_state = tip.execution_outcome().state().state();
+                let execution_outcome = tip.execution_outcome();
+                let bundle_state = execution_outcome.state().state();
                 let tip_timestamp = tip.tip().header().timestamp();
+
+                // Reseed the validator's state cache from this block's post-state so the next
+                // block's validations start warm on the entries the block touched.
+                pool.seed_validation_state_cache(tip.tip().hash(), execution_outcome.state());
 
                 // Removed transactions are collected here and dropped at the end of the
                 // iteration: deallocating them (input data, signatures, allocator work) is

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -617,8 +617,7 @@ where
                 let block_update_start = Instant::now();
 
                 let tip = &new;
-                let execution_outcome = tip.execution_outcome();
-                let bundle_state = execution_outcome.state().state();
+                let bundle_state = tip.execution_outcome().state().state();
                 let tip_timestamp = tip.tip().header().timestamp();
 
                 // Removed transactions are collected here and dropped at the end of the
@@ -956,18 +955,42 @@ where
                 // Record total block update duration
                 metrics.block_update_duration_seconds.record(block_update_start.elapsed());
 
-                // Reseed the validator's state cache from this block's post-state so the next
-                // block's validations start warm on the entries the block touched. This runs
-                // after the pool-mutating steps above so it never delays mined-tx removal or
-                // eviction, which would otherwise let the builder pick up stale transactions.
-                let seed_start = Instant::now();
-                pool.seed_validation_state_cache(tip.tip().hash(), execution_outcome.state());
-                metrics.state_cache_seed_duration_seconds.record(seed_start.elapsed());
-
                 // Deallocating removed transactions is expensive, so do it after all updates are done.
                 drop(removed_txs);
             }
         }
+    }
+}
+
+/// Standalone task that reseeds the validator's tip-scoped state cache from each committed
+/// block's post-execution state.
+///
+/// Kept separate from [`maintain_tempo_pool`] so that building the seeded cache (iterating the
+/// block's touched accounts and storage) never delays the latency-critical pool updates there
+/// (mined-tx removal, eviction), which would otherwise let the builder pick up stale
+/// transactions. Reacting to the canonical stream directly also anchors the cache to the new
+/// tip as early as possible, maximizing the window in which validations can reuse it.
+pub async fn maintain_state_cache<Client>(pool: TempoTransactionPool<Client>)
+where
+    Client: StateProviderFactory
+        + ChainSpecProvider<ChainSpec = TempoChainSpec>
+        + CanonStateSubscriptions<Primitives = TempoPrimitives>
+        + 'static,
+{
+    let metrics = TempoPoolMaintenanceMetrics::default();
+    let mut chain_events = pool.client().canonical_state_stream();
+
+    while let Some(event) = chain_events.next().await {
+        let new = match event {
+            CanonStateNotification::Reorg { new, .. } | CanonStateNotification::Commit { new } => {
+                new
+            }
+        };
+        let seed_start = Instant::now();
+        pool.seed_validation_state_cache(new.tip().hash(), new.execution_outcome().state());
+        metrics
+            .state_cache_seed_duration_seconds
+            .record(seed_start.elapsed());
     }
 }
 

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -621,10 +621,6 @@ where
                 let bundle_state = execution_outcome.state().state();
                 let tip_timestamp = tip.tip().header().timestamp();
 
-                // Reseed the validator's state cache from this block's post-state so the next
-                // block's validations start warm on the entries the block touched.
-                pool.seed_validation_state_cache(tip.tip().hash(), execution_outcome.state());
-
                 // Removed transactions are collected here and dropped at the end of the
                 // iteration: deallocating them (input data, signatures, allocator work) is
                 // expensive and there is a block time of slack after the updates are done.
@@ -959,6 +955,14 @@ where
 
                 // Record total block update duration
                 metrics.block_update_duration_seconds.record(block_update_start.elapsed());
+
+                // Reseed the validator's state cache from this block's post-state so the next
+                // block's validations start warm on the entries the block touched. This runs
+                // after the pool-mutating steps above so it never delays mined-tx removal or
+                // eviction, which would otherwise let the builder pick up stale transactions.
+                let seed_start = Instant::now();
+                pool.seed_validation_state_cache(tip.tip().hash(), execution_outcome.state());
+                metrics.state_cache_seed_duration_seconds.record(seed_start.elapsed());
 
                 // Deallocating removed transactions is expensive, so do it after all updates are done.
                 drop(removed_txs);

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -987,7 +987,11 @@ where
             }
         };
         let seed_start = Instant::now();
-        pool.seed_validation_state_cache(new.tip().hash(), new.execution_outcome().state());
+        pool.seed_validation_state_cache(
+            new.tip().parent_hash(),
+            new.tip().hash(),
+            new.execution_outcome().state(),
+        );
         metrics
             .state_cache_seed_duration_seconds
             .record(seed_start.elapsed());

--- a/crates/transaction-pool/src/metrics.rs
+++ b/crates/transaction-pool/src/metrics.rs
@@ -120,3 +120,15 @@ pub struct TempoPoolMaintenanceMetrics {
     /// Number of transactions re-validated due to quote token updates.
     pub quote_token_revalidated: Counter,
 }
+
+/// Metrics for the Tempo transaction validator.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "transaction_pool.validation")]
+pub struct TempoValidatorMetrics {
+    /// Number of validation calls that reused the tip-scoped state cache (tip matched).
+    pub state_cache_hits: Counter,
+
+    /// Number of validation calls that fell back to an ephemeral empty cache because the
+    /// cached tip did not match the latest canonical tip.
+    pub state_cache_misses: Counter,
+}

--- a/crates/transaction-pool/src/metrics.rs
+++ b/crates/transaction-pool/src/metrics.rs
@@ -96,6 +96,9 @@ pub struct TempoPoolMaintenanceMetrics {
     /// Time spent updating the 2D nonce pool in seconds.
     pub nonce_pool_update_duration_seconds: Histogram,
 
+    /// Time spent reseeding the validator state cache from the block post-state in seconds.
+    pub state_cache_seed_duration_seconds: Histogram,
+
     /// Number of expired transactions evicted.
     pub expired_transactions_evicted: Counter,
 

--- a/crates/transaction-pool/src/state_cache.rs
+++ b/crates/transaction-pool/src/state_cache.rs
@@ -4,6 +4,7 @@ use alloy_primitives::{Address, B256, U256, map::DefaultHashBuilder};
 use dashmap::DashMap;
 use revm::{Database, DatabaseRef, bytecode::Bytecode, database::BundleState, state::AccountInfo};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tempo_precompiles::NONCE_PRECOMPILE_ADDRESS;
 
 /// Concurrent cache of raw state reads anchored to a specific tip.
 ///
@@ -57,7 +58,23 @@ impl StateCache {
     /// map lengths. A large range (e.g. a deep reorg) may seed past the caps, but the counters
     /// then reflect that and the on-demand read path stops inserting until entries drain.
     pub(crate) fn from_post_state(bundle: &BundleState) -> Self {
-        let storage_len = bundle.state.values().map(|a| a.storage.len()).sum();
+        Self::from_post_state_with_parent(bundle, None)
+    }
+
+    /// Builds a cache seeded with post-state and selected hot entries from the parent cache.
+    ///
+    /// When the new tip's parent hash matches the currently cached tip, nonce-precompile entries
+    /// remain valid unless the new block touches them. The child block's post-state is applied
+    /// afterwards, so touched nonce-precompile slots overwrite the carried parent values.
+    pub(crate) fn from_post_state_with_parent(
+        bundle: &BundleState,
+        parent: Option<&StateCache>,
+    ) -> Self {
+        let storage_len = bundle
+            .state
+            .values()
+            .map(|a| a.storage.len())
+            .sum::<usize>();
         let cache = Self {
             accounts: DashMap::with_capacity_and_hasher(bundle.state.len(), Default::default()),
             storage: DashMap::with_capacity_and_hasher(storage_len, Default::default()),
@@ -67,6 +84,22 @@ impl StateCache {
             ),
             ..Default::default()
         };
+
+        if let Some(parent) = parent {
+            // keep NONCE_PRECOMPILE_ADDRESS cached across blocks
+            if let Some(account) = parent.accounts.get(&NONCE_PRECOMPILE_ADDRESS) {
+                cache
+                    .accounts
+                    .insert(NONCE_PRECOMPILE_ADDRESS, account.clone());
+            }
+
+            for entry in parent.storage.iter() {
+                let (address, slot) = *entry.key();
+                if address == NONCE_PRECOMPILE_ADDRESS {
+                    cache.storage.insert((address, slot), *entry.value());
+                }
+            }
+        }
 
         // Contracts are keyed by code hash, which is immutable, so deployed bytecode is always
         // safe to cache.
@@ -279,6 +312,140 @@ mod tests {
 
         // An account the block did not touch still falls through to the db.
         assert!(db.basic_ref(unseeded_addr).unwrap().is_some());
+        assert_eq!(inner.reads.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn carries_nonce_precompile_parent_state() {
+        use alloy_primitives::map::{AddressMap, HashMap};
+        use revm::database::{AccountStatus, BundleAccount, BundleState, states::StorageSlot};
+        use tempo_precompiles::nonce::slots as nonce_slots;
+
+        let carried_slot = U256::from(7);
+        let carried_value = U256::from(123);
+        let carried_zero_slot = U256::from(8);
+        let overwritten_slot = U256::from(9);
+        let old_overwritten_value = U256::from(333);
+        let new_overwritten_value = U256::from(999);
+        let other_addr = Address::with_last_byte(2);
+        let other_slot = U256::from(10);
+
+        let mut parent_nonce_storage = HashMap::default();
+        parent_nonce_storage.insert(
+            nonce_slots::EXPIRING_NONCE_RING_PTR,
+            StorageSlot::new_changed(U256::from(1), U256::ZERO),
+        );
+        parent_nonce_storage.insert(
+            carried_slot,
+            StorageSlot::new_changed(U256::ZERO, carried_value),
+        );
+        parent_nonce_storage.insert(
+            carried_zero_slot,
+            StorageSlot::new_changed(U256::from(1), U256::ZERO),
+        );
+        parent_nonce_storage.insert(
+            overwritten_slot,
+            StorageSlot::new_changed(U256::ZERO, old_overwritten_value),
+        );
+
+        let mut parent_state = AddressMap::default();
+        parent_state.insert(
+            NONCE_PRECOMPILE_ADDRESS,
+            BundleAccount::new(
+                None,
+                Some(AccountInfo {
+                    balance: U256::from(777),
+                    ..Default::default()
+                }),
+                parent_nonce_storage,
+                AccountStatus::Changed,
+            ),
+        );
+
+        let mut other_storage = HashMap::default();
+        other_storage.insert(
+            other_slot,
+            StorageSlot::new_changed(U256::ZERO, U256::from(555)),
+        );
+        parent_state.insert(
+            other_addr,
+            BundleAccount::new(
+                None,
+                Some(AccountInfo::default()),
+                other_storage,
+                AccountStatus::Changed,
+            ),
+        );
+
+        let parent_cache = StateCache::from_post_state(&BundleState {
+            state: parent_state,
+            ..Default::default()
+        });
+
+        let mut child_nonce_storage = HashMap::default();
+        child_nonce_storage.insert(
+            overwritten_slot,
+            StorageSlot::new_changed(old_overwritten_value, new_overwritten_value),
+        );
+        let mut child_state = AddressMap::default();
+        child_state.insert(
+            NONCE_PRECOMPILE_ADDRESS,
+            BundleAccount::new(
+                None,
+                Some(AccountInfo::default()),
+                child_nonce_storage,
+                AccountStatus::Changed,
+            ),
+        );
+
+        let cache = StateCache::from_post_state_with_parent(
+            &BundleState {
+                state: child_state,
+                ..Default::default()
+            },
+            Some(&parent_cache),
+        );
+        let inner = CountingDb::default();
+        let db = StateCacheDb::new(&cache, &inner);
+
+        assert_eq!(
+            db.basic_ref(NONCE_PRECOMPILE_ADDRESS)
+                .unwrap()
+                .unwrap()
+                .balance,
+            U256::ZERO
+        );
+        assert_eq!(
+            db.storage_ref(
+                NONCE_PRECOMPILE_ADDRESS,
+                nonce_slots::EXPIRING_NONCE_RING_PTR
+            )
+            .unwrap(),
+            U256::ZERO
+        );
+        assert_eq!(
+            db.storage_ref(NONCE_PRECOMPILE_ADDRESS, carried_slot)
+                .unwrap(),
+            carried_value
+        );
+        assert_eq!(
+            db.storage_ref(NONCE_PRECOMPILE_ADDRESS, overwritten_slot)
+                .unwrap(),
+            new_overwritten_value
+        );
+        assert_eq!(inner.reads.load(Ordering::Relaxed), 0);
+
+        assert_eq!(
+            db.storage_ref(NONCE_PRECOMPILE_ADDRESS, carried_zero_slot)
+                .unwrap(),
+            U256::ZERO
+        );
+        assert_eq!(inner.reads.load(Ordering::Relaxed), 0);
+
+        assert_eq!(
+            db.storage_ref(other_addr, other_slot).unwrap(),
+            U256::from(42)
+        );
         assert_eq!(inner.reads.load(Ordering::Relaxed), 1);
     }
 

--- a/crates/transaction-pool/src/state_cache.rs
+++ b/crates/transaction-pool/src/state_cache.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::{Address, B256, U256, map::DefaultHashBuilder};
 use dashmap::DashMap;
-use revm::{Database, DatabaseRef, bytecode::Bytecode, state::AccountInfo};
+use revm::{Database, DatabaseRef, bytecode::Bytecode, database::BundleState, state::AccountInfo};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Concurrent cache of raw state reads anchored to a specific tip.
@@ -12,8 +12,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// across all concurrent validation calls so only the first access hits the underlying
 /// state provider.
 ///
-/// The validator replaces the cache whenever a new head block is processed, mirroring the
-/// lifecycle of its cached EVM environment.
+/// On every new head block the validator replaces the cache with a fresh one seeded from that
+/// block's post-execution state (see [`StateCache::from_post_state`]). The accounts, storage
+/// slots and contracts a block touches during execution are the same fee-token, nonce-manager
+/// and system-contract entries the next block's validations read, so seeding keeps those warm
+/// across blocks instead of re-reading them from the state provider every block.
 #[derive(Debug, Default)]
 pub(crate) struct StateCache {
     /// Cached basic account info, including non-existent accounts (`None`).
@@ -39,6 +42,57 @@ impl StateCache {
     const MAX_STORAGE_SLOTS: usize = 1 << 18;
     /// Maximum number of cached contracts.
     const MAX_CONTRACTS: usize = 1 << 12;
+
+    /// Builds a cache seeded with the post-execution state of a committed block range.
+    ///
+    /// The cache starts empty and is populated only with the post-state values found in
+    /// `bundle` (the accounts and storage slots the range touched, plus any contracts it
+    /// deployed). Because it never carries over entries from the previous tip, it cannot
+    /// serve stale reads: destroyed accounts and wiped storage slots simply stay absent and
+    /// are re-read on demand, and the cache size is bounded by the size of the block range
+    /// rather than growing without limit across blocks.
+    ///
+    /// Seeding runs once per block off the hot validation path, so it skips the per-entry cap
+    /// checks the on-demand read path uses and instead sets the entry counters from the final
+    /// map lengths. A large range (e.g. a deep reorg) may seed past the caps, but the counters
+    /// then reflect that and the on-demand read path stops inserting until entries drain.
+    pub(crate) fn from_post_state(bundle: &BundleState) -> Self {
+        let storage_len = bundle.state.values().map(|a| a.storage.len()).sum();
+        let cache = Self {
+            accounts: DashMap::with_capacity_and_hasher(bundle.state.len(), Default::default()),
+            storage: DashMap::with_capacity_and_hasher(storage_len, Default::default()),
+            contracts: DashMap::with_capacity_and_hasher(
+                bundle.contracts.len(),
+                Default::default(),
+            ),
+            ..Default::default()
+        };
+
+        // Contracts are keyed by code hash, which is immutable, so deployed bytecode is always
+        // safe to cache.
+        for (code_hash, code) in &bundle.contracts {
+            cache.contracts.insert(*code_hash, code.clone());
+        }
+
+        for (address, account) in &bundle.state {
+            cache.accounts.insert(*address, account.account_info());
+            for (slot, value) in &account.storage {
+                cache.storage.insert((*address, *slot), value.present_value);
+            }
+        }
+
+        cache
+            .account_count
+            .store(cache.accounts.len(), Ordering::Relaxed);
+        cache
+            .storage_count
+            .store(cache.storage.len(), Ordering::Relaxed);
+        cache
+            .contract_count
+            .store(cache.contracts.len(), Ordering::Relaxed);
+
+        cache
+    }
 }
 
 /// A [`DatabaseRef`] adapter that serves reads from a shared [`StateCache`], falling back
@@ -166,6 +220,66 @@ mod tests {
         fn block_hash_ref(&self, _number: u64) -> Result<B256, Self::Error> {
             Ok(B256::ZERO)
         }
+    }
+
+    #[test]
+    fn seeds_from_post_state_without_hitting_db() {
+        use alloy_primitives::map::{AddressMap, B256Map, HashMap};
+        use revm::database::{AccountStatus, BundleAccount, BundleState, states::StorageSlot};
+
+        let seeded_addr = Address::with_last_byte(1);
+        let seeded_slot = U256::from(7);
+        let seeded_value = U256::from(123);
+        let unseeded_addr = Address::with_last_byte(2);
+        let code_hash = B256::repeat_byte(0xab);
+
+        let seeded_info = AccountInfo {
+            balance: U256::from(999),
+            nonce: 5,
+            ..Default::default()
+        };
+
+        let mut storage = HashMap::default();
+        storage.insert(
+            seeded_slot,
+            StorageSlot::new_changed(U256::ZERO, seeded_value),
+        );
+        let mut state = AddressMap::default();
+        state.insert(
+            seeded_addr,
+            BundleAccount::new(None, Some(seeded_info), storage, AccountStatus::Changed),
+        );
+        let mut contracts = B256Map::default();
+        contracts.insert(code_hash, Bytecode::default());
+        let bundle = BundleState {
+            state,
+            contracts,
+            ..Default::default()
+        };
+
+        let cache = StateCache::from_post_state(&bundle);
+        assert_eq!(cache.account_count.load(Ordering::Relaxed), 1);
+        assert_eq!(cache.storage_count.load(Ordering::Relaxed), 1);
+        assert_eq!(cache.contract_count.load(Ordering::Relaxed), 1);
+
+        let inner = CountingDb::default();
+        let db = StateCacheDb::new(&cache, &inner);
+
+        // Seeded entries are served from the cache, leaving the underlying db untouched.
+        assert_eq!(
+            db.basic_ref(seeded_addr).unwrap().unwrap().balance,
+            U256::from(999)
+        );
+        assert_eq!(
+            db.storage_ref(seeded_addr, seeded_slot).unwrap(),
+            seeded_value
+        );
+        assert!(db.code_by_hash_ref(code_hash).unwrap().is_empty());
+        assert_eq!(inner.reads.load(Ordering::Relaxed), 0);
+
+        // An account the block did not touch still falls through to the db.
+        assert!(db.basic_ref(unseeded_addr).unwrap().is_some());
+        assert_eq!(inner.reads.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -27,7 +27,7 @@ use reth_transaction_pool::{
     error::{PoolError, PoolErrorKind},
     identifier::TransactionId,
 };
-use revm::database::BundleAccount;
+use revm::database::{BundleAccount, BundleState};
 use std::{sync::Arc, time::Instant};
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork};
 use tempo_precompiles::{
@@ -82,6 +82,15 @@ where
             .validator()
             .validator()
             .amm_liquidity_cache()
+    }
+
+    /// Reseeds the validator's tip-scoped state cache from a committed block's post-execution
+    /// state, keeping fee-token, nonce-manager and system-contract reads warm across blocks.
+    pub(crate) fn seed_validation_state_cache(&self, tip_hash: B256, bundle: &BundleState) {
+        self.protocol_pool
+            .validator()
+            .validator()
+            .seed_state_cache(tip_hash, bundle);
     }
 
     /// Returns the configured client

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -86,11 +86,16 @@ where
 
     /// Reseeds the validator's tip-scoped state cache from a committed block's post-execution
     /// state, keeping fee-token, nonce-manager and system-contract reads warm across blocks.
-    pub(crate) fn seed_validation_state_cache(&self, tip_hash: B256, bundle: &BundleState) {
+    pub(crate) fn seed_validation_state_cache(
+        &self,
+        parent_hash: B256,
+        hash: B256,
+        bundle: &BundleState,
+    ) {
         self.protocol_pool
             .validator()
             .validator()
-            .seed_state_cache(tip_hash, bundle);
+            .seed_state_cache(parent_hash, hash, bundle);
     }
 
     /// Returns the configured client

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -401,15 +401,21 @@ where
         }
     }
 
-    /// Replaces the tip-scoped state cache with a fresh one seeded from `tip_hash`'s
+    /// Replaces the tip-scoped state cache with a fresh one seeded from `hash`'s
     /// post-execution state.
     ///
     /// Called from pool maintenance on every commit (and after a reorg), where the new tip's
     /// execution outcome is available. Swapping in a brand new [`Arc`] keeps in-flight
     /// validations that hold the previous cache reading a consistent snapshot, while the next
-    /// validations anchored to `tip_hash` start warm with the entries the block touched.
-    pub fn seed_state_cache(&self, tip_hash: B256, bundle: &BundleState) {
-        *self.cached_state.write() = (tip_hash, Arc::new(StateCache::from_post_state(bundle)));
+    /// validations anchored to `hash` start warm with the entries the block touched.
+    pub fn seed_state_cache(&self, parent_hash: B256, hash: B256, bundle: &BundleState) {
+        let mut cached_state = self.cached_state.write();
+        let cache = if cached_state.0 == parent_hash {
+            StateCache::from_post_state_with_parent(bundle, Some(cached_state.1.as_ref()))
+        } else {
+            StateCache::from_post_state(bundle)
+        };
+        *cached_state = (hash, Arc::new(cache));
     }
 
     /// Validates one transaction with the given throwaway EVM.

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -29,6 +29,7 @@ use revm::{
         ContextTr, JournalTr,
         result::{EVMError, InvalidTransaction},
     },
+    database::BundleState,
 };
 use std::sync::{
     Arc,
@@ -100,8 +101,9 @@ pub struct TempoTransactionValidator<Client> {
     pub(crate) amm_liquidity_cache: AmmLiquidityCache,
     /// Cached EVM environment from the latest tip block, updated on each `on_new_head_block`.
     cached_evm_env: RwLock<EvmEnv<TempoHardfork, TempoBlockEnv>>,
-    /// Tip hash and cache of state reads shared across validation calls, replaced on each
-    /// `on_new_head_block`.
+    /// Tip hash and cache of state reads shared across validation calls. Replaced via
+    /// [`Self::seed_state_cache`] from pool maintenance whenever a new block is committed,
+    /// seeding the next cache from the committed block's post-execution state.
     cached_state: RwLock<(B256, Arc<StateCache>)>,
     /// The Tempo hardfork active at the current tip, stored as an index into
     /// [`TempoHardfork::VARIANTS`] and updated on each `on_new_head_block`.
@@ -391,6 +393,17 @@ where
         } else {
             Arc::new(StateCache::default())
         }
+    }
+
+    /// Replaces the tip-scoped state cache with a fresh one seeded from `tip_hash`'s
+    /// post-execution state.
+    ///
+    /// Called from pool maintenance on every commit (and after a reorg), where the new tip's
+    /// execution outcome is available. Swapping in a brand new [`Arc`] keeps in-flight
+    /// validations that hold the previous cache reading a consistent snapshot, while the next
+    /// validations anchored to `tip_hash` start warm with the entries the block touched.
+    pub fn seed_state_cache(&self, tip_hash: B256, bundle: &BundleState) {
+        *self.cached_state.write() = (tip_hash, Arc::new(StateCache::from_post_state(bundle)));
     }
 
     /// Validates one transaction with the given throwaway EVM.
@@ -741,9 +754,6 @@ where
         self.active_hardfork
             .store(evm_env.cfg_env.spec.variant_index(), Ordering::Relaxed);
         *self.cached_evm_env.write() = evm_env;
-
-        // State changed, drop all cached reads and anchor the new cache to this tip.
-        *self.cached_state.write() = (new_tip_block.hash(), Arc::new(StateCache::default()));
     }
 }
 

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -1,5 +1,6 @@
 use crate::{
     amm::AmmLiquidityCache,
+    metrics::TempoValidatorMetrics,
     state_cache::{StateCache, StateCacheDb},
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
@@ -111,6 +112,8 @@ pub struct TempoTransactionValidator<Client> {
     /// Cached here so hot paths can resolve the active hardfork with a single atomic load
     /// instead of walking the chain spec's fork schedule.
     active_hardfork: AtomicU8,
+    /// Validator metrics, including state cache hit/miss counters.
+    metrics: TempoValidatorMetrics,
 }
 
 impl<Client> TempoTransactionValidator<Client>
@@ -144,6 +147,7 @@ where
             cached_evm_env: parking_lot::RwLock::new(evm_env),
             cached_state: RwLock::new((latest_header.hash(), Arc::new(StateCache::default()))),
             active_hardfork,
+            metrics: TempoValidatorMetrics::default(),
         }
     }
 
@@ -389,8 +393,10 @@ where
     fn state_cache_for_tip(&self, tip_hash: B256) -> Arc<StateCache> {
         let (cached_tip_hash, cached_state) = self.cached_state.read().clone();
         if cached_tip_hash == tip_hash {
+            self.metrics.state_cache_hits.increment(1);
             cached_state
         } else {
+            self.metrics.state_cache_misses.increment(1);
             Arc::new(StateCache::default())
         }
     }


### PR DESCRIPTION
The transaction validator keeps a tip-scoped `StateCache` so repeated state reads (system contract config, fee token slots, sender accounts) are shared across validations. Until now it was replaced with an empty cache on every new head block (#5572), so the first validations after each block re-read state the previous block had already loaded.

Instead of wiping, reseed the cache from the committed block's execution outcome, mirroring how the payload builder reuses `CachedReads`. The accounts, storage slots and contracts a block touches during execution are the same entries the next block's validations read, so seeding keeps them warm. Seeding starts from an empty cache and only inserts post-state values, so it never serves stale reads (destroyed accounts and wiped slots stay absent and are re-read on demand) and stays bounded by the block range rather than growing across blocks. Reorgs work the same way via the new canonical segment's aggregated post-state.

`on_new_head_block` no longer manages the cache (it still refreshes the EVM env and active hardfork); it is now reseeded from `maintain_tempo_pool`, which has the execution outcome. A fresh `Arc` is swapped in so in-flight validations keep a consistent snapshot.