### PR TITLE
ci: add llvm install scripts for benchmarks

### DIFF
--- a/.github/scripts/install_llvm.sh
+++ b/.github/scripts/install_llvm.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+os=${1:?usage: install_llvm.sh <ubuntu|macos> [version]}
+version=${2:-22}
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "$os" in
+    ubuntu)
+        sudo "$script_dir/install_llvm_ubuntu.sh" "$version"
+        ;;
+    macos)
+        "$script_dir/install_llvm_brew.sh" "$version"
+        ;;
+    *)
+        echo "unsupported OS: $os" >&2
+        exit 1
+        ;;
+esac

--- a/.github/scripts/install_llvm_brew.sh
+++ b/.github/scripts/install_llvm_brew.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+v=${1:-22}
+
+brew install "llvm@${v}"
+prefix="$(brew --prefix "llvm@${v}")"
+echo "LLVM_SYS_${v}1_PREFIX=${prefix}" >> "$GITHUB_ENV"
+echo "${prefix}/bin" >> "$GITHUB_PATH"
+
+echo "LLVM $v installed:"
+"${prefix}/bin/llvm-config" --version

--- a/.github/scripts/install_llvm_ubuntu.sh
+++ b/.github/scripts/install_llvm_ubuntu.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+v=${1:-22}
+bins=(clang llvm-config lld ld.lld FileCheck)
+
+apt-get update -qq
+apt-get install -y --no-install-recommends \
+    lsb-release wget gnupg ca-certificates
+apt-get install -y --no-install-recommends software-properties-common 2>/dev/null || true
+
+llvm_sh=$(mktemp)
+wget -qO "$llvm_sh" https://apt.llvm.org/llvm.sh
+chmod +x "$llvm_sh"
+"$llvm_sh" "$v" all
+rm -f "$llvm_sh"
+
+for bin in "${bins[@]}"; do
+    if ! command -v "$bin-$v" &>/dev/null; then
+        echo "Warning: $bin-$v not found" 1>&2
+        continue
+    fi
+    ln -fs "$(which "$bin-$v")" "/usr/bin/$bin"
+done
+
+echo "LLVM $v installed:"
+llvm-config --version


### PR DESCRIPTION
## Summary
- add the missing `.github/scripts/install_llvm.sh` wrapper expected by benchmark CI
- add Ubuntu and macOS LLVM installer helpers matching the upstream reth interface

## Verification
- `bash -n .github/scripts/install_llvm.sh .github/scripts/install_llvm_brew.sh .github/scripts/install_llvm_ubuntu.sh`

Prompted by: @emmajam