### PR TITLE
deps: update reth from main (2026-06-18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8656,7 +8656,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8716,7 +8716,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8736,7 +8736,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8749,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8832,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8895,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8911,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8938,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8963,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8992,7 +8992,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9048,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9171,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9393,7 +9393,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9409,7 +9409,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9425,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9448,7 +9448,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9459,7 +9459,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9487,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9509,7 +9509,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9550,7 +9550,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "clap",
  "eyre",
@@ -9573,7 +9573,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9589,7 +9589,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9605,7 +9605,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9618,7 +9618,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9648,7 +9648,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9662,7 +9662,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9672,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9697,7 +9697,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9717,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9735,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9767,7 +9767,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9819,7 +9819,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "serde",
  "serde_json",
@@ -9829,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9857,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "bytes",
  "futures",
@@ -9877,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9894,7 +9894,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "bindgen",
  "cc",
@@ -9903,7 +9903,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "futures",
  "metrics",
@@ -9916,7 +9916,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9939,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10022,7 +10022,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10046,7 +10046,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10061,7 +10061,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10075,7 +10075,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10092,7 +10092,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10116,7 +10116,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10184,7 +10184,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10239,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10286,7 +10286,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "bytes",
  "eyre",
@@ -10363,7 +10363,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10375,7 +10375,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10399,7 +10399,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10434,7 +10434,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10477,7 +10477,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10526,7 +10526,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10554,7 +10554,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10570,7 +10570,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10585,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10663,7 +10663,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10693,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10736,7 +10736,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10756,7 +10756,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10787,7 +10787,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10834,7 +10834,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10885,7 +10885,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10899,7 +10899,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10930,7 +10930,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10981,7 +10981,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11009,7 +11009,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11023,7 +11023,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11043,7 +11043,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11058,7 +11058,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11084,7 +11084,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11123,7 +11123,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11139,7 +11139,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11149,7 +11149,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "clap",
  "eyre",
@@ -11169,7 +11169,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11188,7 +11188,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11233,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11259,7 +11259,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11287,7 +11287,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11307,7 +11307,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11336,7 +11336,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7e3e0c0#7e3e0c0b6619c7711a4fdd732cfdcc0e057eec5e"
+source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,66 +144,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f152114", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
 reth-codecs = { version = "0.5.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f152114", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f152114", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
 reth-primitives-traits = { version = "0.5.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "7e3e0c0", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f152114", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`7e3e0c0...f152114`](https://github.com/paradigmxyz/reth/compare/7e3e0c0...f152114)

::warning::Failed to summarize upstream reth commits with Amp (exit 1)
::warning::Amp exited with status 1
- perf(engine): skip unnecessary BAL hashed account reads (#25369)
- feat(era): add ere file export (#25304)
- fix(rpc): buffer trace_filter block replays (#25133)
- fix(era): omit total difficulty and accumulator for post-merge ere exports (#25379)
- chore(deps): bump rtCamp/action-slack-notify from 2.3.3 to 2.4.0 (#25385)
- chore(deps): bump taiki-e/install-action from 2.75.24 to 2.81.9 (#25383)
- chore(deps): bump astral-sh/setup-uv from 6.3.1 to 8.2.0 (#25384)

## Migrations

::warning::Failed to summarize source migrations with Amp (exit 1)
::warning::Amp exited with status 1
 Cargo.toml | 114 ++++++++++++++++++++++++++++++-------------------------------
 1 file changed, 57 insertions(+), 57 deletions(-)

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/27736792408)
