### PR TITLE
bench: add perf profiling mode

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -238,6 +238,18 @@ on:
         type: string
         required: false
         default: "120"
+      perf:
+        type: string
+        required: false
+        default: "off"
+      perf-seconds:
+        type: string
+        required: false
+        default: "0"
+      perf-offset:
+        type: string
+        required: false
+        default: "0"
       otlp:
         type: string
         required: false
@@ -372,6 +384,9 @@ jobs:
       BENCH_TRACY: ${{ (inputs.profiling == 'Tracy' || inputs.profiling == 'Both') && 'on' || ((inputs.profiling == 'Off' || inputs.profiling == 'Samply') && 'off' || inputs.tracy) }}
       BENCH_TRACY_SECONDS: ${{ inputs.tracy-seconds || '30' }}
       BENCH_TRACY_OFFSET: ${{ inputs.tracy-offset || '120' }}
+      BENCH_PERF: ${{ inputs.perf || 'off' }}
+      BENCH_PERF_SECONDS: ${{ inputs.perf-seconds || '0' }}
+      BENCH_PERF_OFFSET: ${{ inputs.perf-offset || '0' }}
       BENCH_OTLP: ${{ inputs.otlp != false && inputs.otlp != 'false' }}
       BENCH_VALSCOPE: ${{ inputs.valscope == true || inputs.valscope == 'true' }}
       BENCH_FEATURES: ${{ (inputs.otlp != false && inputs.otlp != 'false') && 'jemalloc,asm-keccak,keccak-cache-global,otlp' || 'jemalloc,asm-keccak,keccak-cache-global' }}
@@ -793,6 +808,7 @@ jobs:
           [ "$BENCH_NO_CACHE" = "true" ] && cmd+=(--no-cache)
           [ "$BENCH_SAMPLY" = "true" ] && cmd+=(--samply)
           [ "$BENCH_TRACY" != "off" ] && cmd+=(--tracy "$BENCH_TRACY" --tracy-seconds "$BENCH_TRACY_SECONDS" --tracy-offset "$BENCH_TRACY_OFFSET")
+          [ "$BENCH_PERF" != "off" ] && cmd+=(--perf "$BENCH_PERF" --perf-seconds "$BENCH_PERF_SECONDS" --perf-offset "$BENCH_PERF_OFFSET")
           [ -n "$BENCH_BASELINE_HARDFORK" ] && cmd+=(--baseline-hardfork="$BENCH_BASELINE_HARDFORK")
           [ -n "$BENCH_FEATURE_HARDFORK" ] && cmd+=(--feature-hardfork="$BENCH_FEATURE_HARDFORK")
           [ -n "$BENCH_BASELINE_FEATURES" ] && cmd+=(--baseline-features="$BENCH_BASELINE_FEATURES")
@@ -864,6 +880,7 @@ jobs:
           [ -n "$BENCH_TXGEN_REF" ] && derek_cmd+=(txgen-ref="$BENCH_TXGEN_REF")
           [ "$BENCH_SAMPLY" = "true" ] && derek_cmd+=(samply)
           [ "$BENCH_TRACY" != "off" ] && derek_cmd+=(tracy="$BENCH_TRACY" tracy-seconds="$BENCH_TRACY_SECONDS" tracy-offset="$BENCH_TRACY_OFFSET")
+          [ "$BENCH_PERF" != "off" ] && derek_cmd+=(perf="$BENCH_PERF" perf-seconds="$BENCH_PERF_SECONDS" perf-offset="$BENCH_PERF_OFFSET")
           [ -n "$BENCH_BASELINE_FEATURES" ] && derek_cmd+=(baseline-features="$BENCH_BASELINE_FEATURES")
           [ -n "$BENCH_FEATURE_FEATURES" ] && derek_cmd+=(feature-features="$BENCH_FEATURE_FEATURES")
           [ -n "$BENCH_BASELINE_ARGS" ] && derek_cmd+=(baseline-args="$BENCH_BASELINE_ARGS")

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -49,6 +49,9 @@ jobs:
       tracy: ${{ steps.args.outputs.tracy }}
       tracy-seconds: ${{ steps.args.outputs.tracy-seconds }}
       tracy-offset: ${{ steps.args.outputs.tracy-offset }}
+      perf: ${{ steps.args.outputs.perf }}
+      perf-seconds: ${{ steps.args.outputs.perf-seconds }}
+      perf-offset: ${{ steps.args.outputs.perf-offset }}
       otlp: ${{ steps.args.outputs.otlp }}
       valscope: ${{ steps.args.outputs.valscope }}
       baseline-args: ${{ steps.args.outputs.baseline-args }}
@@ -113,7 +116,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
-            let pr, actor, mode, preset, duration, bloat, tokenCount, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, baselineFeatures, featureFeatures, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, valscope, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, metrics, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs;
+            let pr, actor, mode, preset, duration, bloat, tokenCount, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, baselineFeatures, featureFeatures, txgenRef, samply, tracy, tracySeconds, tracyOffset, perf, perfSeconds, perfOffset, otlp, valscope, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, metrics, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs;
             let explicitWarmup = false;
             let explicitDuration = false;
             let explicitRunPairs = false;
@@ -122,13 +125,13 @@ jobs:
             actor = context.payload.comment.user.login;
 
             const body = context.payload.comment.body.trim();
-            const intArgs = new Set(['duration', 'bloat', 'token-count', 'tps', 'accounts', 'max-concurrent-requests', 'gas-limit', 'tracy-seconds', 'tracy-offset', 'blocks', 'warmup', 'run-pairs']);
+            const intArgs = new Set(['duration', 'bloat', 'token-count', 'tps', 'accounts', 'max-concurrent-requests', 'gas-limit', 'tracy-seconds', 'tracy-offset', 'perf-seconds', 'perf-offset', 'blocks', 'warmup', 'run-pairs']);
             const refArgs = new Set(['baseline', 'feature', 'txgen-ref']);
-            const stringArgs = new Set(['mode', 'preset', 'tracy', 'baseline-args', 'feature-args', 'baseline-features', 'feature-features', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain', 'baseline-hardfork', 'feature-hardfork']);
+            const stringArgs = new Set(['mode', 'preset', 'tracy', 'perf', 'baseline-args', 'feature-args', 'baseline-features', 'feature-features', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain', 'baseline-hardfork', 'feature-hardfork']);
             const boolArgs = new Set(['samply', 'force-bloat', 'no-cache', 'no-slack', 'otlp', 'valscope', 'metrics']);
             const bloatValues = new Set(['1', '10', '100']);
             const hardforkValues = new Set(['T0', 'T1', 'T1A', 'T1B', 'T1C', 'T2', 'T3', 'T4', 'T5', 'T6']);
-            const defaults = { mode: 'e2e', preset: 'tip20_existing_recipients', duration: '300', bloat: '100', 'token-count': '4', tps: '50000', accounts: '1000', 'max-concurrent-requests': '500', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'baseline-features': '', 'feature-features': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'true', valscope: 'false', metrics: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2' };
+            const defaults = { mode: 'e2e', preset: 'tip20_existing_recipients', duration: '300', bloat: '100', 'token-count': '4', tps: '50000', accounts: '1000', 'max-concurrent-requests': '500', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'baseline-features': '', 'feature-features': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', perf: 'off', 'perf-seconds': '0', 'perf-offset': '0', otlp: 'true', valscope: 'false', metrics: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2' };
             const unknown = [];
             const invalid = [];
             const defaultWarmup = (blockCount) => String(Math.floor(Number(blockCount) / 4));
@@ -210,7 +213,7 @@ jobs:
             if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
             if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
             if (errors.length) {
-              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [otlp] [metrics[=true|false]] [valscope] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
+              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [otlp] [metrics[=true|false]] [valscope] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [perf=stat|record|cache|sched|io|syscalls|all] [perf-seconds=N] [perf-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -239,6 +242,9 @@ jobs:
             tracy = defaults.tracy;
             tracySeconds = defaults['tracy-seconds'];
             tracyOffset = defaults['tracy-offset'];
+            perf = defaults.perf;
+            perfSeconds = defaults['perf-seconds'];
+            perfOffset = defaults['perf-offset'];
             otlp = defaults.otlp;
             valscope = defaults.valscope;
             metrics = defaults.metrics;
@@ -265,7 +271,7 @@ jobs:
               warmup = defaultWarmup(blocks);
             }
 
-            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [otlp] [valscope] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
+            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [otlp] [valscope] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [perf=stat|record|cache|sched|io|syscalls|all] [perf-seconds=N] [perf-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 
             // Validate chain value
             if (!['mainnet', 'testnet'].includes(chain)) {
@@ -344,6 +350,19 @@ jobs:
               core.setFailed(msg);
               return;
             }
+            const perfModes = new Set(['off', 'false', 'none', 'stat', 'record', 'cache', 'sched', 'io', 'syscalls', 'all']);
+            const badPerfModes = perf.split(',').map(v => v.trim().toLowerCase()).filter(Boolean).filter(v => !perfModes.has(v));
+            if (badPerfModes.length) {
+              const msg = `❌ **Invalid bench command**\n\n\`perf=${perf}\` is not valid. Must be a comma-separated subset of \`stat\`, \`record\`, \`cache\`, \`sched\`, \`io\`, \`syscalls\`, \`all\`, or \`off\`.\n\n${usageStr}`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: msg,
+              });
+              core.setFailed(msg);
+              return;
+            }
 
             if (!['manual', 'nightly'].includes(runType)) {
               const msg = `❌ **Invalid benchmark type**\n\n\`run-type=${runType}\` is not valid. Must be \`manual\` or \`nightly\`.`;
@@ -412,6 +431,9 @@ jobs:
             core.setOutput('tracy', tracy);
             core.setOutput('tracy-seconds', tracySeconds);
             core.setOutput('tracy-offset', tracyOffset);
+            core.setOutput('perf', perf);
+            core.setOutput('perf-seconds', perfSeconds);
+            core.setOutput('perf-offset', perfOffset);
             core.setOutput('otlp', otlp);
             core.setOutput('valscope', valscope);
             core.setOutput('baseline-args', baselineArgs || '');
@@ -454,6 +476,7 @@ jobs:
           ACK_TXGEN_REF: ${{ steps.args.outputs.txgen-ref }}
           ACK_SAMPLY: ${{ steps.args.outputs.samply }}
           ACK_TRACY: ${{ steps.args.outputs.tracy }}
+          ACK_PERF: ${{ steps.args.outputs.perf }}
           ACK_OTLP: ${{ steps.args.outputs.otlp }}
           ACK_VALSCOPE: ${{ steps.args.outputs.valscope }}
           ACK_BASELINE_ARGS: ${{ steps.args.outputs.baseline-args }}
@@ -498,6 +521,8 @@ jobs:
             const samplyNote = samply ? ', samply: `enabled`' : '';
             const tracy = process.env.ACK_TRACY;
             const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
+            const perf = process.env.ACK_PERF || 'off';
+            const perfNote = perf !== 'off' ? `, perf: \`${perf}\`` : '';
             const otlp = process.env.ACK_OTLP === 'true';
             const otlpNote = otlp ? ', otlp: `enabled`' : ', otlp: `disabled`';
             const valscope = process.env.ACK_VALSCOPE === 'true';
@@ -511,7 +536,7 @@ jobs:
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
             const featureFlagsNote = `${baselineFeatureFlags ? `, baseline-features: \`${baselineFeatureFlags}\`` : ''}${featureFeatureFlags ? `, feature-features: \`${featureFeatureFlags}\`` : ''}`;
-            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, token-count: \`${tokenCount}\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${naNote}${noCacheNote}`;
+            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, token-count: \`${tokenCount}\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${perfNote}${otlpNote}${valscopeNote}${naNote}${noCacheNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -549,6 +574,9 @@ jobs:
       tracy: ${{ needs.tempo-bench-ack.outputs.tracy }}
       tracy-seconds: ${{ needs.tempo-bench-ack.outputs.tracy-seconds }}
       tracy-offset: ${{ needs.tempo-bench-ack.outputs.tracy-offset }}
+      perf: ${{ needs.tempo-bench-ack.outputs.perf }}
+      perf-seconds: ${{ needs.tempo-bench-ack.outputs.perf-seconds }}
+      perf-offset: ${{ needs.tempo-bench-ack.outputs.perf-offset }}
       otlp: ${{ needs.tempo-bench-ack.outputs.otlp }}
       valscope: ${{ needs.tempo-bench-ack.outputs.valscope }}
       baseline-args: ${{ needs.tempo-bench-ack.outputs.baseline-args }}

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -997,6 +997,9 @@ def run-local-e2e-phase [run: record, ctx: record] {
     if $phase_exit == 0 and not (e2e-wait-for-peers $b_rpc 1 300) { $phase_exit = 1 }
     if $phase_exit == 0 and not (e2e-wait-for-chain-advance $a_rpc 300) { $phase_exit = 1 }
     if $phase_exit == 0 and not (e2e-wait-for-chain-advance $b_rpc 300) { $phase_exit = 1 }
+    if $phase_exit == 0 {
+        start-perf-captures (find-tempo-pids) $phase $ctx.results_dir $ctx.perf --seconds $ctx.perf_seconds --offset $ctx.perf_offset | ignore
+    }
 
     let tracy_output = $"($ctx.results_dir)/tracy-profile-($phase).tracy"
     mut tracy_capture_started = false
@@ -1086,6 +1089,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
     if $tracy_capture_started {
         stop-tracy-capture
     }
+    stop-perf-captures
     stop-e2e-processes-gracefully
     if $ctx.samply { wait-for-samply-profile }
     if ($a_log_dir | path exists) { cp -r $a_log_dir $"($ctx.results_dir)/logs-($phase)-a" }
@@ -1221,6 +1225,9 @@ def "main e2e" [
     --tracy-seconds: int = 30                           # Tracy capture duration limit in seconds
     --tracy-offset: int = 120                           # Seconds to wait before starting tracy capture
     --tracing-otlp: string = ""                         # OTLP endpoint for tracing (auto-derived from GRAFANA_TEMPO/TEMPO_TELEMETRY_URL)
+    --perf: string = "off"                              # Perf profiling: off, stat, record, cache, sched, io, syscalls, all
+    --perf-seconds: int = 0                             # Perf capture duration in seconds (0 = until benchmark phase ends)
+    --perf-offset: int = 0                              # Seconds to wait after node readiness before starting perf
     --victoriametrics-url: string = ""                  # VictoriaMetrics base URL for txgen metric sample import
     --clickhouse-url: string = ""                       # ClickHouse HTTP endpoint for txgen result upload
     --clickhouse-run: string = "feature-1"              # Run label allowed to use the ClickHouse reporter; empty = every run
@@ -1267,6 +1274,7 @@ def "main e2e" [
         print "Error: tracy-capture not found. Install tracy and ensure tracy-capture is in PATH."
         exit 1
     }
+    validate-perf $perf
     let hardfork_mode = $baseline_hardfork != "" or $feature_hardfork != ""
     if $hardfork_mode and ($baseline_hardfork == "" or $feature_hardfork == "") {
         print "Error: --baseline-hardfork and --feature-hardfork must both be provided"
@@ -1447,11 +1455,11 @@ def "main e2e" [
     let global_build_features = (merge-e2e-features $DEFAULT_FEATURES $features)
     let baseline_build_features = if $baseline_features != "" { merge-e2e-features $global_build_features $baseline_features } else { $global_build_features }
     let feature_build_features = if $feature_features != "" { merge-e2e-features $global_build_features $feature_features } else { $global_build_features }
-    let baseline_tbc = (tracy-build-config $baseline_build_features $tracy)
-    let feature_tbc = (tracy-build-config $feature_build_features $tracy)
+    let baseline_tbc = (profiling-build-config $baseline_build_features $tracy $perf)
+    let feature_tbc = (profiling-build-config $feature_build_features $tracy $perf)
     let regenesis_build_features = $global_build_features
-    let regenesis_tbc = (tracy-build-config $regenesis_build_features $tracy)
-    let effective_no_cache = $no_cache or ($tracy != "off")
+    let regenesis_tbc = (profiling-build-config $regenesis_build_features $tracy $perf)
+    let effective_no_cache = $no_cache or ($tracy != "off") or (perf-enabled $perf)
     # Build benchmark binaries in parallel. Regenesis uses latest origin/main so
     # snapshot rewriting is independent of either side being benchmarked.
     # with independent target/ directories, so cargo invocations don't collide.
@@ -1528,6 +1536,9 @@ def "main e2e" [
         tracy_filter: $tracy_filter
         tracy_seconds: $tracy_seconds
         tracy_offset: $tracy_offset
+        perf: $perf
+        perf_seconds: $perf_seconds
+        perf_offset: $perf_offset
         baseline_args: $baseline_args
         feature_args: $feature_args
         bench_args: $bench_args

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -58,6 +58,9 @@ def run-txgen-bench-single [
     --tracy-seconds: int = 0
     --tracy-offset: int = 0
     --tracing-otlp: string = ""
+    --perf: string = "off"
+    --perf-seconds: int = 0
+    --perf-offset: int = 0
 ] {
     print $"=== Starting txgen run: ($run_label) ==="
 
@@ -97,6 +100,7 @@ def run-txgen-bench-single [
     sleep 2sec
     let rpc_timeout = if $bloat > 0 { 600 } else { 120 }
     wait-for-rpc "http://localhost:8545" $rpc_timeout
+    start-perf-captures (find-tempo-pids) $run_label $results_dir $perf --seconds $perf_seconds --offset $perf_offset | ignore
 
     let tracy_output = $"($results_dir)/tracy-profile-($run_label).tracy"
     let tracy_capture_started = if $tracy != "off" {
@@ -160,6 +164,7 @@ def run-txgen-bench-single [
             }
         }
     }
+    stop-perf-captures
 
     print "  Stopping node..."
     let pids = (find-tempo-pids)
@@ -232,6 +237,9 @@ def "main run" [
     --tracy-seconds: int = 30
     --tracy-offset: int = 120
     --tracing-otlp: string = ""
+    --perf: string = "off"                          # Perf profiling: off, stat, record, cache, sched, io, syscalls, all
+    --perf-seconds: int = 0                         # Perf capture duration in seconds (0 = until benchmark phase ends)
+    --perf-offset: int = 0                          # Seconds to wait after node readiness before starting perf
     --baseline-hardfork: string = ""
     --feature-hardfork: string = ""
     --gas-limit: string = ""
@@ -274,6 +282,7 @@ def "main run" [
     if $tracy != "off" and ((which tracy-capture | length) == 0) {
         error make { msg: "tracy-capture not found in PATH" }
     }
+    validate-perf $perf
 
     if ($baseline_hardfork != "" or $feature_hardfork != "") and ($baseline_hardfork == "" or $feature_hardfork == "") {
         error make { msg: "--baseline-hardfork and --feature-hardfork must both be provided" }
@@ -314,10 +323,10 @@ def "main run" [
         git worktree add $feature_wt $feature_sha
     }
 
-    let tbc = (tracy-build-config $features $tracy)
+    let tbc = (profiling-build-config $features $tracy $perf)
     let effective_features = $tbc.features
     let effective_extra_rustflags = $tbc.extra_rustflags
-    let effective_no_cache = $no_cache or ($tracy != "off")
+    let effective_no_cache = $no_cache or ($tracy != "off") or (perf-enabled $perf)
 
     if $baseline == "local" or $feature == "local" {
         print "Building local tempo binaries..."
@@ -509,7 +518,7 @@ def "main run" [
         docker compose -f $"($BENCH_DIR)/docker-compose.yml" up -d
     }
 
-    if $tracy == "full" and (^uname | str trim) == "Linux" {
+    if ($tracy == "full" or (perf-enabled $perf)) and (^uname | str trim) == "Linux" {
         try { sudo sysctl -w kernel.perf_event_paranoid=-1 } catch { }
         try { sudo mount -t tracefs tracefs /sys/kernel/tracing -o remount,mode=755 } catch { }
         try { sudo chmod -R a+r /sys/kernel/tracing } catch { }
@@ -573,6 +582,9 @@ def "main run" [
             --tracy-seconds $tracy_seconds
             --tracy-offset $tracy_offset
             --tracing-otlp $tracing_otlp
+            --perf $perf
+            --perf-seconds $perf_seconds
+            --perf-offset $perf_offset
             --platform $platform
             --scenario $resolved_scenario)
     }

--- a/tempo.nu
+++ b/tempo.nu
@@ -66,6 +66,160 @@ def tracy-build-config [features: string, tracy: string] {
     }
 }
 
+def profiling-build-config [features: string, tracy: string, perf: string] {
+    let tbc = (tracy-build-config $features $tracy)
+    let needs_frame_pointers = (perf-enabled $perf) and ($tbc.extra_rustflags | str contains "force-frame-pointers") == false
+    if $needs_frame_pointers {
+        $tbc | update extra_rustflags $"($tbc.extra_rustflags) -C force-frame-pointers=yes"
+    } else {
+        $tbc
+    }
+}
+
+def perf-enabled [perf: string] {
+    ($perf | str trim) != "" and ($perf | str downcase | str trim) not-in ["off" "false" "none"]
+}
+
+def perf-modes [perf: string] {
+    if not (perf-enabled $perf) { return [] }
+    let raw = (
+        $perf
+        | str downcase
+        | split row ","
+        | each { |m| $m | str trim }
+        | where { |m| $m != "" and $m not-in ["off" "false" "none"] }
+    )
+    if "all" in $raw {
+        ["stat" "record" "cache" "sched" "io" "syscalls"]
+    } else {
+        $raw
+    }
+}
+
+def validate-perf [perf: string] {
+    let valid = ["stat" "record" "cache" "sched" "io" "syscalls" "all" "off" "false" "none"]
+    let invalid = (perf-modes $perf | where { |m| $m not-in $valid })
+    if ($invalid | length) > 0 {
+        print $"Error: --perf must be a comma-separated subset of stat,record,cache,sched,io,syscalls,all \(got: ($invalid | str join ', ')\)"
+        exit 1
+    }
+}
+
+def perf-event-groups [modes: list<string>] {
+    mut groups = []
+    if "cache" in $modes {
+        $groups = ($groups | append "L1-dcache-loads,L1-dcache-load-misses,LLC-loads,LLC-load-misses,dTLB-loads,dTLB-load-misses,iTLB-loads,iTLB-load-misses")
+    }
+    if "sched" in $modes {
+        $groups = ($groups | append "sched:sched_switch,sched:sched_wakeup,context-switches,cpu-migrations")
+    }
+    if "io" in $modes {
+        $groups = ($groups | append "block:block_rq_issue,block:block_rq_complete")
+    }
+    if "syscalls" in $modes {
+        $groups = ($groups | append "syscalls:sys_enter_*")
+    }
+    $groups
+}
+
+def configure-perf-permissions [] {
+    if (^uname | str trim) == "Linux" {
+        try { sudo sysctl -w kernel.perf_event_paranoid=-1 } catch { }
+    }
+}
+
+def start-perf-captures [
+    pids: list<int>,
+    label: string,
+    results_dir: string,
+    perf: string,
+    --seconds: int = 0,
+    --offset: int = 0,
+] {
+    let modes = (perf-modes $perf)
+    if ($modes | is-empty) { return [] }
+    if ((which perf | length) == 0) {
+        print "  Warning: perf not found in PATH; skipping perf capture"
+        return []
+    }
+    if ($pids | is-empty) {
+        print $"  Warning: no tempo PIDs found for perf capture ($label)"
+        return []
+    }
+    configure-perf-permissions
+    let pid_csv = ($pids | each { |pid| $pid | into string } | str join ",")
+    let duration = if $seconds > 0 { $seconds } else { 0 }
+    let wait_prefix = if $offset > 0 { $"sleep ($offset); " } else { "" }
+    let run_suffix = if $duration > 0 { $" -- sleep ($duration)" } else { "" }
+    mut captures = []
+
+    if "stat" in $modes {
+        let out = $"($results_dir)/perf-stat-($label).csv"
+        let cmd = $"($wait_prefix)perf stat -d -d -d -x, -o '($out)' -p ($pid_csv)($run_suffix)"
+        print $"  Starting perf stat for ($label): ($out)"
+        job spawn { sh -c $cmd }
+        $captures = ($captures | append { kind: "stat", label: $label, output: $out })
+    }
+
+    if "record" in $modes {
+        let data = $"($results_dir)/perf-record-($label).data"
+        let script = $"($results_dir)/perf-record-($label).script"
+        let cmd = $"($wait_prefix)perf record -F 99 -g --call-graph dwarf -o '($data)' -p ($pid_csv)($run_suffix); status=$?; if [ -f '($data)' ]; then perf script -i '($data)' > '($script)' 2>/dev/null || true; fi; exit $status"
+        print $"  Starting perf record for ($label): ($data)"
+        job spawn { sh -c $cmd }
+        $captures = ($captures | append { kind: "record", label: $label, output: $data, script: $script })
+    }
+
+    for group in (perf-event-groups $modes) {
+        let safe = ($group | str replace -a ":" "-" | str replace -a "*" "all" | str replace -a "," "_")
+        let data = $"($results_dir)/perf-events-($safe)-($label).data"
+        let script = $"($results_dir)/perf-events-($safe)-($label).script"
+        let cmd = $"($wait_prefix)perf record -e '($group)' -g -o '($data)' -p ($pid_csv)($run_suffix); status=$?; if [ -f '($data)' ]; then perf script -i '($data)' > '($script)' 2>/dev/null || true; fi; exit $status"
+        print $"  Starting perf events \($group\) for ($label): ($data)"
+        job spawn { sh -c $cmd }
+        $captures = ($captures | append { kind: "events", label: $label, output: $data, script: $script, events: $group })
+    }
+
+    $captures
+}
+
+def stop-perf-captures [] {
+    let perf_pids = (
+        ^bash -c "pgrep -f 'perf (stat|record).*bench-results/.*/perf-' || true"
+        | lines
+        | where { |pid| ($pid | str trim) != "" }
+        | each { |pid| $pid | into int }
+    )
+    if ($perf_pids | length) == 0 { return }
+    print $"  Stopping perf captures: ($perf_pids | str join ', ')"
+    for pid in $perf_pids {
+        kill -s 2 $pid
+    }
+    mut wait = 0
+    while $wait < 30 {
+        let remaining = (
+            ^bash -c "pgrep -f 'perf (stat|record).*bench-results/.*/perf-' || true"
+            | lines
+            | where { |pid| ($pid | str trim) != "" }
+        )
+        if ($remaining | length) == 0 { break }
+        sleep 1sec
+        $wait = $wait + 1
+    }
+    if $wait >= 30 {
+        print "  Warning: perf did not exit, sending SIGKILL"
+        let remaining = (
+            ^bash -c "pgrep -f 'perf (stat|record).*bench-results/.*/perf-' || true"
+            | lines
+            | where { |pid| ($pid | str trim) != "" }
+            | each { |pid| $pid | into int }
+        )
+        for pid in $remaining {
+            kill -s 9 $pid
+        }
+    }
+}
+
 def cargo-feature-args [features: string, no_default_features: bool] {
     let no_default_args = if $no_default_features { ["--no-default-features"] } else { [] }
     let feature_args = if $features == "" { [] } else { ["--features" $features] }
@@ -660,6 +814,9 @@ def run-bench-single [
     --tracy-seconds: int = 0
     --tracy-offset: int = 0
     --tracing-otlp: string = ""
+    --perf: string = "off"
+    --perf-seconds: int = 0
+    --perf-offset: int = 0
 ] {
     print $"=== Starting run: ($run_label) ==="
 
@@ -704,6 +861,7 @@ def run-bench-single [
     sleep 2sec
     let rpc_timeout = if $bloat > 0 { 600 } else { 120 }
     wait-for-rpc "http://localhost:8545" $rpc_timeout
+    start-perf-captures (find-tempo-pids) $run_label $results_dir $perf --seconds $perf_seconds --offset $perf_offset | ignore
 
     # Start tracy-capture after RPC is ready (node must be running for connection)
     # If tracy-offset > 0, delay the capture start in a background job so txgen isn't blocked
@@ -774,6 +932,7 @@ def run-bench-single [
             }
         }
     }
+    stop-perf-captures
 
     # Stop node
     print "  Stopping node..."
@@ -2361,6 +2520,9 @@ def "main bench" [
     --tracy-seconds: int = 30                       # Tracy capture duration limit in seconds (0 = unlimited)
     --tracy-offset: int = 120                       # Seconds to wait before starting tracy capture (default: 120)
     --tracing-otlp: string = ""                     # OTLP endpoint for tracing (auto-derived from TEMPO_TELEMETRY_URL if not set)
+    --perf: string = "off"                          # Perf profiling: off, stat, record, cache, sched, io, syscalls, all
+    --perf-seconds: int = 0                         # Perf capture duration in seconds (0 = until benchmark phase ends)
+    --perf-offset: int = 0                          # Seconds to wait after node readiness before starting perf
     --baseline-hardfork: string = ""                # Latest active hardfork for baseline (e.g. T1, T1C, T2)
     --feature-hardfork: string = ""                 # Latest active hardfork for feature (e.g. T1, T1C, T2)
     --gas-limit: string = ""                        # Block gas limit for genesis (raw number, e.g. 1000000000)
@@ -2420,6 +2582,7 @@ def "main bench" [
             exit 1
         }
     }
+    validate-perf $perf
 
     # Validate comparison mode flags
     if ($baseline != "" and $feature == "") or ($baseline == "" and $feature != "") {
@@ -2513,11 +2676,11 @@ def "main bench" [
         }
 
         # Build binaries (apply tracy build config if needed)
-        let tbc = (tracy-build-config $features $tracy)
+        let tbc = (profiling-build-config $features $tracy $perf)
         let effective_features = $tbc.features
         let effective_extra_rustflags = $tbc.extra_rustflags
         # Force --no-cache when tracy is enabled (cached binaries lack tracy features)
-        let effective_no_cache = $no_cache or ($tracy != "off")
+        let effective_no_cache = $no_cache or ($tracy != "off") or (perf-enabled $perf)
 
         if $baseline == "local" or $feature == "local" {
             print "Building local binaries..."
@@ -2743,7 +2906,7 @@ def "main bench" [
         }
 
         # Setup kernel permissions for tracy full mode (CPU sampling)
-        if $tracy == "full" and (^uname | str trim) == "Linux" {
+        if ($tracy == "full" or (perf-enabled $perf)) and (^uname | str trim) == "Linux" {
             print "Configuring system for tracy CPU sampling..."
             # Allow non-root perf event access (required for CPU sampling)
             try { sudo sysctl -w kernel.perf_event_paranoid=-1 } catch { }
@@ -2803,7 +2966,8 @@ def "main bench" [
                 --samply=$samply --samply-args $samply_args_list
                 --tracy $tracy --tracy-filter $tracy_filter
                 --tracy-seconds $tracy_seconds --tracy-offset $tracy_offset
-                --tracing-otlp $tracing_otlp)
+                --tracing-otlp $tracing_otlp
+                --perf $perf --perf-seconds $perf_seconds --perf-offset $perf_offset)
         }
 
         # Generate summary report
@@ -2862,7 +3026,8 @@ def "main bench" [
     }
 
     # Build tempo and xtask first
-    build-tempo ["tempo"] $profile $features
+    let single_tbc = (profiling-build-config $features $tracy $perf)
+    build-tempo --extra-rustflags $single_tbc.extra_rustflags ["tempo"] $profile $single_tbc.features
     build-tempo-xtask $profile
 
     # Start nodes in background (skip build since we already compiled)
@@ -2904,6 +3069,9 @@ def "main bench" [
         wait-for-rpc $url $rpc_timeout
     }
     print "All nodes ready!"
+    let single_results_dir = $"($BENCH_RESULTS_DIR)/(date now | format date "%Y%m%d-%H%M%S")"
+    mkdir $single_results_dir
+    start-perf-captures (find-tempo-pids) "single" $single_results_dir $perf --seconds $perf_seconds --offset $perf_offset | ignore
 
     print "Running txgen benchmark..."
     let submit_rpc_url = ($rpc_urls | str join ",")
@@ -2938,6 +3106,7 @@ def "main bench" [
 
     # Cleanup
     print "Cleaning up..."
+    stop-perf-captures
     main kill
 
     # Wait for samply to finish saving profiles


### PR DESCRIPTION
## Summary
- add `--perf` modes for bench runs: `stat`, `record`, `cache`, `sched`, `io`, `syscalls`, and `all`
- capture perf artifacts next to benchmark results and generate `perf script` outputs for record/event captures
- wire perf flags through `derek bench` comment parsing and the e2e workflow

## Validation
- `nu --commands 'source tempo.nu; source bench-e2e.nu; source contrib/bench/bench-txgen.nu; validate-perf stat,record; validate-perf all; print ok'`\n- `uv run --with pyyaml python - <<'PY' ... yaml.safe_load(...) ... PY`\n- `git diff --check`\n\nPrompted by: @shekhirin