### PR TITLE
bench: include txgen preset in report metadata

### DIFF
--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -313,6 +313,7 @@ def txgen-run-preset-pipeline [
     let metadata_args = [
         "-m" "job=github-tempo-bench-e2e"
         "-m" $"chain_id=($chain_id)"
+        "-m" $"preset=($preset_path | path basename | str replace --regex '\\.yml$' '')"
         "-m" $"target_tps=($tps)"
         "-m" $"run_duration_secs=($duration)"
         "-m" $"accounts=($accounts)"


### PR DESCRIPTION
## Summary
- Add the selected txgen preset name to benchmark report metadata.
- Allows downstream perf report UIs to distinguish nightly/main preset differences explicitly.

Prompted by: @emmajam