### PR TITLE
chore: bump MSRV to Rust 1.96

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -237,7 +237,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.95" # MSRV
+          toolchain: "1.96" # MSRV
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "1.8.2"
 edition = "2024"
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 authors = ["Tempo Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://docs.tempo.xyz"

--- a/Dockerfile.chef
+++ b/Dockerfile.chef
@@ -1,4 +1,4 @@
-FROM rust:1.95-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1 AS chef
+FROM rust:1.96-bookworm@sha256:64d9b7f60e3abb08d477cad983d0a3743acc53a19369ba4482510184c9c807e5 AS chef
 
 RUN cargo install cargo-chef --version 0.1.77 --locked \
  && cargo install sccache --version 0.14.0 --locked

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -15,7 +15,7 @@
 #   ./out/tempo                              the reproducible binary
 #
 # Reproducibility-critical decisions:
-#   * Pinned base image digest (rust 1.95.0 on Debian Bookworm).
+#   * Pinned base image digest (rust 1.96.0 on Debian Bookworm).
 #   * `cargo --locked` so registry deps cannot drift.
 #   * RUSTFLAGS strip every source of nondeterminism we know about:
 #     SOURCE_DATE_EPOCH for build timestamps, --remap-path-prefix for the
@@ -28,8 +28,8 @@
 #   * `[profile.reproducible]` (defined in Cargo.toml) disables incremental,
 #     emits no debuginfo, and inherits `release`'s fat LTO + 1 codegen-unit.
 
-ARG RUST_TOOLCHAIN=1.95.0
-FROM rust:${RUST_TOOLCHAIN}-bookworm@sha256:d0a4aa3ca2e1088ac0c81690914a0d810f2eee188197034edf366ed010a2b382 AS builder
+ARG RUST_TOOLCHAIN=1.96.0
+FROM rust:${RUST_TOOLCHAIN}-bookworm@sha256:64d9b7f60e3abb08d477cad983d0a3743acc53a19369ba4482510184c9c807e5 AS builder
 
 ARG SOURCE_DATE_EPOCH
 ARG VERSION

--- a/scripts/sanitize_toml.py
+++ b/scripts/sanitize_toml.py
@@ -328,7 +328,7 @@ def main():
         else:
             meta = {
                 'edition': '"2024"',
-                'rust-version': '"1.93.0"',
+                'rust-version': '"1.96.0"',
                 'authors': '["Tempo Contributors"]',
                 'license': '"MIT OR Apache-2.0"',
                 'homepage': '"https://docs.tempo.xyz"',


### PR DESCRIPTION
## Summary
- bump workspace MSRV to Rust 1.96.0
- update CI MSRV toolchain to 1.96
- update Rust Docker base images and sanitizer fallback to 1.96

## Testing
- cargo metadata --locked --no-deps --format-version 1
- cargo check --locked --workspace --all-targets
- cargo fmt --check

Prompted by: @shekhirin