### PR TITLE
perf(dkg): use incremental Logs::pre_verify as dealer logs arrive

### DIFF
--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -565,6 +565,38 @@ where
         should_skip_round
     }
 
+    fn preverify_dealer_logs<TStorageContext>(
+        &mut self,
+        storage: &mut state::Storage<TStorageContext>,
+        epoch: Epoch,
+    ) where
+        TStorageContext: commonware_runtime::Metrics + Clock + commonware_runtime::Storage,
+    {
+        if let Some(logs) = storage.verification_logs_mut(epoch) {
+            logs.pre_verify::<ed25519::Batch>(&mut self.context, &Sequential);
+        }
+    }
+
+    fn take_or_build_verification_logs<TStorageContext>(
+        &mut self,
+        storage: &mut state::Storage<TStorageContext>,
+        round: &state::Round,
+    ) -> Logs<MinSig, PublicKey, N3f1>
+    where
+        TStorageContext: commonware_runtime::Metrics + Clock + commonware_runtime::Storage,
+    {
+        self.preverify_dealer_logs(storage, round.epoch());
+        if let Some(logs) = storage.take_verification_logs(round.epoch()) {
+            return logs;
+        }
+
+        let mut logs = Logs::<MinSig, PublicKey, N3f1>::new(round.info().clone());
+        for (k, v) in storage.logs_for_epoch(round.epoch()) {
+            logs.record(k.clone(), v.clone());
+        }
+        logs
+    }
+
     /// Handles a finalized block.
     ///
     /// Returns a new [`State`] after finalizing the boundary block of the epoch.
@@ -683,9 +715,16 @@ where
                             Ok((dealer, log)) => (dealer, log),
                         };
                     storage
-                        .append_dealer_log(round.epoch(), dealer.clone(), log)
+                        .append_dealer_log(round.epoch(), dealer.clone(), log.clone())
                         .await
                         .wrap_err("failed to append log to journal")?;
+                    storage.ingest_dealer_log_for_verification(
+                        round.epoch(),
+                        round.info(),
+                        dealer.clone(),
+                        log,
+                    );
+                    self.preverify_dealer_logs(storage, round.epoch());
                     if self.config.me.public_key() == dealer
                         && let Some(dealer_state) = dealer_state
                     {
@@ -721,10 +760,7 @@ where
             debug!("using cached DKG outcome");
             (outcome.clone(), share.clone())
         } else {
-            let mut logs = Logs::<MinSig, PublicKey, N3f1>::new(round.info().clone());
-            for (k, v) in storage.logs_for_epoch(round.epoch()) {
-                logs.record(k.clone(), v.clone());
-            }
+            let logs = self.take_or_build_verification_logs(storage, round);
 
             let player_outcome = if let Some(player) = player_state.take() {
                 info!("we were a player in the ceremony; finalizing share");
@@ -1116,10 +1152,17 @@ where
                 }
             }
 
-            let mut logs = Logs::<MinSig, PublicKey, N3f1>::new(round.info().clone());
-            for (k, v) in raw_logs {
-                logs.record(k, v);
-            }
+            storage.merge_logs_for_verification(round.epoch(), round.info(), &raw_logs);
+            self.preverify_dealer_logs(storage, round.epoch());
+            let logs = storage
+                .take_verification_logs(round.epoch())
+                .unwrap_or_else(|| {
+                    let mut logs = Logs::<MinSig, PublicKey, N3f1>::new(round.info().clone());
+                    for (k, v) in raw_logs {
+                        logs.record(k, v);
+                    }
+                    logs
+                });
 
             // Create a player-state ad hoc: the DKG player object is not
             // cloneable, and finalizing consumes it.

--- a/crates/consensus/src/dkg/manager/actor/state.rs
+++ b/crates/consensus/src/dkg/manager/actor/state.rs
@@ -12,7 +12,7 @@ use commonware_consensus::{
 use commonware_cryptography::{
     Signer as _,
     bls12381::{
-        dkg::{self, DealerPrivMsg, DealerPubMsg, Info, Output, PlayerAck, SignedDealerLog},
+        dkg::{self, DealerPrivMsg, DealerPubMsg, Info, Logs, Output, PlayerAck, SignedDealerLog},
         primitives::{
             group::Share,
             sharing::{Mode, ModeVersion},
@@ -252,6 +252,70 @@ where
         let cache = self.cache.entry(epoch).or_default();
         cache.logs.insert(dealer, log);
         Ok(())
+    }
+
+    /// Records a dealer log in the epoch's incremental verification set.
+    ///
+    /// On the first log for an epoch, replays all cached logs into a new [`Logs`]
+    /// instance. Subsequent calls only record the newly arrived log.
+    pub(super) fn ingest_dealer_log_for_verification(
+        &mut self,
+        epoch: Epoch,
+        info: &Info<MinSig, PublicKey>,
+        dealer: PublicKey,
+        log: dkg::DealerLog<MinSig, PublicKey>,
+    ) {
+        let events = self.cache.entry(epoch).or_default();
+        if let Some(verification_logs) = events.verification_logs.as_mut() {
+            verification_logs.record(dealer, log);
+            return;
+        }
+
+        let mut verification_logs = Logs::new(info.clone());
+        for (cached_dealer, cached_log) in &events.logs {
+            verification_logs.record(cached_dealer.clone(), cached_log.clone());
+        }
+        events.verification_logs = Some(verification_logs);
+    }
+
+    /// Merges the given dealer logs into the epoch's incremental verification set.
+    pub(super) fn merge_logs_for_verification(
+        &mut self,
+        epoch: Epoch,
+        info: &Info<MinSig, PublicKey>,
+        logs: &BTreeMap<PublicKey, dkg::DealerLog<MinSig, PublicKey>>,
+    ) {
+        let events = self.cache.entry(epoch).or_default();
+        if let Some(verification_logs) = events.verification_logs.as_mut() {
+            for (dealer, log) in logs {
+                verification_logs.record(dealer.clone(), log.clone());
+            }
+            return;
+        }
+
+        let mut verification_logs = Logs::new(info.clone());
+        for (dealer, log) in logs {
+            verification_logs.record(dealer.clone(), log.clone());
+        }
+        events.verification_logs = Some(verification_logs);
+    }
+
+    pub(super) fn verification_logs_mut(
+        &mut self,
+        epoch: Epoch,
+    ) -> Option<&mut Logs<MinSig, PublicKey, N3f1>> {
+        self.cache
+            .get_mut(&epoch)
+            .and_then(|events| events.verification_logs.as_mut())
+    }
+
+    pub(super) fn take_verification_logs(
+        &mut self,
+        epoch: Epoch,
+    ) -> Option<Logs<MinSig, PublicKey, N3f1>> {
+        self.cache
+            .get_mut(&epoch)
+            .and_then(|events| events.verification_logs.take())
     }
 
     /// Appends the height, digest, and parent of the finalized block to the journal.
@@ -737,15 +801,30 @@ pub(super) struct FinalizedBlockInfo {
 }
 
 /// A cache of all events that transpired during a given epoch.
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct Events {
     acks: BTreeMap<PublicKey, PlayerAck<PublicKey>>,
     dealings: BTreeMap<PublicKey, (DealerPubMsg<MinSig>, DealerPrivMsg)>,
     logs: BTreeMap<PublicKey, dkg::DealerLog<MinSig, PublicKey>>,
+    /// Incrementally verified dealer logs for the epoch (see issue #3556).
+    verification_logs: Option<Logs<MinSig, PublicKey, N3f1>>,
     finalized: BTreeMap<Height, FinalizedBlockInfo>,
 
     notarized_blocks: HashMap<Digest, ReducedBlock>,
     dkg_outcomes: HashMap<Digest, (Output<MinSig, PublicKey>, ShareState)>,
+}
+
+impl std::fmt::Debug for Events {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Events")
+            .field("acks", &self.acks)
+            .field("dealings", &self.dealings)
+            .field("logs", &self.logs)
+            .field("finalized", &self.finalized)
+            .field("notarized_blocks", &self.notarized_blocks)
+            .field("dkg_outcomes", &self.dkg_outcomes)
+            .finish()
+    }
 }
 
 impl Events {


### PR DESCRIPTION
Closes #3556

Records dealer logs into an incremental `Logs` instance as each finalized
block arrives and calls `pre_verify` per batch, instead of rebuilding and
verifying everything at the epoch boundary.

Signature verification cost is spread across the epoch, which matters as
the validator set grows.