### PR TITLE
ci: use Foundry revm 41 branch

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: master
+          ref: alexey/revm-41-tempo
           path: foundry
           persist-credentials: false
 
@@ -261,7 +261,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: master
+          ref: alexey/revm-41-tempo
           path: foundry
           persist-credentials: false
 


### PR DESCRIPTION
Temporarily points Tempo Specs CI Foundry checkouts at `foundry-rs/foundry@alexey/revm-41-tempo` so CI can run against the matching Foundry revm/alloy-evm dependency bump.

This should be reverted after the Foundry branch lands and Tempo can point back at Foundry master.

Prompted by: @shekhirin