### PR TITLE
perf: defer state provider drop

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1150,6 +1150,7 @@ where
         );
 
         drop(db);
+        self.executor.spawn_drop(state_provider);
         if build_once_with_shared_trie {
             Ok(BuildOutcome::Freeze(payload))
         } else {


### PR DESCRIPTION
It might happen that persistence finishes in parallel with block building and removes the in-memory blocks from the `BlockchainProvider`. This might leave payload builder being the last user of the in memory overlays, causing them to get dropped and deallocated, blocking payload return