### PR TITLE
perf(txpool): drop redundant mined-hash set in expired eviction

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -640,7 +640,7 @@ where
                 metrics.amm_cache_update_duration_seconds.record(amm_start.elapsed());
 
                 // 3. Collect all block-level invalidation events
-                let mut updates = TempoPoolUpdates::from_chain(tip);
+                let updates = TempoPoolUpdates::from_chain(tip);
 
                 // Remove expiry tracking for mined transactions.
                 state.untrack_many(tip.transaction_hashes());

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -40,8 +40,6 @@ const EVICTION_BUFFER_SECS: u64 = 3;
 /// allowing efficient batch processing of pool updates.
 #[derive(Debug, Default)]
 pub struct TempoPoolUpdates {
-    /// Transaction hashes that have expired (valid_before <= tip_timestamp).
-    pub expired_txs: Vec<TxHash>,
     /// Revoked keychain keys.
     /// Indexed by account for efficient lookup.
     pub revoked_keys: RevokedKeys,
@@ -108,8 +106,7 @@ impl TempoPoolUpdates {
 
     /// Returns true if there are no updates to process.
     pub fn is_empty(&self) -> bool {
-        self.expired_txs.is_empty()
-            && self.revoked_keys.is_empty()
+        self.revoked_keys.is_empty()
             && self.key_authorization_target_changes.is_empty()
             && self.spending_limit_changes.is_empty()
             && self.validator_token_changes.is_empty()
@@ -652,28 +649,23 @@ where
                 // broadcasting near-expiry txs that peers would reject.
                 let max_expiry = tip_timestamp.saturating_add(EVICTION_BUFFER_SECS);
 
-                // Add expired transactions (from local tracking state)
-                let expired = state.drain_expired(max_expiry);
-                if !expired.is_empty() {
-                    let mined_hashes: B256Set = tip.transaction_hashes().copied().collect();
-                    updates.expired_txs = expired
-                        .into_iter()
-                        .filter(|hash| !mined_hashes.contains(hash) && pool.contains(hash))
-                        .collect();
-                }
+                // Collect expired transactions from local tracking state. Mined transactions
+                // were untracked above so they cannot be drained here, and hashes that have
+                // since left the pool are no-ops for `remove_transactions`.
+                let expired_txs = state.drain_expired(max_expiry);
 
                 // 4. Evict expired AA transactions
                 let expired_start = Instant::now();
-                let expired_count = updates.expired_txs.len();
-                if expired_count > 0 {
+                if !expired_txs.is_empty() {
+                    let evicted = pool.remove_transactions(expired_txs);
                     debug!(
                         target: "txpool",
-                        count = expired_count,
+                        count = evicted.len(),
                         tip_timestamp,
                         "Evicting expired AA transactions (valid_before)"
                     );
-                    removed_txs.push(pool.remove_transactions(updates.expired_txs.clone()));
-                    metrics.expired_transactions_evicted.increment(expired_count as u64);
+                    metrics.expired_transactions_evicted.increment(evicted.len() as u64);
+                    removed_txs.push(evicted);
                 }
                 metrics.expired_eviction_duration_seconds.record(expired_start.elapsed());
 


### PR DESCRIPTION
The expired-eviction path in `maintain_tempo_pool` collected every mined transaction hash of the block into a `B256Set` to filter the drained expiry entries. That set is dead work: `untrack_many` already removes mined hashes from expiry tracking before `drain_expired` runs, so the drained set can never contain a hash mined in this block. The `pool.contains` pre-filter is likewise redundant because `remove_transactions` handles absent hashes as no-ops with the same probe cost.

At benchmark load this removes a per-block allocation and hashing of ~10k mined hashes whenever any tracked transaction expires. In the bench profile the set's collect frames disappear entirely (152 → 0 samples). Eviction metrics now count actual removals rather than candidate hashes.

This also removes `TempoPoolUpdates::expired_txs` entirely: unlike the other fields it was never derived from the chain in `from_chain` — only populated by the maintenance loop from its local expiry tracking and consumed immediately — so a local variable suffices.

Extracted from #5638.