### PR TITLE
ci: allow changelog fragments in SDK release skip

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -78,7 +78,8 @@ jobs:
             exit 0
           fi
 
-          allowed='^(Cargo\.lock|crates/(alloy|chainspec|contracts|primitives)/(Cargo\.toml|CHANGELOG\.md))$'
+          # Release PRs may also add/delete consumed changelog fragments.
+          allowed='^(Cargo\.lock|\.changelog/[^/]+\.md|crates/(alloy|chainspec|contracts|primitives)/(Cargo\.toml|CHANGELOG\.md))$'
           if printf '%s\n' "$changed_files" | grep -Ev "$allowed" >/dev/null; then
             echo "release_only_sdk_crates=false" >> "$GITHUB_OUTPUT"
             echo "Found non-release-only SDK crate changes."


### PR DESCRIPTION
## Summary
- Treat .changelog/*.md fragments as release-only SDK metadata in the Specs workflow skip check
- Keeps Forge Test (Rust Precompiles) skipped for release PRs that only update SDK crate metadata and consume changelog fragments

## Validation
- Replayed the PR #5497 changed file list against the updated regex; no files were rejected.