### PR TITLE
ci: reset bench e2e workspace

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -405,6 +405,11 @@ jobs:
       SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
       SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
     steps:
+      - name: Reset workspace directory
+        run: |
+          sudo rm -rf "$GITHUB_WORKSPACE"
+          sudo -u actions-runner mkdir -p "$GITHUB_WORKSPACE"
+
       - name: Configure OTLP telemetry
         if: env.BENCH_OTLP == 'true'
         env:


### PR DESCRIPTION
## Summary
- add the first bench-e2e job step to remove `$GITHUB_WORKSPACE` and recreate it as `actions-runner` before checkout/setup steps

## Verification
- `uv run --with pyyaml python -c 'import yaml; yaml.safe_load(open(".github/workflows/bench-e2e.yml")); print("yaml ok")'`
- `git diff --check`

Prompted by: @shekhirin