### PR TITLE
ci: revert foundry checkout pin in specs workflow

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -260,8 +260,8 @@ jobs:
       - name: Checkout foundry
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: decofe/foundry
-          ref: centaur/pin-tempo-pr-5423
+          repository: foundry-rs/foundry
+          ref: master
           path: foundry
           persist-credentials: false
 


### PR DESCRIPTION
## Summary
- Revert the specs workflow Foundry checkout back to `foundry-rs/foundry` on `master`.

## Testing
- Not run; workflow-only checkout target change.

Prompted by: @shekhirin