### PR TITLE
feat(consensus): ship a minimized persisted cache in snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12834,6 +12834,7 @@ dependencies = [
  "alloy-signer-trezor",
  "alloy-sol-types",
  "base64 0.22.1",
+ "blake3",
  "clap",
  "commonware-codec",
  "commonware-consensus",
@@ -12875,6 +12876,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
+ "tar",
  "tempfile",
  "tempo-alloy",
  "tempo-chainspec",
@@ -12896,6 +12898,7 @@ dependencies = [
  "tracing",
  "tracy-client",
  "url",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,6 +258,7 @@ async-trait = "0.1"
 auto_impl = "1"
 axum = "0.8.8"
 base64 = { version = "0.22", features = ["alloc"], default-features = false }
+blake3 = "1.8"
 bytes = "1.11.1"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 coins-bip32 = "0.12"
@@ -299,6 +300,7 @@ serde = { version = "1.0.228", features = ["derive"], default-features = false }
 serde_json = { version = "1.0.149", features = ["alloc"], default-features = false }
 schnellru = "0.2"
 sha2 = { version = "0.10", default-features = false }
+tar = "0.4"
 tempfile = "3.24.0"
 thiserror = "2.0.18"
 # TODO: restrict this to only the required features
@@ -318,6 +320,7 @@ rayon = "1.11"
 url = "2.5"
 test-case = "3"
 zeroize = "1"
+zstd = "0.13"
 age = { version = "0.11", default-features = false }
 secrecy = "0.10"
 

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -57,6 +57,7 @@ alloy-signer-ledger.workspace = true
 alloy-signer-local.workspace = true
 alloy-signer-trezor.workspace = true
 alloy-sol-types.workspace = true
+blake3.workspace = true
 commonware-codec.workspace = true
 commonware-consensus.workspace = true
 commonware-cryptography.workspace = true
@@ -93,6 +94,7 @@ reth-provider.workspace = true
 reth-rpc-server-types.workspace = true
 secp256k1.workspace = true
 reth-storage-api.workspace = true
+tar.workspace = true
 reth-trie.workspace = true
 reth-trie-db.workspace = true
 clap.workspace = true
@@ -102,6 +104,7 @@ jiff.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
+zstd.workspace = true
 opentelemetry-otlp = { version = "0.31", default-features = false, optional = true }
 pyroscope = { workspace = true, optional = true }
 pyroscope_pprofrs = { workspace = true, optional = true }

--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -210,6 +210,7 @@ mod tests {
             height: 42,
             digest: B256::with_last_byte(0x2a),
             finalization: Bytes::from(vec![0x00, 0x01, 0x02, 0xff]),
+            persisted_cache: None,
         };
 
         write_bootstrap_finalization(dir.path(), &tempo_consensus).unwrap();

--- a/bin/tempo/src/snapshot_manifest.rs
+++ b/bin/tempo/src/snapshot_manifest.rs
@@ -1,5 +1,6 @@
 use std::{
     fs,
+    io::Read,
     path::{Path, PathBuf},
     sync::Arc,
     time::Instant,
@@ -8,30 +9,33 @@ use std::{
 use alloy_primitives::{B256, Bytes};
 use clap::{ArgMatches, FromArgMatches, Parser};
 use commonware_codec::Encode as _;
-use commonware_consensus::simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Finalization};
-use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
 use commonware_runtime::Runner as _;
 use eyre::{Context as _, OptionExt, ensure};
 use reth_chainspec::EthChainSpec as _;
 use reth_cli_commands::download::{
-    manifest::SnapshotManifest, manifest_cmd::SnapshotManifestCommand,
+    manifest::{OutputFileChecksum, SnapshotManifest},
+    manifest_cmd::SnapshotManifestCommand,
 };
 use reth_cli_runner::CliRunner;
 use reth_db::DatabaseEnv;
 use reth_node_builder::NodeTypesWithDBAdapter;
-use reth_provider::{
-    BlockIdReader,
-    providers::{BlockchainProvider, ReadOnlyConfig},
-};
+use reth_provider::providers::{BlockchainProvider, ReadOnlyConfig};
 use serde::{Deserialize, Serialize};
 use tempo_chainspec::spec::{TempoChainSpec, chain_value_parser, chainspec_from_chain_id};
-use tempo_consensus::{consensus::Digest, find_last_finalized_marker};
+use tempo_consensus::{PersistedCache, collect_persisted_cache, write_persisted_cache};
 use tempo_node::node::TempoNode;
 use tempo_telemetry_util::display_duration;
 
 pub(crate) const TEMPO_CONSENSUS_MANIFEST_KEY: &str = "consensus";
 
-type TempoFinalization = Finalization<Scheme<PublicKey, MinSig>, Digest>;
+/// Archive file holding the minimized persisted cache, relative to the
+/// manifest's base URL.
+const CONSENSUS_CACHE_ARCHIVE: &str = "consensus-cache.tar.zst";
+
+/// Scratch directory (under the output dir) the minimized persisted cache
+/// is staged in before packaging. Removed after the archive is written.
+const CONSENSUS_CACHE_STAGING_DIR: &str = "consensus-cache.staging";
+
 type TempoExecutionProvider = BlockchainProvider<NodeTypesWithDBAdapter<TempoNode, DatabaseEnv>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -39,6 +43,33 @@ pub(crate) struct TempoConsensusManifest {
     pub(crate) height: u64,
     pub(crate) digest: B256,
     pub(crate) finalization: Bytes,
+    /// Minimized persisted cache: the consensus-layer finalized blocks
+    /// needed to bring the execution layer up to [`Self::digest`]. Omitted
+    /// when the certificate is already covered by the execution layer
+    /// snapshot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) persisted_cache: Option<PersistedCacheManifest>,
+}
+
+/// Manifest entry describing the packaged minimized persisted cache.
+///
+/// The archive extracts relative to the node's consensus datadir and
+/// contains a prunable finalized-blocks archive holding exactly the blocks
+/// `[first_block, last_block]`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PersistedCacheManifest {
+    /// Archive file name (relative to the manifest's base URL).
+    pub(crate) file: String,
+    /// First block height in the cache (execution finalized height + 1).
+    pub(crate) first_block: u64,
+    /// Last block height in the cache (the certificate height).
+    pub(crate) last_block: u64,
+    /// Compressed archive size in bytes.
+    pub(crate) size: u64,
+    /// Total extracted plain-output size in bytes.
+    pub(crate) decompressed_size: u64,
+    /// Expected extracted plain files for this archive.
+    pub(crate) output_files: Vec<OutputFileChecksum>,
 }
 
 #[derive(Debug, Parser)]
@@ -128,30 +159,60 @@ impl Args {
 
         let consensus_dir = consensus_datadir.unwrap_or_else(|| source_datadir.join("consensus"));
         eprintln!(
-            "reading snapshot finalization. consensus dir: {}, search depth: {}",
+            "extracting persisted cache. consensus dir: {}, search depth: {}",
             consensus_dir.display(),
             finalization_search_depth,
         );
 
-        let (height, finalization) = find_snapshot_finalization(
+        let cache = collect_cache(
             &consensus_dir,
             execution_provider,
             finalization_search_depth,
         )
-        .wrap_err("failed to read finalization state")?;
+        .wrap_err("failed to extract minimized persisted cache")?;
 
-        let digest = finalization.proposal.payload;
-        let consensus_manifest = TempoConsensusManifest {
-            height,
-            digest: digest.0,
-            finalization: finalization.encode().into(),
+        eprintln!(
+            "snapshot certificate height `{}`; execution finalized `{}`, execution tip `{}`, cached blocks `{}`",
+            cache.height,
+            cache.execution_height,
+            manifest.block,
+            cache.block_count(),
+        );
+
+        let persisted_cache = match cache.block_range() {
+            Some((first_block, last_block)) => {
+                let packaged = stage_and_package_cache(&cache, output_dir)
+                    .wrap_err("failed to package minimized persisted cache")?;
+
+                eprintln!(
+                    "packaged minimized persisted cache: blocks [{first_block}, {last_block}], {} bytes compressed",
+                    packaged.size,
+                );
+
+                Some(PersistedCacheManifest {
+                    file: CONSENSUS_CACHE_ARCHIVE.to_string(),
+                    first_block,
+                    last_block,
+                    size: packaged.size,
+                    decompressed_size: packaged.decompressed_size,
+                    output_files: packaged.output_files,
+                })
+            }
+            None => {
+                eprintln!(
+                    "certificate is covered by the execution layer snapshot; \
+                    no persisted cache to package"
+                );
+                None
+            }
         };
 
-        let manifest_height = manifest.block;
-        ensure!(
-            manifest_height >= height,
-            "finalization marker must be at or below execution"
-        );
+        let consensus_manifest = TempoConsensusManifest {
+            height: cache.height,
+            digest: cache.digest().0,
+            finalization: cache.finalization.encode().into(),
+            persisted_cache,
+        };
 
         let mut manifest_json =
             serde_json::to_value(&manifest).wrap_err("failed to serialize merged manifest")?;
@@ -170,7 +231,10 @@ impl Args {
         fs::write(&manifest_path, manifest_json)
             .wrap_err_with(|| format!("failed to write {}", manifest_path.display()))?;
 
-        eprintln!("embedded finalization for height `{height}`; execution=`{manifest_height}`",);
+        eprintln!(
+            "embedded finalization for height `{}`; execution=`{}`",
+            cache.height, manifest.block,
+        );
         Ok(())
     }
 }
@@ -199,27 +263,191 @@ fn resolve_chainspec(
     }
 }
 
-fn find_snapshot_finalization(
+/// Determines the snapshot certificate and reads the minimal persisted
+/// cache out of the node's consensus storage.
+fn collect_cache(
     consensus_dir: &Path,
     execution_provider: TempoExecutionProvider,
     max_depth: u64,
-) -> eyre::Result<(u64, TempoFinalization)> {
+) -> eyre::Result<PersistedCache> {
     let runtime_config =
         commonware_runtime::tokio::Config::default().with_storage_directory(consensus_dir);
 
-    let tip = execution_provider
-        .finalized_block_number()
-        .wrap_err("failed to read finalized block number")?
-        .ok_or_eyre("no finalized execution state")?;
-
     let runner = commonware_runtime::tokio::Runner::new(runtime_config);
     runner.start(|context| async move {
-        find_last_finalized_marker(&context, &execution_provider, max_depth)
+        collect_persisted_cache(&context, &execution_provider, max_depth)
             .await?
             .ok_or_eyre(format!(
-                "no finalization marker found; finalized tip `{tip}` with {max_depth} block lookback"
+                "no finalization certificate matches the snapshot state \
+                ({max_depth} block lookback)"
             ))
     })
+}
+
+/// Writes the minimized persisted cache into a staging directory under
+/// `output_dir`, packages it as [`CONSENSUS_CACHE_ARCHIVE`], and removes
+/// the staging directory.
+fn stage_and_package_cache(
+    cache: &PersistedCache,
+    output_dir: &Path,
+) -> eyre::Result<PackagedArchive> {
+    let staging_dir = output_dir.join(CONSENSUS_CACHE_STAGING_DIR);
+    if staging_dir.exists() {
+        fs::remove_dir_all(&staging_dir)
+            .wrap_err_with(|| format!("failed to clear staging dir: {}", staging_dir.display()))?;
+    }
+    fs::create_dir_all(&staging_dir)
+        .wrap_err_with(|| format!("failed to create staging dir: {}", staging_dir.display()))?;
+
+    let runtime_config =
+        commonware_runtime::tokio::Config::default().with_storage_directory(&staging_dir);
+    let runner = commonware_runtime::tokio::Runner::new(runtime_config);
+    runner.start(|context| async move { write_persisted_cache(&context, cache).await })?;
+
+    let archive_path = output_dir.join(CONSENSUS_CACHE_ARCHIVE);
+    let packaged = package_directory(&staging_dir, &archive_path)?;
+
+    fs::remove_dir_all(&staging_dir)
+        .wrap_err_with(|| format!("failed to remove staging dir: {}", staging_dir.display()))?;
+
+    Ok(packaged)
+}
+
+#[derive(Debug)]
+struct PackagedArchive {
+    /// Compressed archive size in bytes.
+    size: u64,
+    /// Total extracted plain-output size in bytes.
+    decompressed_size: u64,
+    /// Expected extracted plain files.
+    output_files: Vec<OutputFileChecksum>,
+}
+
+/// Packages every file under `source_dir` into a `tar.zst` archive at
+/// `archive_path`, with paths stored relative to `source_dir`.
+///
+/// Mirrors the format of reth's EL component archives: GNU tar entries
+/// (mode 0644) in standard zstd frames with checksums, plus per-file
+/// BLAKE3 checksums for the modular download path.
+fn package_directory(source_dir: &Path, archive_path: &Path) -> eyre::Result<PackagedArchive> {
+    let mut files = Vec::new();
+    collect_files_recursive(source_dir, source_dir, &mut files)?;
+    files.sort_unstable_by(|a, b| a.1.cmp(&b.1));
+    ensure!(
+        !files.is_empty(),
+        "nothing to package under {}",
+        source_dir.display()
+    );
+
+    let archive = fs::File::create(archive_path)
+        .wrap_err_with(|| format!("failed to create {}", archive_path.display()))?;
+    let mut encoder = zstd::Encoder::new(archive, 0).wrap_err("failed to create zstd encoder")?;
+    // Emit standard zstd frames with checksums for compatibility with
+    // external tools such as `pzstd -d`.
+    encoder
+        .include_checksum(true)
+        .wrap_err("failed to enable zstd checksums")?;
+    let mut builder = tar::Builder::new(encoder);
+
+    let mut output_files = Vec::with_capacity(files.len());
+    for (source_path, relative_path) in &files {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(
+            fs::metadata(source_path)
+                .wrap_err_with(|| format!("failed to stat {}", source_path.display()))?
+                .len(),
+        );
+        header.set_mode(0o644);
+        header.set_cksum();
+
+        let source = fs::File::open(source_path)
+            .wrap_err_with(|| format!("failed to open {}", source_path.display()))?;
+        let mut reader = HashingReader::new(source);
+        builder
+            .append_data(&mut header, relative_path, &mut reader)
+            .wrap_err_with(|| format!("failed to archive {}", source_path.display()))?;
+
+        output_files.push(OutputFileChecksum {
+            path: relative_path.to_string_lossy().to_string(),
+            size: reader.bytes_read,
+            blake3: reader.finalize(),
+        });
+    }
+
+    builder.finish().wrap_err("failed to finish tar archive")?;
+    let encoder = builder
+        .into_inner()
+        .wrap_err("failed to flush tar archive")?;
+    encoder.finish().wrap_err("failed to finish zstd stream")?;
+
+    let size = fs::metadata(archive_path)
+        .wrap_err_with(|| format!("failed to stat {}", archive_path.display()))?
+        .len();
+    let decompressed_size = output_files.iter().map(|file| file.size).sum();
+
+    Ok(PackagedArchive {
+        size,
+        decompressed_size,
+        output_files,
+    })
+}
+
+fn collect_files_recursive(
+    root: &Path,
+    dir: &Path,
+    files: &mut Vec<(PathBuf, PathBuf)>,
+) -> eyre::Result<()> {
+    for entry in
+        fs::read_dir(dir).wrap_err_with(|| format!("failed to read dir: {}", dir.display()))?
+    {
+        let entry = entry.wrap_err("failed to read dir entry")?;
+        let path = entry.path();
+        let file_type = entry.file_type().wrap_err("failed to read file type")?;
+        if file_type.is_dir() {
+            collect_files_recursive(root, &path, files)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        let relative = path
+            .strip_prefix(root)
+            .wrap_err("file outside packaging root")?
+            .to_path_buf();
+        files.push((path, relative));
+    }
+    Ok(())
+}
+
+struct HashingReader<R> {
+    inner: R,
+    hasher: blake3::Hasher,
+    bytes_read: u64,
+}
+
+impl<R: Read> HashingReader<R> {
+    fn new(inner: R) -> Self {
+        Self {
+            inner,
+            hasher: blake3::Hasher::new(),
+            bytes_read: 0,
+        }
+    }
+
+    fn finalize(self) -> String {
+        self.hasher.finalize().to_hex().to_string()
+    }
+}
+
+impl<R: Read> Read for HashingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        if n > 0 {
+            self.bytes_read += n as u64;
+            self.hasher.update(&buf[..n]);
+        }
+        Ok(n)
+    }
 }
 
 fn execution_provider(
@@ -290,6 +518,7 @@ mod tests {
             height: 42,
             digest: B256::with_last_byte(0x2a),
             finalization: Bytes::from(vec![0x00, 0x01, 0x02, 0xff]),
+            persisted_cache: None,
         };
 
         let value = serde_json::to_value(manifest).unwrap();
@@ -300,5 +529,105 @@ mod tests {
             "0x000000000000000000000000000000000000000000000000000000000000002a"
         );
         assert_eq!(value["finalization"], "0x000102ff");
+        // Absent cache must not pollute the manifest.
+        assert!(value.get("persisted_cache").is_none());
+    }
+
+    #[test]
+    fn consensus_manifest_round_trips_persisted_cache() {
+        let manifest = TempoConsensusManifest {
+            height: 42,
+            digest: B256::with_last_byte(0x2a),
+            finalization: Bytes::from(vec![0x00, 0x01]),
+            persisted_cache: Some(PersistedCacheManifest {
+                file: CONSENSUS_CACHE_ARCHIVE.to_string(),
+                first_block: 33,
+                last_block: 42,
+                size: 100,
+                decompressed_size: 400,
+                output_files: vec![OutputFileChecksum {
+                    path: "engine-finalized-blocks-prunable-value/0000000000000000".to_string(),
+                    size: 400,
+                    blake3: "abc".to_string(),
+                }],
+            }),
+        };
+
+        let value = serde_json::to_value(&manifest).unwrap();
+        assert_eq!(value["persisted_cache"]["file"], CONSENSUS_CACHE_ARCHIVE);
+        assert_eq!(value["persisted_cache"]["first_block"], 33);
+        assert_eq!(value["persisted_cache"]["last_block"], 42);
+
+        let parsed: TempoConsensusManifest = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed, manifest);
+    }
+
+    #[test]
+    fn old_manifests_without_persisted_cache_still_parse() {
+        let parsed: TempoConsensusManifest = serde_json::from_str(
+            r#"{
+                "height": 42,
+                "digest": "0x000000000000000000000000000000000000000000000000000000000000002a",
+                "finalization": "0xaabbcc"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.height, 42);
+        assert!(parsed.persisted_cache.is_none());
+    }
+
+    #[test]
+    fn package_directory_archives_files_with_checksums() {
+        let staging = tempfile::tempdir().unwrap();
+        let nested = staging
+            .path()
+            .join("engine-finalized-blocks-prunable-value");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("0000000000000000"), b"value-blob").unwrap();
+        let key_dir = staging.path().join("engine-finalized-blocks-prunable-key");
+        fs::create_dir_all(&key_dir).unwrap();
+        fs::write(key_dir.join("0000000000000000"), b"key-blob").unwrap();
+
+        let out = tempfile::tempdir().unwrap();
+        let archive_path = out.path().join(CONSENSUS_CACHE_ARCHIVE);
+        let packaged = package_directory(staging.path(), &archive_path).unwrap();
+
+        assert!(archive_path.exists());
+        assert_eq!(packaged.size, fs::metadata(&archive_path).unwrap().len());
+        assert_eq!(packaged.decompressed_size, 18);
+        assert_eq!(packaged.output_files.len(), 2);
+        // Deterministic ordering by relative path.
+        assert_eq!(
+            packaged.output_files[0].path,
+            "engine-finalized-blocks-prunable-key/0000000000000000"
+        );
+        assert_eq!(
+            packaged.output_files[0].blake3,
+            blake3::hash(b"key-blob").to_hex().to_string()
+        );
+
+        // The archive must extract back to the original tree.
+        let extracted = tempfile::tempdir().unwrap();
+        let archive = fs::File::open(&archive_path).unwrap();
+        let decoder = zstd::Decoder::new(archive).unwrap();
+        tar::Archive::new(decoder).unpack(extracted.path()).unwrap();
+        assert_eq!(
+            fs::read(
+                extracted
+                    .path()
+                    .join("engine-finalized-blocks-prunable-value/0000000000000000")
+            )
+            .unwrap(),
+            b"value-blob"
+        );
+    }
+
+    #[test]
+    fn package_directory_rejects_empty_source() {
+        let staging = tempfile::tempdir().unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let err = package_directory(staging.path(), &out.path().join("x.tar.zst")).unwrap_err();
+        assert!(err.to_string().contains("nothing to package"), "{err}");
     }
 }

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -80,6 +80,10 @@ tracing.workspace = true
 tempo-precompiles = { workspace = true, features = ["test-utils"] }
 tempo-primitives = { workspace = true, features = ["arbitrary"] }
 
+# Certificate fixtures for snapshot persisted-cache tests.
+commonware-consensus = { workspace = true, features = ["mocks"] }
+commonware-cryptography = { workspace = true, features = ["mocks"] }
+
 age.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
 tempfile.workspace = true

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -40,7 +40,10 @@ pub use crate::config::{
 };
 
 pub use args::{Args, PositiveDuration};
-pub use storage::find_last_finalized_marker;
+pub use storage::{
+    find_last_finalized_marker,
+    snapshot::{PersistedCache, collect_persisted_cache, write_persisted_cache},
+};
 
 // Shared by both the consensus and follow engines such that
 // snapshots for overlapping archives can be reused.

--- a/crates/consensus/src/storage/hybrid/mod.rs
+++ b/crates/consensus/src/storage/hybrid/mod.rs
@@ -92,7 +92,7 @@ use tracing::{debug, info, instrument, warn};
 use crate::consensus::{Digest, block::Block};
 
 #[cfg(test)]
-mod test;
+pub(in crate::storage) mod test;
 
 /// Narrow view of reth that [`Hybrid`] needs: a finalized watermark and
 /// canonical-by-height / canonical-by-hash block reads.

--- a/crates/consensus/src/storage/hybrid/test/utils.rs
+++ b/crates/consensus/src/storage/hybrid/test/utils.rs
@@ -57,7 +57,7 @@ const TEST_PARTITION_PREFIX: &str = "test";
 /// height (and the implicit parent linkage). The block is then sealed via
 /// [`SealedBlock::seal_slow`] so its hash matches what the production code
 /// would compute.
-pub(in crate::storage::hybrid) fn make_block(height: u64, parent_hash: B256) -> Block {
+pub(in crate::storage) fn make_block(height: u64, parent_hash: B256) -> Block {
     let header = TempoHeader {
         inner: Header {
             parent_hash,
@@ -74,7 +74,7 @@ pub(in crate::storage::hybrid) fn make_block(height: u64, parent_hash: B256) -> 
 
 /// Build a contiguous chain `[start..start+count]` of [`Block`]s, each
 /// pointing at its predecessor.
-pub(in crate::storage::hybrid) fn make_chain(start: u64, count: usize) -> Vec<Block> {
+pub(in crate::storage) fn make_chain(start: u64, count: usize) -> Vec<Block> {
     let mut chain = Vec::with_capacity(count);
     let mut parent = B256::ZERO;
     for offset in 0..count {
@@ -96,7 +96,7 @@ pub(in crate::storage::hybrid) fn make_chain(start: u64, count: usize) -> Vec<Bl
 /// propagates the error as [`super::Error::Provider`] up to the
 /// marshal.
 #[derive(Clone, Default)]
-pub(in crate::storage::hybrid) struct StubProvider {
+pub(in crate::storage) struct StubProvider {
     by_number: Arc<Mutex<HashMap<u64, Block>>>,
     by_hash: Arc<Mutex<HashMap<B256, Block>>>,
     fail: Arc<AtomicBool>,
@@ -108,14 +108,14 @@ pub(in crate::storage::hybrid) struct StubProvider {
 }
 
 impl StubProvider {
-    pub(in crate::storage::hybrid) fn new() -> Self {
+    pub(in crate::storage) fn new() -> Self {
         Self::default()
     }
 
     /// Seed the stub so subsequent
     /// [`FinalizedBlocksProvider::block_by_height`] /
     /// [`FinalizedBlocksProvider::block_by_hash`] calls return `block`.
-    pub(in crate::storage::hybrid) fn add_block(&self, block: &Block) {
+    pub(in crate::storage) fn add_block(&self, block: &Block) {
         let height = block.height().get();
         let hash = block.block_hash();
         self.by_number.lock().insert(height, block.clone());
@@ -125,14 +125,14 @@ impl StubProvider {
     /// Configure the stub to start failing every read with
     /// [`ProviderError::BestBlockNotFound`]. Used to exercise the
     /// "reth fallback errored" branch in [`super::Hybrid::get`].
-    pub(in crate::storage::hybrid) fn set_fail(&self, fail: bool) {
+    pub(in crate::storage) fn set_fail(&self, fail: bool) {
         self.fail.store(fail, Ordering::SeqCst);
     }
 
     /// Set the finalized block height that the stub reports via
     /// [`FinalizedBlocksProvider::finalized_height`]. Drives
     /// [`Hybrid`]'s cache eviction floor in tests.
-    pub(in crate::storage::hybrid) fn set_reth_finalized(&self, height: u64) {
+    pub(in crate::storage) fn set_reth_finalized(&self, height: u64) {
         *self.reth_finalized.lock() = Some(height);
     }
 
@@ -175,7 +175,7 @@ impl FinalizedBlocksProvider for StubProvider {
 }
 
 /// Build a fresh page cache rooted in `context`.
-pub(in crate::storage::hybrid) fn fresh_page_cache<TContext>(context: &TContext) -> CacheRef
+pub(in crate::storage) fn fresh_page_cache<TContext>(context: &TContext) -> CacheRef
 where
     TContext: BufferPooler,
 {
@@ -190,7 +190,7 @@ where
 /// individual heights — the prunable archive's `prune(min)` is rounded down
 /// to the nearest section boundary, so a 4 096-item section would never
 /// drop a handful of low-numbered test heights.
-pub(in crate::storage::hybrid) async fn fresh_prunable_with_section_size<TContext>(
+pub(in crate::storage) async fn fresh_prunable_with_section_size<TContext>(
     context: &TContext,
     items_per_section: std::num::NonZeroU64,
 ) -> Prunable<TContext>

--- a/crates/consensus/src/storage/mod.rs
+++ b/crates/consensus/src/storage/mod.rs
@@ -28,6 +28,7 @@ use crate::{
 };
 
 pub(crate) mod hybrid;
+pub(crate) mod snapshot;
 
 pub(crate) use hybrid::{FinalizedBlocksProvider, Hybrid};
 
@@ -155,7 +156,7 @@ where
 /// This archive only holds at most `retention_blocks` items at any time;
 /// older blocks are removed by the prune step in
 /// [`Hybrid`].
-async fn init_prunable_finalized_blocks_archive<TContext>(
+pub(in crate::storage) async fn init_prunable_finalized_blocks_archive<TContext>(
     context: &TContext,
     partition_prefix: &str,
     page_cache: CacheRef,

--- a/crates/consensus/src/storage/snapshot.rs
+++ b/crates/consensus/src/storage/snapshot.rs
@@ -1,0 +1,600 @@
+//! Persisted-cache extraction for `tempo snapshot-manifest`.
+//!
+//! A snapshot of a node ships the execution layer's state up to its
+//! finalized watermark plus a consensus floor certificate. To let a
+//! restored node replay the execution layer up to the digest recorded in
+//! that certificate without round-tripping to peers, the snapshot also
+//! carries a *minimized* copy of the consensus layer's hybrid storage
+//! ("persisted cache"): exactly the finalized blocks in
+//! `(execution_finalized, certificate_height]`.
+//!
+//! Blocks at or below the execution layer's finalized watermark are
+//! already durable in the execution layer snapshot and are served from
+//! there by [`super::Hybrid`]'s fallback path, so they are dead weight in
+//! a snapshot. Blocks above the certificate height are not required to
+//! reach the certificate digest. Everything else is dropped.
+//!
+//! [`collect_persisted_cache`] determines the certificate and reads the
+//! covered blocks out of the node's consensus storage;
+//! [`write_persisted_cache`] writes them into a fresh prunable archive
+//! rooted at a staging directory using the production storage layout, so
+//! a restored node can open it as its own persisted cache.
+
+use commonware_consensus::{
+    Heightable as _,
+    simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Finalization},
+};
+use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
+use commonware_runtime::{BufferPooler, Clock, Metrics, Spawner, Storage, buffer::paged::CacheRef};
+use commonware_storage::archive::{Archive as _, Identifier};
+use eyre::{Context as _, OptionExt as _, ensure};
+use reth_provider::{BlockIdReader, BlockReader};
+
+use super::{
+    BUFFER_POOL_CAPACITY, BUFFER_POOL_PAGE_SIZE, init_finalizations_archive,
+    init_prunable_finalized_blocks_archive,
+};
+use crate::consensus::{Digest, block::Block};
+
+type TempoFinalization = Finalization<Scheme<PublicKey, MinSig>, Digest>;
+
+/// Narrow view of the execution layer needed to anchor the persisted
+/// cache: the finalized watermark and canonical block digests at or below
+/// it.
+///
+/// Exists to make unit testing easier; production callers go through the
+/// [`RethAnchor`] adapter over reth's provider traits.
+pub(crate) trait ExecutionAnchor {
+    /// The execution layer's last finalized block height, or `None` if
+    /// nothing has been finalized yet.
+    fn finalized_height(&self) -> eyre::Result<Option<u64>>;
+
+    /// Digest (block hash) of the canonical block at `height`.
+    fn block_digest(&self, height: u64) -> eyre::Result<Option<Digest>>;
+}
+
+/// [`ExecutionAnchor`] adapter over reth's provider traits.
+struct RethAnchor<'a, P: ?Sized>(&'a P);
+
+impl<P> ExecutionAnchor for RethAnchor<'_, P>
+where
+    P: BlockIdReader + BlockReader<Block = tempo_primitives::Block> + ?Sized,
+{
+    fn finalized_height(&self) -> eyre::Result<Option<u64>> {
+        self.0
+            .finalized_block_number()
+            .wrap_err("failed reading finalized block number from execution provider")
+    }
+
+    fn block_digest(&self, height: u64) -> eyre::Result<Option<Digest>> {
+        use alloy_consensus::Sealable as _;
+
+        let block = self
+            .0
+            .block_by_number(height)
+            .wrap_err_with(|| format!("failed reading execution block at height {height}"))?;
+        Ok(block.map(|block| Digest(block.header.hash_slow())))
+    }
+}
+
+/// The minimal persisted-cache payload extracted from a node's consensus
+/// storage for a snapshot.
+///
+/// Holds the highest finalization certificate that the cached blocks can
+/// reach from the execution layer's finalized watermark, plus the blocks
+/// `(execution_height, height]` themselves (opaque outside this crate).
+#[derive(Debug)]
+pub struct PersistedCache {
+    /// The execution layer's finalized height the cache builds on.
+    pub execution_height: u64,
+    /// Digest of the execution layer's finalized block at
+    /// [`Self::execution_height`].
+    pub execution_digest: Digest,
+    /// Height of [`Self::finalization`]. At most
+    /// [`Self::execution_height`] + the number of cached blocks.
+    pub height: u64,
+    /// The target finalization certificate. Its payload is the digest the
+    /// execution layer can be brought up to by replaying the cached
+    /// blocks.
+    pub finalization: TempoFinalization,
+    /// Blocks `(execution_height, height]`, oldest first. Verified to be
+    /// parent-linked from the execution anchor up to the certificate
+    /// digest.
+    blocks: Vec<Block>,
+}
+
+impl PersistedCache {
+    /// Digest recorded in the certificate.
+    pub fn digest(&self) -> Digest {
+        self.finalization.proposal.payload
+    }
+
+    /// Number of blocks in the minimized cache.
+    pub fn block_count(&self) -> usize {
+        self.blocks.len()
+    }
+
+    /// Inclusive height range of the cached blocks, or `None` when the
+    /// certificate is already covered by the execution layer snapshot.
+    pub fn block_range(&self) -> Option<(u64, u64)> {
+        (!self.blocks.is_empty()).then(|| (self.execution_height + 1, self.height))
+    }
+}
+
+/// Determines the snapshot's target finalization certificate and collects
+/// the minimal set of persisted-cache blocks needed to reach it.
+///
+/// Reads the node's consensus storage rooted at `context`'s storage
+/// directory. The target is the highest finalization certificate whose
+/// height is contiguously covered by cached blocks above the execution
+/// layer's finalized watermark (searching at most `max_depth` certificate
+/// heights downwards). The covered blocks are verified to be parent-linked
+/// from the execution layer's finalized block up to the certificate
+/// digest.
+///
+/// The blocks are buffered in memory; the range is bounded by how far the
+/// consensus layer ran ahead of the execution layer when the node was
+/// stopped (at most the persisted cache itself).
+///
+/// Returns `None` when the execution layer has no finalized state, when no
+/// finalization certificates are persisted, or when no certificate within
+/// `max_depth` matches the available state.
+pub async fn collect_persisted_cache<TContext, P>(
+    context: &TContext,
+    execution_provider: &P,
+    max_depth: u64,
+) -> eyre::Result<Option<PersistedCache>>
+where
+    TContext: Clock + Metrics + Spawner + Storage + BufferPooler + Clone + Send + 'static,
+    P: BlockIdReader + BlockReader<Block = tempo_primitives::Block> + Send + Sync + ?Sized,
+{
+    collect_persisted_cache_inner(context, &RethAnchor(execution_provider), max_depth).await
+}
+
+/// Implementation of [`collect_persisted_cache`] generic over the
+/// [`ExecutionAnchor`] seam so tests can stub the execution layer.
+async fn collect_persisted_cache_inner<TContext, P>(
+    context: &TContext,
+    execution_provider: &P,
+    max_depth: u64,
+) -> eyre::Result<Option<PersistedCache>>
+where
+    TContext: Clock + Metrics + Spawner + Storage + BufferPooler + Clone + Send + 'static,
+    P: ExecutionAnchor + ?Sized,
+{
+    let Some(execution_height) = execution_provider.finalized_height()? else {
+        return Ok(None);
+    };
+    let execution_digest = execution_provider
+        .block_digest(execution_height)?
+        .ok_or_eyre(format!(
+            "finalized execution block at height `{execution_height}` is missing"
+        ))?;
+
+    let page_cache = CacheRef::from_pooler(context, BUFFER_POOL_PAGE_SIZE, BUFFER_POOL_CAPACITY);
+    let finalizations =
+        init_finalizations_archive(context, crate::PARTITION_PREFIX, page_cache.clone())
+            .await
+            .wrap_err("failed to open finalizations-by-height archive")?;
+    let Some(last_finalization) = finalizations.last_index() else {
+        return Ok(None);
+    };
+
+    let blocks_archive =
+        init_prunable_finalized_blocks_archive(context, crate::PARTITION_PREFIX, page_cache)
+            .await
+            .wrap_err("failed to open prunable finalized blocks archive")?;
+
+    // Highest cached height contiguously reachable from the execution
+    // anchor. Anything above a gap cannot be replayed into the execution
+    // layer and is useless to a restored node.
+    let (coverage_end, _) = blocks_archive.next_gap(execution_height.saturating_add(1));
+    let coverage_end = coverage_end.unwrap_or(execution_height);
+
+    let upper = last_finalization.min(coverage_end);
+    let lower = upper.saturating_sub(max_depth);
+    for height in (lower..=upper).rev() {
+        let Some(finalization) = finalizations
+            .get(Identifier::Index(height))
+            .await
+            .wrap_err_with(|| format!("failed reading finalization at height {height}"))?
+        else {
+            continue;
+        };
+
+        // Collect the cached blocks `(execution_height, height]` and walk
+        // the parent linkage from the execution anchor.
+        let mut blocks = Vec::new();
+        let mut parent = execution_digest;
+        for cached in execution_height + 1..=height {
+            let block = blocks_archive
+                .get(Identifier::Index(cached))
+                .await
+                .wrap_err_with(|| format!("failed reading cached block at height {cached}"))?
+                .ok_or_eyre(format!(
+                    "cached block at height `{cached}` disappeared during extraction"
+                ))?;
+            ensure!(
+                block.parent_digest() == parent,
+                "cached block at height `{cached}` does not extend digest {parent}",
+            );
+            parent = block.digest();
+            blocks.push(block);
+        }
+
+        // The digest the certificate must commit to: the last cached
+        // block, or the execution layer's block when the certificate sits
+        // at or below the finalized watermark.
+        let tip_digest = match blocks.last() {
+            Some(block) => block.digest(),
+            None if height == execution_height => execution_digest,
+            None => execution_provider
+                .block_digest(height)?
+                .ok_or_eyre(format!(
+                    "execution block at certificate height `{height}` is missing"
+                ))?,
+        };
+
+        let finalization_digest = finalization.proposal.payload;
+        ensure!(
+            finalization_digest == tip_digest,
+            "digest mismatch at height `{height}`. finalization: {finalization_digest}, block: {tip_digest}",
+        );
+
+        return Ok(Some(PersistedCache {
+            execution_height,
+            execution_digest,
+            height,
+            finalization,
+            blocks,
+        }));
+    }
+
+    Ok(None)
+}
+
+/// Writes the minimized persisted cache into a fresh prunable
+/// finalized-blocks archive rooted at `context`'s storage directory.
+///
+/// The archive uses the production storage layout (same partition names
+/// and section sizing), so extracting the staged files into a node's
+/// consensus datadir yields a persisted cache the node opens as its own.
+///
+/// The target storage directory must not already contain a finalized
+/// blocks archive.
+pub async fn write_persisted_cache<TContext>(
+    context: &TContext,
+    cache: &PersistedCache,
+) -> eyre::Result<()>
+where
+    TContext: Clock + Metrics + Spawner + Storage + BufferPooler + Clone + Send + 'static,
+{
+    let page_cache = CacheRef::from_pooler(context, BUFFER_POOL_PAGE_SIZE, BUFFER_POOL_CAPACITY);
+    let mut archive =
+        init_prunable_finalized_blocks_archive(context, crate::PARTITION_PREFIX, page_cache)
+            .await
+            .wrap_err("failed to initialize minimized persisted cache archive")?;
+
+    ensure!(
+        archive.last_index().is_none(),
+        "minimized persisted cache target directory is not empty",
+    );
+
+    for block in &cache.blocks {
+        let height = block.height().get();
+        archive
+            .put(height, block.digest(), block.clone())
+            .await
+            .wrap_err_with(|| format!("failed writing cached block at height {height}"))?;
+    }
+
+    archive
+        .sync()
+        .await
+        .wrap_err("failed to sync minimized persisted cache archive")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use commonware_consensus::{
+        simplex::types::{Finalize, Proposal},
+        types::{Epoch, Round, View},
+    };
+    use commonware_cryptography::certificate::mocks::Fixture;
+    use commonware_macros::test_traced;
+    use commonware_parallel::Sequential;
+    use commonware_runtime::{Runner as _, deterministic};
+    use rand_08::{SeedableRng as _, rngs::StdRng};
+
+    use super::*;
+    use crate::storage::hybrid::test::utils::{fresh_page_cache, make_chain};
+
+    const NAMESPACE: &[u8] = b"snapshot-test";
+
+    /// Stub [`ExecutionAnchor`]: a finalized watermark plus canonical
+    /// digests by height.
+    #[derive(Default)]
+    struct StubAnchor {
+        finalized: Option<u64>,
+        digests: HashMap<u64, Digest>,
+    }
+
+    impl StubAnchor {
+        fn with_chain(finalized: u64, chain: &[Block]) -> Self {
+            Self {
+                finalized: Some(finalized),
+                digests: chain
+                    .iter()
+                    .map(|block| (block.height().get(), block.digest()))
+                    .collect(),
+            }
+        }
+    }
+
+    impl ExecutionAnchor for StubAnchor {
+        fn finalized_height(&self) -> eyre::Result<Option<u64>> {
+            Ok(self.finalized)
+        }
+
+        fn block_digest(&self, height: u64) -> eyre::Result<Option<Digest>> {
+            // Mirror the production provider: only canonical blocks at or
+            // below the finalized watermark matter for anchoring.
+            Ok(self.digests.get(&height).copied())
+        }
+    }
+
+    fn scheme_fixture() -> Fixture<Scheme<PublicKey, MinSig>> {
+        let mut rng = StdRng::seed_from_u64(42);
+        commonware_consensus::simplex::scheme::bls12381_threshold::vrf::fixture::<MinSig, _>(
+            &mut rng, NAMESPACE, 4,
+        )
+    }
+
+    fn make_finalization(
+        fixture: &Fixture<Scheme<PublicKey, MinSig>>,
+        height: u64,
+        digest: Digest,
+    ) -> TempoFinalization {
+        let proposal = Proposal::new(
+            Round::new(Epoch::new(0), View::new(height)),
+            View::new(height.saturating_sub(1)),
+            digest,
+        );
+        let finalizes: Vec<_> = fixture
+            .schemes
+            .iter()
+            .map(|scheme| Finalize::sign(scheme, proposal.clone()).expect("sign finalize"))
+            .collect();
+        Finalization::from_finalizes(&fixture.schemes[0], &finalizes, &Sequential)
+            .expect("assemble finalization")
+    }
+
+    /// Populate the production-prefix archives with `chain` blocks and
+    /// finalization certificates at `cert_heights`.
+    async fn seed_storage<TContext>(
+        context: &TContext,
+        chain: &[Block],
+        cert_heights: &[u64],
+        skip_block_heights: &[u64],
+    ) where
+        TContext: Clock + Metrics + Spawner + Storage + BufferPooler + Clone + Send + 'static,
+    {
+        let fixture = scheme_fixture();
+        let page_cache = fresh_page_cache(context);
+
+        let mut finalizations =
+            init_finalizations_archive(context, crate::PARTITION_PREFIX, page_cache.clone())
+                .await
+                .expect("init finalizations archive");
+        for block in chain {
+            let height = block.height().get();
+            if cert_heights.contains(&height) {
+                let finalization = make_finalization(&fixture, height, block.digest());
+                finalizations
+                    .put(height, block.digest(), finalization)
+                    .await
+                    .expect("put finalization");
+            }
+        }
+        finalizations.sync().await.expect("sync finalizations");
+
+        let mut blocks =
+            init_prunable_finalized_blocks_archive(context, crate::PARTITION_PREFIX, page_cache)
+                .await
+                .expect("init blocks archive");
+        for block in chain {
+            let height = block.height().get();
+            if skip_block_heights.contains(&height) {
+                continue;
+            }
+            blocks
+                .put(height, block.digest(), block.clone())
+                .await
+                .expect("put block");
+        }
+        blocks.sync().await.expect("sync blocks");
+    }
+
+    #[test_traced]
+    fn collects_blocks_up_to_highest_covered_certificate() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let chain = make_chain(0, 21);
+            let anchor = StubAnchor::with_chain(10, &chain);
+            seed_storage(&context.with_label("seed"), &chain, &[5, 10, 15, 20], &[]).await;
+
+            let cache = collect_persisted_cache_inner(&context.with_label("collect"), &anchor, 100)
+                .await
+                .expect("collect")
+                .expect("cache");
+
+            assert_eq!(cache.execution_height, 10);
+            assert_eq!(cache.height, 20);
+            assert_eq!(cache.block_count(), 10);
+            assert_eq!(cache.block_range(), Some((11, 20)));
+            assert_eq!(cache.digest(), chain[20].digest());
+            assert_eq!(cache.execution_digest, chain[10].digest());
+        });
+    }
+
+    #[test_traced]
+    fn coverage_gap_limits_certificate_selection() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let chain = make_chain(0, 21);
+            let anchor = StubAnchor::with_chain(10, &chain);
+            // Block 15 is missing from the cache: certificates above it
+            // are unreachable.
+            seed_storage(&context.with_label("seed"), &chain, &[14, 20], &[15]).await;
+
+            let cache = collect_persisted_cache_inner(&context.with_label("collect"), &anchor, 100)
+                .await
+                .expect("collect")
+                .expect("cache");
+
+            assert_eq!(cache.height, 14);
+            assert_eq!(cache.block_range(), Some((11, 14)));
+            assert_eq!(cache.digest(), chain[14].digest());
+        });
+    }
+
+    #[test_traced]
+    fn certificate_below_execution_floor_yields_empty_cache() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let chain = make_chain(0, 21);
+            let anchor = StubAnchor::with_chain(10, &chain);
+            // Only a certificate below the execution watermark exists.
+            seed_storage(&context.with_label("seed"), &chain, &[8], &[]).await;
+
+            let cache = collect_persisted_cache_inner(&context.with_label("collect"), &anchor, 100)
+                .await
+                .expect("collect")
+                .expect("cache");
+
+            assert_eq!(cache.height, 8);
+            assert_eq!(cache.block_count(), 0);
+            assert_eq!(cache.block_range(), None);
+            assert_eq!(cache.digest(), chain[8].digest());
+        });
+    }
+
+    #[test_traced]
+    fn errors_on_certificate_digest_mismatch() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let chain = make_chain(0, 21);
+            let anchor = StubAnchor::with_chain(10, &chain);
+            seed_storage(&context.with_label("seed"), &chain, &[], &[]).await;
+
+            // A certificate at height 20 committing to the wrong digest.
+            let fixture = scheme_fixture();
+            let bogus = make_finalization(&fixture, 20, chain[19].digest());
+            let page_cache = fresh_page_cache(&context);
+            let mut finalizations = init_finalizations_archive(
+                &context.with_label("rewrite"),
+                crate::PARTITION_PREFIX,
+                page_cache,
+            )
+            .await
+            .expect("init finalizations archive");
+            finalizations
+                .put(20, chain[19].digest(), bogus)
+                .await
+                .expect("put finalization");
+            finalizations.sync().await.expect("sync");
+            drop(finalizations);
+
+            let err = collect_persisted_cache_inner(&context.with_label("collect"), &anchor, 100)
+                .await
+                .expect_err("digest mismatch must error");
+            assert!(err.to_string().contains("digest mismatch"), "{err}");
+        });
+    }
+
+    #[test_traced]
+    fn returns_none_without_finalizations() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let chain = make_chain(0, 21);
+            let anchor = StubAnchor::with_chain(10, &chain);
+            seed_storage(&context.with_label("seed"), &chain, &[], &[]).await;
+
+            let cache = collect_persisted_cache_inner(&context.with_label("collect"), &anchor, 100)
+                .await
+                .expect("collect");
+            assert!(cache.is_none());
+        });
+    }
+
+    /// Build a [`PersistedCache`] covering `(10, 20]` of `chain` directly
+    /// (tests share the module, so the private `blocks` field is in
+    /// reach). Lets write-path tests run against an empty storage root
+    /// without seeding source archives first.
+    fn make_cache(chain: &[Block]) -> PersistedCache {
+        let fixture = scheme_fixture();
+        PersistedCache {
+            execution_height: 10,
+            execution_digest: chain[10].digest(),
+            height: 20,
+            finalization: make_finalization(&fixture, 20, chain[20].digest()),
+            blocks: chain[11..=20].to_vec(),
+        }
+    }
+
+    #[test_traced]
+    fn write_round_trips_through_fresh_archive() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let chain = make_chain(0, 21);
+            let cache = make_cache(&chain);
+
+            write_persisted_cache(&context.with_label("write"), &cache)
+                .await
+                .expect("write");
+
+            let page_cache = fresh_page_cache(&context);
+            let archive = init_prunable_finalized_blocks_archive(
+                &context.with_label("reopen"),
+                crate::PARTITION_PREFIX,
+                page_cache,
+            )
+            .await
+            .expect("reopen archive");
+
+            assert_eq!(archive.first_index(), Some(11));
+            assert_eq!(archive.last_index(), Some(20));
+            for (height, expected) in (11..=20u64).zip(&chain[11..=20]) {
+                let block = archive
+                    .get(Identifier::Index(height))
+                    .await
+                    .expect("get")
+                    .expect("block present");
+                assert_eq!(block.digest(), expected.digest());
+            }
+        });
+    }
+
+    #[test_traced]
+    fn write_rejects_non_empty_target() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let chain = make_chain(0, 21);
+            let cache = make_cache(&chain);
+
+            write_persisted_cache(&context.with_label("first"), &cache)
+                .await
+                .expect("write");
+
+            // The target now already contains a finalized blocks archive.
+            let err = write_persisted_cache(&context.with_label("second"), &cache)
+                .await
+                .expect_err("non-empty target must be rejected");
+            assert!(err.to_string().contains("not empty"), "{err}");
+        });
+    }
+}


### PR DESCRIPTION
Snapshots previously embedded only a consensus floor certificate matching the EL's finalized block; a restored node had to re-fetch every block above the EL watermark from peers.

`tempo snapshot-manifest` now picks the highest persisted finalization contiguously covered by the consensus hybrid storage ("persisted cache"), extracts exactly the blocks `(el_finalized, cert_height]` — verified parent-linked from the EL anchor up to the certificate digest — into a fresh production-layout prunable archive, packages it as `consensus-cache.tar.zst`, and records it in the manifest's `consensus` entry (`persisted_cache`: file, block range, sizes, per-file BLAKE3). Blocks at or below the EL watermark are served by the hybrid store's EL fallback and are no longer dead weight; the manifest field is optional so existing manifests and `tempo download` keep parsing.

Download-side extraction of the new archive is a follow-up.

Note: `tests::consensus_block_budget_defaults_are_stable` and `tests::follow_arg_parses_to_expected_mode` fail in my sandbox on the base commit as well (DownloadDefaults global init race) — unrelated to this change.