### PR TITLE
bench: bump reth to 1a0f9f8 (skip-state-root flag, rebased)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8656,7 +8656,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8716,7 +8716,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8736,7 +8736,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8749,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8832,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8895,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8911,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8938,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8963,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8992,7 +8992,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9048,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9171,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9393,7 +9393,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9409,7 +9409,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9425,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9448,7 +9448,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9459,7 +9459,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9487,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9509,7 +9509,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9550,7 +9550,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "clap",
  "eyre",
@@ -9573,7 +9573,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9589,7 +9589,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9605,7 +9605,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9618,7 +9618,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9648,7 +9648,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9662,7 +9662,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9672,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9697,7 +9697,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9717,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9735,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9767,7 +9767,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9819,7 +9819,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "serde",
  "serde_json",
@@ -9829,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9857,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "bytes",
  "futures",
@@ -9877,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9894,7 +9894,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "bindgen",
  "cc",
@@ -9903,7 +9903,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "futures",
  "metrics",
@@ -9916,7 +9916,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9939,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10022,7 +10022,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10046,7 +10046,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10061,7 +10061,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10075,7 +10075,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10092,7 +10092,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10116,7 +10116,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10184,7 +10184,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10239,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10286,7 +10286,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "bytes",
  "eyre",
@@ -10363,7 +10363,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10375,7 +10375,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10399,7 +10399,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10434,7 +10434,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10477,7 +10477,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10526,7 +10526,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10554,7 +10554,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10570,7 +10570,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10585,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10663,7 +10663,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10693,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10736,7 +10736,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10756,7 +10756,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10787,7 +10787,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10834,7 +10834,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10885,7 +10885,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10899,7 +10899,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10930,7 +10930,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10981,7 +10981,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11009,7 +11009,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11023,7 +11023,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11043,7 +11043,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11058,7 +11058,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11084,7 +11084,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11123,7 +11123,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11139,7 +11139,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11149,7 +11149,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "clap",
  "eyre",
@@ -11169,7 +11169,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11188,7 +11188,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11233,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11259,7 +11259,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11287,7 +11287,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11307,7 +11307,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11336,10 +11336,9 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
- "alloy-rlp",
  "alloy-trie",
  "either",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,66 +144,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f152114", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f152114", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f152114", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f152114", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8", features = [
   "std",
   "optional-checks",
 ] }

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -214,7 +214,10 @@ fn init_engine_defaults() {
         // BENCH: Skip state root computation during validation — trust the proposer's state root.
         // Only prewarming remains active. This isolates execution performance from trie overhead.
         .with_skip_state_root(true)
-        .with_share_sparse_trie_with_payload_builder(true)
+        // BENCH: sparse-trie sharing assumes the validator runs the state root task each
+        // block and hands the trie back; with skip_state_root that handoff never happens
+        // and the payload builder stalls waiting for it.
+        .with_share_sparse_trie_with_payload_builder(false)
         .with_share_execution_cache_with_payload_builder(true)
         .try_init()
         .expect("failed to initialize engine defaults");

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -211,6 +211,9 @@ fn init_engine_defaults() {
         .with_always_process_payload_attributes_on_canonical_head(true)
         // Defer persistence I/O during active payload builds.
         .with_suppress_persistence_during_build(true)
+        // BENCH: Skip state root computation during validation — trust the proposer's state root.
+        // Only prewarming remains active. This isolates execution performance from trie overhead.
+        .with_skip_state_root(true)
         .with_share_sparse_trie_with_payload_builder(true)
         .with_share_execution_cache_with_payload_builder(true)
         .try_init()

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -933,40 +933,39 @@ where
         // run with --engine.skip-state-root and trust whatever root the proposer emits.
         const BENCH_SKIP_STATE_ROOT: bool = true;
 
-        let (state_root_outcome, sparse_trie_state_root_wait_elapsed) =
-            if BENCH_SKIP_STATE_ROOT {
-                None
-            } else if let Some(mut handle) = trie_handle {
-                let state_root_wait_start = Instant::now();
-                let _span = debug_span!(target: "payload_builder", "await_state_root").entered();
-                match handle.state_root() {
-                    Ok(outcome) => {
-                        let elapsed = state_root_wait_start.elapsed();
-                        self.metrics
-                            .sparse_trie_state_root_wait_duration_seconds
-                            .record(elapsed);
-                        debug!(
-                            target: "payload_builder",
-                            id = %payload_id,
-                            state_root = ?outcome.state_root,
-                            "received state root from sparse trie"
-                        );
-                        Some((outcome, elapsed))
-                    }
-                    Err(err) => {
-                        warn!(
-                            target: "payload_builder",
-                            id = %payload_id,
-                            %err,
-                            "sparse trie failed, falling back to sync state root"
-                        );
-                        None
-                    }
+        let (state_root_outcome, sparse_trie_state_root_wait_elapsed) = if BENCH_SKIP_STATE_ROOT {
+            None
+        } else if let Some(mut handle) = trie_handle {
+            let state_root_wait_start = Instant::now();
+            let _span = debug_span!(target: "payload_builder", "await_state_root").entered();
+            match handle.state_root() {
+                Ok(outcome) => {
+                    let elapsed = state_root_wait_start.elapsed();
+                    self.metrics
+                        .sparse_trie_state_root_wait_duration_seconds
+                        .record(elapsed);
+                    debug!(
+                        target: "payload_builder",
+                        id = %payload_id,
+                        state_root = ?outcome.state_root,
+                        "received state root from sparse trie"
+                    );
+                    Some((outcome, elapsed))
                 }
-            } else {
-                None
+                Err(err) => {
+                    warn!(
+                        target: "payload_builder",
+                        id = %payload_id,
+                        %err,
+                        "sparse trie failed, falling back to sync state root"
+                    );
+                    None
+                }
             }
-            .unzip();
+        } else {
+            None
+        }
+        .unzip();
 
         let (block_access_list, block_access_list_hash) = if let Some(bal_rx) = bal_rx {
             let (bal, bal_hash) = bal_rx.blocking_recv().map_err(PayloadBuilderError::other)?;
@@ -976,7 +975,10 @@ where
         };
 
         let (state_root, trie_updates) = if BENCH_SKIP_STATE_ROOT {
-            (parent_header.state_root(), Arc::new(reth_trie_common::updates::TrieUpdates::default()))
+            (
+                parent_header.state_root(),
+                Arc::new(reth_trie_common::updates::TrieUpdates::default()),
+            )
         } else if let Some(outcome) = state_root_outcome {
             (outcome.state_root, outcome.trie_updates)
         } else {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -929,8 +929,14 @@ where
             finish_provider.hashed_post_state(&db.bundle_state)
         };
 
+        // BENCH: skip all state root computation — emit the parent's state root. Validators
+        // run with --engine.skip-state-root and trust whatever root the proposer emits.
+        const BENCH_SKIP_STATE_ROOT: bool = true;
+
         let (state_root_outcome, sparse_trie_state_root_wait_elapsed) =
-            if let Some(mut handle) = trie_handle {
+            if BENCH_SKIP_STATE_ROOT {
+                None
+            } else if let Some(mut handle) = trie_handle {
                 let state_root_wait_start = Instant::now();
                 let _span = debug_span!(target: "payload_builder", "await_state_root").entered();
                 match handle.state_root() {
@@ -969,7 +975,9 @@ where
             (None, None)
         };
 
-        let (state_root, trie_updates) = if let Some(outcome) = state_root_outcome {
+        let (state_root, trie_updates) = if BENCH_SKIP_STATE_ROOT {
+            (parent_header.state_root(), Arc::new(reth_trie_common::updates::TrieUpdates::default()))
+        } else if let Some(outcome) = state_root_outcome {
             (outcome.state_root, outcome.trie_updates)
         } else {
             let (state_root, trie_updates) = finish_provider


### PR DESCRIPTION
Rebase of #3982 onto current main.

Pins reth to [`1a0f9f8`](https://github.com/paradigmxyz/reth/commit/1a0f9f8780f31f4eede5fe01fa9252983f12deb7) — the rebased head of paradigmxyz/reth#24139 (`--engine.skip-state-root` flag), now on top of latest reth main.

Lockfile note: `alloy-eip7928` bumped 0.4.1 → 0.4.3 (required by current reth main).

Purpose: benchmarking execution performance with state root computation skipped. Do not merge.