### PR TITLE
test: add pre-T6 account keychain gas snapshot

### DIFF
--- a/crates/node/tests/it/gas/helpers.rs
+++ b/crates/node/tests/it/gas/helpers.rs
@@ -189,9 +189,11 @@ pub(crate) struct TempoCalls {
     expect_existing_nonce: bool,
 }
 
+#[derive(Debug)]
 pub(crate) struct Receipt {
     pub(crate) tx_hash: B256,
     pub(crate) gas_used: u64,
+    pub(crate) status: bool,
 }
 
 impl TempoCalls {
@@ -266,6 +268,19 @@ impl TempoCalls {
         self,
         sender: &mut TempoTxSender<P>,
     ) -> eyre::Result<Receipt> {
+        let receipt = self.send_raw(sender).await?;
+        eyre::ensure!(receipt.status, "tempo calls reverted: {receipt:?}");
+        Ok(receipt)
+    }
+
+    pub(crate) async fn send_allow_revert<P: Provider>(
+        self,
+        sender: &mut TempoTxSender<P>,
+    ) -> eyre::Result<Receipt> {
+        self.send_raw(sender).await
+    }
+
+    async fn send_raw<P: Provider>(self, sender: &mut TempoTxSender<P>) -> eyre::Result<Receipt> {
         let call_count = self.calls.len();
         eyre::ensure!(call_count > 0, "cannot send TempoCalls with zero calls");
         if self.expect_existing_nonce {
@@ -300,10 +315,13 @@ impl TempoCalls {
                 let status = receipt["status"]
                     .as_str()
                     .ok_or_else(|| eyre::eyre!("tempo calls receipt missing status field"))?;
-                eyre::ensure!(status == "0x1", "tempo calls reverted: {receipt}");
                 let gas_used = hex_u64_field(&receipt, "gasUsed")?;
                 sender.nonce += 1;
-                return Ok(Receipt { tx_hash, gas_used });
+                return Ok(Receipt {
+                    tx_hash,
+                    gas_used,
+                    status: status == "0x1",
+                });
             }
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }

--- a/crates/node/tests/it/gas/snapshots/it__gas__tip20_transfers__account_keychain_authorize_admin_key_t4_gas_snapshot.snap
+++ b/crates/node/tests/it/gas/snapshots/it__gas__tip20_transfers__account_keychain_authorize_admin_key_t4_gas_snapshot.snap
@@ -1,0 +1,5 @@
+---
+source: crates/node/tests/it/gas/tip20_transfers.rs
+expression: gas
+---
+t4_authorize_admin_key_pre_t6_revert: 272108

--- a/crates/node/tests/it/gas/tip20_transfers.rs
+++ b/crates/node/tests/it/gas/tip20_transfers.rs
@@ -1,14 +1,15 @@
 use alloy::{
-    primitives::{Address, FixedBytes, U256},
+    primitives::{Address, B256, FixedBytes, U256},
     providers::Provider,
     sol_types::SolEvent,
 };
 use tempo_chainspec::{hardfork::TempoHardfork, spec::TEMPO_T1_BASE_FEE};
 use tempo_contracts::precompiles::{
-    IAddressRegistry, ITIP20, ITIP403Registry, ITIPFeeAMM, TIP_FEE_MANAGER_ADDRESS,
+    IAccountKeychain, IAddressRegistry, ITIP20, ITIP403Registry, ITIPFeeAMM,
+    TIP_FEE_MANAGER_ADDRESS, account_keychain::IAccountKeychain::authorizeAdminKeyCall,
 };
 use tempo_precompiles::{
-    ADDRESS_REGISTRY_ADDRESS, PATH_USD_ADDRESS, TIP403_REGISTRY_ADDRESS,
+    ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, PATH_USD_ADDRESS, TIP403_REGISTRY_ADDRESS,
     test_util::{VIRTUAL_MASTER, VIRTUAL_SALT},
 };
 use tempo_primitives::TempoAddressExt;
@@ -682,6 +683,44 @@ async fn test_tip20_transfer_with_memo_t0_gas_snapshot() -> eyre::Result<()> {
     gas.record("t0_transfer_with_memo", receipt.gas_used);
 
     print_gas_snapshot("TIP20 T0 transferWithMemo gas snapshot", &gas);
+    insta::assert_yaml_snapshot!(gas);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_account_keychain_authorize_admin_key_t4_gas_snapshot() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = TestNodeBuilder::new()
+        .with_genesis(make_genesis_at(TempoHardfork::T4))
+        .build_http_only()
+        .await?;
+    let mut sender = TempoTxSender::connect(setup.http_url, test_signer(0)?).await?;
+    sender.sync_nonce().await?;
+
+    let receipt = TempoCalls::new()
+        .gas_limit(10_000_000)
+        .fee_token(None)
+        .push(
+            ACCOUNT_KEYCHAIN_ADDRESS,
+            authorizeAdminKeyCall {
+                keyId: fixed_signer(0x42).address(),
+                signatureType: IAccountKeychain::SignatureType::P256,
+                witness: B256::repeat_byte(0x59),
+            },
+        )
+        .send_allow_revert(&mut sender)
+        .await?;
+    assert!(
+        !receipt.status,
+        "authorizeAdminKey must remain gated off before T6"
+    );
+
+    let mut gas = GasSnapshot::new();
+    gas.record("t4_authorize_admin_key_pre_t6_revert", receipt.gas_used);
+
+    print_gas_snapshot("Account keychain T4 authorizeAdminKey gas snapshot", &gas);
     insta::assert_yaml_snapshot!(gas);
 
     Ok(())


### PR DESCRIPTION
## Summary
- Add a gas snapshot regression test for a T4 Tempo AA transaction calling `IAccountKeychain.authorizeAdminKey`.
- The test uses the generated ABI call and asserts the call remains gated off before T6, then snapshots the pre-regression revert gas.
- Add an allow-revert path to the gas test helper so reverted Tempo AA calls can still be snapshotted.

## Verification
- `cargo +nightly fmt --check`
- `cargo +nightly test -p tempo-node --test it test_account_keychain_authorize_admin_key_t4_gas_snapshot --no-run`
- Cherry-picked onto pre-optimization `dc67dee01`; `CARGO_TARGET_DIR=/Users/alpharush/dev/tempo-fuzz/out/tempo/target cargo +nightly test -p tempo-node --test it test_account_keychain_authorize_admin_key_t4_gas_snapshot --no-run`
- Re-ran reduced block-harness root cause: T4 `authorizeAdminKey` succeeds post-change with `533720` gas and reverts pre-change with `272108` gas.

Note: full local node execution is blocked in this Codex sandbox with `Operation not permitted` during node startup. The escalation request for `cargo +nightly test ... -- --nocapture` was rejected by the approval layer, so the live node pass/fail check should be supplied by CI or a local unsandboxed run.