### PR TITLE
perf(txpool): linear-scan fee-token lookup in eviction scan

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -257,6 +257,23 @@ impl TempoPoolUpdates {
             || !self.spending_limit_changes.is_empty()
             || !self.spending_limit_spends.is_empty()
     }
+
+    /// Returns the fee balance changes if they are few enough to scan linearly.
+    ///
+    /// The set of fee tokens that saw balance changes is usually tiny (a handful of tokens),
+    /// so iterating the entries with direct address comparisons is cheaper than hashing the
+    /// fee token for every pooled transaction. Returns `None` when there are no changes or
+    /// when a block touches many tokens, in which case callers should use
+    /// [`fee_balance_changes`](Self::fee_balance_changes) lookups so the per-transaction
+    /// cost stays bounded.
+    pub fn scannable_fee_balance_changes(&self) -> Option<&AddressMap<AddressSet>> {
+        /// Above this many changed tokens the linear scan no longer beats a hashmap lookup.
+        const FEE_BALANCE_LINEAR_SCAN_LIMIT: usize = 16;
+
+        (!self.fee_balance_changes.is_empty()
+            && self.fee_balance_changes.len() <= FEE_BALANCE_LINEAR_SCAN_LIMIT)
+            .then_some(&self.fee_balance_changes)
+    }
 }
 
 /// Transaction-pool relevant subset of `IAccountKeychain::IAccountKeychainEvents`.

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -222,6 +222,8 @@ where
             !updates.key_authorization_target_changes.is_empty();
         let mut fee_balance_cache: HashMap<(Address, Address), U256> = HashMap::default();
 
+        let fee_balance_tokens = updates.scannable_fee_balance_changes();
+
         for tx in transactions {
             // Avoid recovering key ids unless a keychain invalidation can use them.
             if has_keychain_subject_updates || has_key_authorization_target_updates {
@@ -336,7 +338,15 @@ where
             {
                 let fee_token = tx.transaction.effective_fee_token();
                 // only resolve the fee payer if the fee token saw balance changes
-                if let Some(accounts) = updates.fee_balance_changes.get(&fee_token) {
+                let accounts = if let Some(tokens) = fee_balance_tokens {
+                    tokens
+                        .iter()
+                        .find(|(token, _)| **token == fee_token)
+                        .map(|(_, accounts)| accounts)
+                } else {
+                    updates.fee_balance_changes.get(&fee_token)
+                };
+                if let Some(accounts) = accounts {
                     let Ok(fee_payer) = tx.transaction.fee_payer() else {
                         continue;
                     };


### PR DESCRIPTION
The eviction scan resolves each pooled transaction's effective fee token and looks it up in `fee_balance_changes` to decide whether the fee payer's balance needs re-checking. That map is keyed by token and typically holds only a handful of entries (the fee tokens that saw transfers in the block), while the scan visits every pooled transaction. This replaces the per-transaction hashmap lookup with a bounded linear scan over the changed fee tokens using direct address comparisons, falling back to the map lookup when a block touches more than 16 tokens so the per-transaction cost stays bounded.

An isolated run-pairs=2 bench with profiles shows this change is neutral at `token-count=4`: the scan's total cost is unchanged (the linear compares replace the hash+probe in the same leaf categories), because at this token count every lookup is a hit and the full token comparison happens either way. The expected benefit is the miss-dominated case — many registered fee tokens with few changed per block — where a short-circuiting address compare against a handful of entries beats hashing the token for every pooled transaction. An earlier figure measured on the combined branch (#5638) attributed a hashing-share drop to this change; that drop belongs mostly to the filter short-circuit split out into #5649.

Extracted from #5638.