### PR TITLE
chore: bump reth for reserved engine cores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8670,7 +8670,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8697,7 +8697,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8730,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8750,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8763,7 +8763,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8846,7 +8846,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8856,7 +8856,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8909,7 +8909,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -8939,7 +8939,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8952,7 +8952,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9006,7 +9006,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9032,7 +9032,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9102,7 +9102,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9126,7 +9126,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9150,7 +9150,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9185,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9242,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9270,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9293,7 +9293,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9318,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9407,7 +9407,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9423,7 +9423,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9439,7 +9439,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9472,7 +9472,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9500,7 +9500,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9522,7 +9522,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "clap",
  "eyre",
@@ -9586,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9618,7 +9618,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9631,7 +9631,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9661,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9685,7 +9685,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -9710,7 +9710,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9730,7 +9730,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9761,7 +9761,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9780,7 +9780,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9818,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9832,7 +9832,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "serde",
  "serde_json",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9870,7 +9870,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "bytes",
  "futures",
@@ -9890,7 +9890,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9907,7 +9907,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "bindgen",
  "cc",
@@ -9916,7 +9916,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "futures",
  "metrics",
@@ -9929,7 +9929,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9938,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9952,7 +9952,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10010,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10035,7 +10035,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -10059,7 +10059,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10074,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10088,7 +10088,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10105,7 +10105,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10129,7 +10129,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10197,7 +10197,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10252,7 +10252,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10299,7 +10299,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10323,7 +10323,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10347,7 +10347,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "bytes",
  "eyre",
@@ -10376,7 +10376,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10388,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10424,7 +10424,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10447,7 +10447,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10490,7 +10490,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -10539,7 +10539,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10567,7 +10567,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10583,7 +10583,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10598,7 +10598,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10676,7 +10676,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10706,7 +10706,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10749,7 +10749,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10769,7 +10769,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10800,7 +10800,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10847,7 +10847,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10898,7 +10898,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10912,7 +10912,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10943,7 +10943,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10994,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11022,7 +11022,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11036,7 +11036,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11071,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -11097,7 +11097,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11115,7 +11115,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11136,7 +11136,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11152,7 +11152,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11162,7 +11162,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "clap",
  "eyre",
@@ -11182,7 +11182,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11201,7 +11201,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11246,7 +11246,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11272,7 +11272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11300,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11320,7 +11320,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "alloy-evm",
@@ -11349,7 +11349,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=472ecbb8c6ad213220079b70af63f190a8f32f9d#472ecbb8c6ad213220079b70af63f190a8f32f9d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31#d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,66 +145,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
 reth-codecs = { version = "0.5.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
 reth-primitives-traits = { version = "0.5.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "472ecbb8c6ad213220079b70af63f190a8f32f9d", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "d6b8de5a55d9c43346490ee0fbcc46e0c0c48a31", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
## Summary
- Bump all pinned reth git dependencies to the compatible reth commit with reserved-core thread affinity support.
- This pulls in pinning for engine/payload-builder and prewarm/builder-prewarm work onto the two reserved CPUs.

## Verification
- `cargo check -p tempo-payload-builder`

Depends on paradigmxyz/reth#25325

Prompted by: @shekhirin