### PR TITLE
ci: make update-reth amp fix loop resilient to amp failures

### DIFF
--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -111,10 +111,13 @@ jobs:
         run: |
           # Wrapper that runs amp with --stream-json, extracts the thread URL,
           # logs it, and still prints the final result text.
+          # Must NOT use `set -e`: if amp exits non-zero, we still want to print
+          # its output (otherwise failures are silent) and propagate the code.
           cat > /usr/local/bin/amp-run <<'WRAPPER'
           #!/usr/bin/env bash
-          set -euo pipefail
-          OUTPUT=$(amp "$@" --stream-json --take-me-back 2>&1)
+          set -uo pipefail
+          OUTPUT=$(amp "$@" --stream-json 2>&1)
+          AMP_EXIT=$?
           FIRST_LINE=$(echo "$OUTPUT" | head -1 || true)
           THREAD_ID=$(echo "$FIRST_LINE" | jq -r '.session_id // empty' 2>/dev/null || true)
           if [ -n "$THREAD_ID" ]; then
@@ -122,6 +125,11 @@ jobs:
           fi
           # Print the final result text
           echo "$OUTPUT" | jq -r 'select(.type=="result") | .result // empty' 2>/dev/null || true
+          if [ "$AMP_EXIT" -ne 0 ]; then
+            echo "amp exited with code $AMP_EXIT; raw output:" >&2
+            echo "$OUTPUT" >&2
+            exit "$AMP_EXIT"
+          fi
           # Propagate error if amp failed
           IS_ERROR=$(echo "$OUTPUT" | jq -r 'select(.type=="result") | .is_error // false' 2>/dev/null || true)
           if [ "$IS_ERROR" = "true" ]; then
@@ -129,6 +137,16 @@ jobs:
           fi
           WRAPPER
           chmod +x /usr/local/bin/amp-run
+
+      # ── amp smoke test ────────────────────────────────────────
+      - name: Verify Amp CLI
+        env:
+          AMP_API_KEY: ${{ secrets.AMP_API_KEY }}
+        run: |
+          amp --version
+          # Fail fast and loudly if auth or flags are broken, before the
+          # expensive fix loops run.
+          amp-run -x "Reply with exactly: OK"
 
       # ── update reth rev ─────────────────────────────────────────
       - name: Update reth rev in Cargo.toml
@@ -212,8 +230,15 @@ jobs:
             fi
 
             echo "::group::Amp attempt $attempt"
+            set +e
             amp-run --dangerously-allow-all -x "$AMP_PROMPT"
+            amp_exit=$?
+            set -e
             echo "::endgroup::"
+            if [ "$amp_exit" -ne 0 ]; then
+              echo "::warning::amp-run failed with exit code $amp_exit on attempt $attempt — retrying"
+              continue
+            fi
 
             echo "::group::Verify cargo clippy"
             set +e
@@ -276,8 +301,15 @@ jobs:
             fi
 
             echo "::group::Amp attempt $attempt"
+            set +e
             amp-run --dangerously-allow-all -x "$AMP_PROMPT"
+            amp_exit=$?
+            set -e
             echo "::endgroup::"
+            if [ "$amp_exit" -ne 0 ]; then
+              echo "::warning::amp-run failed with exit code $amp_exit on attempt $attempt — retrying"
+              continue
+            fi
 
             echo "::group::Verify test compilation"
             set +e
@@ -523,8 +555,14 @@ jobs:
                 PRE_SHA=$(git rev-parse HEAD)
 
                 echo "::group::Amp stuck CI investigation"
+                set +e
                 amp-run --dangerously-allow-all -x < /tmp/amp-prompt.txt
+                amp_exit=$?
+                set -e
                 echo "::endgroup::"
+                if [ "$amp_exit" -ne 0 ]; then
+                  echo "::warning::amp-run failed with exit code $amp_exit during stuck CI investigation"
+                fi
 
                 if [ -n "$(git status --porcelain)" ]; then
                   git add -A
@@ -571,8 +609,14 @@ jobs:
             PRE_SHA=$(git rev-parse HEAD)
 
             echo "::group::Amp CI fix"
+            set +e
             amp-run --dangerously-allow-all -x < /tmp/amp-prompt.txt
+            amp_exit=$?
+            set -e
             echo "::endgroup::"
+            if [ "$amp_exit" -ne 0 ]; then
+              echo "::warning::amp-run failed with exit code $amp_exit during CI fix attempt"
+            fi
 
             # Amp may have committed+pushed already; also handle uncommitted changes
             if [ -n "$(git status --porcelain)" ]; then


### PR DESCRIPTION
## Problem

The nightly reth bump job ([run 27423961142](https://github.com/tempoxyz/tempo/actions/runs/27423961142/job/81056632834)) died on "Amp attempt 1" in ~0.4s with **zero output**, so amp never got a chance to fix the `alloy-eip7928` version conflict.

Root cause: the `amp-run` wrapper uses `set -euo pipefail` and captures amp via `OUTPUT=$(amp ... 2>&1)`. When amp exits non-zero (e.g. an instant auth error — `Error: Invalid or missing API key` exits 1 in ~0.4s, matching the observed timing exactly), the wrapper aborts at the assignment **without printing $OUTPUT**, and the unguarded `amp-run` call under `bash -e` kills the whole step before the retry loop runs.

## Changes

- **Wrapper**: capture amp's exit code, always print its output (raw error included on failure), then propagate the code — failures are no longer silent
- **Drop `--take-me-back`**: no longer a documented amp flag
- **Smoke test step** after install: `amp --version` + a trivial `-x` run, so auth/flag breakage fails fast and loudly instead of mid-loop
- **Guard all 4 `amp-run` call sites** with `set +e`: a failed amp attempt logs a `::warning` and retries (clippy/test loops) or falls through to existing no-changes handling (CI-fix loop) instead of aborting the job

## Verification

Tested the new wrapper locally with an invalid key:
```
$ AMP_API_KEY=dummy ./amp-run -x "hi"
amp exited with code 1; raw output:
Error: Invalid or missing API key. Run 'amp login' to authenticate.
wrapper exit: 1
```

Note: if the next nightly run shows the same instant exit, the new logs will print the real amp error — if it's an invalid `AMP_API_KEY` secret, that needs rotating separately.