### PR TITLE
fix(cli): initialize tracing before running snapshot cmd

### DIFF
--- a/bin/tempo/src/lib.rs
+++ b/bin/tempo/src/lib.rs
@@ -56,6 +56,7 @@ use futures::{
     FutureExt as _,
     future::{Either, FusedFuture as _},
 };
+use reth_cli_runner::CliRunner;
 use reth_ethereum::{chainspec::EthChainSpec as _, cli::Commands, evm::revm::primitives::B256};
 use reth_network_api::Peers;
 use reth_node_builder::{NodeHandle, WithLaunchContext};
@@ -167,7 +168,28 @@ pub fn tempo_main_with(mut overrides: TempoOverrides) -> eyre::Result<()> {
     // `from_arg_matches` would map them to their original variants.
     match matches.subcommand() {
         Some(("snapshot-manifest", sub)) => return snapshot_manifest::run(sub),
-        Some(("download", sub)) => return snapshot_download::run(sub),
+        Some(("download", sub)) => {
+            let runner =
+                CliRunner::try_default_runtime().wrap_err("failed to build download runtime")?;
+            let mut cli = match TempoCli::from_arg_matches(&matches) {
+                Ok(cli) => cli,
+                Err(err) => err.exit(),
+            };
+
+            if let Some(chain_spec) = cli.command.chain_spec() {
+                cli.logs.log_file_directory = cli
+                    .logs
+                    .log_file_directory
+                    .join(chain_spec.chain().to_string());
+            }
+
+            let mut tracing_app = cli.configure();
+            tracing_app
+                .init_tracing(&runner)
+                .wrap_err("failed to initialize tracing")?;
+
+            return snapshot_download::run_with_runner(sub, runner);
+        }
         _ => {}
     }
 
@@ -565,9 +587,11 @@ pub fn tempo_main_with(mut overrides: TempoOverrides) -> eyre::Result<()> {
 mod tests {
     use std::{sync::Once, time::Duration};
 
-    use clap::Parser;
+    use clap::{CommandFactory, FromArgMatches, Parser};
 
-    use super::{TempoCli, apply_tempo_cli_overrides, defaults, follow::FollowMode};
+    use super::{
+        TempoCli, apply_tempo_cli_overrides, defaults, follow::FollowMode, snapshot_download,
+    };
     use reth_ethereum::cli::Commands;
 
     fn init_defaults_once() {
@@ -581,6 +605,31 @@ mod tests {
             panic!("expected node command");
         };
         node_cmd.ext.follow
+    }
+
+    #[test]
+    fn wrapped_download_matches_parse_for_tracing() {
+        init_defaults_once();
+
+        let matches = TempoCli::command()
+            .mut_subcommand("download", |_| snapshot_download::Args::command())
+            .try_get_matches_from([
+                "tempo",
+                "download",
+                "--manifest-url",
+                "https://snap/manifest.json",
+                "--datadir",
+                "/d",
+                "--skip-consensus=false",
+                "--log.stdout.filter",
+                "debug",
+            ])
+            .unwrap();
+
+        let cli = TempoCli::from_arg_matches(&matches).unwrap();
+
+        assert!(matches!(cli.command, Commands::Download(_)));
+        assert_eq!(cli.logs.log_stdout_filter, "debug");
     }
 
     #[test]

--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -39,7 +39,7 @@ pub(crate) struct Args {
     consensus_datadir: Option<PathBuf>,
 }
 
-pub(crate) fn run(matches: &ArgMatches) -> eyre::Result<()> {
+pub(crate) fn run_with_runner(matches: &ArgMatches, runner: CliRunner) -> eyre::Result<()> {
     let args = Args::from_arg_matches(matches).wrap_err("failed to parse args")?;
 
     let datadir = matches
@@ -51,7 +51,6 @@ pub(crate) fn run(matches: &ArgMatches) -> eyre::Result<()> {
     let manifest_url = matches.get_one::<String>("manifest_url").cloned();
     let manifest_path = matches.get_one::<PathBuf>("manifest_path").cloned();
 
-    let runner = CliRunner::try_default_runtime().wrap_err("failed to build obtain runtime")?;
     runner.block_on(async move {
         eprintln!("running execution layer download...");
 

--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -10,6 +10,7 @@ use reth_cli_commands::download::DownloadCommand;
 use reth_cli_runner::CliRunner;
 use tempo_chainspec::spec::TempoChainSpecParser;
 use tempo_telemetry_util::display_duration;
+use tracing::info;
 
 use crate::snapshot_manifest::{TEMPO_CONSENSUS_MANIFEST_KEY, TempoConsensusManifest};
 
@@ -52,7 +53,7 @@ pub(crate) fn run_with_runner(matches: &ArgMatches, runner: CliRunner) -> eyre::
     let manifest_path = matches.get_one::<PathBuf>("manifest_path").cloned();
 
     runner.block_on(async move {
-        eprintln!("running execution layer download...");
+        info!("running execution layer download...");
 
         let start = Instant::now();
         args.inner
@@ -60,13 +61,13 @@ pub(crate) fn run_with_runner(matches: &ArgMatches, runner: CliRunner) -> eyre::
             .await
             .wrap_err("execution layer download failed")?;
 
-        eprintln!(
+        info!(
             "execution layer download finished in {}",
             display_duration(start.elapsed())
         );
 
         if args.skip_consensus {
-            eprintln!("--skip-consensus set. skipping consensus layer");
+            info!("--skip-consensus set. skipping consensus layer");
             return Ok(());
         }
 
@@ -131,7 +132,7 @@ fn write_bootstrap_finalization(
     fs::write(&path, consensus_manifest.finalization.as_ref())
         .wrap_err_with(|| format!("failed to write finalization to {}", path.display()))?;
 
-    eprintln!("persisted bootstrap finalization: {}", path.display());
+    info!(path = %path.display(), "persisted bootstrap finalization");
     Ok(())
 }
 


### PR DESCRIPTION
Previously we did not initialize tracing before running and overwriting the snapshot manifest and download cmds, because we no longer go through the default cli app path. Now we initialize a `TempoCli` and run `init_tracing` before dispatching to the `snapshot_download` run fn