### PR TITLE
fix: include repo in scheduled bench stale alert

### DIFF
--- a/.github/workflows/bench-replay-scheduled.yml
+++ b/.github/workflows/bench-replay-scheduled.yml
@@ -175,6 +175,7 @@ jobs:
                   type: 'mrkdwn',
                   text: [
                     '*Scheduled replay benchmark did not run* because the latest nightly Docker build is stale.',
+                    `*Repo:* <https://github.com/${repo}|Tempo>`,
                     '',
                     `The latest nightly image was built from a commit that is *${ageHours}h old* (threshold: 24h).`,
                     `Stale commit: \`${shortSha}\` (built at ${created})`,


### PR DESCRIPTION
Adds the Tempo repo field to the scheduled replay stale-nightly Slack alert. Scheduled benchmark result notifications already use the shared on-demand template with `Repo`.

Prompted by: @shekhirin