### PR TITLE
fix(bench): tag e2e ClickHouse rows by preset

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -391,7 +391,7 @@ jobs:
       BENCH_FEATURE_ENV: ${{ inputs.feature-env }}
       BENCH_RUN_PAIRS: ${{ inputs.run-pairs || '3' }}
       BENCH_CLICKHOUSE_RUN: ${{ inputs.clickhouse-run || 'feature-1' }}
-      BENCHMARK_ID: bench-e2e-${{ github.run_id }}
+      BENCHMARK_ID: bench-e2e-${{ github.run_id }}-${{ inputs.preset }}
       BENCH_COMMENT_ID: ${{ inputs.comment-id }}
       BENCH_PR_HEAD_SHA: ${{ inputs.pr-head-sha }}
       BENCH_PR_HEAD_REF: ${{ inputs.pr-head-ref }}

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -275,6 +275,7 @@ def txgen-run-preset-pipeline [
     if not ($spec_path | path exists) {
         error make { msg: $"txgen preset file not found: ($spec_path)" }
     }
+    let benchmark_kind = ($spec_path | path basename | str replace --regex '\.yml$' '')
     let tx_token_count = if $tip20_token_count > 0 { $tip20_token_count } else { $bloat_token_count }
     txgen-configure-tip20-token-env $tx_token_count
     txgen-configure-existing-recipients-env $spec_path $bloat_mib $bloat_token_count
@@ -326,6 +327,7 @@ def txgen-run-preset-pipeline [
         "-m" $"git-ref=($git_ref_label)"
         "-m" $"build_profile=($build_profile)"
         "-m" $"mode=($benchmark_mode)"
+        "-m" $"benchmark_kind=($benchmark_kind)"
     ]
         | append (if $benchmark_id != "" { ["-m" $"benchmark_id=($benchmark_id)"] } else { [] })
         | append (if $benchmark_run != "" { ["-m" $"benchmark_run=($benchmark_run)"] } else { [] })


### PR DESCRIPTION
## Summary
- Include the txgen preset in the e2e `BENCHMARK_ID` so scheduled matrix jobs write distinct ClickHouse benchmark IDs.
- Add `benchmark_kind` metadata derived from the preset filename for ClickHouse consumers and Centaur alerts.

## Why
The scheduled e2e workflow now runs multiple presets (`tip20` and `tip20_existing_recipients`). Without preset-specific labels, both jobs share the same benchmark id and downstream alerts cannot reliably render per-preset rows.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/bench-e2e.yml"); puts "yaml ok"'`
- `nu -n -c 'source contrib/bench/txgen/helpers.nu; print ok'`
- `nu --ide-check 20 contrib/bench/txgen/helpers.nu` (type hints only)
- `git diff --check`