### PR TITLE
[codex] Add bench-style Cyclops audit comment aliases

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -41,7 +41,11 @@ jobs:
       github.event.issue.pull_request &&
       (
         startsWith(github.event.comment.body, 'cyclops audit') ||
+        startsWith(github.event.comment.body, 'decofe audit') ||
+        startsWith(github.event.comment.body, '@decofe audit') ||
+        startsWith(github.event.comment.body, 'decofe cyclops audit') ||
         startsWith(github.event.comment.body, '@decofe cyclops audit') ||
+        startsWith(github.event.comment.body, 'derek cyclops audit') ||
         startsWith(github.event.comment.body, 'derek audit')
       )
     permissions:
@@ -87,12 +91,12 @@ jobs:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             const usage = [
-              '**Usage:** `cyclops audit [fast] [iterations=N] [hours=N] [config=pr-review.yaml] ',
+              '**Usage:** `@decofe audit [fast] [iterations=N] [hours=N] [config=pr-review.yaml] ',
               '[models="anthropic/claude-opus-4-7,openai/gpt-5.5"] [run-label=LABEL] ',
-              '[dry-run] [note="per-run audit guidance"]`',
+              '[dry-run] [note="per-run audit guidance"]` or `derek audit ...`',
             ].join('');
             const body = context.payload.comment.body.trim();
-            const prefix = /^(?:@decofe\s+)?(?:cyclops\s+audit|derek\s+audit)\b/i;
+            const prefix = /^(?:@?decofe\s+(?:cyclops\s+)?audit|derek\s+(?:cyclops\s+)?audit|cyclops\s+audit)\b/i;
             const args = body.replace(prefix, '').trim();
             const parts = [];
             const argRegex = /(\S+?[=:]"[^"]*"|\S+?[=:]'[^']*'|\S+?[=:]\S+|\S+)/g;


### PR DESCRIPTION
## Summary

Adds bench-style comment aliases for triggering Cyclops PR review from Tempo PR comments.

New accepted forms:

- `@decofe audit`
- `decofe audit`
- `@decofe cyclops audit`
- `decofe cyclops audit`
- `derek audit`
- `derek cyclops audit`
- existing `cyclops audit`

The existing merged Argo path remains unchanged: the workflow publishes a `pr_audit` event, `dev-infra` routes it through `sensor-pr-audit.yaml`, and `workflows` runs `cyclops-scan-pr-review`.

## Validation

- `actionlint .github/workflows/pr-audit.yml`
- Ruby YAML parse
- Node prefix parser smoke test

## Notes

No dev-infra/workflows PR is included because current `main` already contains the sensor and workflow-template support for comment-triggered Cyclops PR reviews.