### PR TITLE
perf(txpool): narrow TIP-20 Transfer decoding in pool maintenance

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -139,8 +139,33 @@ impl TempoPoolUpdates {
             .flatten()
             .flat_map(|receipt| &receipt.logs)
         {
+            // Fee token pause events and balance changes.
+            //
+            // Checked first because TIP-20 `Transfer` logs dominate block receipts; this avoids
+            // three address comparisons per transfer before reaching the matching branch.
+            if log.address.is_tip20() {
+                match Tip20PoolEvent::decode(log) {
+                    Some(Tip20PoolEvent::PauseStateUpdate(event)) => {
+                        updates.pause_events.push((log.address, event.isPaused));
+                    }
+                    Some(Tip20PoolEvent::TransferPolicyUpdate) => {
+                        updates.transfer_policy_updates.insert(log.address);
+                    }
+                    Some(Tip20PoolEvent::QuoteTokenUpdate) => {
+                        updates.quote_token_updates.insert(log.address);
+                    }
+                    Some(Tip20PoolEvent::Transfer { from }) => {
+                        updates
+                            .fee_balance_changes
+                            .entry(log.address)
+                            .or_default()
+                            .insert(from);
+                    }
+                    None => {}
+                }
+            }
             // Key revocations and spending limit changes
-            if log.address == ACCOUNT_KEYCHAIN_ADDRESS {
+            else if log.address == ACCOUNT_KEYCHAIN_ADDRESS {
                 match AccountKeychainPoolEvent::decode(log) {
                     Some(AccountKeychainPoolEvent::KeyRevoked(event)) => {
                         updates.revoked_keys.insert(event.account, event.publicKey);
@@ -210,28 +235,6 @@ impl TempoPoolUpdates {
                             .push((event.policyId, event.account));
                     }
                     Some(_) | None => {}
-                }
-            }
-            // Fee token pause events and balance changes
-            else if log.address.is_tip20() {
-                match Tip20PoolEvent::decode(log) {
-                    Some(Tip20PoolEvent::PauseStateUpdate(event)) => {
-                        updates.pause_events.push((log.address, event.isPaused));
-                    }
-                    Some(Tip20PoolEvent::TransferPolicyUpdate) => {
-                        updates.transfer_policy_updates.insert(log.address);
-                    }
-                    Some(Tip20PoolEvent::QuoteTokenUpdate) => {
-                        updates.quote_token_updates.insert(log.address);
-                    }
-                    Some(Tip20PoolEvent::Transfer(event)) => {
-                        updates
-                            .fee_balance_changes
-                            .entry(log.address)
-                            .or_default()
-                            .insert(event.from);
-                    }
-                    None => {}
                 }
             }
         }
@@ -352,14 +355,20 @@ enum Tip20PoolEvent {
     TransferPolicyUpdate,
     /// [`ITIP20::QuoteTokenUpdate`] log.
     QuoteTokenUpdate,
-    /// [`ITIP20::Transfer`] log.
-    Transfer(ITIP20::Transfer),
+    /// [`ITIP20::Transfer`] log; only the debited `from` account is retained.
+    Transfer { from: Address },
 }
 
 impl Tip20PoolEvent {
     /// Decodes only TIP-20 events used by transaction-pool maintenance.
     fn decode(log: &Log) -> Option<Self> {
         match first_topic(log)? {
+            // `Transfer` is by far the most common TIP-20 log, so avoid a full event decode
+            // and read the indexed `from` directly from `topics[1]`. We only need the debited
+            // account for `fee_balance_changes`; `to` and `amount` are unused.
+            ITIP20::Transfer::SIGNATURE_HASH => log.topics().get(1).map(|topic| Self::Transfer {
+                from: Address::from_word(*topic),
+            }),
             ITIP20::PauseStateUpdate::SIGNATURE_HASH => {
                 decode_event(log).map(Self::PauseStateUpdate)
             }
@@ -370,7 +379,6 @@ impl Tip20PoolEvent {
             ITIP20::QuoteTokenUpdate::SIGNATURE_HASH => {
                 decode_event::<ITIP20::QuoteTokenUpdate>(log).map(|_| Self::QuoteTokenUpdate)
             }
-            ITIP20::Transfer::SIGNATURE_HASH => decode_event(log).map(Self::Transfer),
             _ => None,
         }
     }
@@ -1411,7 +1419,13 @@ mod tests {
                     amount: U256::from(42),
                 },
             );
-            assert_decodes_like_generated!(Tip20PoolEvent, Transfer, ITIP20::Transfer, log);
+            // `Transfer` decoding is specialized to read only the indexed `from` topic, so
+            // compare that against the field a full event decode would produce.
+            let expected = generated_decode::<ITIP20::Transfer>(&log);
+            match Tip20PoolEvent::decode(&log) {
+                Some(Tip20PoolEvent::Transfer { from }) => assert_eq!(from, expected.from),
+                _ => panic!("unexpected decoded event"),
+            }
         }
     }
 


### PR DESCRIPTION
TIP-20 `Transfer` logs dominate block receipts, but pool maintenance only needs the debited `from` account to populate `fee_balance_changes` — `to` and `amount` are unused. `from_chain` now reads the indexed `from` directly from `topics[1]` instead of running a full event decode for every transfer in the block.

Since transfers are by far the most common log, the TIP-20 branch is also checked first in the address dispatch (before the keychain/fee-manager/registry system addresses) and the `Transfer` arm first within the TIP-20 decoder.

In bench profiles this reduced `from_chain` from 1.56% to 0.99% of maintenance time (−38% self-time).

Extracted from #5638.