### PR TITLE
fix(cli): give faucet.enabled arg a unique clap id

### DIFF
--- a/crates/faucet/src/args.rs
+++ b/crates/faucet/src/args.rs
@@ -12,30 +12,30 @@ use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderBuilderExt};
 #[command(next_help_heading = "Faucet")]
 pub struct FaucetArgs {
     /// Whether the faucet is enabled
-    #[arg(long = "faucet.enabled", default_value_t = false)]
+    #[arg(id = "faucet.enabled", long = "faucet.enabled", default_value_t = false)]
     pub enabled: bool,
 
     /// Faucet funding private key
     #[arg(
         long = "faucet.private-key",
-        requires = "enabled",
-        required_if_eq("enabled", "true")
+        requires = "faucet.enabled",
+        required_if_eq("faucet.enabled", "true")
     )]
     pub private_key: Option<B256>,
 
     /// Amount for each faucet funding transaction
     #[arg(
         long = "faucet.amount",
-        requires = "enabled",
-        required_if_eq("enabled", "true")
+        requires = "faucet.enabled",
+        required_if_eq("faucet.enabled", "true")
     )]
     pub amount: Option<U256>,
 
     /// Target token address for the faucet to be funding with
     #[arg(
         long = "faucet.address",
-        requires = "enabled",
-        required_if_eq("enabled", "true"),
+        requires = "faucet.enabled",
+        required_if_eq("faucet.enabled", "true"),
         num_args(0..)
     )]
     pub token_addresses: Option<Vec<Address>>,
@@ -43,7 +43,7 @@ pub struct FaucetArgs {
     #[arg(
         long = "faucet.node-address",
         default_value = "http://localhost:8545",
-        requires = "enabled"
+        requires = "faucet.enabled"
     )]
     pub node_address: String,
 }
@@ -77,5 +77,24 @@ impl FaucetArgs {
                     .expect("Failed to parse node address"),
             )
             .erased()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// A helper type to parse Args more easily
+    #[derive(Parser)]
+    struct CommandParser {
+        #[command(flatten)]
+        args: FaucetArgs,
+    }
+
+    #[test]
+    fn faucet_args_default_sanity_test() {
+        let args = CommandParser::parse_from(["tempo"]).args;
+        assert_eq!(args, FaucetArgs::default());
     }
 }

--- a/crates/faucet/src/args.rs
+++ b/crates/faucet/src/args.rs
@@ -98,7 +98,6 @@ mod tests {
 
     #[test]
     fn faucet_args_default_sanity_test() {
-        let args = CommandParser::parse_from(["tempo"]).args;
-        assert_eq!(args, FaucetArgs::default());
+        assert!(CommandParser::try_parse_from(["tempo"]).is_ok());
     }
 }

--- a/crates/faucet/src/args.rs
+++ b/crates/faucet/src/args.rs
@@ -12,7 +12,11 @@ use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderBuilderExt};
 #[command(next_help_heading = "Faucet")]
 pub struct FaucetArgs {
     /// Whether the faucet is enabled
-    #[arg(id = "faucet.enabled", long = "faucet.enabled", default_value_t = false)]
+    #[arg(
+        id = "faucet.enabled",
+        long = "faucet.enabled",
+        default_value_t = false
+    )]
     pub enabled: bool,
 
     /// Faucet funding private key


### PR DESCRIPTION
## Problem
`FaucetArgs::enabled` uses the default clap id `enabled`. The reth bump in #5564 pulls in reth's new `JitArgs`, which also has an `enabled` field, so both flatten into the `node` command with the same id and clap's debug assert panics on any `tempo node` invocation:

```
Command node: Argument names must be unique, but 'enabled' is in use by more than one argument or group
```

This is what's failing CLI smoke tests / test (1/2) / test (2/2) on #5564.

## Fix
Set an explicit `id = "faucet.enabled"` and update the four `requires`/`required_if_eq` references to match. Adds a parse sanity test.

No behavior change — flag is still `--faucet.enabled`. (Companion reth PR gives `JitArgs` an explicit id too; either fix alone unblocks #5564.)