### PR TITLE
test(gas): snapshot pre-T8 TIP20 burn gas

### DIFF
--- a/crates/node/tests/it/gas/snapshots/it__gas__tip20_transfers__tip20_burn_t5_gas_snapshot.snap
+++ b/crates/node/tests/it/gas/snapshots/it__gas__tip20_transfers__tip20_burn_t5_gas_snapshot.snap
@@ -1,0 +1,5 @@
+---
+source: crates/node/tests/it/gas/tip20_transfers.rs
+expression: gas
+---
+t5_burn: 303453

--- a/crates/node/tests/it/gas/tip20_transfers.rs
+++ b/crates/node/tests/it/gas/tip20_transfers.rs
@@ -686,3 +686,32 @@ async fn test_tip20_transfer_with_memo_t0_gas_snapshot() -> eyre::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tip20_burn_t5_gas_snapshot() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = TestNodeBuilder::new()
+        .with_genesis(make_genesis_at(TempoHardfork::T5))
+        .build_http_only()
+        .await?;
+    let sender = TempoTxSender::connect(setup.http_url, test_signer(0)?).await?;
+    let token = ITIP20::new(PATH_USD_ADDRESS, sender.provider.clone());
+
+    let mut gas = GasSnapshot::new();
+    let receipt = token
+        .burn(U256::from(100u64))
+        .from(sender.address())
+        .gas_price(TEMPO_T1_BASE_FEE as u128)
+        .gas(1_000_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    gas.record("t5_burn", receipt.gas_used);
+
+    print_gas_snapshot("TIP20 T5 burn gas snapshot", &gas);
+    insta::assert_yaml_snapshot!(gas);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds a normal node gas snapshot for `ITIP20.burn` at T5 in `crates/node/tests/it/gas/tip20_transfers.rs`.

This is the reduced pre-T8 case that catches the intermediate `sinc`/`sdec` optimization regression where `_transfer` did a balance pre-check and then still used `decrement_balance`, charging an extra warm balance SLOAD before T8.

## Verification

- `cargo +nightly test -p tempo-node --test it gas::tip20_transfers::test_tip20_burn_t5_gas_snapshot -- --nocapture` on `origin/main`: passes, `t5_burn: 303453`
- Same test cherry-picked onto `56cd5504a balance check in _transfer`: fails, observed `t5_burn: 303553` (`+100` gas)
- Same test cherry-picked onto current PR #5605 head `6638eda01`: passes, `t5_burn: 303453`

No fuzz harness or JSON fixture is committed.