### PR TITLE
chore: bump workspace rust version to 1.96

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "1.8.2"
 edition = "2024"
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 authors = ["Tempo Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://docs.tempo.xyz"


### PR DESCRIPTION
## Summary
- bump the workspace `rust-version` from 1.95.0 to 1.96.0
- align the package MSRV with the existing Docker and sanitizer toolchain pins

## Testing
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`

Prompted by: @grandizzy