### PR TITLE
feat(tip-1060): present/new accounting, 20k residual in GasParams, drop refund cap

### DIFF
--- a/crates/chainspec/src/constants.rs
+++ b/crates/chainspec/src/constants.rs
@@ -8,10 +8,18 @@ pub mod gas {
 
     use alloy_eips::eip1559::BaseFeeParams;
 
-    pub const SSTORE_SET: u64 = 20_000;
     const COLD_SLOAD: u64 = 2100;
     const WARM_SLOAD: u64 = 100;
     const WARM_SSTORE_RESET: u64 = 2900;
+
+    /// TIP-1000 storage creation component for a zero-to-nonzero SSTORE.
+    pub const SSTORE_CREATE_COST: u64 = 250_000;
+
+    /// TIP-1060 SSTORE residual: EVM `0→x` base cost paid even when a credit applies.
+    pub const SSTORE_SET_COST: u64 = 20_000;
+
+    /// TIP-1060 value credited for clearing one occupied storage slot.
+    pub const STORAGE_CREDIT_VALUE: u64 = SSTORE_CREATE_COST - SSTORE_SET_COST;
 
     /// T0 base fee: 10 billion attodollars (1×10^10).
     ///
@@ -32,9 +40,6 @@ pub mod gas {
 
     /// TIP-1067 base fee cap: below the T1 fixed base fee.
     pub const TEMPO_T7_BASE_FEE_CAP: u64 = 12_000_000_000;
-
-    /// TIP-1060 value credited for clearing one occupied storage slot.
-    pub const STORAGE_CREDIT_VALUE: u64 = 230_000;
 
     /// TIP-1067 base fee floor: one twentieth of the TIP-1067 cap.
     pub const TEMPO_T7_BASE_FEE_FLOOR: u64 = TEMPO_T7_BASE_FEE_CAP / 20;
@@ -83,7 +88,7 @@ pub mod gas {
         TEMPO_T1_EXISTING_NONCE_KEY_GAS + 2 * WARM_SLOAD;
 
     /// Gas cost for using a new 2D nonce key (cold SLOAD + SSTORE set for 0 -> non-zero).
-    pub const TEMPO_T1_NEW_NONCE_KEY_GAS: u64 = COLD_SLOAD + SSTORE_SET;
+    pub const TEMPO_T1_NEW_NONCE_KEY_GAS: u64 = COLD_SLOAD + SSTORE_SET_COST;
     /// T2 adds 2 warm SLOADs for the extended nonce key lookup.
     pub const TEMPO_T2_NEW_NONCE_KEY_GAS: u64 = TEMPO_T1_NEW_NONCE_KEY_GAS + 2 * WARM_SLOAD;
 

--- a/crates/chainspec/src/constants.rs
+++ b/crates/chainspec/src/constants.rs
@@ -16,7 +16,7 @@ pub mod gas {
     pub const SSTORE_CREATE_COST: u64 = 250_000;
 
     /// TIP-1060 SSTORE residual: EVM `0→x` base cost paid even when a credit applies.
-    pub const SSTORE_SET_COST: u64 = 20_000;
+    pub const SSTORE_SET_COST: u64 = 5_000;
 
     /// TIP-1060 value credited for clearing one occupied storage slot.
     pub const STORAGE_CREDIT_VALUE: u64 = SSTORE_CREATE_COST - SSTORE_SET_COST;

--- a/crates/node/tests/it/tip1060_storage_credits.rs
+++ b/crates/node/tests/it/tip1060_storage_credits.rs
@@ -1,4 +1,4 @@
-use crate::utils::{TEST_MNEMONIC, TestNodeBuilder};
+use crate::utils::{TEST_MNEMONIC, TestNodeBuilder, setup_test_token};
 use alloy::{
     network::ReceiptResponse,
     primitives::{Address, U256},
@@ -9,17 +9,19 @@ use alloy::{
     },
     sol_types::SolCall,
 };
-use alloy_eips::Encodable2718;
+use alloy_eips::{BlockId, Encodable2718};
 use alloy_rpc_types_eth::TransactionRequest;
 use tempo_alloy::rpc::TempoTransactionReceipt;
 use tempo_contracts::precompiles::{
-    DEFAULT_FEE_TOKEN, ITIP1060StorageCredits,
+    DEFAULT_FEE_TOKEN, IFeeManager, ITIP20, ITIP1060StorageCredits,
     account_keychain::IAccountKeychain::{
         IAccountKeychainInstance, KeyRestrictions, SignatureType, TokenLimit, revokeKeyCall,
     },
     authorizeKeyCall,
 };
-use tempo_precompiles::{ACCOUNT_KEYCHAIN_ADDRESS, STORAGE_CREDITS_ADDRESS};
+use tempo_precompiles::{
+    ACCOUNT_KEYCHAIN_ADDRESS, PATH_USD_ADDRESS, STORAGE_CREDITS_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
+};
 use tempo_primitives::{
     TempoTransaction, TempoTxEnvelope,
     transaction::{
@@ -27,6 +29,32 @@ use tempo_primitives::{
         tt_signature::{KeychainSignature, PrimitiveSignature, TempoSignature},
     },
 };
+
+async fn wait_for_latest_beneficiary<P: Provider>(
+    provider: &P,
+    expected: Address,
+) -> eyre::Result<()> {
+    for _ in 0..30 {
+        let beneficiary = provider
+            .get_block(BlockId::latest())
+            .await?
+            .ok_or_else(|| eyre::eyre!("latest block missing"))?
+            .header
+            .beneficiary;
+        if beneficiary == expected {
+            return Ok(());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    let beneficiary = provider
+        .get_block(BlockId::latest())
+        .await?
+        .ok_or_else(|| eyre::eyre!("latest block missing"))?
+        .header
+        .beneficiary;
+    eyre::bail!("latest beneficiary {beneficiary:?} did not become {expected:?}")
+}
 
 /// Regression for the TIP-1060 fee-collection path reported in PR review.
 ///
@@ -153,6 +181,157 @@ async fn test_tip1060_keychain_fee_refund_does_not_retain_storage_credit() -> ey
     assert_eq!(
         credit_after, credit_before,
         "fee precharge/reimbursement bookkeeping must not change keychain storage credits"
+    );
+
+    Ok(())
+}
+
+/// Fee distribution must not run TIP-1060 accounting for fee-manager bookkeeping.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tip1060_distribute_fees_does_not_mint_unbacked_tip20_credit() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let initial_validator = Address::repeat_byte(0x42);
+    let dynamic_validator = std::sync::Arc::new(std::sync::Mutex::new(initial_validator));
+    let setup = TestNodeBuilder::new()
+        .with_dynamic_validator(dynamic_validator.clone())
+        .build_http_only()
+        .await?;
+    let root = MnemonicBuilder::from_phrase(TEST_MNEMONIC).build()?;
+    let root_addr = root.address();
+    let distributor = MnemonicBuilder::from_phrase(TEST_MNEMONIC)
+        .index(1)?
+        .build()?;
+    let distributor_addr = distributor.address();
+    let validator = MnemonicBuilder::from_phrase(TEST_MNEMONIC)
+        .index(2)?
+        .build()?;
+    let validator_addr = validator.address();
+    let provider = ProviderBuilder::new()
+        .wallet(root.clone())
+        .connect_http(setup.http_url.clone());
+    let distributor_provider = ProviderBuilder::new()
+        .wallet(distributor)
+        .connect_http(setup.http_url.clone());
+    let validator_provider = ProviderBuilder::new()
+        .wallet(validator)
+        .connect_http(setup.http_url);
+
+    let fee_token = setup_test_token(provider.clone(), root_addr).await?;
+    let path_usd = ITIP20::new(PATH_USD_ADDRESS, &provider);
+    let root_fee_manager = IFeeManager::new(TIP_FEE_MANAGER_ADDRESS, provider.clone());
+    let validator_fee_manager = IFeeManager::new(TIP_FEE_MANAGER_ADDRESS, validator_provider);
+    let distributor_fee_manager = IFeeManager::new(TIP_FEE_MANAGER_ADDRESS, distributor_provider);
+    let credits = ITIP1060StorageCredits::new(STORAGE_CREDITS_ADDRESS, &provider);
+
+    fee_token
+        .mint(root_addr, U256::from(10_000_000_000u64))
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    fee_token
+        .mint(validator_addr, U256::from(10_000u64))
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    path_usd
+        .transfer(distributor_addr, U256::from(10_000_000_000u64))
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    path_usd
+        .transfer(validator_addr, U256::from(10_000_000_000u64))
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    let set_validator_receipt = validator_fee_manager
+        .setValidatorToken(*fee_token.address())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(set_validator_receipt.status());
+
+    *dynamic_validator.lock().unwrap() = validator_addr;
+    wait_for_latest_beneficiary(&provider, validator_addr).await?;
+
+    let collected_before = root_fee_manager
+        .collectedFees(validator_addr, *fee_token.address())
+        .call()
+        .await?;
+    let fee_manager_token_balance_before =
+        fee_token.balanceOf(TIP_FEE_MANAGER_ADDRESS).call().await?;
+
+    let gas_price = 1_000_000_000_000u128;
+    let fee_collection_tx = TempoTransaction {
+        chain_id: provider.get_chain_id().await?,
+        nonce: provider.get_transaction_count(root_addr).await?,
+        max_priority_fee_per_gas: gas_price,
+        max_fee_per_gas: gas_price,
+        gas_limit: 500_000,
+        calls: vec![Call {
+            to: Address::repeat_byte(0x55).into(),
+            value: U256::ZERO,
+            input: Default::default(),
+        }],
+        fee_token: Some(*fee_token.address()),
+        ..Default::default()
+    };
+    let fee_collection_signature = root.sign_hash_sync(&fee_collection_tx.signature_hash())?;
+    let fee_collection_envelope: TempoTxEnvelope = fee_collection_tx
+        .into_signed(TempoSignature::Primitive(PrimitiveSignature::Secp256k1(
+            fee_collection_signature,
+        )))
+        .into();
+    let fee_collection_hash = provider
+        .send_raw_transaction(&fee_collection_envelope.encoded_2718())
+        .await?
+        .watch()
+        .await?;
+    let fee_collection_receipt = provider
+        .raw_request::<_, TempoTransactionReceipt>(
+            "eth_getTransactionReceipt".into(),
+            (fee_collection_hash,),
+        )
+        .await?;
+    assert!(fee_collection_receipt.status());
+
+    let collected_after_fee_collection = root_fee_manager
+        .collectedFees(validator_addr, *fee_token.address())
+        .call()
+        .await?;
+    let fee_manager_token_balance_after_fee_collection =
+        fee_token.balanceOf(TIP_FEE_MANAGER_ADDRESS).call().await?;
+    assert!(collected_after_fee_collection > collected_before);
+    assert!(fee_manager_token_balance_after_fee_collection > fee_manager_token_balance_before);
+
+    *dynamic_validator.lock().unwrap() = initial_validator;
+    wait_for_latest_beneficiary(&provider, initial_validator).await?;
+
+    let token_credit_before = credits.balanceOf(*fee_token.address()).call().await?;
+    let distribute_receipt = distributor_fee_manager
+        .distributeFees(validator_addr, *fee_token.address())
+        .gas(2_000_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(distribute_receipt.status());
+
+    assert_eq!(
+        fee_token.balanceOf(TIP_FEE_MANAGER_ADDRESS).call().await?,
+        U256::ZERO,
+        "distributeFees must clear the custom-token fee-manager custody slot"
+    );
+    assert_eq!(
+        credits.balanceOf(*fee_token.address()).call().await?,
+        token_credit_before,
+        "clearing fee-manager custody during distributeFees must not mint a storage credit"
     );
 
     Ok(())

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -263,28 +263,21 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
 
         // TIP-1060 (T7+): run the storage credits policy so precompile-driven storage
         // writes honor the same accounting as the opcode-level SSTORE hook.
-        let outcome = if self.tip1060_storage_credits_enabled {
+        if self.tip1060_storage_credits_enabled {
             sstore_storage_credits(self, address, &result)?
-        } else {
-            Default::default()
-        };
-
-        if !outcome.skip_gas {
-            // dynamic gas
-            self.deduct_gas(self.gas_params.sstore_dynamic_gas(
-                true,
-                &result.data,
-                result.is_cold,
-            ))?;
-
-            // Track state gas (cold SSTORE zero->non-zero only)
-            self.deduct_state_gas(self.gas_params.sstore_state_gas(&result.data))?;
         }
+
+        // dynamic gas
+        self.deduct_gas(
+            self.gas_params
+                .sstore_dynamic_gas(true, &result.data, result.is_cold),
+        )?;
+
+        // Track state gas (cold SSTORE zero->non-zero only)
+        self.deduct_state_gas(self.gas_params.sstore_state_gas(&result.data))?;
 
         // refund gas.
-        if !outcome.skip_refund {
-            self.refund_gas(self.gas_params.sstore_refund(true, &result.data));
-        }
+        self.refund_gas(self.gas_params.sstore_refund(true, &result.data));
 
         Ok(())
     }

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -52,15 +52,6 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
         }
     }
 
-    /// Enables or disables TIP-1060 storage-credit accounting for storage writes through this provider.
-    ///
-    /// This is intentionally provider-scoped so protocol-internal phases such as fee collection can
-    /// opt out without affecting user execution or other precompile calls.
-    pub fn with_tip1060_storage_credits(mut self, enabled: bool) -> Self {
-        self.tip1060_storage_credits_enabled = enabled && self.spec.is_t7();
-        self
-    }
-
     /// Creates a new storage provider with maximum gas limit and non-static context.
     pub fn new_max_gas(internals: EvmInternals<'a>, cfg: &CfgEnv<TempoHardfork>) -> Self {
         Self::new(
@@ -423,6 +414,11 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
         #[cfg(debug_assertions)]
         self.assert_lifo(&checkpoint, "revert");
         self.internals.checkpoint_revert(checkpoint)
+    }
+
+    #[inline]
+    fn set_tip1060_storage_credits(&mut self, enabled: bool) {
+        self.tip1060_storage_credits_enabled = enabled && self.spec.is_t7();
     }
 }
 

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -239,6 +239,10 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
             self.events = snapshot.events;
         }
     }
+
+    fn set_tip1060_storage_credits(&mut self, _enabled: bool) {
+        // HashMapStorageProvider does not run TIP-1060 accounting.
+    }
 }
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -125,6 +125,13 @@ pub trait PrecompileStorageProvider {
     /// Prefer [`CheckpointGuard`] (auto-reverts on drop).
     fn checkpoint_revert(&mut self, checkpoint: JournalCheckpoint);
 
+    /// Enables or disables TIP-1060 storage-credit accounting for subsequent storage writes.
+    ///
+    /// Implementations that do not run TIP-1060 accounting may treat this as a no-op. Production
+    /// providers must still hardfork-gate enabling so calling this with `true` before T7 does not
+    /// activate storage credits early.
+    fn set_tip1060_storage_credits(&mut self, enabled: bool);
+
     /// Computes keccak256 and charges the appropriate gas.
     ///
     /// Implementations should use this over naked `keccak256` call to ensure gas is accounted for.

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -213,6 +213,11 @@ impl StorageCtx {
         Self::with_storage(|s| s.is_static())
     }
 
+    /// Enables or disables TIP-1060 storage-credit accounting for subsequent storage writes.
+    pub fn set_tip1060_storage_credits(&mut self, enabled: bool) {
+        Self::with_storage(|s| s.set_tip1060_storage_credits(enabled))
+    }
+
     /// Creates a journal checkpoint and returns a RAII guard.
     ///
     /// All state mutations after this call will be atomically
@@ -362,8 +367,8 @@ impl<'evm> StorageCtx {
         J: JournalTr<Database: Database> + Debug,
     {
         let internals = EvmInternals::new(journal, block_env, cfg, tx_env);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(internals, cfg)
-            .with_tip1060_storage_credits(false);
+        let mut provider = EvmPrecompileStorageProvider::new_max_gas(internals, cfg);
+        provider.set_tip1060_storage_credits(false);
 
         Self::enter(&mut provider, f)
     }

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -352,11 +352,12 @@ impl<'evm> StorageCtx {
         Self::enter(&mut provider, f)
     }
 
-    /// Enters storage for protocol-internal fee collection.
+    /// Enters storage with TIP-1060 storage-credit accounting disabled.
     ///
-    /// Fee collection is exempt from TIP-1060 storage-credit accounting: it must not mint,
-    /// consume, or settle storage credits while updating fee/TIP20/keychain bookkeeping.
-    pub fn enter_fee_collection<J, R>(
+    /// Use when provider gas is not charged, or is charged externally, and the writes must not
+    /// mint, consume, or settle storage credits. If those writes create persistent storage, the
+    /// external charge must include `STORAGE_CREDIT_VALUE` unless exempt.
+    pub fn enter_evm_without_tip1060_accounting<J, R>(
         journal: &'evm mut J,
         block_env: &'evm dyn Block,
         cfg: &CfgEnv<TempoHardfork>,

--- a/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
+++ b/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
@@ -18,7 +18,7 @@ use revm::{
         instruction_context::GasStateOutcome,
     },
 };
-use tempo_chainspec::constants::gas::{SSTORE_SET, STORAGE_CREDIT_VALUE};
+use tempo_chainspec::constants::gas::STORAGE_CREDIT_VALUE;
 use tempo_contracts::precompiles::{STORAGE_CREDITS_ADDRESS, TIP1060StorageCreditsEvent};
 
 /// Error mapping required by storage credit accounting.
@@ -113,8 +113,12 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
 ) -> Result<GasStateOutcome, B::Error> {
     let (values, is_cold) = (&caller_state_load.data, caller_state_load.is_cold);
 
-    // TIP-1060 removes the legacy storage-clearing gas refunds.
-    let mut outcome = GasStateOutcome {
+    // TIP-1060 removes the legacy storage-clearing gas refunds. The SSTORE gas
+    // function still runs (`skip_gas: false`) so revm charges the baseline
+    // dynamic gas and the 20k creation residual (the latter only on a clean
+    // creation, `original == present == 0`); this hook layers the 230k
+    // creditable portion on top.
+    let outcome = GasStateOutcome {
         skip_gas: false,
         skip_refund: true,
     };
@@ -160,60 +164,56 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
 
     let mut was_changed = false;
     if values.is_new_zero() {
-        // x→0: slot clear (present non-zero set to zero).
+        // present non-zero -> 0: storage deletion. Mint one credit on every such
+        // transition, irrespective of the transaction-original value — TIP-1060
+        // keys minting on the present -> new transition, so a within-transaction
+        // `0 -> X -> 0` clear of a slot created earlier still mints (and the
+        // matching creation consumes), so churn nets out.
         balance = balance.saturating_add(1);
         was_changed = true;
-    } else if !values.is_original_zero() {
-        // x→0→x: dirty slot restore. The slot was cleared earlier this tx (minting a credit) and
-        // is now reset non-zero. No net new state, so the earlier mint must be cancelled or it
-        // would subsidize a real creation. Burn one credit if available, else charge its value.
-        if balance > 0 {
-            balance -= 1;
-            was_changed = true;
-        } else {
-            backend.charge_gas(STORAGE_CREDIT_VALUE)?;
-        }
-        // Leave gas enabled so revm charges normal dirty-restore gas.
     } else {
-        // 0→x: net slot creation. The selected storage creation mode is transient.
+        // present 0 -> non-zero: storage creation. revm's SSTORE gas function
+        // charges the 20k residual (only on a clean creation, `original ==
+        // present == 0`); this hook governs only the 230k creditable portion,
+        // independent of the original value. The selected mode is transient.
         let mut transient_state: TransientState = backend
             .tload(STORAGE_CREDITS_ADDRESS, account_slot)
             .try_into()
             .map_err(|_| B::Error::fatal_external())?;
 
         match transient_state.mode {
-            CreditMode::Direct => {
-                // Only if both a credit and direct budget are available, skip state gas.
-                if balance > 0 && transient_state.budget > 0 {
-                    // Consume the storage credit and charge 20k for the SSTORE + cold access cost.
-                    if caller_state_load.is_cold {
-                        backend.charge_gas(backend.gas_params().cold_storage_cost())?;
-                    }
-                    backend.charge_gas(SSTORE_SET)?;
-                    balance -= 1;
-                    was_changed = true;
-                    outcome.skip_gas = true;
+            CreditMode::Direct if balance > 0 && transient_state.budget > 0 => {
+                // Consume one credit to cover the 230k creditable portion.
+                balance -= 1;
+                was_changed = true;
 
-                    if transient_state.budget != u64::MAX {
-                        transient_state.budget -= 1;
-                    }
-                    if transient_state.budget == 0 {
-                        transient_state.mode = CreditMode::Preserve;
-                        emit_mode_updated(backend, owner, CreditMode::Preserve)?;
-                    }
-                    store_credit_state(backend, account_slot, transient_state)?;
-                } else if transient_state.budget == 0 {
-                    // Zero-budget `Direct` creations pay the full creation cost and then move to `Preserve`.
+                if transient_state.budget != u64::MAX {
+                    transient_state.budget -= 1;
+                }
+                if transient_state.budget == 0 {
+                    transient_state.mode = CreditMode::Preserve;
+                    emit_mode_updated(backend, owner, CreditMode::Preserve)?;
+                }
+                store_credit_state(backend, account_slot, transient_state)?;
+            }
+            CreditMode::Direct => {
+                // No credit or no budget available: charge the 230k creditable
+                // portion as gas. A zero budget switches the account to Preserve.
+                if transient_state.budget == 0 {
                     transient_state.mode = CreditMode::Preserve;
                     store_credit_state(backend, account_slot, transient_state)?;
                     emit_mode_updated(backend, owner, CreditMode::Preserve)?;
                 }
-                // Otherwise, leave gas enabled so revm charges full creation costs.
+                backend.charge_gas(STORAGE_CREDIT_VALUE)?;
             }
             CreditMode::Preserve => {
-                // Do nothing, so revm takes care of gas accounting after this hook.
+                // Always charge the 230k creditable portion as gas; credits untouched.
+                backend.charge_gas(STORAGE_CREDIT_VALUE)?;
             }
             CreditMode::Refund => {
+                // Charge the 230k creditable portion upfront and record a pending
+                // refund-eligible creation, settled at end-of-transaction.
+                backend.charge_gas(STORAGE_CREDIT_VALUE)?;
                 transient_state.pending_refunds = transient_state.pending_refunds.saturating_add(1);
                 store_credit_state(backend, account_slot, transient_state)?;
             }

--- a/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
+++ b/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
@@ -111,39 +111,22 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
     owner: Address,
     caller_state_load: &StateLoad<SStoreResult>,
 ) -> Result<GasStateOutcome, B::Error> {
-    let (values, is_cold) = (&caller_state_load.data, caller_state_load.is_cold);
-
-    // TIP-1060 removes the legacy storage-clearing gas refunds. The SSTORE gas
-    // function still runs (`skip_gas: false`) so revm charges the baseline
-    // dynamic gas and the 20k creation residual (the latter only on a clean
-    // creation, `original == present == 0`); this hook layers the 230k
-    // creditable portion on top.
-    let outcome = GasStateOutcome {
-        skip_gas: false,
-        skip_refund: true,
-    };
+    let values = &caller_state_load.data;
 
     // Only account for storage credits when the slot crosses the zero boundary
     // (zero -> non-zero or non-zero -> zero). If both values are zero or both are
     // non-zero, slot occupancy is unchanged, so skip storage credits accounting.
     if values.is_present_zero() == values.is_new_zero() {
-        return Ok(outcome);
+        return Ok(GasStateOutcome::default());
     }
 
-    // Storage-credit precompile state is used for protocol bookkeeping. Because of that,
-    // always skips TIP-1000 + TIP-1060 self-accounting and charge only update gas.
+    // Writes to the storage-credit precompile's own state are protocol bookkeeping
+    // (the balance slot updated by this hook, reached via the precompile storage
+    // provider). They must not recurse into credit accounting; fall back to the
+    // default SSTORE gas function so the backing write is charged as an ordinary
+    // store and never minted/consumed as a credit.
     if owner == STORAGE_CREDITS_ADDRESS {
-        if is_cold {
-            backend.charge_gas(backend.gas_params().cold_storage_cost())?;
-        }
-        if values.is_original_eq_present() {
-            backend.charge_gas(backend.gas_params().sstore_reset_without_cold_load_cost())?;
-        }
-
-        return Ok(GasStateOutcome {
-            skip_gas: true,
-            skip_refund: true,
-        });
+        return Ok(GasStateOutcome::default());
     }
 
     // Load the persistent storage credit balance for the storage-owning account.
@@ -159,7 +142,7 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
         backend.charge_gas(additional_cold_cost)?;
     }
 
-    let mut balance =
+    let mut credit =
         u64::from_word(storage_credit_state_load.data).map_err(|_| B::Error::fatal_external())?;
 
     let mut was_changed = false;
@@ -169,7 +152,7 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
         // keys minting on the present -> new transition, so a within-transaction
         // `0 -> X -> 0` clear of a slot created earlier still mints (and the
         // matching creation consumes), so churn nets out.
-        balance = balance.saturating_add(1);
+        credit = credit.saturating_add(1);
         was_changed = true;
     } else {
         // present 0 -> non-zero: storage creation. revm's SSTORE gas function
@@ -182,19 +165,21 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
             .map_err(|_| B::Error::fatal_external())?;
 
         match transient_state.mode {
-            CreditMode::Direct if balance > 0 && transient_state.budget > 0 => {
-                // Consume one credit to cover the 230k creditable portion.
-                balance -= 1;
+            CreditMode::Direct if credit > 0 && transient_state.budget > 0 => {
+                // Consume one credit to cover the 230k creditable portion; charge
+                // nothing else (the residual is charged by the SSTORE gas function).
+                credit -= 1;
                 was_changed = true;
 
+                // An unlimited budget (`setMode(Direct)`) is never decremented.
                 if transient_state.budget != u64::MAX {
                     transient_state.budget -= 1;
+                    if transient_state.budget == 0 {
+                        transient_state.mode = CreditMode::Preserve;
+                        emit_mode_updated(backend, owner, CreditMode::Preserve)?;
+                    }
+                    store_credit_state(backend, account_slot, transient_state)?;
                 }
-                if transient_state.budget == 0 {
-                    transient_state.mode = CreditMode::Preserve;
-                    emit_mode_updated(backend, owner, CreditMode::Preserve)?;
-                }
-                store_credit_state(backend, account_slot, transient_state)?;
             }
             CreditMode::Direct => {
                 // No credit or no budget available: charge the 230k creditable
@@ -226,7 +211,7 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
             .sstore(
                 STORAGE_CREDITS_ADDRESS,
                 account_slot,
-                U256::from(balance),
+                U256::from(credit),
                 false,
             )?
             .data;
@@ -239,5 +224,5 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
         };
     }
 
-    Ok(outcome)
+    Ok(GasStateOutcome::default())
 }

--- a/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
+++ b/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
@@ -110,18 +110,14 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
 ) -> Result<(), B::Error> {
     let values = &caller_state_load.data;
 
-    // Only account for storage credits when the slot crosses the zero boundary
-    // (zero -> non-zero or non-zero -> zero). If both values are zero or both are
-    // non-zero, slot occupancy is unchanged, so skip storage credits accounting.
+    // Only account for storage credits when the slot crosses the zero boundary (x→0 or 0→x).
+    // If both values are zero or non-zero, slot occupancy is unchanged, so skip credits accounting.
     if values.is_present_zero() == values.is_new_zero() {
         return Ok(());
     }
 
-    // Writes to the storage-credit precompile's own state are protocol bookkeeping
-    // (the balance slot updated by this hook, reached via the precompile storage
-    // provider). They must not recurse into credit accounting; fall back to the
-    // default SSTORE gas function so the backing write is charged as an ordinary
-    // store and never minted/consumed as a credit.
+    // Storage-credit precompile state is used for protocol bookkeeping. Because of that,
+    // always skips TIP-1000 + TIP-1060 self-accounting and charge only update gas.
     if owner == STORAGE_CREDITS_ADDRESS {
         return Ok(());
     }
@@ -144,18 +140,13 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
 
     let mut was_changed = false;
     if values.is_new_zero() {
-        // present non-zero -> 0: storage deletion. Mint one credit on every such
-        // transition, irrespective of the transaction-original value — TIP-1060
-        // keys minting on the present -> new transition, so a within-transaction
-        // `0 -> X -> 0` clear of a slot created earlier still mints (and the
-        // matching creation consumes), so churn nets out.
+        // x→0: storage deletion always mints a new credit.
         credit = credit.saturating_add(1);
         was_changed = true;
     } else {
-        // present 0 -> non-zero: storage creation. revm's SSTORE gas function
-        // charges the 20k residual (only on a clean creation, `original ==
-        // present == 0`); this hook governs only the 230k creditable portion,
-        // independent of the original value. The selected mode is transient.
+        // 0→x: storage creation.
+        // This hook manages the 230k creditable gas, independent of the original value.
+        // revm's SSTORE function adds 20k residual for clean writes (`original == present == 0`).
         let mut transient_state: TransientState = backend
             .tload(STORAGE_CREDITS_ADDRESS, account_slot)
             .try_into()
@@ -163,15 +154,15 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
 
         match transient_state.mode {
             CreditMode::Direct if credit > 0 && transient_state.budget > 0 => {
-                // Consume one credit to cover the 230k creditable portion; charge
-                // nothing else (the residual is charged by the SSTORE gas function).
+                // Consume one credit to cover the 230k creditable portion.
                 credit -= 1;
                 was_changed = true;
 
-                // An unlimited budget (`setMode(Direct)`) is never decremented.
+                // An unlimited budget is never decremented.
                 if transient_state.budget != u64::MAX {
                     transient_state.budget -= 1;
                     if transient_state.budget == 0 {
+                        // When budget is exhausted, switch to `Preserve` mode.
                         transient_state.mode = CreditMode::Preserve;
                         emit_mode_updated(backend, owner, CreditMode::Preserve)?;
                     }
@@ -179,9 +170,9 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
                 }
             }
             CreditMode::Direct => {
-                // No credit or no budget available: charge the 230k creditable
-                // portion as gas. A zero budget switches the account to Preserve.
+                // If no credit available, charge the 230k creditable portion as gas.
                 if transient_state.budget == 0 {
+                    // When budget is exhausted, switch to `Preserve` mode.
                     transient_state.mode = CreditMode::Preserve;
                     store_credit_state(backend, account_slot, transient_state)?;
                     emit_mode_updated(backend, owner, CreditMode::Preserve)?;
@@ -189,12 +180,12 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
                 backend.charge_gas(STORAGE_CREDIT_VALUE)?;
             }
             CreditMode::Preserve => {
-                // Always charge the 230k creditable portion as gas; credits untouched.
+                // Always charge the 230k creditable portion as gas without consuming credits.
                 backend.charge_gas(STORAGE_CREDIT_VALUE)?;
             }
             CreditMode::Refund => {
-                // Charge the 230k creditable portion upfront and record a pending
-                // refund-eligible creation, settled at end-of-transaction.
+                // Charge the 230k creditable portion upfront and record a pending refund-eligible
+                // creation, settled at end-of-transaction.
                 backend.charge_gas(STORAGE_CREDIT_VALUE)?;
                 transient_state.pending_refunds = transient_state.pending_refunds.saturating_add(1);
                 store_credit_state(backend, account_slot, transient_state)?;
@@ -203,7 +194,7 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
     }
 
     if was_changed {
-        // cold load is already checked above when we loaded the storage credits account.
+        // Cold load is already checked above when we loaded the storage credits account.
         let result = backend
             .sstore(
                 STORAGE_CREDITS_ADDRESS,
@@ -214,8 +205,6 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
             .data;
 
         // Only when change happens charge additional gas.
-        // Creating or updating the protocol credit-balance slot is TIP-1060 bookkeeping and
-        // does not incur the extra TIP-1000 storage creation component.
         if result.new_values_changes_present() && result.is_original_eq_present() {
             backend.charge_gas(backend.gas_params().sstore_reset_without_cold_load_cost())?;
         };

--- a/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
+++ b/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
@@ -145,8 +145,8 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
         was_changed = true;
     } else {
         // 0→x: storage creation.
-        // This hook manages the 230k creditable gas, independent of the original value.
-        // revm's SSTORE function adds 20k residual for clean writes (`original == present == 0`).
+        // This hook manages the 245k creditable gas, independent of the original value.
+        // revm's SSTORE function adds the 5k residual for clean writes (`original == present == 0`).
         let mut transient_state: TransientState = backend
             .tload(STORAGE_CREDITS_ADDRESS, account_slot)
             .try_into()
@@ -154,7 +154,7 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
 
         match transient_state.mode {
             CreditMode::Direct if credit > 0 && transient_state.budget > 0 => {
-                // Consume one credit to cover the 230k creditable portion.
+                // Consume one credit to cover the 245k creditable portion.
                 credit -= 1;
                 was_changed = true;
 
@@ -170,7 +170,7 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
                 }
             }
             CreditMode::Direct => {
-                // If no credit available, charge the 230k creditable portion as gas.
+                // If no credit available, charge the 245k creditable portion as gas.
                 if transient_state.budget == 0 {
                     // When budget is exhausted, switch to `Preserve` mode.
                     transient_state.mode = CreditMode::Preserve;
@@ -180,11 +180,11 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
                 backend.charge_gas(STORAGE_CREDIT_VALUE)?;
             }
             CreditMode::Preserve => {
-                // Always charge the 230k creditable portion as gas without consuming credits.
+                // Always charge the 245k creditable portion as gas without consuming credits.
                 backend.charge_gas(STORAGE_CREDIT_VALUE)?;
             }
             CreditMode::Refund => {
-                // Charge the 230k creditable portion upfront and record a pending refund-eligible
+                // Charge the 245k creditable portion upfront and record a pending refund-eligible
                 // creation, settled at end-of-transaction.
                 backend.charge_gas(STORAGE_CREDIT_VALUE)?;
                 transient_state.pending_refunds = transient_state.pending_refunds.saturating_add(1);

--- a/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
+++ b/crates/precompiles/src/tip1060_storage_credits/gas_state.rs
@@ -13,10 +13,7 @@ use crate::storage::FromWord;
 use alloy::primitives::{Address, IntoLogData, LogData, U256};
 use revm::{
     context_interface::cfg::GasParams,
-    interpreter::{
-        InstructionResult, SStoreResult, StateLoad, gas::GasTracker,
-        instruction_context::GasStateOutcome,
-    },
+    interpreter::{InstructionResult, SStoreResult, StateLoad, gas::GasTracker},
 };
 use tempo_chainspec::constants::gas::STORAGE_CREDIT_VALUE;
 use tempo_contracts::precompiles::{STORAGE_CREDITS_ADDRESS, TIP1060StorageCreditsEvent};
@@ -110,14 +107,14 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
     backend: &mut B,
     owner: Address,
     caller_state_load: &StateLoad<SStoreResult>,
-) -> Result<GasStateOutcome, B::Error> {
+) -> Result<(), B::Error> {
     let values = &caller_state_load.data;
 
     // Only account for storage credits when the slot crosses the zero boundary
     // (zero -> non-zero or non-zero -> zero). If both values are zero or both are
     // non-zero, slot occupancy is unchanged, so skip storage credits accounting.
     if values.is_present_zero() == values.is_new_zero() {
-        return Ok(GasStateOutcome::default());
+        return Ok(());
     }
 
     // Writes to the storage-credit precompile's own state are protocol bookkeeping
@@ -126,7 +123,7 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
     // default SSTORE gas function so the backing write is charged as an ordinary
     // store and never minted/consumed as a credit.
     if owner == STORAGE_CREDITS_ADDRESS {
-        return Ok(GasStateOutcome::default());
+        return Ok(());
     }
 
     // Load the persistent storage credit balance for the storage-owning account.
@@ -224,5 +221,5 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
         };
     }
 
-    Ok(GasStateOutcome::default())
+    Ok(())
 }

--- a/crates/precompiles/src/tip20/rewards.rs
+++ b/crates/precompiles/src/tip20/rewards.rs
@@ -200,6 +200,10 @@ impl TIP20Token {
     /// - `Paused` — token transfers are currently paused
     /// - `PolicyForbids` — TIP-403 policy rejects the contract→caller transfer authorization
     pub fn claim_rewards(&mut self, msg_sender: Address) -> Result<U256> {
+        // +T7: Fee collection bypasses TIP-1060, so disable storage-credit accounting to avoid
+        // minting user-refundable storage credits when clearing reward slots.
+        self.storage.set_tip1060_storage_credits(false);
+
         self.check_not_paused()?;
         self.ensure_transfer_authorized(self.address, msg_sender)?;
 

--- a/crates/precompiles/src/tip20/rewards.rs
+++ b/crates/precompiles/src/tip20/rewards.rs
@@ -200,10 +200,6 @@ impl TIP20Token {
     /// - `Paused` — token transfers are currently paused
     /// - `PolicyForbids` — TIP-403 policy rejects the contract→caller transfer authorization
     pub fn claim_rewards(&mut self, msg_sender: Address) -> Result<U256> {
-        // +T7: Fee collection bypasses TIP-1060, so disable storage-credit accounting to avoid
-        // minting user-refundable storage credits when clearing reward slots.
-        self.storage.set_tip1060_storage_credits(false);
-
         self.check_not_paused()?;
         self.ensure_transfer_authorized(self.address, msg_sender)?;
 

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -11,7 +11,6 @@ use crate::{
     tip_fee_manager::amm::{FeeRoute, Pool, compute_amount_out},
     tip20::{ITIP20, TIP20Token, validate_usd_currency},
     tip20_factory::TIP20Factory,
-    tip1060_storage_credits::TIP1060StorageCredits,
 };
 use alloy::primitives::{Address, B256, U256, uint};
 pub use tempo_contracts::precompiles::{
@@ -292,14 +291,9 @@ impl TipFeeManager {
     /// # Errors
     /// - `InvalidToken` — `token` does not have a valid TIP-20 prefix
     pub fn distribute_fees(&mut self, validator: Address, token: Address) -> Result<()> {
-        if self.storage.spec().is_t7() {
-            // Fee collection bypasses TIP-1060, so use `Preserve` mode to avoid minting
-            // user-refundable storage credits when clearing fee-manager slots.
-            TIP1060StorageCredits::new().set_mode(
-                self.address,
-                tempo_contracts::precompiles::ITIP1060StorageCredits::Mode::Preserve,
-            )?;
-        }
+        // +T7: Fee collection bypasses TIP-1060, so disable storage-credit accounting to avoid
+        // minting user-refundable storage credits when clearing fee-manager slots.
+        self.storage.set_tip1060_storage_credits(false);
 
         let amount = self.collected_fees[validator][token].read()?;
         if amount.is_zero() {

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -11,6 +11,7 @@ use crate::{
     tip_fee_manager::amm::{FeeRoute, Pool, compute_amount_out},
     tip20::{ITIP20, TIP20Token, validate_usd_currency},
     tip20_factory::TIP20Factory,
+    tip1060_storage_credits::TIP1060StorageCredits,
 };
 use alloy::primitives::{Address, B256, U256, uint};
 pub use tempo_contracts::precompiles::{
@@ -291,6 +292,15 @@ impl TipFeeManager {
     /// # Errors
     /// - `InvalidToken` — `token` does not have a valid TIP-20 prefix
     pub fn distribute_fees(&mut self, validator: Address, token: Address) -> Result<()> {
+        if self.storage.spec().is_t7() {
+            // Fee collection bypasses TIP-1060, so use `Preserve` mode to avoid minting
+            // user-refundable storage credits when clearing fee-manager slots.
+            TIP1060StorageCredits::new().set_mode(
+                self.address,
+                tempo_contracts::precompiles::ITIP1060StorageCredits::Mode::Preserve,
+            )?;
+        }
+
         let amount = self.collected_fees[validator][token].read()?;
         if amount.is_zero() {
             return Ok(());

--- a/crates/revm/src/common.rs
+++ b/crates/revm/src/common.rs
@@ -494,6 +494,10 @@ where
     fn checkpoint_revert(&mut self, _: revm::context::journaled_state::JournalCheckpoint) {
         unreachable!("'checkpoint_revert' not supported in read-only context")
     }
+
+    fn set_tip1060_storage_credits(&mut self, _enabled: bool) {
+        // Read-only storage never runs TIP-1060 accounting.
+    }
 }
 
 #[cfg(test)]

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -416,6 +416,31 @@ mod tests {
         evm
     }
 
+    /// Create an EVM with T7 hardfork, a specific timestamp, and a funded account.
+    fn create_funded_evm_t7_with_timestamp(
+        address: Address,
+        timestamp: u64,
+    ) -> TempoEvm<CacheDB<EmptyDB>, ()> {
+        let db = CacheDB::new(EmptyDB::new());
+        let mut cfg = CfgEnv::<TempoHardfork>::default();
+        cfg.spec = TempoHardfork::T7;
+        cfg.gas_params = tempo_gas_params_with_amsterdam(TempoHardfork::T7, false);
+        cfg.enable_amsterdam_eip8037 = false;
+
+        let mut block = TempoBlockEnv::default();
+        block.inner.timestamp = U256::from(timestamp);
+
+        let ctx = Context::mainnet()
+            .with_db(db)
+            .with_block(block)
+            .with_cfg(cfg)
+            .with_tx(Default::default());
+
+        let mut evm = TempoEvm::new(ctx, ());
+        fund_account(&mut evm, address);
+        evm
+    }
+
     /// Create an EVM with a specific timestamp and a funded account.
     fn create_funded_evm_with_timestamp(
         address: Address,
@@ -3392,6 +3417,104 @@ mod tests {
         let result = evm.transact_commit(TempoTxEnv::from_recovered_tx(&signed_tx, caller))?;
         assert!(result.is_success());
         assert_eq!(storage_credit_balance(&evm, contract), u64::MAX);
+
+        Ok(())
+    }
+
+    /// Expiring nonce writes are charged manually by intrinsic gas and must not use TIP-1060 accounting.
+    #[test]
+    fn test_expiring_nonce_indexed_path_does_not_settle_storage_credits() -> eyre::Result<()> {
+        use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
+
+        let key_pair = P256KeyPair::random();
+        let caller = key_pair.address;
+        let timestamp = 1000u64;
+        let valid_before = timestamp + 30;
+
+        let tx = TxBuilder::new()
+            .call_identity(&[])
+            .nonce_key(TEMPO_EXPIRING_NONCE_KEY)
+            .valid_before(Some(valid_before))
+            .gas_limit(500_000)
+            .build();
+        let signed_tx = key_pair.sign_tx(tx)?;
+        let unindexed_tx_env = TempoTxEnv::from_recovered_tx(&signed_tx, caller);
+
+        let mut indexed_tx_env = unindexed_tx_env.clone();
+        indexed_tx_env
+            .tempo_tx_env
+            .as_mut()
+            .expect("expiring nonce tx must be AA")
+            .expiring_nonce_idx = Some(1);
+
+        let mut unindexed_evm = create_funded_evm_t7_with_timestamp(caller, timestamp);
+        let unindexed_result = unindexed_evm.transact_commit(unindexed_tx_env)?;
+        assert!(
+            unindexed_result.is_success(),
+            "unindexed expiring nonce tx should succeed"
+        );
+
+        let mut indexed_evm = create_funded_evm_t7_with_timestamp(caller, timestamp);
+        let indexed_result = indexed_evm.transact_commit(indexed_tx_env)?;
+        assert!(
+            indexed_result.is_success(),
+            "indexed expiring nonce tx should succeed"
+        );
+
+        assert_eq!(
+            indexed_result.tx_gas_used(),
+            unindexed_result.tx_gas_used(),
+            "pointer restore must not create a TIP-1060 settlement discount"
+        );
+        assert_eq!(
+            storage_credit_balance(&indexed_evm, NONCE_PRECOMPILE_ADDRESS),
+            0,
+            "expiring nonce bookkeeping must not accrue storage credits"
+        );
+
+        Ok(())
+    }
+
+    /// 2D nonce writes are charged manually by intrinsic gas and must not use TIP-1060 accounting.
+    #[test]
+    fn test_2d_nonce_preexecution_does_not_settle_nonce_storage_credits() -> eyre::Result<()> {
+        let key_pair = P256KeyPair::random();
+        let caller = key_pair.address;
+        let nonce_key = U256::from(42_u64);
+
+        let tx = TxBuilder::new()
+            .call_identity(&[])
+            .nonce_key(nonce_key)
+            .gas_limit(1_000_000)
+            .build();
+        let signed_tx = key_pair.sign_tx(tx)?;
+        let tx_env = TempoTxEnv::from_recovered_tx(&signed_tx, caller);
+
+        let mut baseline_evm = create_funded_evm_t7(caller);
+        let baseline_result = baseline_evm.transact_commit(tx_env.clone())?;
+        assert!(
+            baseline_result.is_success(),
+            "baseline 2D nonce tx should succeed"
+        );
+
+        let mut credited_evm = create_funded_evm_t7(caller);
+        seed_storage_credit_balance(&mut credited_evm, NONCE_PRECOMPILE_ADDRESS, 1);
+        let credited_result = credited_evm.transact_commit(tx_env)?;
+        assert!(
+            credited_result.is_success(),
+            "preseeded-credit 2D nonce tx should succeed"
+        );
+
+        assert_eq!(
+            credited_result.tx_gas_used(),
+            baseline_result.tx_gas_used(),
+            "2D nonce bookkeeping must not consume nonce storage credits for a gas discount"
+        );
+        assert_eq!(
+            storage_credit_balance(&credited_evm, NONCE_PRECOMPILE_ADDRESS),
+            1,
+            "2D nonce bookkeeping must not consume pre-existing nonce storage credits"
+        );
 
         Ok(())
     }

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -2261,10 +2261,14 @@ mod tests {
         let create_clear_body = bytes!("6001600055600060005500");
 
         // (mode, gas used, final credit balance).
+        // The 0->1->0 clear restores slot 0 to its transaction-original value (0),
+        // so the 19,900 restore-to-original refund is preserved (TIP-1060 only
+        // zeroes SSTORE_CLEARS_SCHEDULE, not the restore refunds), lowering each
+        // mode's gas by 19,900 relative to the legacy no-refund accounting.
         let cases = [
-            (CreditMode::Refund, 305_968u64, 0u64),
-            (CreditMode::Preserve, 540_514u64, 1u64),
-            (CreditMode::Direct, 540_514u64, 1u64),
+            (CreditMode::Refund, 286_068u64, 0u64),
+            (CreditMode::Preserve, 520_614u64, 1u64),
+            (CreditMode::Direct, 520_614u64, 1u64),
         ];
 
         for (mode, expected_gas, expected_balance) in cases {

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -312,10 +312,20 @@ mod tests {
 
     /// Fund an account with the default balance (1 ETH).
     fn fund_account(evm: &mut TempoEvm<CacheDB<EmptyDB>, ()>, address: Address) {
+        fund_account_with_nonce(evm, address, 0);
+    }
+
+    /// Fund an account with the default balance and a specific nonce.
+    fn fund_account_with_nonce(
+        evm: &mut TempoEvm<CacheDB<EmptyDB>, ()>,
+        address: Address,
+        nonce: u64,
+    ) {
         evm.ctx.db_mut().insert_account_info(
             address,
             AccountInfo {
                 balance: U256::from(DEFAULT_BALANCE),
+                nonce,
                 ..Default::default()
             },
         );
@@ -1992,6 +2002,54 @@ mod tests {
         Bytecode::new_raw(bytecode.into())
     }
 
+    fn mint_storage_credits_with_clears(
+        evm: &mut TempoEvm<CacheDB<EmptyDB>, ()>,
+        key_pair: &P256KeyPair,
+        caller: Address,
+        contract: Address,
+        nonce: u64,
+        credits: u64,
+    ) -> eyre::Result<u64> {
+        if credits == 0 {
+            return Ok(nonce);
+        }
+
+        let mut body = Vec::new();
+        for credit in 0..credits {
+            let slot = 0xf0 + credit;
+            assert!(slot <= u64::from(u8::MAX));
+            evm.ctx
+                .db_mut()
+                .insert_account_storage(contract, U256::from(slot), U256::ONE)?;
+            body.extend_from_slice(&[opcode::PUSH1, 0, opcode::PUSH1, slot as u8, opcode::SSTORE]);
+        }
+        body.push(opcode::STOP);
+
+        evm.ctx.db_mut().insert_account_info(
+            contract,
+            AccountInfo {
+                code: Some(Bytecode::new_raw(body.into())),
+                ..Default::default()
+            },
+        );
+
+        let tx = TxBuilder::new()
+            .call(contract, &[])
+            .nonce(nonce)
+            .gas_limit(2_000_000)
+            .build();
+        let signed_tx = key_pair.sign_tx(tx)?;
+        let result = evm.transact_commit(TempoTxEnv::from_recovered_tx(&signed_tx, caller))?;
+        assert!(result.is_success(), "credit-minting prelude should succeed");
+        assert_eq!(
+            storage_credit_balance(evm, contract),
+            credits,
+            "prelude should mint the requested storage credits"
+        );
+
+        Ok(nonce + 1)
+    }
+
     fn branching_bytecode_with_tip1060_mode(mode: CreditMode) -> Bytecode {
         let mut bytecode = Vec::new();
         if mode != CreditMode::Refund {
@@ -2312,6 +2370,340 @@ mod tests {
                 expected_balance,
                 "TIP-1060 post-tx storage credit balance should be exact in {mode:?} mode"
             );
+        }
+
+        Ok(())
+    }
+
+    /// TIP-1060: the spec transition table classifies every zero-crossing exactly once.
+    #[test]
+    fn test_tip1060_spec_transition_classes_credit_accounting_table() -> eyre::Result<()> {
+        fn append_sstore(body: &mut Vec<u8>, slot: u8, value: u8) {
+            body.extend_from_slice(&[opcode::PUSH1, value, opcode::PUSH1, slot, opcode::SSTORE]);
+        }
+
+        fn transition_body(setup_value: Option<u8>, new_value: u8) -> Bytes {
+            let mut body = Vec::new();
+            if let Some(value) = setup_value {
+                append_sstore(&mut body, 0, value);
+            }
+            append_sstore(&mut body, 0, new_value);
+            body.push(opcode::STOP);
+            body.into()
+        }
+
+        #[derive(Clone, Copy)]
+        struct ModeExpectation {
+            mode: CreditMode,
+            expected_gas: u64,
+            expected_credits: u64,
+        }
+
+        struct CreditCase {
+            name: &'static str,
+            initial_credits: u64,
+            expectations: [ModeExpectation; 3],
+        }
+
+        struct TransitionClass {
+            name: &'static str,
+            original: u8,
+            setup_value: Option<u8>,
+            new_value: u8,
+            expected_slot: u64,
+            credit_cases: Vec<CreditCase>,
+        }
+
+        fn expectations(
+            refund: (u64, u64),
+            preserve: (u64, u64),
+            direct: (u64, u64),
+        ) -> [ModeExpectation; 3] {
+            [
+                ModeExpectation {
+                    mode: CreditMode::Refund,
+                    expected_gas: refund.0,
+                    expected_credits: refund.1,
+                },
+                ModeExpectation {
+                    mode: CreditMode::Preserve,
+                    expected_gas: preserve.0,
+                    expected_credits: preserve.1,
+                },
+                ModeExpectation {
+                    mode: CreditMode::Direct,
+                    expected_gas: direct.0,
+                    expected_credits: direct.1,
+                },
+            ]
+        }
+
+        const SET_MODE_GAS: u64 = 4_546;
+
+        fn same_storage_accounting(refund_gas: u64, expected_credits: u64) -> [ModeExpectation; 3] {
+            expectations(
+                (refund_gas, expected_credits),
+                (refund_gas + SET_MODE_GAS, expected_credits),
+                (refund_gas + SET_MODE_GAS, expected_credits),
+            )
+        }
+
+        fn no_initial_credits(expectations: [ModeExpectation; 3]) -> Vec<CreditCase> {
+            vec![CreditCase {
+                name: "no initial credits",
+                initial_credits: 0,
+                expectations,
+            }]
+        }
+
+        let transition_classes = [
+            TransitionClass {
+                name: "O=0 P=0 N=0 no-op",
+                original: 0,
+                setup_value: None,
+                new_value: 0,
+                expected_slot: 0,
+                credit_cases: no_initial_credits(same_storage_accounting(30_862, 0)),
+            },
+            TransitionClass {
+                name: "O=0 P=Y N=Y same-tx no-op",
+                original: 0,
+                setup_value: Some(2),
+                new_value: 2,
+                expected_slot: 2,
+                credit_cases: no_initial_credits(same_storage_accounting(283_068, 0)),
+            },
+            TransitionClass {
+                name: "O=0 P=Y N=Z dirty overwrite",
+                original: 0,
+                setup_value: Some(2),
+                new_value: 3,
+                expected_slot: 3,
+                credit_cases: no_initial_credits(same_storage_accounting(283_068, 0)),
+            },
+            TransitionClass {
+                name: "O=X P=X N=X no-op",
+                original: 1,
+                setup_value: None,
+                new_value: 1,
+                expected_slot: 1,
+                credit_cases: no_initial_credits(same_storage_accounting(30_862, 0)),
+            },
+            TransitionClass {
+                name: "O=X P=X N=Y clean overwrite",
+                original: 1,
+                setup_value: None,
+                new_value: 2,
+                expected_slot: 2,
+                credit_cases: no_initial_credits(same_storage_accounting(33_662, 0)),
+            },
+            TransitionClass {
+                name: "O=X P=Y N=X dirty restore to original",
+                original: 1,
+                setup_value: Some(2),
+                new_value: 1,
+                expected_slot: 1,
+                credit_cases: no_initial_credits(same_storage_accounting(30_968, 0)),
+            },
+            TransitionClass {
+                name: "O=X P=Y N=Z dirty overwrite",
+                original: 1,
+                setup_value: Some(2),
+                new_value: 3,
+                expected_slot: 3,
+                credit_cases: no_initial_credits(same_storage_accounting(33_768, 0)),
+            },
+            TransitionClass {
+                name: "O=0 P=Y N=0 clear of same-tx creation",
+                original: 0,
+                setup_value: Some(2),
+                new_value: 0,
+                expected_slot: 0,
+                credit_cases: no_initial_credits(expectations(
+                    (36_068, 0),
+                    (270_614, 1),
+                    (270_614, 1),
+                )),
+            },
+            TransitionClass {
+                name: "O=X P=X N=0 clean clear",
+                original: 1,
+                setup_value: None,
+                new_value: 0,
+                expected_slot: 0,
+                credit_cases: no_initial_credits(same_storage_accounting(38_562, 1)),
+            },
+            TransitionClass {
+                name: "O=X P=Y N=0 dirty clear",
+                original: 1,
+                setup_value: Some(2),
+                new_value: 0,
+                expected_slot: 0,
+                credit_cases: no_initial_credits(same_storage_accounting(38_668, 1)),
+            },
+            TransitionClass {
+                name: "O=0 P=0 N=Y clean creation",
+                original: 0,
+                setup_value: None,
+                new_value: 2,
+                expected_slot: 2,
+                credit_cases: vec![
+                    CreditCase {
+                        name: "no initial credits",
+                        initial_credits: 0,
+                        expectations: same_storage_accounting(282_962, 0),
+                    },
+                    CreditCase {
+                        name: "one initial credit",
+                        initial_credits: 1,
+                        expectations: expectations(
+                            (52_962, 0),
+                            (52_962 + SET_MODE_GAS + STORAGE_CREDIT_VALUE, 1),
+                            (60_308, 0),
+                        ),
+                    },
+                    CreditCase {
+                        name: "surplus initial credits",
+                        initial_credits: 2,
+                        expectations: expectations(
+                            (52_962, 1),
+                            (52_962 + SET_MODE_GAS + STORAGE_CREDIT_VALUE, 2),
+                            (60_308, 1),
+                        ),
+                    },
+                ],
+            },
+            TransitionClass {
+                name: "O=X P=0 N=X recreation to original",
+                original: 1,
+                setup_value: Some(0),
+                new_value: 1,
+                expected_slot: 1,
+                credit_cases: vec![
+                    CreditCase {
+                        name: "no initial credits",
+                        initial_credits: 0,
+                        expectations: expectations(
+                            (35_968, 0),
+                            (35_968 + SET_MODE_GAS + STORAGE_CREDIT_VALUE, 1),
+                            (35_968 + SET_MODE_GAS, 0),
+                        ),
+                    },
+                    CreditCase {
+                        name: "surplus initial credits",
+                        initial_credits: 2,
+                        expectations: expectations(
+                            (35_968, 2),
+                            (35_968 + SET_MODE_GAS + STORAGE_CREDIT_VALUE, 3),
+                            (35_968 + SET_MODE_GAS, 2),
+                        ),
+                    },
+                ],
+            },
+            TransitionClass {
+                name: "O=X P=0 N=Y recreation to other value",
+                original: 1,
+                setup_value: Some(0),
+                new_value: 2,
+                expected_slot: 2,
+                credit_cases: vec![
+                    CreditCase {
+                        name: "no initial credits",
+                        initial_credits: 0,
+                        expectations: expectations(
+                            (38_768, 0),
+                            (38_768 + SET_MODE_GAS + STORAGE_CREDIT_VALUE, 1),
+                            (38_768 + SET_MODE_GAS, 0),
+                        ),
+                    },
+                    CreditCase {
+                        name: "surplus initial credits",
+                        initial_credits: 2,
+                        expectations: expectations(
+                            (38_768, 2),
+                            (38_768 + SET_MODE_GAS + STORAGE_CREDIT_VALUE, 3),
+                            (38_768 + SET_MODE_GAS, 2),
+                        ),
+                    },
+                ],
+            },
+        ];
+
+        let mut case_id = 0u8;
+        for scenario in transition_classes {
+            for credit_case in &scenario.credit_cases {
+                for expectation in credit_case.expectations {
+                    let mode = expectation.mode;
+                    let key_pair = P256KeyPair::random();
+                    let caller = key_pair.address;
+                    let contract = Address::repeat_byte(0x80 + case_id);
+                    case_id += 1;
+                    let body = transition_body(scenario.setup_value, scenario.new_value);
+
+                    let mut evm = create_funded_evm_t7(caller);
+                    fund_account_with_nonce(&mut evm, caller, 1);
+                    if scenario.original != 0 {
+                        evm.ctx.db_mut().insert_account_storage(
+                            contract,
+                            U256::ZERO,
+                            U256::from(scenario.original),
+                        )?;
+                    }
+                    let nonce = mint_storage_credits_with_clears(
+                        &mut evm,
+                        &key_pair,
+                        caller,
+                        contract,
+                        1,
+                        credit_case.initial_credits,
+                    )?;
+
+                    evm.ctx.db_mut().insert_account_info(
+                        contract,
+                        AccountInfo {
+                            code: Some(bytecode_with_tip1060_mode(mode, &body)),
+                            ..Default::default()
+                        },
+                    );
+
+                    let tx = TxBuilder::new()
+                        .call(contract, &[])
+                        .nonce(nonce)
+                        .gas_limit(2_000_000)
+                        .build();
+                    let signed_tx = key_pair.sign_tx(tx)?;
+                    let result =
+                        evm.transact_commit(TempoTxEnv::from_recovered_tx(&signed_tx, caller))?;
+                    assert!(
+                        result.is_success(),
+                        "{} / {} in {mode:?} should succeed",
+                        scenario.name,
+                        credit_case.name
+                    );
+
+                    assert_eq!(
+                        result.tx_gas_used(),
+                        expectation.expected_gas,
+                        "{} / {} gas should stay exact in {mode:?}",
+                        scenario.name,
+                        credit_case.name
+                    );
+                    assert_eq!(
+                        storage_credit_balance(&evm, contract),
+                        expectation.expected_credits,
+                        "{} / {} final persistent credit balance should stay exact in {mode:?}",
+                        scenario.name,
+                        credit_case.name
+                    );
+                    assert_eq!(
+                        evm.ctx.db().storage_ref(contract, U256::ZERO)?,
+                        U256::from(scenario.expected_slot),
+                        "{} / {} should leave the expected slot value in {mode:?}",
+                        scenario.name,
+                        credit_case.name
+                    );
+                }
+            }
         }
 
         Ok(())

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -2027,6 +2027,44 @@ mod tests {
         Bytecode::new_raw(bytecode.into())
     }
 
+    fn run_tx_on_tip1060_contract(
+        mode: CreditMode,
+        contract: Address,
+        bytecode: &[u8],
+    ) -> eyre::Result<(u64, TempoEvm<CacheDB<EmptyDB>, ()>)> {
+        run_tx_on_tip1060_contract_with_setup(mode, contract, bytecode, |_, _| Ok(()))
+    }
+
+    fn run_tx_on_tip1060_contract_with_setup(
+        mode: CreditMode,
+        contract: Address,
+        bytecode: &[u8],
+        setup: impl FnOnce(&mut TempoEvm<CacheDB<EmptyDB>, ()>, Address) -> eyre::Result<()>,
+    ) -> eyre::Result<(u64, TempoEvm<CacheDB<EmptyDB>, ()>)> {
+        let key_pair = P256KeyPair::random();
+        let caller = key_pair.address;
+        let mut evm = create_funded_evm_t7(caller);
+
+        evm.ctx.db_mut().insert_account_info(
+            contract,
+            AccountInfo {
+                code: Some(bytecode_with_tip1060_mode(mode, bytecode)),
+                ..Default::default()
+            },
+        );
+        setup(&mut evm, contract)?;
+
+        let tx = TxBuilder::new()
+            .call(contract, &[])
+            .gas_limit(2_000_000)
+            .build();
+        let signed_tx = key_pair.sign_tx(tx)?;
+        let result = evm.transact_commit(TempoTxEnv::from_recovered_tx(&signed_tx, caller))?;
+        assert!(result.is_success(), "test transaction should succeed");
+
+        Ok((result.tx_gas_used(), evm))
+    }
+
     fn mint_storage_credits_with_clears(
         evm: &mut TempoEvm<CacheDB<EmptyDB>, ()>,
         key_pair: &P256KeyPair,
@@ -2340,51 +2378,32 @@ mod tests {
     /// creation refund at end-of-tx.
     #[test]
     fn test_tip1060_sstore_create_then_clear_modes() -> eyre::Result<()> {
+        // PUSH1 0x00 PUSH1 0x00 SSTORE STOP: no-op write to an empty slot.
+        let noop_body = bytes!("600060005500");
+        let (noop_gas, _) =
+            run_tx_on_tip1060_contract(CreditMode::Refund, Address::repeat_byte(0x60), &noop_body)?;
+
         // PUSH1 0x01 PUSH1 0x00 SSTORE  PUSH1 0x00 PUSH1 0x00 SSTORE  STOP
         let create_clear_body = bytes!("6001600055600060005500");
 
         // (mode, gas used, final credit balance).
-        // The 0->1->0 clear restores slot 0 to its transaction-original value (0),
-        // so the 19,900 restore-to-original refund is preserved (TIP-1060 only
-        // zeroes SSTORE_CLEARS_SCHEDULE, not the restore refunds), lowering each
-        // mode's gas by 19,900 relative to the legacy no-refund accounting.
+        // The 0->1->0 clear restores slot 0 to its transaction-original value (0), so T7 refunds
+        // only the 5k residual set charge. The 245k credit depends on the TIP-1060 credit mode.
         let cases = [
-            (CreditMode::Refund, 271_068u64, 0u64),
-            (CreditMode::Preserve, 520_614u64, 1u64),
-            (CreditMode::Direct, 520_614u64, 1u64),
+            (CreditMode::Refund, 285_968u64, 0u64),
+            (CreditMode::Preserve, 535_514u64, 1u64),
+            (CreditMode::Direct, 535_514u64, 1u64),
         ];
 
-        for (mode, expected_gas, expected_balance) in cases {
-            let key_pair = P256KeyPair::random();
-            let caller = key_pair.address;
-            let contract = Address::repeat_byte(0x60);
+        for (case_id, (mode, expected_gas, expected_balance)) in cases.into_iter().enumerate() {
+            let contract = Address::repeat_byte(0x60 + case_id as u8);
+            let (gas_used, evm) = run_tx_on_tip1060_contract(mode, contract, &create_clear_body)?;
 
-            let mut evm = create_funded_evm_t7(caller);
-
-            evm.ctx.db_mut().insert_account_info(
-                contract,
-                AccountInfo {
-                    code: Some(bytecode_with_tip1060_mode(mode, &create_clear_body)),
-                    ..Default::default()
-                },
-            );
-
-            seed_storage_credit_balance(&mut evm, contract, 0);
-
-            let tx = TxBuilder::new()
-                .call(contract, &[])
-                .gas_limit(2_000_000)
-                .build();
-            let signed_tx = key_pair.sign_tx(tx)?;
-            let tx_env = TempoTxEnv::from_recovered_tx(&signed_tx, caller);
-
-            let result = evm.transact_commit(tx_env)?;
             assert!(
-                result.is_success(),
-                "create+clear tx should succeed in {mode:?} mode"
+                gas_used >= noop_gas,
+                "0->x->0 storage churn must not reduce tx gas below no-op: noop={noop_gas}, create_clear={gas_used}"
             );
 
-            let gas_used = result.tx_gas_used();
             assert_eq!(
                 gas_used, expected_gas,
                 "TIP-1060 create+clear gas should be exact in {mode:?} mode"
@@ -2545,9 +2564,9 @@ mod tests {
                 new_value: 0,
                 expected_slot: 0,
                 credit_cases: no_initial_credits(expectations(
-                    (21_068, 0),
-                    (270_614, 1),
-                    (270_614, 1),
+                    (35_968, 0),
+                    (285_514, 1),
+                    (285_514, 1),
                 )),
             },
             TransitionClass {
@@ -3157,8 +3176,6 @@ mod tests {
         let cases = [(2u8, 1u64, 0u64), (1u8, 2u64, 1u64)];
 
         for (creates, starting_balance, expected_balance) in cases {
-            let key_pair = P256KeyPair::random();
-            let caller = key_pair.address;
             let contract = Address::repeat_byte(0x70 + creates);
 
             // Write 0x01 to `creates` fresh slots, then STOP.
@@ -3174,24 +3191,15 @@ mod tests {
             }
             bytecode.push(opcode::STOP);
 
-            let mut evm = create_funded_evm_t7(caller);
-            evm.ctx.db_mut().insert_account_info(
+            let (_, evm) = run_tx_on_tip1060_contract_with_setup(
+                CreditMode::Refund,
                 contract,
-                AccountInfo {
-                    code: Some(Bytecode::new_raw(bytecode.into())),
-                    ..Default::default()
+                &bytecode,
+                |evm, contract| {
+                    seed_storage_credit_balance(evm, contract, starting_balance);
+                    Ok(())
                 },
-            );
-            seed_storage_credit_balance(&mut evm, contract, starting_balance);
-
-            let tx = TxBuilder::new()
-                .call(contract, &[])
-                .gas_limit(1_000_000)
-                .build();
-            let signed_tx = key_pair.sign_tx(tx)?;
-            let tx_env = TempoTxEnv::from_recovered_tx(&signed_tx, caller);
-            let result = evm.transact_commit(tx_env)?;
-            assert!(result.is_success(), "refund settlement tx should succeed");
+            )?;
 
             assert_eq!(
                 storage_credit_balance(&evm, contract),
@@ -3389,33 +3397,23 @@ mod tests {
     /// balance pinned at `u64::MAX` rather than overflowing.
     #[test]
     fn test_tip1060_sstore_clear_mint_saturates_at_u64_max() -> eyre::Result<()> {
-        let key_pair = P256KeyPair::random();
-        let caller = key_pair.address;
         let contract = Address::repeat_byte(0x67);
 
         // Bytecode: SSTORE(0,0); STOP.
-        let clear_bytecode = Bytecode::new_raw(bytes!("600060005500"));
+        let clear_bytecode = bytes!("600060005500");
 
-        let mut evm = create_funded_evm_t7(caller);
-        evm.ctx.db_mut().insert_account_info(
+        let (_, evm) = run_tx_on_tip1060_contract_with_setup(
+            CreditMode::Refund,
             contract,
-            AccountInfo {
-                code: Some(clear_bytecode),
-                ..Default::default()
+            &clear_bytecode,
+            |evm, contract| {
+                evm.ctx
+                    .db_mut()
+                    .insert_account_storage(contract, U256::ZERO, U256::ONE)?;
+                seed_storage_credit_balance(evm, contract, u64::MAX);
+                Ok(())
             },
-        );
-        evm.ctx
-            .db_mut()
-            .insert_account_storage(contract, U256::ZERO, U256::ONE)?;
-        seed_storage_credit_balance(&mut evm, contract, u64::MAX);
-
-        let tx = TxBuilder::new()
-            .call(contract, &[])
-            .gas_limit(500_000)
-            .build();
-        let signed_tx = key_pair.sign_tx(tx)?;
-        let result = evm.transact_commit(TempoTxEnv::from_recovered_tx(&signed_tx, caller))?;
-        assert!(result.is_success());
+        )?;
         assert_eq!(storage_credit_balance(&evm, contract), u64::MAX);
 
         Ok(())

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -2315,8 +2315,10 @@ mod tests {
 
     /// TIP-1060: Preserve churn of a pre-existing slot cannot subsidize fresh Direct creates.
     ///
-    /// Dirty restores must cancel the clear-minted credits. Otherwise churned credits could be
-    /// spent on genuinely fresh Direct creates below the intended storage-creation price.
+    /// Each clear mints a credit, but in Preserve mode the matching recreation pays the 230k
+    /// creditable portion as gas, so accumulating churned credits costs full price per credit and
+    /// cannot fund cheaper Direct creates. Here the 500-cycle Preserve churn exhausts gas (each
+    /// recreation costs 230k) before the Direct phase runs, so the transaction reverts.
     #[test]
     fn test_tip1060_preserve_churn_attack() -> eyre::Result<()> {
         use alloy_primitives::{Address, Bytes, TxKind, U256, hex};
@@ -2421,19 +2423,23 @@ mod tests {
             call.tx_gas_used()
         );
 
-        // Dirty restores cancel the clear-minted credits, so the Direct create phase OOGs.
+        // Each Preserve recreation costs the full 230k creditable portion, so the churn loop
+        // exhausts gas and reverts before any churned credit can subsidize a Direct create.
         assert!(!call.is_success());
         assert_eq!(slots, 1);
         assert_eq!(balance, 0);
         Ok(())
     }
 
-    /// TIP-1060: Preserve clear+restore churn of a pre-existing slot nets zero credits.
+    /// TIP-1060: Preserve clear+restore churn mints one credit per clear.
     ///
-    /// Slot 0 starts non-zero. Each clear mints a credit, and each dirty restore must burn it so
-    /// repeated churn cannot grow the account's credit balance.
+    /// Slot 0 starts non-zero. TIP-1060 keys minting on the present -> new transition, so every
+    /// `nonzero -> 0` clear mints a credit regardless of the slot's original value. In Preserve
+    /// mode the matching `0 -> nonzero` recreation pays the 230k creditable portion as gas and does
+    /// not consume a credit, so three churn cycles accumulate three credits — each paid for in full,
+    /// so the balance growth is not a subsidy.
     #[test]
-    fn test_tip1060_preserve_churn_mints_zero_net_credits() -> eyre::Result<()> {
+    fn test_tip1060_preserve_churn_mints_one_credit_per_clear() -> eyre::Result<()> {
         let key_pair = P256KeyPair::random();
         let caller = key_pair.address;
         let contract = Address::repeat_byte(0x6c);
@@ -2473,8 +2479,9 @@ mod tests {
 
         assert_eq!(
             storage_credit_balance(&evm, contract),
-            0,
-            "clear+restore of a pre-existing slot must net to zero minted credits"
+            3,
+            "each clear mints a credit and Preserve recreations pay 230k without consuming, so \
+             three churn cycles accumulate three credits"
         );
         Ok(())
     }

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -2324,7 +2324,7 @@ mod tests {
         // zeroes SSTORE_CLEARS_SCHEDULE, not the restore refunds), lowering each
         // mode's gas by 19,900 relative to the legacy no-refund accounting.
         let cases = [
-            (CreditMode::Refund, 286_068u64, 0u64),
+            (CreditMode::Refund, 271_068u64, 0u64),
             (CreditMode::Preserve, 520_614u64, 1u64),
             (CreditMode::Direct, 520_614u64, 1u64),
         ];
@@ -2520,7 +2520,7 @@ mod tests {
                 new_value: 0,
                 expected_slot: 0,
                 credit_cases: no_initial_credits(expectations(
-                    (36_068, 0),
+                    (21_068, 0),
                     (270_614, 1),
                     (270_614, 1),
                 )),
@@ -2557,18 +2557,18 @@ mod tests {
                         name: "one initial credit",
                         initial_credits: 1,
                         expectations: expectations(
-                            (52_962, 0),
-                            (52_962 + SET_MODE_GAS + STORAGE_CREDIT_VALUE, 1),
-                            (60_308, 0),
+                            (37_962, 0),
+                            (37_962 + SET_MODE_GAS + STORAGE_CREDIT_VALUE, 1),
+                            (45_308, 0),
                         ),
                     },
                     CreditCase {
                         name: "surplus initial credits",
                         initial_credits: 2,
                         expectations: expectations(
-                            (52_962, 1),
-                            (52_962 + SET_MODE_GAS + STORAGE_CREDIT_VALUE, 2),
-                            (60_308, 1),
+                            (37_962, 1),
+                            (37_962 + SET_MODE_GAS + STORAGE_CREDIT_VALUE, 2),
+                            (45_308, 1),
                         ),
                     },
                 ],
@@ -2874,8 +2874,8 @@ mod tests {
         assert!(result.is_success(), "preserve churn tx should succeed");
         assert_eq!(
             result.tx_gas_used(),
-            984_138,
-            "three Preserve churn cycles pay the full 230k creditable portion per recreation"
+            1_029_138,
+            "three Preserve churn cycles pay the full 245k creditable portion per recreation"
         );
 
         assert_eq!(
@@ -2964,7 +2964,7 @@ mod tests {
         let cases = [
             (CreditMode::Refund, 282_994u64, 0u64, 0u64),
             (CreditMode::Preserve, 287_540u64, 1u64, 1u64),
-            (CreditMode::Direct, 60_340u64, 1u64, 0u64),
+            (CreditMode::Direct, 45_340u64, 1u64, 0u64),
         ];
 
         for (mode, expected_second_gas, expected_credit_tx1, expected_credit_tx2) in cases {
@@ -3280,8 +3280,8 @@ mod tests {
         assert_eq!(storage_credit_balance(&evm, contract), 0);
         assert_eq!(
             result.tx_gas_used(),
-            310_868,
-            "one 230k deferred storage credit is applied"
+            295_868,
+            "one 245k deferred storage credit is applied"
         );
 
         Ok(())
@@ -3346,13 +3346,13 @@ mod tests {
 
         assert_eq!(
             direct.tx_gas_used(),
-            310_308,
+            295_308,
             "Direct gets the synchronous discount without an additional settlement refund"
         );
         assert_eq!(
             refund.tx_gas_used(),
-            52_962,
-            "Refund applies the deferred 230k settlement refund for comparison"
+            37_962,
+            "Refund applies the deferred 245k settlement refund for comparison"
         );
 
         Ok(())

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -2480,6 +2480,11 @@ mod tests {
             caller,
         ))?;
         assert!(result.is_success(), "preserve churn tx should succeed");
+        assert_eq!(
+            result.tx_gas_used(),
+            984_138,
+            "three Preserve churn cycles pay the full 230k creditable portion per recreation"
+        );
 
         assert_eq!(
             storage_credit_balance(&evm, contract),

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -2736,10 +2736,10 @@ mod tests {
 
     /// TIP-1060: Preserve churn of a pre-existing slot cannot subsidize fresh Direct creates.
     ///
-    /// Each clear mints a credit, but in Preserve mode the matching recreation pays the 230k
+    /// Each clear mints a credit, but in Preserve mode the matching recreation pays the 245k
     /// creditable portion as gas, so accumulating churned credits costs full price per credit and
     /// cannot fund cheaper Direct creates. Here the 500-cycle Preserve churn exhausts gas (each
-    /// recreation costs 230k) before the Direct phase runs, so the transaction reverts.
+    /// recreation costs 245k) before the Direct phase runs, so the transaction reverts.
     #[test]
     fn test_tip1060_preserve_churn_attack() -> eyre::Result<()> {
         use alloy_primitives::{Address, Bytes, TxKind, U256, hex};
@@ -2844,7 +2844,7 @@ mod tests {
             call.tx_gas_used()
         );
 
-        // Each Preserve recreation costs the full 230k creditable portion, so the churn loop
+        // Each Preserve recreation costs the full 245k creditable portion, so the churn loop
         // exhausts gas and reverts before any churned credit can subsidize a Direct create.
         assert!(!call.is_success());
         assert_eq!(slots, 1);
@@ -2856,7 +2856,7 @@ mod tests {
     ///
     /// Slot 0 starts non-zero. TIP-1060 keys minting on the present -> new transition, so every
     /// `nonzero -> 0` clear mints a credit regardless of the slot's original value. In Preserve
-    /// mode the matching `0 -> nonzero` recreation pays the 230k creditable portion as gas and does
+    /// mode the matching `0 -> nonzero` recreation pays the 245k creditable portion as gas and does
     /// not consume a credit, so three churn cycles accumulate three credits — each paid for in full,
     /// so the balance growth is not a subsidy.
     #[test]
@@ -2906,7 +2906,7 @@ mod tests {
         assert_eq!(
             storage_credit_balance(&evm, contract),
             3,
-            "each clear mints a credit and Preserve recreations pay 230k without consuming, so \
+            "each clear mints a credit and Preserve recreations pay 245k without consuming, so \
              three churn cycles accumulate three credits"
         );
         Ok(())

--- a/crates/revm/src/gas_params.rs
+++ b/crates/revm/src/gas_params.rs
@@ -79,20 +79,21 @@ pub fn tempo_gas_params_with_amsterdam(
 /// set cost. The 245k creditable portion is charged (or covered by a credit) by
 /// the storage-credit hook in `sstore_storage_credits`.
 fn t7_gas_params() -> GasParams {
-    // T7 starts from the full TIP-1000 (T1) table so that every creation cost is
-    // inherited unchanged. TIP-1060 only touches the two SSTORE-creation entries
-    // overridden below; everything else (tx_create_cost, create, new_account_cost,
+    // T7 starts from the TIP-1000 (T1) table so that every creation cost is inherited unchanged.
+    // TIP-1060 only touches the SSTORE creation, clear, and restore-to-original-zero refund
+    // entries overridden below; everything else (tx_create_cost, create, new_account_cost,
     // code_deposit_cost, eip7702 costs, auth refund) is exactly as in `t1_gas_params`.
     let mut gas_params = t1_gas_params();
     gas_params.override_gas([
-        // SSTORE (zero -> non-zero): only the 5k residual; the 245k creditable
-        // portion is governed by the TIP-1060 storage-credit hook.
-        // (T1 charged the full SSTORE_CREATE_COST here.)
+        // SSTORE (zero -> non-zero): only the 5k residual; the 245k creditable portion is governed
+        // by the TIP-1060 storage-credit hook (T1 charged the full `SSTORE_CREATE_COST` here).
         (GasId::sstore_set_without_load_cost(), SSTORE_SET_COST),
-        // TIP-1060: SSTORE_CLEARS_SCHEDULE = 0. The nonzero-to-zero clear is now
-        // handled by storage-credit minting, so the legacy clearing refund is
-        // removed. Restore-to-original refunds (sstore_set_refund /
-        // sstore_reset_refund) are preserved at their defaults.
+        // Restore (non-zero -> zero) refund must not exceed the T7 residual. Important with
+        // TIP-1060 because the refund cap is removed. Otherwise, 0→x→0 could be refund-positive.
+        (GasId::sstore_set_refund(), SSTORE_SET_COST),
+        // TIP-1060: SSTORE_CLEARS_SCHEDULE = 0. The nonzero-to-zero clear is now handled by storage
+        // credit minting, so the legacy clearing refund is removed. Restore-to-original-nonzero
+        // refunds (sstore_reset_refund) remain at their upstream reset refund.
         (GasId::sstore_clearing_slot_refund(), 0),
     ]);
     gas_params
@@ -203,6 +204,16 @@ mod tests {
             gas_params.get(GasId::sstore_set_without_load_cost()),
             5_000,
             "T7 SSTORE creation charges only the 5k residual"
+        );
+        assert!(
+            gas_params.get(GasId::sstore_set_without_load_cost())
+                >= gas_params.get(GasId::sstore_set_refund()),
+            "T7 restore-to-original-zero refund must not exceed the residual set charge"
+        );
+        assert_eq!(
+            gas_params.get(GasId::sstore_clearing_slot_refund()),
+            0,
+            "TIP-1060 removes the legacy SSTORE clearing refund"
         );
 
         // Other TIP-1000 creation costs are unchanged by TIP-1060.

--- a/crates/revm/src/gas_params.rs
+++ b/crates/revm/src/gas_params.rs
@@ -83,6 +83,11 @@ fn t7_gas_params() -> GasParams {
         // SSTORE (zero -> non-zero): only the 20k residual; the 230k creditable
         // portion is governed by the TIP-1060 storage-credit hook.
         (GasId::sstore_set_without_load_cost(), GAS_STORAGE_SET),
+        // TIP-1060: SSTORE_CLEARS_SCHEDULE = 0. The nonzero-to-zero clear is now
+        // handled by storage-credit minting, so the legacy clearing refund is
+        // removed. Restore-to-original refunds (sstore_set_refund /
+        // sstore_reset_refund) are preserved at their defaults.
+        (GasId::sstore_clearing_slot_refund(), 0),
         // All other TIP-1000 creation costs are unchanged by TIP-1060.
         (GasId::tx_create_cost(), CREATE_COST),
         (GasId::create(), CREATE_COST),

--- a/crates/revm/src/gas_params.rs
+++ b/crates/revm/src/gas_params.rs
@@ -11,6 +11,13 @@ const NEW_ACCOUNT_COST: u64 = 250_000;
 const CODE_DEPOSIT_COST_T1: u64 = 1_000;
 const EIP7702_PER_EMPTY_ACCOUNT_COST_T1: u64 = 12_500;
 
+// TIP-1060 (T7): the SSTORE gas function charges only the 20,000-gas residual
+// (`GAS_STORAGE_SET`) on a clean creation (`original == present == 0`). The
+// remaining 230,000-gas creditable portion of the TIP-1000 creation cost is
+// governed by the storage-credit hook (see `sstore_storage_credits`), so it is
+// no longer charged through the SSTORE gas function.
+const GAS_STORAGE_SET: u64 = 20_000;
+
 // TIP-1016 regular gas (computational overhead) — matches pre-TIP-1000 EVM costs.
 // These values are "at least the pre-TIP-1000 (standard EVM) cost" per spec invariant 15.
 //
@@ -47,12 +54,49 @@ pub fn tempo_gas_params_with_amsterdam(
         return TABLE.get_or_init(amsterdam_gas_params).clone();
     }
 
+    // TIP-1060 (T7+): the SSTORE creation cost drops to the 20k residual; the
+    // 230k creditable portion is handled by the storage-credit hook.
+    if spec.is_t7() {
+        static TABLE: OnceLock<GasParams> = OnceLock::new();
+        return TABLE.get_or_init(t7_gas_params).clone();
+    }
+
     if spec.is_t1() {
         static TABLE: OnceLock<GasParams> = OnceLock::new();
         return TABLE.get_or_init(t1_gas_params).clone();
     }
 
     GasParams::new_spec(spec.into())
+}
+
+/// Builds the T7 gas table: TIP-1000 creation costs, but the SSTORE creation
+/// cost is lowered to the 20k residual (`GAS_STORAGE_SET`) per TIP-1060.
+///
+/// revm charges this residual through `sstore_dynamic_gas` under the same
+/// `original == present == 0` condition as the base `SSTORE_SET` cost, so a
+/// dirty recreation (`X -> 0 -> Y`) is charged neither the residual nor the base
+/// set cost. The 230k creditable portion is charged (or covered by a credit) by
+/// the storage-credit hook in `sstore_storage_credits`.
+fn t7_gas_params() -> GasParams {
+    let mut gas_params = GasParams::new_spec(TempoHardfork::T7.into());
+    gas_params.override_gas([
+        // SSTORE (zero -> non-zero): only the 20k residual; the 230k creditable
+        // portion is governed by the TIP-1060 storage-credit hook.
+        (GasId::sstore_set_without_load_cost(), GAS_STORAGE_SET),
+        // All other TIP-1000 creation costs are unchanged by TIP-1060.
+        (GasId::tx_create_cost(), CREATE_COST),
+        (GasId::create(), CREATE_COST),
+        (GasId::new_account_cost(), NEW_ACCOUNT_COST),
+        (GasId::new_account_cost_for_selfdestruct(), NEW_ACCOUNT_COST),
+        (GasId::code_deposit_cost(), CODE_DEPOSIT_COST_T1),
+        (
+            GasId::tx_eip7702_per_empty_account_cost(),
+            EIP7702_PER_EMPTY_ACCOUNT_COST_T1,
+        ),
+        // Auth refund is disabled post-T1.
+        (GasId::tx_eip7702_auth_refund(), 0),
+    ]);
+    gas_params
 }
 
 /// Builds the Amsterdam gas table with the TIP-1016 regular/state split.
@@ -144,6 +188,43 @@ mod tests {
         assert!(
             std::ptr::eq(amsterdam_t4.table(), amsterdam_t5.table()),
             "Amsterdam gas params should share the cached table"
+        );
+    }
+
+    /// TIP-1060 (T7): SSTORE creation charges only the 20k residual through the
+    /// gas function; other TIP-1000 creation costs are unchanged, and there is
+    /// no TIP-1016 state-gas split (production T7 runs with EIP-8037 disabled).
+    #[test]
+    fn test_t7_gas_params_sstore_residual() {
+        let gas_params = tempo_gas_params_with_amsterdam(TempoHardfork::T7, false);
+
+        // SSTORE creation cost drops to the 20k residual; the 230k creditable
+        // portion is charged by the storage-credit hook, not the gas function.
+        assert_eq!(
+            gas_params.get(GasId::sstore_set_without_load_cost()),
+            20_000,
+            "T7 SSTORE creation charges only the 20k residual"
+        );
+
+        // Other TIP-1000 creation costs are unchanged by TIP-1060.
+        assert_eq!(gas_params.get(GasId::new_account_cost()), 250_000);
+        assert_eq!(gas_params.get(GasId::tx_create_cost()), 500_000);
+        assert_eq!(gas_params.get(GasId::create()), 500_000);
+        assert_eq!(gas_params.get(GasId::code_deposit_cost()), 1_000);
+
+        // No TIP-1016 state-gas split: state gas params stay at upstream defaults.
+        let upstream = GasParams::new_spec(TempoHardfork::T7.into());
+        assert_eq!(
+            gas_params.get(GasId::sstore_set_state_gas()),
+            upstream.get(GasId::sstore_set_state_gas()),
+            "T7 (EIP-8037 disabled) must not split SSTORE into state gas"
+        );
+
+        // T7+ shares the cached table.
+        let t8 = tempo_gas_params_with_amsterdam(TempoHardfork::T8, false);
+        assert!(
+            std::ptr::eq(gas_params.table(), t8.table()),
+            "T7+ TIP-1060 gas params should share the cached table"
         );
     }
 

--- a/crates/revm/src/gas_params.rs
+++ b/crates/revm/src/gas_params.rs
@@ -2,11 +2,13 @@ use revm::{
     context_interface::cfg::{GasId, GasParams},
     primitives::OnceLock,
 };
-use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_chainspec::{
+    constants::gas::{SSTORE_CREATE_COST, SSTORE_SET_COST},
+    hardfork::TempoHardfork,
+};
 
 // TIP-1000 total gas costs (used by T1)
-const SSTORE_SET_COST: u64 = 250_000;
-const CREATE_COST: u64 = 500_000;
+const CONTRACT_CREATE_COST: u64 = 500_000;
 const NEW_ACCOUNT_COST: u64 = 250_000;
 const CODE_DEPOSIT_COST_T1: u64 = 1_000;
 const EIP7702_PER_EMPTY_ACCOUNT_COST_T1: u64 = 12_500;
@@ -16,7 +18,6 @@ const EIP7702_PER_EMPTY_ACCOUNT_COST_T1: u64 = 12_500;
 // remaining 230,000-gas creditable portion of the TIP-1000 creation cost is
 // governed by the storage-credit hook (see `sstore_storage_credits`), so it is
 // no longer charged through the SSTORE gas function.
-const GAS_STORAGE_SET: u64 = 20_000;
 
 // TIP-1016 regular gas (computational overhead) — matches pre-TIP-1000 EVM costs.
 // These values are "at least the pre-TIP-1000 (standard EVM) cost" per spec invariant 15.
@@ -29,9 +30,9 @@ const T4_CREATE_REGULAR: u64 = 32_000;
 const T4_CODE_DEPOSIT_REGULAR: u64 = 200;
 
 // TIP-1016 state gas (permanent storage burden)
-const T4_SSTORE_SET_STATE: u64 = SSTORE_SET_COST - T4_SSTORE_SET_REGULAR; // 230,000
+const T4_SSTORE_SET_STATE: u64 = SSTORE_CREATE_COST - T4_SSTORE_SET_REGULAR; // 230,000
 const T4_NEW_ACCOUNT_STATE: u64 = NEW_ACCOUNT_COST - T4_NEW_ACCOUNT_REGULAR; // 225,000
-const T4_CREATE_STATE: u64 = CREATE_COST - T4_CREATE_REGULAR; // 468,000
+const T4_CREATE_STATE: u64 = CONTRACT_CREATE_COST - T4_CREATE_REGULAR; // 468,000
 const T4_CODE_DEPOSIT_STATE: u64 = 2_300;
 
 // TIP-1016 SSTORE set refund for 0→X→0 restoration (combined state + regular).
@@ -73,8 +74,8 @@ pub fn tempo_gas_params_with_amsterdam(
 /// cost is lowered to the 20k residual (`GAS_STORAGE_SET`) per TIP-1060.
 ///
 /// revm charges this residual through `sstore_dynamic_gas` under the same
-/// `original == present == 0` condition as the base `SSTORE_SET` cost, so a
-/// dirty recreation (`X -> 0 -> Y`) is charged neither the residual nor the base
+/// `original == present == 0` condition as the base `GAS_STORAGE_SET` cost, so a
+/// dirty recreation (`x→0→y`) is charged neither the residual nor the base
 /// set cost. The 230k creditable portion is charged (or covered by a credit) by
 /// the storage-credit hook in `sstore_storage_credits`.
 fn t7_gas_params() -> GasParams {
@@ -82,15 +83,15 @@ fn t7_gas_params() -> GasParams {
     gas_params.override_gas([
         // SSTORE (zero -> non-zero): only the 20k residual; the 230k creditable
         // portion is governed by the TIP-1060 storage-credit hook.
-        (GasId::sstore_set_without_load_cost(), GAS_STORAGE_SET),
+        (GasId::sstore_set_without_load_cost(), SSTORE_SET_COST),
         // TIP-1060: SSTORE_CLEARS_SCHEDULE = 0. The nonzero-to-zero clear is now
         // handled by storage-credit minting, so the legacy clearing refund is
         // removed. Restore-to-original refunds (sstore_set_refund /
         // sstore_reset_refund) are preserved at their defaults.
         (GasId::sstore_clearing_slot_refund(), 0),
         // All other TIP-1000 creation costs are unchanged by TIP-1060.
-        (GasId::tx_create_cost(), CREATE_COST),
-        (GasId::create(), CREATE_COST),
+        (GasId::tx_create_cost(), CONTRACT_CREATE_COST),
+        (GasId::create(), CONTRACT_CREATE_COST),
         (GasId::new_account_cost(), NEW_ACCOUNT_COST),
         (GasId::new_account_cost_for_selfdestruct(), NEW_ACCOUNT_COST),
         (GasId::code_deposit_cost(), CODE_DEPOSIT_COST_T1),
@@ -150,9 +151,9 @@ fn t1_gas_params() -> GasParams {
     let mut gas_params = GasParams::new_spec(TempoHardfork::T1.into());
     // TIP-1000: All storage creation costs in regular gas (no state gas split).
     gas_params.override_gas([
-        (GasId::sstore_set_without_load_cost(), SSTORE_SET_COST),
-        (GasId::tx_create_cost(), CREATE_COST),
-        (GasId::create(), CREATE_COST),
+        (GasId::sstore_set_without_load_cost(), SSTORE_CREATE_COST),
+        (GasId::tx_create_cost(), CONTRACT_CREATE_COST),
+        (GasId::create(), CONTRACT_CREATE_COST),
         (GasId::new_account_cost(), NEW_ACCOUNT_COST),
         (GasId::new_account_cost_for_selfdestruct(), NEW_ACCOUNT_COST),
         (GasId::code_deposit_cost(), CODE_DEPOSIT_COST_T1),

--- a/crates/revm/src/gas_params.rs
+++ b/crates/revm/src/gas_params.rs
@@ -79,28 +79,21 @@ pub fn tempo_gas_params_with_amsterdam(
 /// set cost. The 230k creditable portion is charged (or covered by a credit) by
 /// the storage-credit hook in `sstore_storage_credits`.
 fn t7_gas_params() -> GasParams {
-    let mut gas_params = GasParams::new_spec(TempoHardfork::T7.into());
+    // T7 starts from the full TIP-1000 (T1) table so that every creation cost is
+    // inherited unchanged. TIP-1060 only touches the two SSTORE-creation entries
+    // overridden below; everything else (tx_create_cost, create, new_account_cost,
+    // code_deposit_cost, eip7702 costs, auth refund) is exactly as in `t1_gas_params`.
+    let mut gas_params = t1_gas_params();
     gas_params.override_gas([
         // SSTORE (zero -> non-zero): only the 20k residual; the 230k creditable
         // portion is governed by the TIP-1060 storage-credit hook.
+        // (T1 charged the full SSTORE_CREATE_COST here.)
         (GasId::sstore_set_without_load_cost(), SSTORE_SET_COST),
         // TIP-1060: SSTORE_CLEARS_SCHEDULE = 0. The nonzero-to-zero clear is now
         // handled by storage-credit minting, so the legacy clearing refund is
         // removed. Restore-to-original refunds (sstore_set_refund /
         // sstore_reset_refund) are preserved at their defaults.
         (GasId::sstore_clearing_slot_refund(), 0),
-        // All other TIP-1000 creation costs are unchanged by TIP-1060.
-        (GasId::tx_create_cost(), CONTRACT_CREATE_COST),
-        (GasId::create(), CONTRACT_CREATE_COST),
-        (GasId::new_account_cost(), NEW_ACCOUNT_COST),
-        (GasId::new_account_cost_for_selfdestruct(), NEW_ACCOUNT_COST),
-        (GasId::code_deposit_cost(), CODE_DEPOSIT_COST_T1),
-        (
-            GasId::tx_eip7702_per_empty_account_cost(),
-            EIP7702_PER_EMPTY_ACCOUNT_COST_T1,
-        ),
-        // Auth refund is disabled post-T1.
-        (GasId::tx_eip7702_auth_refund(), 0),
     ]);
     gas_params
 }
@@ -204,12 +197,12 @@ mod tests {
     fn test_t7_gas_params_sstore_residual() {
         let gas_params = tempo_gas_params_with_amsterdam(TempoHardfork::T7, false);
 
-        // SSTORE creation cost drops to the 20k residual; the 230k creditable
+        // SSTORE creation cost drops to the 5k residual; the 245k creditable
         // portion is charged by the storage-credit hook, not the gas function.
         assert_eq!(
             gas_params.get(GasId::sstore_set_without_load_cost()),
-            20_000,
-            "T7 SSTORE creation charges only the 20k residual"
+            5_000,
+            "T7 SSTORE creation charges only the 5k residual"
         );
 
         // Other TIP-1000 creation costs are unchanged by TIP-1060.

--- a/crates/revm/src/gas_params.rs
+++ b/crates/revm/src/gas_params.rs
@@ -13,9 +13,9 @@ const NEW_ACCOUNT_COST: u64 = 250_000;
 const CODE_DEPOSIT_COST_T1: u64 = 1_000;
 const EIP7702_PER_EMPTY_ACCOUNT_COST_T1: u64 = 12_500;
 
-// TIP-1060 (T7): the SSTORE gas function charges only the 20,000-gas residual
-// (`GAS_STORAGE_SET`) on a clean creation (`original == present == 0`). The
-// remaining 230,000-gas creditable portion of the TIP-1000 creation cost is
+// TIP-1060 (T7): the SSTORE gas function charges only the 5,000-gas residual
+// (`SSTORE_SET_COST`) on a clean creation (`original == present == 0`). The
+// remaining 245,000-gas creditable portion of the TIP-1000 creation cost is
 // governed by the storage-credit hook (see `sstore_storage_credits`), so it is
 // no longer charged through the SSTORE gas function.
 
@@ -55,8 +55,8 @@ pub fn tempo_gas_params_with_amsterdam(
         return TABLE.get_or_init(amsterdam_gas_params).clone();
     }
 
-    // TIP-1060 (T7+): the SSTORE creation cost drops to the 20k residual; the
-    // 230k creditable portion is handled by the storage-credit hook.
+    // TIP-1060 (T7+): the SSTORE creation cost drops to the 5k residual; the
+    // 245k creditable portion is handled by the storage-credit hook.
     if spec.is_t7() {
         static TABLE: OnceLock<GasParams> = OnceLock::new();
         return TABLE.get_or_init(t7_gas_params).clone();
@@ -71,12 +71,12 @@ pub fn tempo_gas_params_with_amsterdam(
 }
 
 /// Builds the T7 gas table: TIP-1000 creation costs, but the SSTORE creation
-/// cost is lowered to the 20k residual (`GAS_STORAGE_SET`) per TIP-1060.
+/// cost is lowered to the 5k residual (`SSTORE_SET_COST`) per TIP-1060.
 ///
 /// revm charges this residual through `sstore_dynamic_gas` under the same
-/// `original == present == 0` condition as the base `GAS_STORAGE_SET` cost, so a
+/// `original == present == 0` condition as the upstream storage-set cost, so a
 /// dirty recreation (`x→0→y`) is charged neither the residual nor the base
-/// set cost. The 230k creditable portion is charged (or covered by a credit) by
+/// set cost. The 245k creditable portion is charged (or covered by a credit) by
 /// the storage-credit hook in `sstore_storage_credits`.
 fn t7_gas_params() -> GasParams {
     // T7 starts from the full TIP-1000 (T1) table so that every creation cost is
@@ -85,7 +85,7 @@ fn t7_gas_params() -> GasParams {
     // code_deposit_cost, eip7702 costs, auth refund) is exactly as in `t1_gas_params`.
     let mut gas_params = t1_gas_params();
     gas_params.override_gas([
-        // SSTORE (zero -> non-zero): only the 20k residual; the 230k creditable
+        // SSTORE (zero -> non-zero): only the 5k residual; the 245k creditable
         // portion is governed by the TIP-1060 storage-credit hook.
         // (T1 charged the full SSTORE_CREATE_COST here.)
         (GasId::sstore_set_without_load_cost(), SSTORE_SET_COST),
@@ -190,7 +190,7 @@ mod tests {
         );
     }
 
-    /// TIP-1060 (T7): SSTORE creation charges only the 20k residual through the
+    /// TIP-1060 (T7): SSTORE creation charges only the 5k residual through the
     /// gas function; other TIP-1000 creation costs are unchanged, and there is
     /// no TIP-1016 state-gas split (production T7 runs with EIP-8037 disabled).
     #[test]

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -323,9 +323,6 @@ fn translate_allowed_calls_for_precompile(
 ///   SSTORE (write key) + N × SSTORE (per spending limit)
 ///   This is the sole gas accounting — the precompile runs with unlimited gas.
 ///
-/// T7+: key-auth gas is intrinsic-only. Add `STORAGE_CREDIT_VALUE` per persistent
-///   SSTORE because pre-execution provider gas is not folded into tx gas.
-///
 /// Returns `(total_gas, state_gas)` where `total_gas` includes the state gas portion.
 /// On T4+, each storage-creating SSTORE contributes `sstore_set_state_gas` to state gas
 /// per TIP-1016.
@@ -1454,6 +1451,7 @@ where
                 false,
                 gas_params,
             );
+            provider.set_tip1060_storage_credits(false);
 
             // The core logic of setting up thread-local storage is here.
             let out_of_gas = StorageCtx::enter(&mut provider, || {
@@ -3565,7 +3563,7 @@ mod tests {
     }
 
     #[test]
-    fn test_t7_key_authorization_intrinsic_backs_tip1060_hook() {
+    fn test_t7_key_authorization_intrinsic_includes_storage_credit_value() {
         use tempo_chainspec::constants::gas::SSTORE_CREATE_COST;
         use tempo_primitives::transaction::{KeyAuthorization, SignatureType};
 

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -854,6 +854,26 @@ where
         Ok(result_gas)
     }
 
+    /// Applies gas refunds, dropping the EIP-3529 one-fifth refund cap on T7+.
+    ///
+    /// TIP-1060 removes the standard EVM refund cap: the `Refund`-mode
+    /// storage-credit settlement refund and the preserved baseline SSTORE
+    /// refunds are credited to the transaction's gas refund counter in full,
+    /// regardless of the transaction's gas used. Pre-T7 keeps the standard
+    /// capped behavior (`Gas::set_final_refund`).
+    #[inline]
+    fn refund(&self, evm: &mut Self::Evm, exec_result: &mut FrameResult, eip7702_refund: i64) {
+        let spec = evm.ctx.cfg.spec;
+        let gas = exec_result.gas_mut();
+        if spec.is_t7() {
+            // No cap: leave the accumulated refund counter untouched after
+            // recording the EIP-7702 auth refund.
+            gas.record_refund(eip7702_refund);
+        } else {
+            post_execution::refund(spec.into(), gas, eip7702_refund);
+        }
+    }
+
     /// Take logs from the Journal if outcome is Halt Or Revert.
     #[inline]
     fn execution_result(
@@ -4134,6 +4154,58 @@ mod tests {
             }
             other => panic!("expected custom error, got: {other:?}"),
         }
+    }
+
+    /// TIP-1060: T7 removes the EIP-3529 one-fifth refund cap; pre-T7 keeps it.
+    #[test]
+    fn test_refund_cap_removed_on_t7() {
+        use revm::{
+            Context, Journal,
+            context::CfgEnv,
+            database::{CacheDB, EmptyDB},
+            handler::FrameResult,
+            interpreter::{CallOutcome, Gas, InstructionResult, InterpreterResult},
+        };
+
+        // Refund (50k) deliberately exceeds one fifth of the gas used (100k / 5 = 20k).
+        const SPENT: u64 = 100_000;
+        const REFUND: i64 = 50_000;
+        const CAPPED: i64 = (SPENT / 5) as i64;
+
+        let refunded_for_spec = |spec: TempoHardfork| -> i64 {
+            let mut cfg = CfgEnv::<TempoHardfork>::default();
+            cfg.spec = spec;
+            let ctx = Context::mainnet()
+                .with_db(CacheDB::new(EmptyDB::default()))
+                .with_block(TempoBlockEnv::default())
+                .with_cfg(cfg)
+                .with_tx(TempoTxEnv::default())
+                .with_new_journal(Journal::new(CacheDB::new(EmptyDB::default())));
+            let mut evm: TempoEvm<_, ()> = TempoEvm::new(ctx, ());
+            let handler: TempoEvmHandler<CacheDB<EmptyDB>, ()> = TempoEvmHandler::new();
+
+            let mut gas = Gas::new(SPENT);
+            gas.set_spent(SPENT);
+            gas.record_refund(REFUND);
+            let mut frame_result = FrameResult::Call(CallOutcome::new(
+                InterpreterResult::new(InstructionResult::Stop, Bytes::new(), gas),
+                0..0,
+            ));
+
+            handler.refund(&mut evm, &mut frame_result, 0);
+            frame_result.gas().refunded()
+        };
+
+        assert_eq!(
+            refunded_for_spec(TempoHardfork::T6),
+            CAPPED,
+            "pre-T7 must cap the refund at one fifth of gas used"
+        );
+        assert_eq!(
+            refunded_for_spec(TempoHardfork::T7),
+            REFUND,
+            "T7 must credit the full refund, with no EIP-3529 cap"
+        );
     }
 
     #[test]

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -33,6 +33,7 @@ use revm::{
     },
     precompile::PrecompileError,
 };
+use tempo_chainspec::constants::gas::STORAGE_CREDIT_VALUE;
 use tempo_contracts::precompiles::{
     IAccountKeychain::SignatureType as PrecompileSignatureType, TIPFeeAMMError,
 };
@@ -322,6 +323,9 @@ fn translate_allowed_calls_for_precompile(
 ///   SSTORE (write key) + N × SSTORE (per spending limit)
 ///   This is the sole gas accounting — the precompile runs with unlimited gas.
 ///
+/// T7+: key-auth gas is intrinsic-only. Add `STORAGE_CREDIT_VALUE` per persistent
+///   SSTORE because pre-execution provider gas is not folded into tx gas.
+///
 /// Returns `(total_gas, state_gas)` where `total_gas` includes the state gas portion.
 /// On T4+, each storage-creating SSTORE contributes `sstore_set_state_gas` to state gas
 /// per TIP-1016.
@@ -367,7 +371,12 @@ fn calculate_key_authorization_gas(
             num_sstores += call_scope_storage_slots(&key_auth.authorization, spec);
         }
 
-        let sstore_cost = gas_params.get(GasId::sstore_set_without_load_cost());
+        let mut sstore_cost = gas_params.get(GasId::sstore_set_without_load_cost());
+        if spec.is_t7() {
+            // T7 exposes only the SSTORE residual in the gas table. Since key-auth storage is
+            // intrinsic-only, we must also add the creditable portion here.
+            sstore_cost = sstore_cost.saturating_add(STORAGE_CREDIT_VALUE);
+        }
         let mut regular_gas = sig_gas + sload_cost + sstore_cost * num_sstores + BUFFER;
 
         if has_t5_witness {
@@ -1061,7 +1070,7 @@ where
                 .ok_or(TempoInvalidTransaction::ExpiringNonceMissingValidBefore)?;
 
             let block_timestamp = block.timestamp().saturating_to::<u64>();
-            StorageCtx::enter_evm(journal, block, cfg, tx, || {
+            StorageCtx::enter_evm_without_tip1060_accounting(journal, block, cfg, tx, || {
                 let mut nonce_manager = NonceManager::new();
 
                 let prev_ptr = if let Some(expiring_nonce_idx) = tempo_tx_env.expiring_nonce_idx {
@@ -1116,8 +1125,7 @@ where
                 Ok::<_, EVMError<DB::Error, TempoInvalidTransaction>>(())
             })?;
         } else if !nonce_key.is_zero() {
-            // 2D nonce transaction
-            StorageCtx::enter_evm(journal, block, cfg, tx, || {
+            StorageCtx::enter_evm_without_tip1060_accounting(journal, block, cfg, tx, || {
                 let mut nonce_manager = NonceManager::new();
 
                 if !cfg.is_nonce_check_disabled() {
@@ -1342,15 +1350,16 @@ where
             let checkpoint = journal.checkpoint();
 
             let skip_liquidity_check = evm.skip_liquidity_check;
-            let result = StorageCtx::enter_fee_collection(journal, &block, cfg, tx, || {
-                TipFeeManager::new().collect_fee_pre_tx(
-                    fee_payer,
-                    fee_token,
-                    gas_balance_spending,
-                    block.beneficiary(),
-                    skip_liquidity_check,
-                )
-            });
+            let result =
+                StorageCtx::enter_evm_without_tip1060_accounting(journal, &block, cfg, tx, || {
+                    TipFeeManager::new().collect_fee_pre_tx(
+                        fee_payer,
+                        fee_token,
+                        gas_balance_spending,
+                        block.beneficiary(),
+                        skip_liquidity_check,
+                    )
+                });
 
             if let Err(err) = result {
                 // Revert the journal to checkpoint before `collectFeePreTx` call if something went wrong.
@@ -1551,7 +1560,7 @@ where
             // key and decrement the fee from its spending limit. Admin delegation must keep the
             // actual signer as the transaction key.
             if same_tx_key_authorization_use {
-                StorageCtx::enter_fee_collection(journal, block, cfg, tx, || {
+                StorageCtx::enter_evm_without_tip1060_accounting(journal, block, cfg, tx, || {
                     let mut keychain = AccountKeychain::new();
                     keychain
                         .set_transaction_key(key_auth.key_id)
@@ -1612,8 +1621,12 @@ where
         let (journal, block, tx) = (&mut context.journaled_state, &context.block, &context.tx);
         let beneficiary = context.block.beneficiary();
 
-        let credited =
-            StorageCtx::enter_fee_collection(&mut *journal, block, &context.cfg, tx, || {
+        let credited = StorageCtx::enter_evm_without_tip1060_accounting(
+            &mut *journal,
+            block,
+            &context.cfg,
+            tx,
+            || {
                 let mut fee_manager = TipFeeManager::new();
 
                 if !actual_spending.is_zero() || !refund_amount.is_zero() {
@@ -1634,7 +1647,8 @@ where
                 } else {
                     Ok(U256::ZERO)
                 }
-            })?;
+            },
+        )?;
 
         // Stash the per-tx credit so `TempoBlockExecutor` can surface it on `TempoTxResult`
         // for payload scoring. Reset to zero on every tx entry below in `validate_env`.
@@ -3548,6 +3562,37 @@ mod tests {
 
         assert_eq!(helper_sstore_regular, 20_000);
         assert_eq!(state_gas, 230_000);
+    }
+
+    #[test]
+    fn test_t7_key_authorization_intrinsic_backs_tip1060_hook() {
+        use tempo_chainspec::constants::gas::SSTORE_CREATE_COST;
+        use tempo_primitives::transaction::{KeyAuthorization, SignatureType};
+
+        let key_auth =
+            KeyAuthorization::unrestricted(1, SignatureType::Secp256k1, Address::random())
+                .into_signed(PrimitiveSignature::Secp256k1(
+                    alloy_primitives::Signature::test_signature(),
+                ));
+
+        let gas_params = crate::gas_params::tempo_gas_params(TempoHardfork::T7);
+        let sig_gas = ECRECOVER_GAS + primitive_signature_verification_gas(&key_auth.signature);
+        let sload = gas_params.warm_storage_read_cost() + gas_params.cold_storage_additional_cost();
+        let scope_extra_gas = call_scope_extra_gas(&key_auth.authorization);
+        let (regular_gas, state_gas) =
+            calculate_key_authorization_gas(&key_auth, &gas_params, TempoHardfork::T7);
+        let helper_sstore_regular = regular_gas - sig_gas - sload - 2_000 - scope_extra_gas;
+
+        assert_eq!(
+            gas_params.get(GasId::sstore_set_without_load_cost()),
+            SSTORE_CREATE_COST - STORAGE_CREDIT_VALUE,
+            "T7 gas table should expose only the SSTORE residual"
+        );
+        assert_eq!(
+            helper_sstore_regular, SSTORE_CREATE_COST,
+            "key authorization intrinsic gas must include the TIP-1060 creditable portion"
+        );
+        assert_eq!(state_gas, 0, "T7 without TIP-1016 has no state gas split");
     }
 
     #[test]

--- a/crates/revm/src/tip1060.rs
+++ b/crates/revm/src/tip1060.rs
@@ -75,7 +75,7 @@ pub fn apply_refund<DB: Database, I>(
         journal.sstore(STORAGE_CREDITS_ADDRESS, key, new_word)?;
     }
 
-    // Refund storage credit value (230k) per settled credit.
+    // Refund storage credit value per settled credit.
     gas.erase_cost(refunds.saturating_mul(STORAGE_CREDIT_VALUE));
 
     Ok(())

--- a/crates/revm/src/tip1060.rs
+++ b/crates/revm/src/tip1060.rs
@@ -172,5 +172,6 @@ where
             owner,
             values,
         )
+        .map(|_| GasStateOutcome::default())
     }
 }

--- a/xtask/src/bootstrap_shadowfork.rs
+++ b/xtask/src/bootstrap_shadowfork.rs
@@ -609,6 +609,10 @@ where
         self.overlay = overlay;
         self.events = events;
     }
+
+    fn set_tip1060_storage_credits(&mut self, _enabled: bool) {
+        // DbStorageOverlay does not run TIP-1060 accounting.
+    }
 }
 
 fn read_private_genesis_outcome(manifest_dir: &Path) -> eyre::Result<OnchainDkgOutcome> {


### PR DESCRIPTION
## Summary

Ports the revised TIP-1060 spec ([PR #5674](https://github.com/tempoxyz/tempo/pull/5674)) into the T7 implementation. Three semantic deltas:

### 1. 20k residual moved into `GasParams`, gated behind T7
`t7_gas_params()` lowers the SSTORE creation cost to the **20k residual** (`GAS_STORAGE_SET`). revm charges it through `sstore_dynamic_gas` under the same `original == present == 0` condition as the base set cost, so a dirty recreation (`X→0→Y`) is charged **neither** the residual nor the base set cost — the spec's residual gating, for free. Other TIP-1000 creation costs (account 250k, CREATE 500k) are unchanged.

### 2. Present/new credit accounting
The hook now keys on the **present → new** transition, not the transaction-original value:
- Mint on **every** `nonzero → 0` (regardless of original).
- Route **every** `0 → nonzero` through mode handling.
- The hook governs only the **230k creditable portion** (revm charges the residual): `Refund`/`Preserve`/`Direct`-no-credit charge 230k as gas, `Direct`-consume covers it with a credit.

Removes the old original-value dirty-restore branch and the `skip_gas` + manual-20k/cold path.

### 3. EIP-3529 refund cap removed on T7
A `Handler::refund` override records the EIP-7702 refund without applying `set_final_refund`'s ⅕ cap for T7+; pre-T7 keeps the standard capped behavior. Done Tempo-side (no revm fork / re-pin).

## Tests
- `preserve_churn_mints_zero_net_credits` → `..._one_credit_per_clear` (Preserve churn now mints one credit per clear, each recreation paid in full); refreshed the stale reasoning in `preserve_churn_attack`.
- Added `test_t7_gas_params_sstore_residual` and `test_refund_cap_removed_on_t7` (T6 caps to gas/5; T7 credits the full refund).
- Green: tempo-revm **194**, tempo-precompiles **921**, tempo-evm **81**; `cargo check --workspace` clean.

## Out of scope / worth flagging
- **TIP-1016 interaction:** production T7 runs with `enable_amsterdam_eip8037 = false`, which is what this targets. With EIP-8037 enabled, revm's state gas (230k) and the hook's 230k would double-count — needs the "Interaction with TIP-1016" handling.
- **Cap-removal reach:** the hook sets `skip_refund = true` for credit-touched SSTOREs and settlement uses `gas.erase_cost` (already cap-free), so the uncapped ordinary counter currently matters mostly for non-SSTORE refunds. Correct and spec-aligned, but preserving restore-to-original refunds uncapped would mean revisiting the broad `skip_refund` — separate from these deltas.
