### PR TITLE
perf(txpool): skip expiry untracking when nothing is tracked

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -444,6 +444,11 @@ impl TempoPoolState {
     /// This avoids repeating the `expiry_map` lookup for every mined hash while
     /// preserving O(1)-ish removal from each `B256Set` bucket.
     fn untrack_many<'a>(&mut self, hashes: impl IntoIterator<Item = &'a TxHash>) {
+        // Skip iterating the mined hashes if nothing is tracked for expiry.
+        if self.tx_to_expiry.is_empty() {
+            return;
+        }
+
         let mut hashes_by_expiry: BTreeMap<u64, B256Set> = BTreeMap::new();
 
         for hash in hashes {
@@ -700,7 +705,7 @@ where
                     let mut by_token = {
                         let all_txs = all_txs.get_or_insert_with(|| pool.all_transactions());
                         all_txs.iter()
-                            .filter(|tx| !removed_this_iteration.contains(tx.hash()))
+                            .filter(|tx| removed_this_iteration.is_empty() || !removed_this_iteration.contains(tx.hash()))
                             .fold(
                                 AddressMap::<Vec<TxHash>>::default(),
                                 |mut by_token, tx| {
@@ -850,7 +855,7 @@ where
                         let all_txs = all_txs.get_or_insert_with(|| pool.all_transactions());
                         all_txs
                             .iter()
-                            .filter(|tx| !removed_this_iteration.contains(tx.hash()))
+                            .filter(|tx| removed_this_iteration.is_empty() || !removed_this_iteration.contains(tx.hash()))
                             .filter(|tx| {
                                 tx.transaction
                                     .resolved_fee_token()
@@ -915,7 +920,7 @@ where
                             &updates,
                             all_txs
                                 .iter()
-                                .filter(|tx| !removed_this_iteration.contains(tx.hash())),
+                                .filter(|tx| removed_this_iteration.is_empty() || !removed_this_iteration.contains(tx.hash())),
                         )
                     };
                     for tx in &evicted {

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -705,7 +705,7 @@ where
                     let mut by_token = {
                         let all_txs = all_txs.get_or_insert_with(|| pool.all_transactions());
                         all_txs.iter()
-                            .filter(|tx| removed_this_iteration.is_empty() || !removed_this_iteration.contains(tx.hash()))
+                            .filter(|tx| !removed_this_iteration.contains(tx.hash()))
                             .fold(
                                 AddressMap::<Vec<TxHash>>::default(),
                                 |mut by_token, tx| {
@@ -855,7 +855,7 @@ where
                         let all_txs = all_txs.get_or_insert_with(|| pool.all_transactions());
                         all_txs
                             .iter()
-                            .filter(|tx| removed_this_iteration.is_empty() || !removed_this_iteration.contains(tx.hash()))
+                            .filter(|tx| !removed_this_iteration.contains(tx.hash()))
                             .filter(|tx| {
                                 tx.transaction
                                     .resolved_fee_token()
@@ -920,7 +920,7 @@ where
                             &updates,
                             all_txs
                                 .iter()
-                                .filter(|tx| removed_this_iteration.is_empty() || !removed_this_iteration.contains(tx.hash())),
+                                .filter(|tx| !removed_this_iteration.contains(tx.hash())),
                         )
                     };
                     for tx in &evicted {


### PR DESCRIPTION
`untrack_many` iterated the block's mined hashes and called `tx_to_expiry.remove` for each one even when nothing is tracked for expiry — the common case in throughput-heavy blocks where few or no AA transactions carry `valid_before` or key expiry. Unlike hashbrown's read paths (`get`/`contains` return early on an empty table before hashing), `remove` computes the key hash unconditionally, so an explicit `is_empty` guard skips both the iteration and the per-hash work.

An earlier version of this PR also added `is_empty` short-circuits to the `removed_this_iteration` filters, but those use `contains`, which hashbrown already serves from its empty-table fast path without hashing — redundant, dropped.

Extracted from #5638.