### PR TITLE
ci: remove Derek bench user allowlist

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -78,9 +78,7 @@ jobs:
           github-token: ${{ secrets.DEREK_BENCH_ACK_TOKEN }}
           script: |
             const org = 'tempoxyz';
-            const allowedUsers = new Set(['rkrasiuk']);
             const checkMembership = async (username) => {
-              if (allowedUsers.has(username)) return true;
               try {
                 const { status } = await github.rest.orgs.checkMembershipForUser({ org, username });
                 return status === 204 || status === 302;


### PR DESCRIPTION
## Summary
- remove the hardcoded rkrasiuk allowlist from Derek bench comment authorization
- require commenters and PR authors to pass normal org membership checks

## Testing
- not run; workflow-only authorization change

Prompted by: @shekhirin