### PR TITLE
ci(bench): keep bench e2e Cargo target outside workspace

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -391,6 +391,7 @@ jobs:
       BENCH_FEATURE_ENV: ${{ inputs.feature-env }}
       BENCH_RUN_PAIRS: ${{ inputs.run-pairs || '3' }}
       BENCH_CLICKHOUSE_RUN: ${{ inputs.clickhouse-run || 'feature-1' }}
+      BENCH_CARGO_TARGET_ROOT: /mnt/bench-cargo-target/tempo-e2e
       BENCHMARK_ID: bench-e2e-${{ github.run_id }}
       BENCH_COMMENT_ID: ${{ inputs.comment-id }}
       BENCH_PR_HEAD_SHA: ${{ inputs.pr-head-sha }}

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1435,13 +1435,16 @@ def "main e2e" [
     # Build benchmark binaries in parallel. Regenesis uses latest origin/main so
     # snapshot rewriting is independent of either side being benchmarked.
     # with independent target/ directories, so cargo invocations don't collide.
+    let baseline_target_key = (bench-cache-key $baseline $baseline_tbc.features $no_default_features)
+    let feature_target_key = (bench-cache-key $feature $feature_tbc.features $no_default_features)
     mut builds = [
-        { wt: $baseline_wt, ref_name: $baseline, sha: $baseline, label: "baseline", features: $baseline_tbc.features, extra_rustflags: $baseline_tbc.extra_rustflags, bench_features: $baseline_build_features }
-        { wt: $feature_wt, ref_name: $feature, sha: $feature, label: "feature", features: $feature_tbc.features, extra_rustflags: $feature_tbc.extra_rustflags, bench_features: $feature_build_features }
+        { wt: $baseline_wt, ref_name: $baseline, sha: $baseline, label: "baseline", features: $baseline_tbc.features, extra_rustflags: $baseline_tbc.extra_rustflags, bench_features: $baseline_build_features, target_key: $baseline_target_key }
+        { wt: $feature_wt, ref_name: $feature, sha: $feature, label: "feature", features: $feature_tbc.features, extra_rustflags: $feature_tbc.extra_rustflags, bench_features: $feature_build_features, target_key: $feature_target_key }
     ]
     let regenesis_sha = if $regenesis_needed { git rev-parse origin/main | str trim } else { "" }
+    let regenesis_target_key = if $regenesis_needed { bench-cache-key $regenesis_sha $regenesis_tbc.features $no_default_features } else { "" }
     if $regenesis_needed {
-        $builds = ($builds | append { wt: $regenesis_wt, ref_name: "origin/main", sha: $regenesis_sha, label: "regenesis-main", features: $regenesis_tbc.features, extra_rustflags: $regenesis_tbc.extra_rustflags, bench_features: $regenesis_build_features })
+        $builds = ($builds | append { wt: $regenesis_wt, ref_name: "origin/main", sha: $regenesis_sha, label: "regenesis-main", features: $regenesis_tbc.features, extra_rustflags: $regenesis_tbc.extra_rustflags, bench_features: $regenesis_build_features, target_key: $regenesis_target_key })
     }
     $builds | par-each { |b|
         if $effective_no_cache {
@@ -1450,9 +1453,9 @@ def "main e2e" [
             build-in-worktree --no-default-features=$no_default_features $b.wt $b.ref_name $profile $b.features $b.sha
         }
     } | ignore
-    let baseline_tempo = (worktree-bin $baseline_wt $profile "tempo")
-    let feature_tempo = (worktree-bin $feature_wt $profile "tempo")
-    let regenesis_tempo = if $regenesis_needed { worktree-bin $regenesis_wt $profile "tempo" } else { "" }
+    let baseline_tempo = (worktree-bin $baseline_wt $profile "tempo" $baseline_target_key)
+    let feature_tempo = (worktree-bin $feature_wt $profile "tempo" $feature_target_key)
+    let regenesis_tempo = if $regenesis_needed { worktree-bin $regenesis_wt $profile "tempo" $regenesis_target_key } else { "" }
     let baseline_arg_filter = (supported-node-arg-filter $baseline_tempo $E2E_LOCAL_RETH_ARGS)
     let feature_arg_filter = (supported-node-arg-filter $feature_tempo $E2E_LOCAL_RETH_ARGS)
     let removed_arg_config = $"(format-removed-node-arg-config 'baseline' $baseline_arg_filter.removed)(format-removed-node-arg-config 'feature' $feature_arg_filter.removed)"

--- a/tempo.nu
+++ b/tempo.nu
@@ -72,6 +72,23 @@ def cargo-feature-args [features: string, no_default_features: bool] {
     $no_default_args | append $feature_args
 }
 
+def cargo-profile-dir [profile: string] {
+    if $profile == "dev" { "debug" } else { $profile }
+}
+
+def cargo-target-dir [worktree_dir: string, target_key: string] {
+    let root = ($env | get -o BENCH_CARGO_TARGET_ROOT | default "")
+    if $root == "" {
+        $"($worktree_dir)/target"
+    } else {
+        $"($root)/($target_key)"
+    }
+}
+
+def cargo-bin-path [target_dir: string, profile: string, bin_name: string] {
+    $"($target_dir)/(cargo-profile-dir $profile)/($bin_name)"
+}
+
 # Validate mode is either "dev" or "consensus"
 def validate-mode [mode: string] {
     if $mode != "dev" and $mode != "consensus" {
@@ -446,16 +463,13 @@ def try-cache-download [worktree_dir: string, profile: string, commit_sha: strin
     }
 
     # All binaries exist – download them
-    let target_dir = if $profile == "dev" {
-        $"($worktree_dir)/target/debug"
-    } else {
-        $"($worktree_dir)/target/($profile)"
-    }
-    mkdir $target_dir
+    let target_dir = (cargo-target-dir $worktree_dir $cache_key)
+    let profile_dir = $"($target_dir)/(cargo-profile-dir $profile)"
+    mkdir $profile_dir
 
     for bin in $bins {
         let remote = $"($MINIO_BUCKET)/($cache_key)/($bin)"
-        let local = $"($target_dir)/($bin)"
+        let local = (cargo-bin-path $target_dir $profile $bin)
         print $"Downloading cached ($bin) for ($commit_sha | str substring 0..8)..."
         try {
             mc cp $remote $local
@@ -468,7 +482,7 @@ def try-cache-download [worktree_dir: string, profile: string, commit_sha: strin
 
     # Verify binaries work
     for bin in $bins {
-        let local = $"($target_dir)/($bin)"
+        let local = (cargo-bin-path $target_dir $profile $bin)
         try {
             run-external $local "--version"
         } catch {
@@ -485,14 +499,10 @@ def try-cache-download [worktree_dir: string, profile: string, commit_sha: strin
 def cache-upload [worktree_dir: string, profile: string, commit_sha: string, cache_key: string] {
     if not (has-mc) { return }
 
-    let target_dir = if $profile == "dev" {
-        $"($worktree_dir)/target/debug"
-    } else {
-        $"($worktree_dir)/target/($profile)"
-    }
+    let target_dir = (cargo-target-dir $worktree_dir $cache_key)
 
     for bin in ["tempo"] {
-        let local = $"($target_dir)/($bin)"
+        let local = (cargo-bin-path $target_dir $profile $bin)
         let remote = $"($MINIO_BUCKET)/($cache_key)/($bin)"
         print $"Uploading ($bin) to cache for ($commit_sha | str substring 0..8)..."
         try {
@@ -518,7 +528,8 @@ def build-in-worktree [worktree_dir: string, ref: string, profile: string, featu
     let build_cmd = ["cargo" "build" "--profile" $profile]
         | append $feature_args
         | append ["--bin" "tempo"]
-    with-env { RUSTFLAGS: $rustflags } {
+    let target_dir = (cargo-target-dir $worktree_dir $cache_key)
+    with-env { RUSTFLAGS: $rustflags, CARGO_TARGET_DIR: $target_dir } {
         do { cd $worktree_dir; run-external ($build_cmd | first) ...($build_cmd | skip 1) }
     }
 
@@ -527,12 +538,10 @@ def build-in-worktree [worktree_dir: string, ref: string, profile: string, featu
 }
 
 # Get the path to a built binary in a worktree
-def worktree-bin [worktree_dir: string, profile: string, bin_name: string] {
-    if $profile == "dev" {
-        $"($worktree_dir)/target/debug/($bin_name)"
-    } else {
-        $"($worktree_dir)/target/($profile)/($bin_name)"
-    }
+def worktree-bin [worktree_dir: string, profile: string, bin_name: string, target_key?: string] {
+    let key = ($target_key | default "")
+    let target_dir = if $key == "" { $"($worktree_dir)/target" } else { cargo-target-dir $worktree_dir $key }
+    cargo-bin-path $target_dir $profile $bin_name
 }
 
 # Dedup CLI args: if extra_args provides a flag already present in base_args,


### PR DESCRIPTION
## Summary
- set `BENCH_CARGO_TARGET_ROOT` for the bench-e2e workflow outside `GITHUB_WORKSPACE`
- route worktree Cargo builds, MinIO binary cache paths, and binary lookup through per-cache-key target directories
- keep existing local behavior when `BENCH_CARGO_TARGET_ROOT` is unset

## Validation
- `nu --commands 'source tempo.nu'`\n- `nu --commands 'source bench-e2e.nu'`\n- `nu --commands 'source tempo.nu; worktree-bin . profiling tempo'`\n- `nu --commands 'source tempo.nu; with-env { BENCH_CARGO_TARGET_ROOT: /mnt/bench-cargo-target/tempo-e2e } { worktree-bin . profiling tempo abc123-features-jemalloc }'`\n- `git diff --check`\n\nPrompted by: @shekhirin