### PR TITLE
ci(bench): retry bench chart pushes from fresh clones

### DIFF
--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -188,25 +188,47 @@ jobs:
           SAVE_MATRIX: ${{ needs.resolve-refs.outputs.save-matrix }}
         run: |
           CHARTS_REPO="https://x-access-token:${DEREK_TOKEN}@github.com/decofe/tempo-bench-charts.git"
-          TMP_DIR=$(mktemp -d)
+          TMP_DIR=""
 
-          if git clone --depth 1 --branch state "${CHARTS_REPO}" "${TMP_DIR}" 2>/dev/null; then
-            true
-          else
-            git init "${TMP_DIR}"
-            git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
-          fi
+          prepare_state() {
+            if [ -n "${TMP_DIR}" ]; then
+              rm -rf "${TMP_DIR}"
+            fi
 
-          echo "$SAVE_MATRIX" | jq -c '.include[]' | while read -r entry; do
-            state_file="$(echo "$entry" | jq -r '.state_file')"
-            feature_ref="$(echo "$entry" | jq -r '.feature_ref')"
-            mkdir -p "$(dirname "${TMP_DIR}/${state_file}")"
-            echo "${feature_ref}" > "${TMP_DIR}/${state_file}"
-            git -C "${TMP_DIR}" add "${state_file}"
+            TMP_DIR=$(mktemp -d)
+            if git clone --depth 1 --branch state "${CHARTS_REPO}" "${TMP_DIR}" 2>/dev/null; then
+              true
+            else
+              git init "${TMP_DIR}"
+              git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
+            fi
+
+            echo "$SAVE_MATRIX" | jq -c '.include[]' | while read -r entry; do
+              state_file="$(echo "$entry" | jq -r '.state_file')"
+              feature_ref="$(echo "$entry" | jq -r '.feature_ref')"
+              mkdir -p "$(dirname "${TMP_DIR}/${state_file}")"
+              echo "${feature_ref}" > "${TMP_DIR}/${state_file}"
+              git -C "${TMP_DIR}" add "${state_file}"
+            done
+          }
+
+          for attempt in 1 2 3 4 5; do
+            prepare_state
+            if git -C "${TMP_DIR}" diff --cached --quiet; then
+              echo "No state change"
+              rm -rf "${TMP_DIR}"
+              exit 0
+            fi
+            git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
+              commit -m "bench: update e2e nightly state"
+            if git -C "${TMP_DIR}" push origin HEAD:state; then
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::Failed to push state after ${attempt} attempts"
+              rm -rf "${TMP_DIR}"
+              exit 1
+            fi
+            sleep "$attempt"
           done
-
-          git -C "${TMP_DIR}" diff --cached --quiet && echo "No state change" && exit 0
-          git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
-            commit -m "bench: update e2e nightly state"
-          git -C "${TMP_DIR}" push origin HEAD:state
           rm -rf "${TMP_DIR}"

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -543,20 +543,39 @@ jobs:
           fi
           CHARTS_REPO="https://x-access-token:${{ secrets.DEREK_TOKEN }}@github.com/decofe/tempo-bench-charts.git"
 
-          TMP_DIR=$(mktemp -d)
-          if git clone --depth 1 "${CHARTS_REPO}" "${TMP_DIR}" 2>/dev/null; then
-            true
-          else
-            git init "${TMP_DIR}"
-            git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
-          fi
+          TMP_DIR=""
+          prepare_charts() {
+            if [ -n "${TMP_DIR}" ]; then
+              rm -rf "${TMP_DIR}"
+            fi
 
-          mkdir -p "${TMP_DIR}/${CHART_DIR}"
-          cp "$BENCH_WORK_DIR"/charts/*.png "${TMP_DIR}/${CHART_DIR}/"
-          git -C "${TMP_DIR}" add "${CHART_DIR}"
-          git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
-            commit -m "bench replay charts for ${BENCH_CHAIN} run ${RUN_ID}"
-          git -C "${TMP_DIR}" push origin HEAD:main
+            TMP_DIR=$(mktemp -d)
+            if git clone --depth 1 "${CHARTS_REPO}" "${TMP_DIR}" 2>/dev/null; then
+              true
+            else
+              git init "${TMP_DIR}"
+              git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
+            fi
+
+            mkdir -p "${TMP_DIR}/${CHART_DIR}"
+            cp "$BENCH_WORK_DIR"/charts/*.png "${TMP_DIR}/${CHART_DIR}/"
+            git -C "${TMP_DIR}" add "${CHART_DIR}"
+          }
+
+          for attempt in 1 2 3 4 5; do
+            prepare_charts
+            git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
+              commit -m "bench replay charts for ${BENCH_CHAIN} run ${RUN_ID}"
+            if git -C "${TMP_DIR}" push origin HEAD:main; then
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::Failed to push charts after ${attempt} attempts"
+              rm -rf "${TMP_DIR}"
+              exit 1
+            fi
+            sleep "$attempt"
+          done
           echo "sha=$(git -C "${TMP_DIR}" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "path=${CHART_DIR}" >> "$GITHUB_OUTPUT"
           rm -rf "${TMP_DIR}"


### PR DESCRIPTION
## Summary
- retry replay bench chart pushes by recreating the charts repo clone on each attempt
- retry bench E2E state pushes by recreating the charts repo clone on each attempt
- recopy generated chart/state files before each push attempt

## Testing
- git diff --check

Prompted by: @shekhirin