### PR TITLE
Disable bench checkout cleanup

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -473,6 +473,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           ref: ${{ steps.checkout-ref.outputs.ref }}
+          clean: false
 
       - name: Checkout ValScope report builder
         if: env.BENCH_VALSCOPE == 'true'


### PR DESCRIPTION
## Summary
- set `clean: false` on the bench-e2e repository checkout
- keep existing explicit cleanup limited to `bench-results/`

## Context
The failed job died inside actions/checkout before benchmarks ran. Checkout deleted the stale workspace contents, then tried to run git-local auth cleanup in a directory without `.git` and exited 128. Disabling checkout cleanup avoids that broken cleanup path without deleting cargo caches or other runner-local build state.

Prompted by: @klkvr

## Validation
- uv run --with pyyaml python -c "import yaml; yaml.safe_load(open('.github/workflows/bench-e2e.yml')); print('ok')"