### PR TITLE
docs: add TIP-1081 block-scoped validator fee token resolution

### DIFF
--- a/tips/tip-1081.md
+++ b/tips/tip-1081.md
@@ -1,0 +1,63 @@
+---
+id: TIP-1081
+title: Block-Scoped Validator Fee Token Resolution
+description: Resolve the beneficiary's preferred fee token once per beneficiary scope instead of twice per transaction.
+authors: Brian Picciano (@mediocregopher)
+status: Draft
+related: tempoxyz/tempo#5439
+protocolVersion: T8
+---
+
+# TIP-1081: Block-Scoped Validator Fee Token Resolution
+
+## Abstract
+
+Fee collection currently resolves the block beneficiary's preferred fee token from `FeeManager` storage twice per transaction: once in `collectFeePreTx` and once in `collectFeePostTx`. Because `setValidatorToken` rejects calls from the current beneficiary (`CannotChangeWithinBlock`), the value is immutable for the duration of a beneficiary's scope, making the per-transaction reads redundant.
+
+This TIP moves resolution to a single storage read at each beneficiary scope boundary — block start and each sub-block boundary — and removes the per-transaction reads. Because the per-transaction read warms the `validatorTokens[beneficiary]` storage slot in each transaction's access set, removing it is gas-observable and must activate at a hardfork.
+
+## Motivation
+
+The two per-transaction reads sit on the hottest path in the protocol: every fee-paying transaction performs a mapping-slot derivation (keccak) plus a journaled `SLOAD`, and the first per-transaction access additionally inserts into the journal's per-transaction storage map. Execution profiles show this journal work (account/storage-map loads and the associated allocations) as a measurable share of per-transaction overhead.
+
+Caching the resolved value inside the node without a protocol change (attempted in tempoxyz/tempo#5439) is not viable: the per-transaction `SLOAD` warms `validatorTokens[beneficiary]` in that transaction's EIP-2929 access set, and the slot is user-readable via `validatorTokens(address)` on the fee-manager dispatch. Skipping the read on cache hits flips a subsequent in-transaction user read of that slot from warm to cold, diverging `gas_used` and therefore receipts from unpatched nodes. The redundant work and the observable warming are the same operation, so the read can only be removed by a coordinated protocol change.
+
+Alternative considered: caching the resolved value with storage-slot-change invalidation (the design of #5439, fork-gated). Rejected in favor of scope-boundary resolution, which needs no invalidation machinery at all because the protocol already guarantees immutability within the scope.
+
+## Assumptions
+
+- `setValidatorToken` is the only writer of `validatorTokens` slots, and it rejects `sender == beneficiary` (`CannotChangeWithinBlock`). If a new writer is ever introduced without this restriction, scope-boundary resolution becomes unsound and this TIP must be revisited.
+- Sub-blocks may have different beneficiaries than the outer block, and a validator can update their own token from a scope they do not propose. Resolution therefore happens per scope boundary, not once per block.
+- Pre-activation behavior (per-transaction reads, including their warming side effect) is preserved exactly under all pre-T8 hardforks.
+
+## Threat Model
+
+- **Validators**: cannot change their own preferred fee token within a scope they propose (existing `CannotChangeWithinBlock` rule, unchanged). A validator changing their token from another scope takes effect at their next scope boundary, same as today.
+- **Users / transaction senders**: cannot influence the resolved value mid-scope; `setValidatorToken` only writes the sender's own mapping entry. Users relying on fee-collection's incidental warming of `validatorTokens[beneficiary]` for cheap reads must warm the slot themselves (access list or first read) post-activation.
+- Out of scope: changes to fee routing, AMM behavior, or `setValidatorToken` semantics.
+
+---
+
+# Specification
+
+From T8 activation:
+
+1. **Scope-boundary resolution.** At the start of block execution, and again at every beneficiary change within the block (sub-block boundary), the node performs a single read of `validatorTokens[beneficiary]`, applying the existing zero-value fallback to `DEFAULT_FEE_TOKEN`. The resolved value is held for the duration of that scope.
+2. **Per-transaction reads removed.** `collectFeePreTx` and `collectFeePostTx` use the scope-resolved value and MUST NOT read `validatorTokens[beneficiary]` per transaction. All other fee-collection reads and writes are unchanged.
+3. **Gas and access-set semantics.** The scope-boundary read is a protocol-level operation: it is not gas-charged and does not modify any transaction's access set. Consequently, from activation, `validatorTokens[beneficiary]` is cold at the start of every transaction unless warmed by the transaction itself (access list or prior in-transaction read). Pre-activation, fee collection warms this slot in every fee-paying transaction; this TIP removes that warming.
+4. **`setValidatorToken` unchanged.** The `CannotChangeWithinBlock` restriction remains and is the invariant that makes scope-resolution sound. A token change made by validator V in a scope V does not propose becomes visible at V's next scope boundary — identical to current behavior, where the change becomes visible to the next transaction only in scopes V does not propose.
+
+# Tooling
+
+N/A — no interface, encoding, or RPC changes. `validatorTokens(address)` remains callable with unchanged semantics; only its warm/cold status at transaction start changes. Gas-estimation tooling that replays execution is unaffected because estimation runs the same post-activation rules.
+
+# Observability
+
+N/A — no new events. The resolved value per scope is already derivable from `ValidatorTokenSet` events plus block/sub-block beneficiaries. Node implementations SHOULD expose the scope-resolution in trace-level logs for debugging.
+
+# Invariants
+
+- **Equivalence:** for every transaction in a beneficiary scope, fee routing uses exactly the value a fresh `validatorTokens[beneficiary]` read would return at the scope's first transaction. Test: validator V updates their token in sub-block A (proposed by X); a later sub-block proposed by V in the same block routes fees through the new token.
+- **Immutability within scope:** no transaction can alter the resolved value for the remainder of its scope (guaranteed by `CannotChangeWithinBlock`). Test: `setValidatorToken` from the beneficiary continues to revert.
+- **Gas vectors:** post-activation, a transaction whose first action reads `validatorTokens[beneficiary]` pays cold-read gas; pre-activation it pays warm-read gas. Both must be covered by execution-spec tests pinned to the fork boundary.
+- **Pre-fork equivalence:** blocks executed under pre-T8 rules produce byte-identical receipts with and without this change.


### PR DESCRIPTION
Follow-up to #5439 (closed as consensus-observable without a fork gate).

Drafts the fork-gated alternative discussed there: resolve `validatorTokens[beneficiary]` once per beneficiary scope (block start + each sub-block boundary) and drop both per-transaction reads from `collectFeePreTx`/`collectFeePostTx`. `CannotChangeWithinBlock` makes the value immutable within a scope, so no cache-invalidation machinery is needed.

Notes:
- TIP number **1081 is provisional** — highest claimed I could find across merged TIPs and open PRs was 1080; happy to renumber.
- `protocolVersion: T8` assumes T8 is the next unscheduled fork; adjust if not.
- Authors field credits @mediocregopher from #5439 — adjust as appropriate.