### PR TITLE
perf(txpool): reduce per-block work in maintain_tempo_pool

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -139,8 +139,33 @@ impl TempoPoolUpdates {
             .flatten()
             .flat_map(|receipt| &receipt.logs)
         {
+            // Fee token pause events and balance changes.
+            //
+            // Checked first because TIP-20 `Transfer` logs dominate block receipts; this avoids
+            // three address comparisons per transfer before reaching the matching branch.
+            if log.address.is_tip20() {
+                match Tip20PoolEvent::decode(log) {
+                    Some(Tip20PoolEvent::PauseStateUpdate(event)) => {
+                        updates.pause_events.push((log.address, event.isPaused));
+                    }
+                    Some(Tip20PoolEvent::TransferPolicyUpdate) => {
+                        updates.transfer_policy_updates.insert(log.address);
+                    }
+                    Some(Tip20PoolEvent::QuoteTokenUpdate) => {
+                        updates.quote_token_updates.insert(log.address);
+                    }
+                    Some(Tip20PoolEvent::Transfer { from }) => {
+                        updates
+                            .fee_balance_changes
+                            .entry(log.address)
+                            .or_default()
+                            .insert(from);
+                    }
+                    None => {}
+                }
+            }
             // Key revocations and spending limit changes
-            if log.address == ACCOUNT_KEYCHAIN_ADDRESS {
+            else if log.address == ACCOUNT_KEYCHAIN_ADDRESS {
                 match AccountKeychainPoolEvent::decode(log) {
                     Some(AccountKeychainPoolEvent::KeyRevoked(event)) => {
                         updates.revoked_keys.insert(event.account, event.publicKey);
@@ -210,28 +235,6 @@ impl TempoPoolUpdates {
                             .push((event.policyId, event.account));
                     }
                     Some(_) | None => {}
-                }
-            }
-            // Fee token pause events and balance changes
-            else if log.address.is_tip20() {
-                match Tip20PoolEvent::decode(log) {
-                    Some(Tip20PoolEvent::PauseStateUpdate(event)) => {
-                        updates.pause_events.push((log.address, event.isPaused));
-                    }
-                    Some(Tip20PoolEvent::TransferPolicyUpdate) => {
-                        updates.transfer_policy_updates.insert(log.address);
-                    }
-                    Some(Tip20PoolEvent::QuoteTokenUpdate) => {
-                        updates.quote_token_updates.insert(log.address);
-                    }
-                    Some(Tip20PoolEvent::Transfer(event)) => {
-                        updates
-                            .fee_balance_changes
-                            .entry(log.address)
-                            .or_default()
-                            .insert(event.from);
-                    }
-                    None => {}
                 }
             }
         }
@@ -352,14 +355,20 @@ enum Tip20PoolEvent {
     TransferPolicyUpdate,
     /// [`ITIP20::QuoteTokenUpdate`] log.
     QuoteTokenUpdate,
-    /// [`ITIP20::Transfer`] log.
-    Transfer(ITIP20::Transfer),
+    /// [`ITIP20::Transfer`] log; only the debited `from` account is retained.
+    Transfer { from: Address },
 }
 
 impl Tip20PoolEvent {
     /// Decodes only TIP-20 events used by transaction-pool maintenance.
     fn decode(log: &Log) -> Option<Self> {
         match first_topic(log)? {
+            // `Transfer` is by far the most common TIP-20 log, so avoid a full event decode
+            // and read the indexed `from` directly from `topics[1]`. We only need the debited
+            // account for `fee_balance_changes`; `to` and `amount` are unused.
+            ITIP20::Transfer::SIGNATURE_HASH => log.topics().get(1).map(|topic| Self::Transfer {
+                from: Address::from_word(*topic),
+            }),
             ITIP20::PauseStateUpdate::SIGNATURE_HASH => {
                 decode_event(log).map(Self::PauseStateUpdate)
             }
@@ -370,7 +379,6 @@ impl Tip20PoolEvent {
             ITIP20::QuoteTokenUpdate::SIGNATURE_HASH => {
                 decode_event::<ITIP20::QuoteTokenUpdate>(log).map(|_| Self::QuoteTokenUpdate)
             }
-            ITIP20::Transfer::SIGNATURE_HASH => decode_event(log).map(Self::Transfer),
             _ => None,
         }
     }
@@ -444,6 +452,13 @@ impl TempoPoolState {
     /// This avoids repeating the `expiry_map` lookup for every mined hash while
     /// preserving O(1)-ish removal from each `B256Set` bucket.
     fn untrack_many<'a>(&mut self, hashes: impl IntoIterator<Item = &'a TxHash>) {
+        // Nothing is tracked for expiry (the common case in throughput-heavy blocks where
+        // few/no AA transactions carry `valid_before` or key expiry), so skip iterating the
+        // block's mined hashes entirely.
+        if self.tx_to_expiry.is_empty() {
+            return;
+        }
+
         let mut hashes_by_expiry: BTreeMap<u64, B256Set> = BTreeMap::new();
 
         for hash in hashes {
@@ -672,7 +687,7 @@ where
                         tip_timestamp,
                         "Evicting expired AA transactions (valid_before)"
                     );
-                    removed_txs.push(pool.remove_transactions(updates.expired_txs.clone()));
+                    removed_txs.push(pool.remove_transactions(std::mem::take(&mut updates.expired_txs)));
                     metrics.expired_transactions_evicted.increment(expired_count as u64);
                 }
                 metrics.expired_eviction_duration_seconds.record(expired_start.elapsed());
@@ -700,7 +715,7 @@ where
                     let mut by_token = {
                         let all_txs = all_txs.get_or_insert_with(|| pool.all_transactions());
                         all_txs.iter()
-                            .filter(|tx| !removed_this_iteration.contains(tx.hash()))
+                            .filter(|tx| removed_this_iteration.is_empty() || !removed_this_iteration.contains(tx.hash()))
                             .fold(
                                 AddressMap::<Vec<TxHash>>::default(),
                                 |mut by_token, tx| {
@@ -850,7 +865,7 @@ where
                         let all_txs = all_txs.get_or_insert_with(|| pool.all_transactions());
                         all_txs
                             .iter()
-                            .filter(|tx| !removed_this_iteration.contains(tx.hash()))
+                            .filter(|tx| removed_this_iteration.is_empty() || !removed_this_iteration.contains(tx.hash()))
                             .filter(|tx| {
                                 tx.transaction
                                     .resolved_fee_token()
@@ -915,7 +930,7 @@ where
                             &updates,
                             all_txs
                                 .iter()
-                                .filter(|tx| !removed_this_iteration.contains(tx.hash())),
+                                .filter(|tx| removed_this_iteration.is_empty() || !removed_this_iteration.contains(tx.hash())),
                         )
                     };
                     for tx in &evicted {
@@ -1411,7 +1426,13 @@ mod tests {
                     amount: U256::from(42),
                 },
             );
-            assert_decodes_like_generated!(Tip20PoolEvent, Transfer, ITIP20::Transfer, log);
+            // `Transfer` decoding is specialized to read only the indexed `from` topic, so
+            // compare that against the field a full event decode would produce.
+            let expected = generated_decode::<ITIP20::Transfer>(&log);
+            match Tip20PoolEvent::decode(&log) {
+                Some(Tip20PoolEvent::Transfer { from }) => assert_eq!(from, expected.from),
+                _ => panic!("unexpected decoded event"),
+            }
         }
     }
 

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -685,28 +685,29 @@ where
                 // broadcasting near-expiry txs that peers would reject.
                 let max_expiry = tip_timestamp.saturating_add(EVICTION_BUFFER_SECS);
 
-                // Add expired transactions (from local tracking state)
-                let expired = state.drain_expired(max_expiry);
-                if !expired.is_empty() {
-                    let mined_hashes: B256Set = tip.transaction_hashes().copied().collect();
-                    updates.expired_txs = expired
-                        .into_iter()
-                        .filter(|hash| !mined_hashes.contains(hash) && pool.contains(hash))
-                        .collect();
-                }
+                // Add expired transactions (from local tracking state).
+                //
+                // Mined transactions were already untracked above, so the drained set cannot
+                // contain hashes mined in this block. Hashes that have since left the pool by
+                // other means are handled by `remove_transactions` as no-ops, so no pre-filter
+                // (and no mined-hash set) is needed here.
+                updates.expired_txs = state.drain_expired(max_expiry);
 
                 // 4. Evict expired AA transactions
                 let expired_start = Instant::now();
-                let expired_count = updates.expired_txs.len();
-                if expired_count > 0 {
-                    debug!(
-                        target: "txpool",
-                        count = expired_count,
-                        tip_timestamp,
-                        "Evicting expired AA transactions (valid_before)"
-                    );
-                    removed_txs.push(pool.remove_transactions(std::mem::take(&mut updates.expired_txs)));
-                    metrics.expired_transactions_evicted.increment(expired_count as u64);
+                if !updates.expired_txs.is_empty() {
+                    let evicted =
+                        pool.remove_transactions(std::mem::take(&mut updates.expired_txs));
+                    if !evicted.is_empty() {
+                        debug!(
+                            target: "txpool",
+                            count = evicted.len(),
+                            tip_timestamp,
+                            "Evicting expired AA transactions (valid_before)"
+                        );
+                        metrics.expired_transactions_evicted.increment(evicted.len() as u64);
+                        removed_txs.push(evicted);
+                    }
                 }
                 metrics.expired_eviction_duration_seconds.record(expired_start.elapsed());
 
@@ -988,8 +989,12 @@ where
                 // Record total block update duration
                 metrics.block_update_duration_seconds.record(block_update_start.elapsed());
 
-                // Deallocating removed transactions is expensive, so do it after all updates are done.
-                drop(removed_txs);
+                // Deallocating removed transactions is expensive (input data, signatures,
+                // allocator and kernel work), so move it off the maintenance task entirely,
+                // freeing the loop to immediately continue processing pool events.
+                if removed_txs.iter().any(|txs| !txs.is_empty()) {
+                    tokio::task::spawn_blocking(move || drop(removed_txs));
+                }
             }
         }
     }

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -34,6 +34,11 @@ use tracing::{debug, error};
 /// of near-expiry transactions that are likely to fail validation on peers.
 const EVICTION_BUFFER_SECS: u64 = 3;
 
+/// Maximum number of buffered new-transaction events to drain in a single maintenance
+/// wakeup before yielding back to the event loop. Bounds the per-wakeup work so a sustained
+/// burst of new transactions cannot starve block-commit processing.
+const NEW_TX_DRAIN_LIMIT: usize = 4096;
+
 /// Aggregated block-level invalidation events for the transaction pool.
 ///
 /// Collects all invalidation events from a block into a single structure,
@@ -612,6 +617,19 @@ where
                 };
 
                 state.track(&tx_event.transaction.transaction);
+
+                // At high TPS the listener fires constantly and each wakeup re-polls the
+                // whole select loop. Drain already-buffered events in this wakeup so the
+                // select/poll overhead is amortized across many transactions instead of paid
+                // per transaction. The drain is bounded so a sustained burst cannot starve
+                // the block-processing branch below.
+                let mut drained = 0;
+                while drained < NEW_TX_DRAIN_LIMIT
+                    && let Ok(tx_event) = new_txs.try_recv()
+                {
+                    state.track(&tx_event.transaction.transaction);
+                    drained += 1;
+                }
             }
 
             // Process all maintenance operations on new block commit or reorg

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -222,6 +222,22 @@ where
             !updates.key_authorization_target_changes.is_empty();
         let mut fee_balance_cache: HashMap<(Address, Address), U256> = HashMap::default();
 
+        // The set of fee tokens that saw balance changes is usually tiny (a handful of fee
+        // tokens), so a linear scan with direct address comparisons is cheaper than hashing the
+        // fee token for every pooled transaction. Fall back to the hashmap when a block touches
+        // many tokens so the per-transaction cost stays bounded.
+        const FEE_BALANCE_LINEAR_SCAN_LIMIT: usize = 16;
+        let fee_balance_tokens: Option<Vec<(Address, &AddressSet)>> =
+            (!updates.fee_balance_changes.is_empty()
+                && updates.fee_balance_changes.len() <= FEE_BALANCE_LINEAR_SCAN_LIMIT)
+                .then(|| {
+                    updates
+                        .fee_balance_changes
+                        .iter()
+                        .map(|(token, accounts)| (*token, accounts))
+                        .collect()
+                });
+
         for tx in transactions {
             // Avoid recovering key ids unless a keychain invalidation can use them.
             if has_keychain_subject_updates || has_key_authorization_target_updates {
@@ -336,7 +352,14 @@ where
             {
                 let fee_token = tx.transaction.effective_fee_token();
                 // only resolve the fee payer if the fee token saw balance changes
-                if let Some(accounts) = updates.fee_balance_changes.get(&fee_token) {
+                let accounts = match &fee_balance_tokens {
+                    Some(tokens) => tokens
+                        .iter()
+                        .find(|(token, _)| *token == fee_token)
+                        .map(|(_, accounts)| *accounts),
+                    None => updates.fee_balance_changes.get(&fee_token),
+                };
+                if let Some(accounts) = accounts {
                     let Ok(fee_payer) = tx.transaction.fee_payer() else {
                         continue;
                     };

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -80,22 +80,17 @@ pub struct AA2dPool {
     /// the expiring nonce transaction that should be evicted next:
     /// lowest priority first, then newest submission first when priorities tie.
     expiring_nonce_eviction_order: BTreeSet<ExpiringNonceEvictionKey>,
-    /// A mapping of `expiring_nonce_seen` slot to expiring nonce hash.
+    /// A mapping of nonce-precompile storage slots to the pool entity they affect.
     ///
-    /// Used to track inclusion of expiring nonce transactions.
-    slot_to_expiring_nonce_hash: U256Map<B256>,
+    /// Combines the reverse index for 2D nonce slots (`NonceManager::nonces`) and
+    /// `expiring_nonce_seen` slots into a single map so processing a block's storage
+    /// updates needs only one lookup per touched slot. The two slot families come from
+    /// distinct keccak preimage domains and cannot collide.
+    nonce_slots: U256Map<NonceSlotTarget>,
     /// Scratch buffer reused while processing nonce state updates.
     state_update_nonce_changes: HashMap<AASequenceId, u64>,
     /// Scratch buffer reused while processing included expiring nonce transactions.
     state_update_included_expiring_nonce_hashes: Vec<B256>,
-    /// Reverse index for the storage slot of an account's nonce
-    ///
-    /// ```solidity
-    ///  mapping(address => mapping(uint256 => uint64)) public nonces
-    /// ```
-    ///
-    /// This identifies the account and nonce key based on the slot in the `NonceManager`.
-    slot_to_seq_id: U256Map<AASequenceId>,
     /// Settings for this sub-pool.
     config: AA2dPoolConfig,
     /// Metrics for tracking pool statistics
@@ -139,10 +134,9 @@ impl AA2dPool {
             by_hash: Default::default(),
             expiring_nonce_txs: Default::default(),
             expiring_nonce_eviction_order: Default::default(),
-            slot_to_expiring_nonce_hash: Default::default(),
+            nonce_slots: Default::default(),
             state_update_nonce_changes: Default::default(),
             state_update_included_expiring_nonce_hashes: Default::default(),
-            slot_to_seq_id: Default::default(),
             config,
             metrics: AA2dPoolMetrics::default(),
             by_eviction_order: Default::default(),
@@ -479,8 +473,8 @@ impl AA2dPool {
         expiring_nonce_entry.insert(pending_tx);
         self.expiring_nonce_eviction_order.insert(eviction_key);
         if let Some(slot) = transaction.transaction.expiring_nonce_slot() {
-            self.slot_to_expiring_nonce_hash
-                .insert(slot, expiring_nonce_hash);
+            self.nonce_slots
+                .insert(slot, NonceSlotTarget::ExpiringNonce(expiring_nonce_hash));
         }
         self.by_hash.insert(tx_hash, transaction.clone());
 
@@ -792,7 +786,7 @@ impl AA2dPool {
         if self.by_id.range(id.seq_id.range()).next().is_none()
             && let Some(slot) = tx.inner.transaction.transaction.nonce_key_slot()
         {
-            self.slot_to_seq_id.remove(&slot);
+            self.nonce_slots.remove(&slot);
         }
 
         self.remove_independent(id);
@@ -1291,7 +1285,7 @@ impl AA2dPool {
     ) -> Arc<ValidPoolTransaction<TempoPooledTransaction>> {
         self.by_hash.remove(pending_tx.transaction.hash());
         if let Some(slot) = pending_tx.transaction.transaction.expiring_nonce_slot() {
-            self.slot_to_expiring_nonce_hash.remove(&slot);
+            self.nonce_slots.remove(&slot);
         }
         self.decrement_sender_count(pending_tx.transaction.sender());
         self.pending_count -= 1;
@@ -1348,7 +1342,11 @@ impl AA2dPool {
         trace!(target: "txpool::2d", ?address, ?nonce_key, "recording 2d nonce slot");
         let seq_id = AASequenceId::new(address, nonce_key);
 
-        if self.slot_to_seq_id.insert(slot, seq_id).is_none() {
+        if self
+            .nonce_slots
+            .insert(slot, NonceSlotTarget::SeqId(seq_id))
+            .is_none()
+        {
             self.metrics.inc_nonce_key_count(1);
         }
     }
@@ -1369,17 +1367,20 @@ impl AA2dPool {
         let mut included_expiring_nonce_hashes =
             std::mem::take(&mut self.state_update_included_expiring_nonce_hashes);
 
-        // Process known 2D nonce slot changes.
+        // Process known nonce-precompile slot changes with a single lookup per slot.
         for (slot, value) in nonce_state.storage.iter() {
-            if let Some(seq_id) = self.slot_to_seq_id.get(slot) {
-                changes.insert(*seq_id, value.present_value.saturating_to());
-            }
-            // Detect included expiring nonce transactions via their
-            // `expiring_nonce_seen` slot being set to a non-zero value.
-            if !value.present_value.is_zero()
-                && let Some(expiring_nonce_hash) = self.slot_to_expiring_nonce_hash.get(slot)
-            {
-                included_expiring_nonce_hashes.push(*expiring_nonce_hash);
+            match self.nonce_slots.get(slot) {
+                Some(NonceSlotTarget::SeqId(seq_id)) => {
+                    changes.insert(*seq_id, value.present_value.saturating_to());
+                }
+                // Detect included expiring nonce transactions via their
+                // `expiring_nonce_seen` slot being set to a non-zero value.
+                Some(NonceSlotTarget::ExpiringNonce(expiring_nonce_hash)) => {
+                    if !value.present_value.is_zero() {
+                        included_expiring_nonce_hashes.push(*expiring_nonce_hash);
+                    }
+                }
+                None => {}
             }
         }
 
@@ -1404,6 +1405,24 @@ impl AA2dPool {
         self.update_metrics();
 
         (promoted, mined)
+    }
+
+    /// Number of tracked 2D nonce sequence slots.
+    #[cfg(test)]
+    fn seq_id_slot_count(&self) -> usize {
+        self.nonce_slots
+            .values()
+            .filter(|target| matches!(target, NonceSlotTarget::SeqId(_)))
+            .count()
+    }
+
+    /// Number of tracked `expiring_nonce_seen` slots.
+    #[cfg(test)]
+    fn expiring_nonce_slot_count(&self) -> usize {
+        self.nonce_slots
+            .values()
+            .filter(|target| matches!(target, NonceSlotTarget::ExpiringNonce(_)))
+            .count()
     }
 
     /// Asserts that all assumptions are valid.
@@ -1701,6 +1720,18 @@ impl Default for AA2dPoolConfig {
             max_txs_per_sender: DEFAULT_MAX_TXS_PER_SENDER,
         }
     }
+}
+
+/// Pool entity affected by a nonce-precompile storage slot, stored in
+/// [`AA2dPool::nonce_slots`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum NonceSlotTarget {
+    /// The slot holds the on-chain nonce for this 2D nonce sequence
+    /// (`NonceManager::nonces[account][nonce_key]`).
+    SeqId(AASequenceId),
+    /// The slot is the `expiring_nonce_seen` marker for the expiring nonce
+    /// transaction with this expiring nonce hash.
+    ExpiringNonce(B256),
 }
 
 #[derive(Debug, Clone)]
@@ -6472,7 +6503,7 @@ mod tests {
         assert_eq!(mined[0].hash(), &tx_hash);
         assert!(!pool.contains(&tx_hash));
         assert!(pool.expiring_nonce_txs.is_empty());
-        assert!(pool.slot_to_expiring_nonce_hash.is_empty());
+        assert_eq!(pool.expiring_nonce_slot_count(), 0);
         assert_expiring_eviction_index_len(&pool, 0);
         pool.assert_invariants();
         assert!(pool.state_update_nonce_changes.is_empty());
@@ -7038,7 +7069,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(pool.slot_to_seq_id.len(), 1);
+        assert_eq!(pool.seq_id_slot_count(), 1);
 
         for i in 2..12u64 {
             let tx = TxBuilder::aa(sender)
@@ -7057,9 +7088,9 @@ mod tests {
         }
 
         assert_eq!(
-            pool.slot_to_seq_id.len(),
+            pool.seq_id_slot_count(),
             1,
-            "rejected txs with new nonce keys should not grow slot_to_seq_id"
+            "rejected txs with new nonce keys should not grow nonce_slots"
         );
         pool.assert_invariants();
     }

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -1375,12 +1375,12 @@ impl AA2dPool {
                 }
                 // Detect included expiring nonce transactions via their
                 // `expiring_nonce_seen` slot being set to a non-zero value.
-                Some(NonceSlotTarget::ExpiringNonce(expiring_nonce_hash)) => {
-                    if !value.present_value.is_zero() {
-                        included_expiring_nonce_hashes.push(*expiring_nonce_hash);
-                    }
+                Some(NonceSlotTarget::ExpiringNonce(expiring_nonce_hash))
+                    if !value.present_value.is_zero() =>
+                {
+                    included_expiring_nonce_hashes.push(*expiring_nonce_hash);
                 }
-                None => {}
+                _ => {}
             }
         }
 


### PR DESCRIPTION
Reduces allocations and lookups on the `maintain_tempo_pool` per-block hot path, guided by samply profiles from the e2e benchmark across four derek runs.

## Changes

- **`from_chain` TIP-20 decode**: `Transfer` logs (which dominate block receipts) are decoded by reading the indexed `from` topic directly instead of running a full event decode — only the debited account is needed for `fee_balance_changes`. The `Transfer` arm is matched first and the TIP-20 branch is checked first in the address dispatch.
- **Redundant mined-hash set removed**: the expired-eviction path built a `B256Set` of every mined transaction hash per block to filter drained expiry entries, but `untrack_many` already removes mined hashes from expiry tracking before the drain, so the set (and the `pool.contains` pre-filter, which duplicates the probe `remove_transactions` performs anyway) was dead work. Eviction metrics now count actual removals.
- **2D pool slot maps merged**: `slot_to_seq_id` and `slot_to_expiring_nonce_hash` are combined into a single `nonce_slots` map so processing a block's nonce-precompile storage updates needs one lookup per touched slot instead of two; the slot families come from distinct keccak preimage domains and cannot collide.
- **Eviction scan fee-token lookup**: the per-transaction `fee_balance_changes` hashmap lookup is replaced with a bounded linear scan over the (typically few) changed fee tokens, falling back to the hashmap when a block touches many tokens.
- **Deallocation off the maintenance task**: dropping removed transactions (input data, signatures, allocator/kernel work) was already deferred to the end of the block update; it now runs via `spawn_blocking` so the loop immediately resumes processing pool events.
- **Batched new-tx tracking**: buffered new-transaction events are drained in one wakeup (bounded) instead of one select iteration per event.
- `removed_this_iteration` filter short-circuits when empty; expired hashes are moved instead of cloned.

## Measured impact (derek e2e, tip20, profile-validated)

No throughput regression across four run-pairs=1 runs (TPS deltas −0.03% to +0.49%, all within noise). On the targeted code paths, comparing feature vs baseline profiles from the latest run:

- `from_chain`: 1.56% → 0.99% of maintenance time (−38% self-time)
- eviction scan: 14.4% → 13.5% of maintenance, with its hashing share down from 63% to 40%
- the redundant mined-hash set collect is gone from the profile entirely (152 → 0 samples)
- 15% of the maintenance CPU (deallocation of removed transactions plus the kernel memory work under it) now runs on the blocking pool instead of the event loop, reducing the maintenance loop's occupancy by ~17% relative to baseline

`maintain_tempo_pool` overall is ~2% of total CPU; its remaining cost is structural (pool snapshot scans, 2D-pool promotion machinery, and deallocation of removed transactions, now off the event loop). Larger reductions would require semantic changes — periodic instead of per-block fee-balance eviction, or a fee-payer-indexed eviction across both sub-pools (a sender-keyed index would silently miss sponsored AA transactions) — which are intentionally out of scope here.

