### PR TITLE
chore: bump workspace version to 1.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12897,7 +12897,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13045,7 +13045,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13106,7 +13106,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13135,7 +13135,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13149,7 +13149,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13200,7 +13200,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13244,7 +13244,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13263,7 +13263,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "eyre",
  "indenter",
@@ -13271,7 +13271,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13284,7 +13284,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13354,7 +13354,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -13392,7 +13392,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13411,7 +13411,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13443,7 +13443,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13491,14 +13491,14 @@ dependencies = [
 
 [[package]]
 name = "tempo-programmatic-node"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "tempo",
 ]
 
 [[package]]
 name = "tempo-revm"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13532,7 +13532,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "clap",
@@ -13557,7 +13557,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "eyre",
  "jiff",
@@ -13566,7 +13566,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13606,7 +13606,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13618,7 +13618,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.8.2"
+version = "1.9.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]


### PR DESCRIPTION
Draft PR to apply the v1.9.1 Cargo workspace version bump onto `release/v1.9.1` through the protected-branch flow.

Diff is only `Cargo.toml` and `Cargo.lock`; Docker and reproducible-build files are intentionally untouched.

Keep draft until CI is green.