### PR TITLE
docs(tip-1077): minimize time wheel keccaks

### DIFF
--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -13,8 +13,8 @@ protocolVersion: TBD
 ## Abstract
 
 This TIP replaces TIP-1009's expiring nonce circular buffer with a fixed time-wheel replay table.
-`valid_before` selects one of 32 reusable time buckets, and the transaction replay hash selects a
-deterministic probe path inside that bucket.
+`valid_before` selects one of 32 reusable time buckets, and the sender-scoped transaction replay
+hash directly selects a deterministic probe path inside that bucket.
 
 The table is sized at 131,072 cells per bucket, for 4,194,304 total cells. A fully populated table
 is 128 MiB of cell values, or 256 MiB when counted as `(storage slot, storage value)` pairs.
@@ -29,7 +29,9 @@ depends on how many expiring nonce transactions came before it in the block.
 
 The time wheel keeps replay state bounded without a global append pointer. The common path is a
 read and write of one replay-table cell derived from transaction contents, so the builder can
-prewarm the first cell directly from `(replay_hash, valid_before)`.
+prewarm the first cell directly from `(replay_hash, valid_before)`. Replay cells use a reserved
+direct storage range rather than Solidity mapping layout, so probing a cell does not require a
+mapping-slot hash.
 
 ## Assumptions
 
@@ -73,17 +75,29 @@ EXPIRING_NONCE_BUCKET_COUNT    = 32
 EXPIRING_NONCE_BUCKET_CAPACITY = 131_072
 EXPIRING_NONCE_MAX_PROBES      = 32
 
-EXPIRING_NONCE_CELL_DOMAIN        = "tempo-expiring-nonce-cell"
-EXPIRING_NONCE_FINGERPRINT_DOMAIN = "tempo-expiring-nonce-fingerprint"
-EXPIRING_NONCE_FINGERPRINT_BITS   = 192
+EXPIRING_NONCE_CELL_COUNT      = 4_194_304
+EXPIRING_NONCE_CELL_BASE_SLOT  = 0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa2400000
+EXPIRING_NONCE_CELL_END_SLOT   = 0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa27fffff
+EXPIRING_NONCE_CELL_SLOT_DOMAIN = "tempo.expiringNonceCells.v1"
+EXPIRING_NONCE_FINGERPRINT_BITS = 192
 ```
 
 `EXPIRING_NONCE_BUCKET_COUNT` MUST be greater than `EXPIRING_NONCE_MAX_EXPIRY_SECS`.
 `EXPIRING_NONCE_BUCKET_CAPACITY` MUST be a power of two.
+`EXPIRING_NONCE_CELL_COUNT` MUST equal
+`EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY`.
+
+`EXPIRING_NONCE_CELL_BASE_SLOT` is the 4,194,304-slot-aligned value of
+`keccak256(EXPIRING_NONCE_CELL_SLOT_DOMAIN)`, with the low 22 bits cleared.
+`EXPIRING_NONCE_CELL_END_SLOT` is
+`EXPIRING_NONCE_CELL_BASE_SLOT + EXPIRING_NONCE_CELL_COUNT - 1`.
+The domain documents how the range was selected; implementations MUST use the fixed constants and
+MUST NOT compute this hash while processing transactions.
 
 ## Storage Layout
 
-The Nonce precompile keeps the existing 2D nonce mapping and adds a fresh replay-cell mapping:
+The Nonce precompile keeps the existing 2D nonce mapping and reserves a direct replay-cell storage
+range:
 
 ```solidity
 contract Nonce {
@@ -91,10 +105,21 @@ contract Nonce {
 
     // Slots 1, 2, and 3 are reserved for the pre-TIP-1077 expiring nonce
     // seen mapping, ring mapping, and ring pointer.
-
-    mapping(uint32 => bytes32) public expiringNonceCells;                  // slot 4
 }
 ```
+
+Replay cells are not stored in a Solidity-style mapping. For `cell_id` in
+`[0, EXPIRING_NONCE_CELL_COUNT)`, the corresponding storage slot is:
+
+```text
+cell_slot = EXPIRING_NONCE_CELL_BASE_SLOT + cell_id
+```
+
+The inclusive slot range
+`[EXPIRING_NONCE_CELL_BASE_SLOT, EXPIRING_NONCE_CELL_END_SLOT]` is reserved forever for expiring
+nonce replay cells. Future Nonce precompile fields MUST NOT be assigned inside this range.
+Mapping-derived slots are assumed collision-resistant under the same Keccak preimage assumptions as
+Solidity mapping layout.
 
 Each replay cell stores:
 
@@ -107,7 +132,7 @@ where:
 ```text
 stored_valid_before = high 64 bits of cell
 stored_fingerprint  = low 192 bits of cell
-fingerprint         = low_192_bits(keccak256(FINGERPRINT_DOMAIN || replay_hash))
+fingerprint         = low 192 bits of H
 ```
 
 A zero storage word has `stored_valid_before == 0` and is reusable.
@@ -126,6 +151,9 @@ V = tx.valid_before
 T = block.timestamp
 ```
 
+`H` MUST be the canonical protocol-computed replay hash, `keccak256(encode_for_signing || sender)`.
+It is not user-provided input.
+
 The transaction first chooses its time bucket:
 
 ```text
@@ -135,9 +163,9 @@ bucket = V % EXPIRING_NONCE_BUCKET_COUNT
 It then chooses a deterministic probe path inside that bucket:
 
 ```text
-seed = keccak256(EXPIRING_NONCE_CELL_DOMAIN || H)
-home = uint32_be(seed[0..4]) % EXPIRING_NONCE_BUCKET_CAPACITY
-step = (uint32_be(seed[4..8]) | 1) % EXPIRING_NONCE_BUCKET_CAPACITY
+home        = uint32_be(H[0..4]) & (EXPIRING_NONCE_BUCKET_CAPACITY - 1)
+step        = (uint32_be(H[4..8]) & (EXPIRING_NONCE_BUCKET_CAPACITY - 1)) | 1
+fingerprint = H[8..32]
 ```
 
 For probe `i`:
@@ -145,10 +173,13 @@ For probe `i`:
 ```text
 position_i = (home + i * step) % EXPIRING_NONCE_BUCKET_CAPACITY
 cell_id_i  = bucket * EXPIRING_NONCE_BUCKET_CAPACITY + position_i
+slot_i     = EXPIRING_NONCE_CELL_BASE_SLOT + cell_id_i
 ```
 
 `step` is forced odd so that, with power-of-two bucket capacity, the probe path can cycle through
 the bucket instead of being trapped in a smaller divisor-sized subset.
+Since `EXPIRING_NONCE_BUCKET_CAPACITY` is a power of two, implementations MAY use bit masks instead
+of modulo operations for `home` and `position_i`.
 
 ## Replay Algorithm
 
@@ -164,16 +195,17 @@ T < V <= T + EXPIRING_NONCE_MAX_EXPIRY_SECS
 Then the Nonce precompile executes:
 
 ```text
-fingerprint = low_192_bits(keccak256(FINGERPRINT_DOMAIN || H))
+fingerprint = H[8..32]
 
 for i in 0..EXPIRING_NONCE_MAX_PROBES:
     cell_id = cell_id_i
-    word = expiringNonceCells[cell_id]
+    slot = EXPIRING_NONCE_CELL_BASE_SLOT + cell_id
+    word = sload(slot)
     stored_v = high_64_bits(word)
     stored_f = low_192_bits(word)
 
     if stored_v != V:
-        expiringNonceCells[cell_id] = V || fingerprint
+        sstore(slot, V || fingerprint)
         accept
 
     if stored_f == fingerprint:
@@ -213,6 +245,19 @@ equivalent dynamic metering mechanism in the precompile storage layer. With the 
 the 20k TPS sizing assumption, the expected accepted transaction reads about 1.085 cells.
 
 No expiring nonce insertion or later overwrite mints or consumes TIP-1060 storage credits.
+
+The time-wheel lookup performs no Keccak beyond the canonical replay hash `H`. If `H` has already
+been computed by transaction validation or pool deduplication, deriving `bucket`, `home`, `step`,
+`fingerprint`, `cell_id`, and `slot` requires only slicing and arithmetic:
+
+```text
+steady-state lookup keccaks after H = 0
+steady-state lookup keccaks total   = 1, if H must be computed
+```
+
+During the temporary hardfork migration dual-check, implementations still perform the old
+`expiringNonceSeen[H]` mapping lookup until `migration_cutoff`; that compatibility check adds one
+old mapping-slot hash during the migration window only.
 
 ## Parameter Selection
 
@@ -269,14 +314,15 @@ slot 3: expiringNonceRingPtr
 
 At the activation block:
 
-1. New expiring nonce insertions MUST use `expiringNonceCells` at slot 4.
+1. New expiring nonce insertions MUST use the direct replay-cell slot range
+   `[EXPIRING_NONCE_CELL_BASE_SLOT, EXPIRING_NONCE_CELL_END_SLOT]`.
 2. The old ring pointer, ring mapping, and seen mapping MUST NOT be updated.
 3. Slots 1, 2, and 3 MUST remain reserved.
 4. Payload-builder prewarming MUST switch to the time-wheel first-cell slot.
 5. Transaction pool deduplication MUST continue to key expiring nonce transactions by `H`.
    Inclusion tracking MUST stop watching `expiringNonceSeen[H]`; it MUST remove a pooled
-   transaction when a canonical state update writes `V || fingerprint(H)` to one of that
-   transaction's TIP-1077 probe-path cells.
+   transaction when a canonical state update writes `V || H[8..32]` to one of that transaction's
+   TIP-1077 direct probe-path slots.
 
 To preserve replay protection across the hardfork boundary, implementations MUST perform a
 temporary dual replay check:
@@ -372,6 +418,21 @@ cell. Only 30 `valid_before` seconds are live at once, so one cell per bucket al
 Bucket count provides expiry separation. Bucket capacity provides throughput within one expiry
 second. Both are required.
 
+### Solidity-Style Replay Cell Mapping
+
+The time wheel could store cells in a flat Solidity-style mapping:
+
+```text
+expiringNonceCells[cell_id] = valid_before || fingerprint
+```
+
+This keeps the storage layout familiar, but every probed cell requires computing
+`keccak256(cell_id || mapping_slot)` before the `SLOAD`. At the chosen capacity, the expected
+accepted transaction reads about 1.085 cells, so mapping layout would add about 1.085 Keccak
+computations per accepted transaction on average and up to 32 in the worst probe path. The direct
+slot range preserves the same bounded table and probe behavior while making each probe slot
+derivable with integer addition.
+
 ### Larger Time Wheel
 
 A larger time wheel reduces collisions and makes first-cell prewarming more reliable. The
@@ -412,9 +473,11 @@ Nodes SHOULD expose metrics for:
 6. **Probe exhaustion.** If all probed cells contain different live fingerprints for the same
    `valid_before`, the transaction MUST be rejected with `ExpiringNonceSetFull`.
 7. **Bounded state.** New replay state MUST be limited to
-   `EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY` cells.
+   `EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY` cells in the reserved direct slot
+   range.
 8. **No explicit cleanup dependency.** Replay correctness MUST NOT depend on offchain pruning,
    MEV services, or TIP-1060 storage credits.
 9. **No nonce mutation.** Expiring nonce transactions MUST NOT increment protocol nonces or 2D
    nonces.
-10. **Storage layout hygiene.** Old ring slots 1, 2, and 3 MUST remain reserved after activation.
+10. **Storage layout hygiene.** Old ring slots 1, 2, and 3 MUST remain reserved after activation,
+    and future Nonce precompile fields MUST NOT overlap the direct replay-cell slot range.

--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -163,9 +163,8 @@ bucket = V % EXPIRING_NONCE_BUCKET_COUNT
 It then chooses a deterministic probe path inside that bucket:
 
 ```text
-home        = uint32_be(H[0..4]) & (EXPIRING_NONCE_BUCKET_CAPACITY - 1)
-step        = (uint32_be(H[4..8]) & (EXPIRING_NONCE_BUCKET_CAPACITY - 1)) | 1
-fingerprint = H[8..32]
+home = uint32_be(H[0..4]) % EXPIRING_NONCE_BUCKET_CAPACITY
+step = (uint32_be(H[4..8]) | 1) % EXPIRING_NONCE_BUCKET_CAPACITY
 ```
 
 For probe `i`:
@@ -179,7 +178,7 @@ slot_i     = EXPIRING_NONCE_CELL_BASE_SLOT + cell_id_i
 `step` is forced odd so that, with power-of-two bucket capacity, the probe path can cycle through
 the bucket instead of being trapped in a smaller divisor-sized subset.
 Since `EXPIRING_NONCE_BUCKET_CAPACITY` is a power of two, implementations MAY use bit masks instead
-of modulo operations for `home` and `position_i`.
+of modulo operations for `home`, `step`, and `position_i`.
 
 ## Replay Algorithm
 


### PR DESCRIPTION
Updates TIP-1077 to derive the time-wheel probe path and fingerprint directly from the sender-scoped replay hash, and to store replay cells in a reserved direct slot range instead of a Solidity-style mapping. This removes steady-state keccaks after `H` while preserving the bounded wheel, probe behavior, and hardfork migration dual-check.

Validation: `git diff --check`.