### PR TITLE
feat(tempo): add programmatic node overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13490,6 +13490,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempo-programmatic-node"
+version = "1.8.2"
+dependencies = [
+ "tempo",
+]
+
+[[package]]
 name = "tempo-revm"
 version = "1.8.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
   "crates/telemetry-util",
   "crates/transaction-pool",
   "crates/revm",
+  "examples/programmatic-node",
   "xtask",
 ]
 

--- a/bin/tempo/src/cli.rs
+++ b/bin/tempo/src/cli.rs
@@ -7,13 +7,13 @@ use tempo_chainspec::spec::TempoChainSpecParser;
 use tempo_faucet::args::FaucetArgs;
 use tempo_node::TempoNodeArgs;
 
-pub(crate) type TempoCli =
+pub type TempoCli =
     Cli<TempoChainSpecParser, TempoArgs, TempoRpcModuleValidator, tempo_cmd::TempoSubcommand>;
 
 pub(crate) const TEMPO_CUSTOM_RPC_MODULES: &[&str] = &["consensus", "operator", "tempo", "token"];
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct TempoRpcModuleValidator;
+pub struct TempoRpcModuleValidator;
 
 impl RpcModuleValidator for TempoRpcModuleValidator {
     fn parse_selection(s: &str) -> Result<RpcModuleSelection, String> {
@@ -39,7 +39,7 @@ impl RpcModuleValidator for TempoRpcModuleValidator {
 
 // TODO: migrate this to tempo_node eventually.
 #[derive(Debug, Clone, clap::Args)]
-pub(crate) struct TempoArgs {
+pub struct TempoArgs {
     /// Run in follow mode from an upstream node.
     /// If provided without a value, defaults to the RPC URL for the selected chain.
     #[arg(long, value_name = "WEBSOCKET_URL", default_missing_value = "auto", num_args(0..=1), env = "TEMPO_FOLLOW")]
@@ -89,14 +89,14 @@ pub(crate) struct TempoArgs {
 }
 
 impl TempoArgs {
-    pub(crate) fn is_following_uncertified(&self) -> bool {
+    pub fn is_following_uncertified(&self) -> bool {
         self.follow.is_some() && !self.follow_certify
     }
 
     /// Whether the consensus engine should be active.
     ///
     /// The engine runs when not in dev mode and not following uncertified.
-    pub(crate) fn has_consensus_engine(&self, dev: bool) -> bool {
+    pub fn has_consensus_engine(&self, dev: bool) -> bool {
         !dev && !self.is_following_uncertified()
     }
 }

--- a/bin/tempo/src/init_state.rs
+++ b/bin/tempo/src/init_state.rs
@@ -58,8 +58,7 @@ const HASH_WORKER_QUEUE_DEPTH: usize = 256;
 
 /// Initialize state from a binary dump file.
 #[derive(Debug, Parser)]
-pub(crate) struct InitFromBinaryDump<C: reth_cli::chainspec::ChainSpecParser = TempoChainSpecParser>
-{
+pub struct InitFromBinaryDump<C: reth_cli::chainspec::ChainSpecParser = TempoChainSpecParser> {
     #[command(flatten)]
     env: EnvironmentArgs<C>,
 

--- a/bin/tempo/src/lib.rs
+++ b/bin/tempo/src/lib.rs
@@ -25,20 +25,25 @@ use tracy_client as _;
 #[cfg(feature = "otlp")]
 use opentelemetry_otlp as _;
 
-mod cli;
+pub mod cli;
 mod defaults;
 mod follow;
-mod init_state;
-mod p2p_proxy;
-mod regenesis;
+pub mod init_state;
+mod overrides;
+pub mod p2p_proxy;
+pub mod regenesis;
 mod snapshot_download;
 mod snapshot_manifest;
-mod tempo_cmd;
+pub mod tempo_cmd;
 mod utils;
 
-#[cfg(test)]
-pub(crate) use crate::cli::TempoRpcModuleValidator;
-pub(crate) use crate::cli::{TempoArgs, TempoCli};
+pub use crate::{
+    cli::{TempoArgs, TempoCli, TempoRpcModuleValidator},
+    overrides::{TempoNodeMapper, TempoOverrides},
+};
+pub use reth_cli_util as cli_util;
+pub use tempo_node;
+pub use tempo_node as node;
 
 use crate::utils::{
     block_on_consensus_public_key, fetch_bootnodes, install_crypto_provider,
@@ -59,9 +64,14 @@ use tempo_chainspec::spec::TempoChainSpec;
 use tempo_consensus::{feed as consensus_feed, run_consensus_stack, run_follow_stack};
 use tempo_evm::{TempoEvmConfig, consensus::TempoConsensus};
 use tempo_faucet::faucet::{TempoFaucetExt, TempoFaucetExtApiServer};
+pub use tempo_node::{
+    AccountInfoReader, InvalidPoolTransactionError, PoolTransaction, PoolTransactionError,
+    StatefulValidationFn, StatelessValidationFn, TempoNode, TempoNodeArgs,
+    TempoPayloadBuilderBuilder, TempoPoolBuilder, TempoPoolTransactionError,
+    TempoPooledTransaction, TransactionOrigin,
+};
 use tempo_node::{
     TempoFullNode,
-    node::TempoNode,
     rpc::consensus::{TempoConsensusApiServer, TempoConsensusRpc},
     telemetry::{PrometheusMetricsConfig, install_prometheus_metrics},
 };
@@ -81,6 +91,20 @@ fn apply_tempo_cli_overrides(cli: &mut TempoCli) {
 
 /// Runs the Tempo node CLI.
 pub fn tempo_main() -> eyre::Result<()> {
+    tempo_main_with(TempoOverrides::default())
+}
+
+/// Runs the Tempo node CLI with programmatic startup overrides.
+///
+/// This is the embedding entrypoint for binaries that want the standard Tempo
+/// CLI behavior plus programmatic hooks for behavior that cannot be expressed
+/// through command-line arguments. [`tempo_main`] is equivalent to calling this
+/// function with [`TempoOverrides::default`].
+///
+/// Overrides are applied after CLI parsing and before the execution node is
+/// launched. See [`TempoOverrides`] for the currently supported hooks and an
+/// example that injects additional transaction pool validation.
+pub fn tempo_main_with(mut overrides: TempoOverrides) -> eyre::Result<()> {
     install_crypto_provider();
 
     reth_cli_util::sigsegv_handler::install();
@@ -400,7 +424,10 @@ pub fn tempo_main() -> eyre::Result<()> {
             node,
             node_exit_future,
         } = builder
-            .node(TempoNode::new(&args.node_args, validator_key))
+            .node(overrides.apply_tempo_node(TempoNode::new(
+                &args.node_args,
+                validator_key,
+            )))
             .apply(|mut builder: WithLaunchContext<_>| {
                 // Enable discv5 peer discovery
                 builder

--- a/bin/tempo/src/overrides.rs
+++ b/bin/tempo/src/overrides.rs
@@ -1,0 +1,129 @@
+use tempo_node::TempoNode;
+
+/// Function used to modify the [`TempoNode`] before launch.
+pub type TempoNodeMapper = dyn FnOnce(TempoNode) -> TempoNode + Send + 'static;
+
+/// Optional programmatic overrides for [`tempo_main_with`](crate::tempo_main_with).
+///
+/// These hooks are applied during startup after CLI arguments have been parsed.
+/// Empty overrides are a no-op, so embedding binaries can start from
+/// [`TempoOverrides::default`] or [`TempoOverrides::new`] and opt into only the
+/// hooks they need.
+///
+/// The initial one-shot hook surface maps the [`TempoNode`] produced from CLI arguments
+/// before it is passed to Reth's node launcher. This is useful for settings that
+/// are intentionally not exposed as CLI flags, such as additional transaction
+/// pool validation.
+///
+/// # Example
+///
+/// This rejects externally sourced transactions whose encoded size exceeds a
+/// local policy limit while preserving the rest of the CLI-derived node
+/// configuration.
+///
+/// ```no_run
+/// use tempo::{
+///     InvalidPoolTransactionError, PoolTransaction, TempoOverrides, tempo_main_with,
+/// };
+///
+/// fn main() -> eyre::Result<()> {
+///     const MAX_EXTERNAL_TX_ENCODED_LEN: usize = 128 * 1024;
+///
+///     let overrides = TempoOverrides::new().map_tempo_node(|node| {
+///         node.map_pool_builder(|pool| {
+///             pool.with_additional_stateless_validation(|origin, tx| {
+///                 let size = tx.encoded_length();
+///                 if origin.is_external() && size > MAX_EXTERNAL_TX_ENCODED_LEN {
+///                     return Err(InvalidPoolTransactionError::OversizedData {
+///                         size,
+///                         limit: MAX_EXTERNAL_TX_ENCODED_LEN,
+///                     });
+///                 }
+///
+///                 Ok(())
+///             })
+///         })
+///     });
+///
+///     tempo_main_with(overrides)
+/// }
+/// ```
+#[derive(Default)]
+pub struct TempoOverrides {
+    pub(crate) tempo_node_mapper: Option<Box<TempoNodeMapper>>,
+}
+
+impl TempoOverrides {
+    /// Creates empty overrides.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a mapper for the [`TempoNode`] built from CLI arguments.
+    ///
+    /// Multiple mappers are applied in the order they were added.
+    pub fn map_tempo_node<F>(mut self, mapper: F) -> Self
+    where
+        F: FnOnce(TempoNode) -> TempoNode + Send + 'static,
+    {
+        self.tempo_node_mapper = Some(match self.tempo_node_mapper.take() {
+            Some(previous) => Box::new(move |node| mapper(previous(node))),
+            None => Box::new(mapper),
+        });
+        self
+    }
+
+    pub(crate) fn apply_tempo_node(&mut self, node: TempoNode) -> TempoNode {
+        match self.tempo_node_mapper.take() {
+            Some(mapper) => mapper(node),
+            None => node,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    use super::TempoOverrides;
+    use tempo_node::TempoNode;
+
+    #[test]
+    fn maps_tempo_node() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+
+        let mut overrides = TempoOverrides::new().map_tempo_node(move |node| {
+            called_clone.store(true, Ordering::Relaxed);
+            node
+        });
+
+        let _ = overrides.apply_tempo_node(TempoNode::default());
+
+        assert!(called.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn applies_tempo_node_mappers_in_order() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let first = calls.clone();
+        let second = calls.clone();
+
+        let mut overrides = TempoOverrides::new()
+            .map_tempo_node(move |node| {
+                first.lock().unwrap().push(1);
+                node
+            })
+            .map_tempo_node(move |node| {
+                second.lock().unwrap().push(2);
+                node
+            });
+
+        let _ = overrides.apply_tempo_node(TempoNode::default());
+
+        assert_eq!(*calls.lock().unwrap(), vec![1, 2]);
+    }
+}

--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -54,7 +54,7 @@ const SOFT_BODY_RESPONSE_SIZE_LIMIT: usize = 1024 * 1024; // 1 MiB
 #[command(
     about = "Run a proxy P2P node that serves cached block data fetched from an RPC endpoint"
 )]
-pub(crate) struct P2pProxyArgs {
+pub struct P2pProxyArgs {
     /// RPC endpoint to fetch blocks from (HTTP or WebSocket).
     #[arg(long, required = true)]
     rpc_url: String,

--- a/bin/tempo/src/regenesis.rs
+++ b/bin/tempo/src/regenesis.rs
@@ -28,7 +28,7 @@ use tracing::info;
 
 /// Patch a block-0 database to use a new genesis header.
 #[derive(Debug, Parser)]
-pub(crate) struct Regenesis<C: reth_cli::chainspec::ChainSpecParser = TempoChainSpecParser> {
+pub struct Regenesis<C: reth_cli::chainspec::ChainSpecParser = TempoChainSpecParser> {
     #[command(flatten)]
     env: EnvironmentArgs<C>,
 }

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -55,14 +55,14 @@ fn get_env(key: &str) -> eyre::Result<String> {
 /// the actual implementation lives in `tempo_ext::run()`. We capture all
 /// trailing arguments and re-dispatch.
 #[derive(Debug, clap::Args)]
-pub(crate) struct ExtArgs {
+pub struct ExtArgs {
     #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
     args: Vec<String>,
 }
 
 /// Tempo-specific subcommands that extend the reth CLI.
 #[derive(Debug, Subcommand)]
-pub(crate) enum TempoSubcommand {
+pub enum TempoSubcommand {
     /// Consensus-related commands.
     #[command(subcommand)]
     Consensus(ConsensusSubcommand),
@@ -139,7 +139,7 @@ impl ExtendedCommand for TempoSubcommand {
 }
 
 #[derive(Debug, Subcommand)]
-pub(crate) enum ConsensusSubcommand {
+pub enum ConsensusSubcommand {
     /// Add a new validator to the validator config contract.
     AddValidator(AddValidator),
     /// Shows the verification key for an ed25519 signing key.
@@ -260,7 +260,7 @@ async fn read_validator_from_contract(
 
 /// Shared validator identity arguments used across add/rotate/sign commands.
 #[derive(Debug, clap::Args)]
-pub(crate) struct ValidatorIdentityArgs {
+pub struct ValidatorIdentityArgs {
     /// The validator's Ethereum address
     #[arg(long, value_name = "ETHEREUM_ADDRESS")]
     validator_address: Address,
@@ -293,7 +293,7 @@ impl ValidatorIdentityArgs {
 /// Either a pre-computed signature or a signing key to compute it from.
 #[derive(Debug, clap::Args)]
 #[group(required = true, multiple = false, args = ["signature", "signing_key"])]
-pub(crate) struct ValidatorSignatureArgs {
+pub struct ValidatorSignatureArgs {
     /// A pre-computed ed25519 signature over the validator identity.
     #[arg(long, value_name = "SIGNATURE")]
     signature: Option<Bytes>,
@@ -323,7 +323,7 @@ impl ValidatorSignatureArgs {
 }
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct SigningKeyArgs {
+pub struct SigningKeyArgs {
     /// Passphrase source for decrypting `--signing-key`.
     ///
     /// A FIFO path, including shell process substitution like `<(...)`, is preferred.
@@ -350,7 +350,7 @@ impl SigningKeyArgs {
 }
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct WalletArgs {
+pub struct WalletArgs {
     /// Path to the file holding the validator's Ethereum private key.
     #[arg(long, value_name = "FILE", help_heading = "Wallet options - raw")]
     wallet_key: Option<PathBuf>,
@@ -435,7 +435,7 @@ impl WalletArgs {
 
 /// Shared arguments for commands that update the validator config contract.
 #[derive(Debug, clap::Args)]
-pub(crate) struct ValidatorTransactionArgs {
+pub struct ValidatorTransactionArgs {
     #[command(flatten)]
     wallet: WalletArgs,
 
@@ -517,7 +517,7 @@ impl ValidatorTransactionArgs {
 }
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct AddValidator {
+pub struct AddValidator {
     #[command(flatten)]
     identity: ValidatorIdentityArgs,
     #[command(flatten)]
@@ -565,7 +565,7 @@ impl AddValidator {
 }
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct TransferValidatorOwnership {
+pub struct TransferValidatorOwnership {
     /// Validator ethereum address, ed25519 public key, or index
     #[arg()]
     id: ValidatorId,
@@ -603,7 +603,7 @@ impl TransferValidatorOwnership {
 }
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct RotateValidator {
+pub struct RotateValidator {
     #[command(flatten)]
     identity: ValidatorIdentityArgs,
     #[command(flatten)]
@@ -649,7 +649,7 @@ impl RotateValidator {
 
 #[derive(Debug, clap::Args)]
 #[group(required = true, args = ["signing_key"])]
-pub(crate) struct CreateAddValidatorSignatureArgs {
+pub struct CreateAddValidatorSignatureArgs {
     #[command(flatten)]
     identity: ValidatorIdentityArgs,
     /// The fee recipient address
@@ -693,7 +693,7 @@ impl CreateAddValidatorSignatureArgs {
 
 #[derive(Debug, clap::Args)]
 #[group(required = true, args = ["signing_key"])]
-pub(crate) struct CreateRotateValidatorSignatureArgs {
+pub struct CreateRotateValidatorSignatureArgs {
     #[command(flatten)]
     identity: ValidatorIdentityArgs,
     /// RPC used to fetch the chain id
@@ -733,7 +733,7 @@ impl CreateRotateValidatorSignatureArgs {
 }
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct SetValidatorIpAddress {
+pub struct SetValidatorIpAddress {
     /// Validator ethereum address, ed25519 public key, or index
     #[arg()]
     id: ValidatorId,
@@ -770,7 +770,7 @@ impl SetValidatorIpAddress {
 }
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct DeactivateValidator {
+pub struct DeactivateValidator {
     /// Validator ethereum address, ed25519 public key, or index
     #[arg()]
     id: ValidatorId,
@@ -795,7 +795,7 @@ impl DeactivateValidator {
 }
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct SetValidatorFeeRecipient {
+pub struct SetValidatorFeeRecipient {
     /// Validator ethereum address, ed25519 public key, or index
     #[arg()]
     id: ValidatorId,
@@ -823,7 +823,7 @@ impl SetValidatorFeeRecipient {
 }
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct GenerateSigningKey {
+pub struct GenerateSigningKey {
     /// Destination of the generated signing key.
     #[arg(long, short, value_name = "FILE")]
     output: PathBuf,
@@ -940,7 +940,7 @@ fn read_signing_key<P1: AsRef<Path>, P2: AsRef<Path>>(
 }
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct EncryptSigningKey {
+pub struct EncryptSigningKey {
     /// Existing plaintext ed25519 signing key file.
     #[arg(long, short, value_name = "FILE")]
     input: PathBuf,
@@ -1005,7 +1005,7 @@ impl EncryptSigningKey {
 }
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct ShowVerificationKey {
+pub struct ShowVerificationKey {
     /// Signing key to show the verification key for.
     #[arg(long, short, value_name = "FILE")]
     private_key: PathBuf,
@@ -1033,7 +1033,7 @@ impl ShowVerificationKey {
 }
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct ValidatorInfo {
+pub struct ValidatorInfo {
     /// Validator ethereum address, ed25519 public key, or index
     #[arg()]
     id: ValidatorId,
@@ -1200,7 +1200,7 @@ struct InfoOutput {
 }
 
 #[derive(Debug, clap::Args)]
-pub(crate) struct Info {
+pub struct Info {
     /// RPC URL to query. Defaults to <https://rpc.presto.tempo.xyz>
     #[arg(long, default_value = "https://rpc.presto.tempo.xyz")]
     rpc_url: String,

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -6,11 +6,19 @@
 pub use tempo_payload_types::{TempoExecutionData, TempoPayloadTypes};
 pub use version::{init_version_metadata, version_metadata};
 
-use crate::node::{TempoAddOns, TempoNode};
-pub use crate::node::{TempoNodeArgs, TempoPoolBuilder};
+use crate::node::TempoAddOns;
+pub use crate::node::{TempoNode, TempoNodeArgs, TempoPayloadBuilderBuilder, TempoPoolBuilder};
 use reth_ethereum::provider::db::DatabaseEnv;
 use reth_node_builder::{FullNode, NodeAdapter, RethFullAdapter};
-pub use tempo_transaction_pool::validator::DEFAULT_AA_VALID_AFTER_MAX_SECS;
+pub use reth_storage_api::AccountInfoReader;
+pub use reth_transaction_pool::{
+    PoolTransaction, StatefulValidationFn, StatelessValidationFn, TransactionOrigin,
+    error::{InvalidPoolTransactionError, PoolTransactionError},
+};
+pub use tempo_transaction_pool::{
+    transaction::{TempoPoolTransactionError, TempoPooledTransaction},
+    validator::DEFAULT_AA_VALID_AFTER_MAX_SECS,
+};
 
 pub mod engine;
 pub mod node;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -188,6 +188,39 @@ impl TempoNode {
         ProviderFactoryBuilder::default()
     }
 
+    /// Sets the transaction pool builder.
+    pub fn with_pool_builder(mut self, pool_builder: TempoPoolBuilder) -> Self {
+        self.pool_builder = pool_builder;
+        self
+    }
+
+    /// Maps the transaction pool builder.
+    pub fn map_pool_builder<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(TempoPoolBuilder) -> TempoPoolBuilder,
+    {
+        self.pool_builder = f(self.pool_builder);
+        self
+    }
+
+    /// Sets the payload builder builder.
+    pub fn with_payload_builder_builder(
+        mut self,
+        payload_builder_builder: TempoPayloadBuilderBuilder,
+    ) -> Self {
+        self.payload_builder_builder = payload_builder_builder;
+        self
+    }
+
+    /// Maps the payload builder builder.
+    pub fn map_payload_builder_builder<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(TempoPayloadBuilderBuilder) -> TempoPayloadBuilderBuilder,
+    {
+        self.payload_builder_builder = f(self.payload_builder_builder);
+        self
+    }
+
     /// Sets the validator key for filtering subblock transactions.
     pub fn with_validator_key(mut self, validator_key: Option<B256>) -> Self {
         self.validator_key = validator_key;
@@ -477,7 +510,14 @@ impl TempoPoolBuilder {
     /// Sets an additional stateless validation check applied at the end of the inner ETH
     /// validator's stateless validation.
     ///
-    /// See [`EthTransactionValidator::set_additional_stateless_validation`](reth_transaction_pool::EthTransactionValidator::set_additional_stateless_validation).
+    /// This is the programmatic equivalent of installing a custom check with
+    /// [`EthTransactionValidator::set_additional_stateless_validation`](reth_transaction_pool::EthTransactionValidator::set_additional_stateless_validation).
+    /// It is intended to be used from a [`TempoNode`] mapper, for example via
+    /// `tempo::TempoOverrides::map_tempo_node`, when the validation policy should not be exposed
+    /// as a CLI argument.
+    ///
+    /// The closure receives the transaction origin and pooled transaction. Return `Ok(())` to
+    /// accept the transaction or [`InvalidPoolTransactionError`] to reject it.
     pub fn with_additional_stateless_validation<F>(mut self, f: F) -> Self
     where
         F: Fn(
@@ -693,5 +733,61 @@ where
                 build_time_multiplier: self.build_time_multiplier,
             },
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TempoNode, TempoNodeArgs, TempoPayloadBuilderBuilder, TempoPoolBuilder};
+
+    #[test]
+    fn tempo_node_maps_pool_builder() {
+        let node = TempoNode::new(
+            &TempoNodeArgs {
+                aa_valid_after_max_secs: 12,
+                ..Default::default()
+            },
+            None,
+        )
+        .map_pool_builder(|pool| pool.with_max_tempo_authorizations(7));
+
+        assert_eq!(node.pool_builder.aa_valid_after_max_secs, 12);
+        assert_eq!(node.pool_builder.max_tempo_authorizations, 7);
+    }
+
+    #[test]
+    fn tempo_node_sets_pool_builder() {
+        let node = TempoNode::default().with_pool_builder(TempoPoolBuilder {
+            aa_valid_after_max_secs: 42,
+            ..Default::default()
+        });
+
+        assert_eq!(node.pool_builder.aa_valid_after_max_secs, 42);
+    }
+
+    #[test]
+    fn tempo_node_maps_payload_builder_builder() {
+        let node = TempoNode::new(&TempoNodeArgs::default(), None).map_payload_builder_builder(
+            |mut payload| {
+                payload.state_provider_metrics = true;
+                payload
+            },
+        );
+
+        assert!(node.payload_builder_builder.state_provider_metrics);
+        assert_eq!(
+            node.payload_builder_builder.build_time_multiplier,
+            TempoNodeArgs::default().builder_build_time_multiplier
+        );
+    }
+
+    #[test]
+    fn tempo_node_sets_payload_builder_builder() {
+        let node = TempoNode::default().with_payload_builder_builder(TempoPayloadBuilderBuilder {
+            state_provider_metrics: true,
+            ..Default::default()
+        });
+
+        assert!(node.payload_builder_builder.state_provider_metrics);
     }
 }

--- a/examples/programmatic-node/Cargo.toml
+++ b/examples/programmatic-node/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "tempo-programmatic-node"
+description = "Template for embedding the Tempo node launcher with programmatic overrides"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+tempo = { path = "../../bin/tempo" }
+# tempo = { git = "https://github.com/tempoxyz/tempo" }

--- a/examples/programmatic-node/src/main.rs
+++ b/examples/programmatic-node/src/main.rs
@@ -1,0 +1,82 @@
+//! Template binary for launching Tempo with programmatic overrides.
+
+use tempo::{
+    InvalidPoolTransactionError, PoolTransaction, PoolTransactionError, TempoOverrides,
+    tempo_main_with,
+};
+
+#[global_allocator]
+static ALLOC: tempo::cli_util::allocator::Allocator = tempo::cli_util::allocator::new_allocator();
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    const MAX_EXTERNAL_TX_ENCODED_LEN: usize = 128 * 1024;
+
+    let overrides = TempoOverrides::new().map_tempo_node(|node| {
+        // Modify the node's transaction pool validation before the CLI launches Tempo.
+        node.map_pool_builder(|pool| {
+            // Reject externally sourced transactions whose encoded size exceeds a local limit.
+            pool.with_additional_stateless_validation(|origin, tx| {
+                let size = tx.encoded_length();
+                if origin.is_external() && size > MAX_EXTERNAL_TX_ENCODED_LEN {
+                    return Err(InvalidPoolTransactionError::OversizedData {
+                        size,
+                        limit: MAX_EXTERNAL_TX_ENCODED_LEN,
+                    });
+                }
+
+                Ok(())
+            })
+            // Reject transactions whose sender state resolves to a zero-balance account.
+            .with_additional_stateful_validation(|_origin, tx, state| {
+                let account = match state.basic_account(tx.sender_ref()) {
+                    Ok(account) => account.unwrap_or_default(),
+                    Err(_err) => {
+                        return Err(InvalidPoolTransactionError::other(
+                            ProgrammaticPoolError::SenderStateUnavailable,
+                        ));
+                    }
+                };
+
+                if account.balance.is_zero() {
+                    return Err(InvalidPoolTransactionError::other(
+                        ProgrammaticPoolError::ZeroBalanceSender,
+                    ));
+                }
+
+                Ok(())
+            })
+        })
+    });
+
+    tempo_main_with(overrides)?;
+    Ok(())
+}
+
+/// Custom pool rejection reasons returned by this programmatic validation layer.
+#[derive(Debug)]
+enum ProgrammaticPoolError {
+    SenderStateUnavailable,
+    ZeroBalanceSender,
+}
+
+impl std::fmt::Display for ProgrammaticPoolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SenderStateUnavailable => f.write_str("failed to read sender account state"),
+            Self::ZeroBalanceSender => f.write_str("sender account has zero balance"),
+        }
+    }
+}
+
+impl std::error::Error for ProgrammaticPoolError {}
+
+impl PoolTransactionError for ProgrammaticPoolError {
+    fn is_bad_transaction(&self) -> bool {
+        // These are local policy rejections, not malformed peer data that should be penalized.
+        false
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}


### PR DESCRIPTION
Adds `TempoOverrides` and `tempo_main_with` so embedding binaries can adjust Tempo node setup before launch without adding CLI flags.

Exposes the needed node and pool validation types from `tempo`, adds mapper helpers on `TempoNode`, and includes a `examples/programmatic-node` template showing stateless and stateful transaction-pool validation with a custom `PoolTransactionError`.