### PR TITLE
ci: restore Foundry master checkout

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: alexey/revm-41-tempo
+          ref: master
           path: foundry
           persist-credentials: false
 
@@ -261,7 +261,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: alexey/revm-41-tempo
+          ref: master
           path: foundry
           persist-credentials: false
 


### PR DESCRIPTION
Restores the specs workflow Foundry checkout back to `master` after the temporary revm bump branch was merged.

Prompted by: @shekhirin