### PR TITLE
ci(bench): clean e2e checkout workspace with sudo

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -468,6 +468,11 @@ jobs:
             core.info(`PR #${process.env.BENCH_PR}, using pinned head SHA ${sha}`);
             core.setOutput('ref', sha);
 
+      - name: Clean up checkout workspace
+        run: |
+          sudo rm -rf "$GITHUB_WORKSPACE"
+          mkdir -p "$GITHUB_WORKSPACE"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false


### PR DESCRIPTION
## Summary
- remove the bench-e2e checkout workspace with sudo before actions/checkout
- recreate the workspace so checkout starts from a clean runner-owned directory

## Testing
- git diff --check
- `uv run --with pyyaml python -c 'import yaml; yaml.safe_load(open(".github/workflows/bench-e2e.yml")); print("yaml ok")'`

Prompted by: @shekhirin