### PR TITLE
fix: accept deprecated follow certify flag without value

### DIFF
--- a/bin/tempo/src/cli.rs
+++ b/bin/tempo/src/cli.rs
@@ -54,7 +54,7 @@ pub struct TempoArgs {
     /// DEPRECATED. Certification is now enabled by default in follow mode. Use
     /// --follow.nocertify to disable. This argument is a no-op.
     #[arg(long = "follow.experimental.certify", requires = "follow", hide = true)]
-    pub(crate) follow_experimental_certify: Option<bool>,
+    pub(crate) follow_experimental_certify: bool,
 
     /// HTTP endpoint that returns a JSON object mapping chain IDs to bootnode lists.
     ///

--- a/bin/tempo/src/lib.rs
+++ b/bin/tempo/src/lib.rs
@@ -632,6 +632,26 @@ mod tests {
     }
 
     #[test]
+    fn deprecated_follow_certification_flag_is_noop() {
+        init_defaults_once();
+
+        let cli = TempoCli::try_parse_from([
+            "tempo",
+            "node",
+            "--follow",
+            "--follow.experimental.certify",
+        ])
+        .unwrap();
+
+        let Commands::Node(node_cmd) = cli.command else {
+            panic!("expected node command");
+        };
+
+        assert!(!node_cmd.ext.is_following_uncertified());
+        assert!(node_cmd.ext.has_consensus_engine(false));
+    }
+
+    #[test]
     fn consensus_block_budget_defaults_are_stable() {
         init_defaults_once();
 


### PR DESCRIPTION
## Summary
- change deprecated hidden `--follow.experimental.certify` from `Option<bool>` to bare `bool`
- keep the flag as a true no-op while accepting existing bare usages
- add a CLI parser regression test for the deprecated flag

## Validation
- `cargo test -p tempo follow_certification`

Prompted by: @SuperFluffy