### PR TITLE
perf(txpool): offload removed transaction deallocation to blocking pool

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -955,8 +955,12 @@ where
                 // Record total block update duration
                 metrics.block_update_duration_seconds.record(block_update_start.elapsed());
 
-                // Deallocating removed transactions is expensive, so do it after all updates are done.
-                drop(removed_txs);
+                // Deallocating removed transactions is expensive (input data, signatures,
+                // allocator and kernel work), so move it off the maintenance task entirely,
+                // freeing the loop to immediately continue processing pool events.
+                if removed_txs.iter().any(|txs| !txs.is_empty()) {
+                    tokio::task::spawn_blocking(move || drop(removed_txs));
+                }
             }
         }
     }


### PR DESCRIPTION
Transactions removed during pool maintenance (mined, expired, invalidated, stale) were collected and dropped at the end of the block update so the deallocation does not delay the updates themselves. The drop still ran on the maintenance task, though, occupying the event loop with allocator and kernel memory work during the post-block slack.

Move the deallocation to `spawn_blocking` so the loop returns to processing pool events immediately. In the bench profile this shifts 15% of the maintenance task's CPU (the drops plus the kernel memory work under them) onto the blocking pool, reducing the event loop's occupancy by roughly 17% relative.

Extracted from #5638.