### PR TITLE
Fix e2e existing recipient bloat token count

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1030,7 +1030,8 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --platform "tempo"
                 --scenario $scenario
                 --bloat-mib $ctx.bloat
-                --bloat-token-count $ctx.token_count
+                --tip20-token-count $ctx.token_count
+                --bloat-token-count ($TIP20_TOKEN_IDS | length)
                 --victoriametrics-url $ctx.victoriametrics_url
                 --clickhouse-url $phase_clickhouse_url
                 --skip-funding=($ctx.bloat > 0))

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -265,6 +265,7 @@ def txgen-run-preset-pipeline [
     --victoriametrics-url: string = ""
     --clickhouse-url: string = ""
     --bloat-mib: int = 0
+    --tip20-token-count: int = 0
     --bloat-token-count: int = 4
     --skip-funding                                   # Skip faucet funding (accounts already funded at genesis via state bloat)
 ] {
@@ -274,7 +275,8 @@ def txgen-run-preset-pipeline [
     if not ($spec_path | path exists) {
         error make { msg: $"txgen preset file not found: ($spec_path)" }
     }
-    txgen-configure-tip20-token-env $bloat_token_count
+    let tx_token_count = if $tip20_token_count > 0 { $tip20_token_count } else { $bloat_token_count }
+    txgen-configure-tip20-token-env $tx_token_count
     txgen-configure-existing-recipients-env $spec_path $bloat_mib $bloat_token_count
     if not $skip_funding {
         txgen-fund-accounts $txgen_tempo_bin $spec_path $generate_rpc_url


### PR DESCRIPTION
## Summary
- separate txgen TIP20 token selection from the state-bloat token layout count
- make e2e benches compute existing-recipient ranges from the actual 4-token bloat layout
- keep existing callers backward compatible by defaulting tx token count to bloat token count

Prompted by: @klkvr

## Validation
- `nu --ide-check 0 contrib/bench/txgen/helpers.nu`
- `nu --ide-check 0 bench-e2e.nu`
- `git diff --check`