### PR TITLE
docs(tip-1083): increase testnet gas limit

### DIFF
--- a/tips/tip-1083.md
+++ b/tips/tip-1083.md
@@ -12,40 +12,21 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP configures Tempo Moderato/testnet builders to target a 1,000,000,000 gas block limit. The change is testnet-only and uses the existing Ethereum parent gas-limit adjustment rule, so block gas limit increases gradually from the current 500,000,000 gas value instead of jumping to 1 gigagas in a single block. Existing post-T4 lane semantics remain unchanged: shared gas remains 0, proposer transactions may use the full block budget, and non-payment transactions remain capped by the existing general gas limit.
+This TIP configures Tempo Moderato/testnet builders to target a 1,000,000,000 gas block limit. The change is testnet-only and uses the existing Ethereum parent gas-limit adjustment rule, so the block gas limit ramps gradually from the current 500,000,000 gas value instead of jumping to 1 gigagas in a single block.
+
+Post-T4 lane semantics are unchanged: shared gas remains 0, proposer transactions may use the full header gas limit, and non-payment transactions remain capped by the existing general gas limit.
 
 ## Motivation
 
-Tempo testnet should be able to exercise higher payment-lane throughput than the current mainnet launch parameters while keeping the risk isolated from mainnet. Raising the Moderato/testnet block gas target to 1 gigagas doubles available block capacity for testnet load generation, integration testing, and validator performance evaluation without changing transaction semantics.
+Tempo testnet should be able to exercise higher payment-lane throughput than the current mainnet launch parameters while keeping the risk isolated from mainnet. Raising the Moderato/testnet block gas target to 1 gigagas doubles available block capacity for load generation, integration testing, and validator performance evaluation.
 
-An instant 500,000,000 to 1,000,000,000 gas jump would require a consensus exception because the existing parent gas-limit rule rejects sudden increases. This TIP instead keeps that protection intact and changes only builder policy: upgraded builders move the header gas limit toward the 1 gigagas target by the maximum existing parent-bounded step.
-
-The alternative is to continue testing at the 500,000,000 gas limit defined in TIP-1010. That keeps testnet aligned with mainnet but limits the ability to observe block propagation, payload construction, execution, and database behavior under the next capacity target.
-
-## Assumptions
-
-- This TIP applies only to the Tempo Moderato/testnet builder policy. Mainnet parameters remain governed by TIP-1010 or a future mainnet-specific TIP.
-- Existing consensus validation for parent gas-limit deltas remains active. A child block that jumps directly from 500,000,000 gas to 1,000,000,000 gas remains invalid.
-- The rollout is a coordinated testnet builder release or configuration change, not a consensus exception.
-- The activation point is post-T4, so `shared_gas_limit` remains 0 and explicit subblocks remain disabled.
-- The existing testnet general gas limit remains unchanged unless another TIP changes it. This proposal increases payment-lane headroom, not general-contract capacity.
-- Validators, RPC nodes, load generators, and indexers can be upgraded before or during the ramp. Validators that do not update builder policy still validate ramped blocks and, when proposing, preserve the parent gas limit; this slows the ramp but does not create an incompatible block by itself.
-- The target testnet validator set and hardware profile are representative enough to surface payload construction, execution, propagation, and indexing regressions before any mainnet capacity proposal.
-
-## Threat Model
-
-- **Validators and block builders** are trusted to run the scheduled Moderato/testnet builder policy. A stale builder may stop increasing the gas limit when it is leader, delaying the ramp, but should not fall out of consensus merely because other builders ramp within the parent-bound rule.
-- **Transaction submitters and load generators** may try to saturate the enlarged payment lane as capacity grows. This is in scope and should be used to measure whether execution, networking, and storage remain healthy through the ramp and at 1 gigagas.
-- **RPC providers and indexers** must tolerate gradually larger blocks and higher event volume. Resource exhaustion in those systems is in scope for testnet monitoring, but this TIP does not change RPC correctness rules.
-- **General-contract workloads** remain bounded by the existing general gas limit. Attempts to use the higher total block gas limit to run larger non-payment workloads are out of scope and must continue to be rejected by lane enforcement.
+An instant 500,000,000 to 1,000,000,000 gas jump would require a consensus exception because the existing parent gas-limit rule rejects sudden increases. This TIP keeps that protection intact and changes only builder policy: upgraded builders move the header gas limit toward the 1 gigagas target by the maximum existing parent-bounded step.
 
 ---
 
 # Specification
 
-## Activation Scope
-
-At the activation time or block, Tempo Moderato/testnet builders MUST target:
+At activation, upgraded Moderato/testnet builders target:
 
 | Parameter | Value |
 |---|---:|
@@ -55,11 +36,11 @@ At the activation time or block, Tempo Moderato/testnet builders MUST target:
 | Non-shared gas limit | Current header `gas_limit` |
 | General gas limit | Unchanged from the pre-activation testnet value |
 
-Mainnet chainspecs and mainnet builder policy MUST NOT change as part of this TIP.
+Mainnet chainspecs and mainnet builder policy are unchanged.
 
 ## Ramp Rule
 
-For each new Moderato/testnet block after activation, an upgraded builder MUST choose the block header `gas_limit` by moving from the parent gas limit toward the target while staying within the existing parent gas-limit bound:
+For each new Moderato/testnet block after activation, an upgraded builder chooses the block header `gas_limit` by moving from the parent gas limit toward the target while staying within the existing parent gas-limit bound:
 
 ```python
 target_block_gas_limit = 1_000_000_000
@@ -78,84 +59,59 @@ block_gas_limit = clamp(
 
 From a 500,000,000 gas parent, the first upgraded child block has a gas limit of 500,488,280 gas. If every proposer applies the ramp rule and no blocks hold the parent value unchanged, the chain reaches the 1,000,000,000 gas target in roughly 710 blocks.
 
-Once the parent gas limit is 1,000,000,000 gas, upgraded builders MUST keep proposing 1,000,000,000 gas unless a later TIP changes the target.
+Once the parent gas limit is 1,000,000,000 gas, upgraded builders continue proposing 1,000,000,000 gas unless a later TIP changes the target.
 
 ## Gas Budget Semantics
 
-The enlarged block gas limit uses the current post-T4 payment/general lane model:
+The current post-T4 payment/general lane model is preserved:
 
 1. T4+ subblocks remain disabled, so `shared_gas_limit = 0`.
 2. Proposer-selected payment and general transactions share the current block header gas limit.
 3. General transactions are additionally capped by `general_gas_limit`.
-4. Payment-lane transactions MAY consume the remaining block capacity after general transactions.
+4. Payment-lane transactions may consume the remaining block capacity after general transactions.
 
-During the ramp, payment-lane headroom grows with the current header gas limit:
+During the ramp:
 
 ```text
 payment-lane headroom = block_gas_limit - shared_gas_limit - general_gas_limit
 ```
 
-If the testnet general gas limit is 30,000,000 gas and shared gas is 0, the payment-lane headroom reaches 970,000,000 gas at the 1 gigagas target. For a 50,000 gas TIP-20 transfer, that target supports up to 20,000 transfers per block before the general reservation, or up to 19,400 proposer payment-lane transfers per block after reserving 30,000,000 gas for general transactions.
+If the testnet general gas limit is 30,000,000 gas and shared gas is 0, payment-lane headroom reaches 970,000,000 gas at the 1 gigagas target. For a 50,000 gas TIP-20 transfer, that target supports up to 20,000 transfers per block before the general reservation, or up to 19,400 proposer payment-lane transfers per block after reserving 30,000,000 gas for general transactions.
 
 ## Block Validity
 
-This TIP does not add a new consensus exception. Testnet block validity continues to use the existing parent gas-limit rule and lane checks. A block MUST be invalid if any of the following hold:
+This TIP does not add a new consensus exception. A block with a header gas limit below 1,000,000,000 gas is valid during the ramp if it satisfies existing consensus rules. A block that jumps directly from 500,000,000 gas to 1,000,000,000 gas is invalid.
 
-- The child header gas limit increase or decrease violates the existing parent gas-limit bound.
-- `shared_gas_limit` does not match the value derived from the active hardfork and header gas limit.
-- Total non-payment proposer gas used exceeds `general_gas_limit`.
-- Total block gas used exceeds the header `gas_limit`.
+Validators that do not update builder policy still validate ramped blocks. When they propose, they may preserve the parent gas limit, slowing the ramp but not creating an incompatible block by itself.
 
-A block with a header gas limit below 1,000,000,000 gas is valid during the ramp if it satisfies existing consensus rules. A block that jumps directly from 500,000,000 gas to 1,000,000,000 gas is invalid.
+The transaction gas cap is unchanged by this TIP. Transactions that exceed the existing per-transaction gas cap continue to be rejected.
 
-The transaction gas cap is unchanged by this TIP. Transactions that exceed the existing per-transaction gas cap MUST continue to be rejected.
+## Rollout and Monitoring
 
-## Rollout
+Operators should publish the activation time or block, the 1,000,000,000 gas target, and the expected ramp behavior.
 
-The change MUST activate through a scheduled Moderato/testnet builder policy rollout. Operators SHOULD publish release notes that state the activation time or block, the 1,000,000,000 gas target, the expected ramp behavior, and the resulting target total, shared, non-shared, and general gas limits.
+During the ramp, operators should monitor parent gas limit, proposed gas limit, target gas limit, builder stop reason, block propagation latency, execution time, RPC latency, indexing lag, and consensus validation errors labeled by gas-limit rule.
 
-Before activation, testnet maintainers SHOULD run sustained load at or above the previous 500,000,000 gas limit to establish a baseline. During the ramp, maintainers SHOULD monitor each block's header gas limit and builder stop reason to confirm the network is moving toward the target. After the target is reached, maintainers SHOULD run sustained payment-lane load near the new block limit and compare block production, propagation, execution, RPC, and indexing behavior against the baseline.
-
-# Tooling
-
-Chainspec and payload-building tooling MUST expose both the current block header gas limit and the configured testnet target gas limit. Test helpers and fixtures that assert testnet block gas parameters MUST be updated to expect:
-
-- `target_block_gas_limit = 1,000,000,000`
-- First upgraded child from a 500,000,000 gas parent: `block_gas_limit = 500,488,280`
-- `shared_gas_limit = 0`
-- `non_shared_gas_limit = block_gas_limit`
-- `general_gas_limit` unchanged from the pre-activation testnet value
-
-Load-generation presets SHOULD add or update a 1 gigagas testnet profile so operators can fill the enlarged payment lane once the ramp reaches the target. Tools that decide whether the ramp has completed SHOULD compare the current header gas limit to the target rather than assuming the target is active immediately at rollout.
-
-# Observability
-
-N/A: no new event type is required. Existing block builder, execution, RPC, and node metrics MUST be sufficient to answer the following operational questions during the ramp and at 1 gigagas:
-
-| Question | Required signal |
-|---|---|
-| Are builders moving toward the target? | Parent gas limit, proposed gas limit, target gas limit, and ramp step per block |
-| Are builders filling the available block budget? | Total gas used, shared gas used, general gas used, payment-lane gas used, and builder stop reason per block |
-| Are blocks propagating within the expected testnet slot budget? | Block proposal, receive, validation, and import latency |
-| Is execution staying within resource budgets? | Block execution time, payload build time, database read/write latency, cache hit rates, CPU, memory, and disk I/O |
-| Are RPC and indexing systems keeping up? | RPC latency, pending queue depth, log/indexing lag, dropped connections, and error rates |
-| Are nodes rejecting blocks for gas-limit reasons? | Consensus validation errors labeled by gas-limit rule |
-
-Dashboards and alerts SHOULD compare pre-activation 500,000,000 gas behavior, in-ramp behavior, and post-ramp 1,000,000,000 gas behavior.
+---
 
 # Invariants
 
-- Mainnet block gas parameters and builder policy MUST NOT change because of this TIP.
-- Upgraded Moderato/testnet builders MUST target a 1,000,000,000 gas block limit after activation.
-- Upgraded builders MUST move toward the target only through the existing parent-bounded gas limit adjustment.
-- A child block MUST NOT jump directly from 500,000,000 gas to 1,000,000,000 gas.
-- Testnet blocks below 1,000,000,000 gas MUST remain valid during the ramp when they satisfy existing consensus rules.
-- Once the parent gas limit is 1,000,000,000 gas, upgraded builders MUST keep proposing 1,000,000,000 gas unless a later TIP changes the target.
-- `shared_gas_limit` MUST remain 0 on testnet after activation.
-- `non_shared_gas_limit` MUST equal `block_gas_limit - shared_gas_limit`, producing the current header gas limit while shared gas is 0.
-- `general_gas_limit` MUST remain unchanged unless another TIP explicitly changes it.
-- Payment-lane transactions MUST be able to consume unused non-shared capacity after general transactions.
-- Non-payment transactions MUST remain bounded by `general_gas_limit`.
-- The per-transaction gas cap MUST remain unchanged.
-- Blocks that exceed any applicable total, shared, non-shared, or general gas limit MUST be rejected.
-- Test coverage MUST include ramp-step calculation, activation-boundary behavior, block validity under the parent gas-limit rule, shared and non-shared budget derivation, general-lane enforcement, target completion behavior, and unchanged mainnet parameters.
+- Mainnet block gas parameters and builder policy are unchanged.
+- Upgraded Moderato/testnet builders target a 1,000,000,000 gas block limit after activation.
+- Upgraded builders move toward the target only through the existing parent-bounded gas limit adjustment.
+- A child block does not jump directly from 500,000,000 gas to 1,000,000,000 gas.
+- Testnet blocks below 1,000,000,000 gas remain valid during the ramp when they satisfy existing consensus rules.
+- Once the parent gas limit is 1,000,000,000 gas, upgraded builders keep proposing 1,000,000,000 gas unless a later TIP changes the target.
+- `shared_gas_limit` remains 0 on testnet after activation.
+- `non_shared_gas_limit` equals `block_gas_limit - shared_gas_limit`, producing the current header gas limit while shared gas is 0.
+- `general_gas_limit` remains unchanged unless another TIP explicitly changes it.
+- Non-payment transactions remain bounded by `general_gas_limit`.
+- The per-transaction gas cap remains unchanged.
+
+## Test Cases
+
+- Ramp-step calculation from a 500,000,000 gas parent produces 500,488,280 gas.
+- A direct 500,000,000 to 1,000,000,000 gas child block is rejected by existing parent gas-limit validation.
+- Blocks below 1,000,000,000 gas remain valid during the ramp when parent-bound validation passes.
+- Shared, non-shared, and general gas limits are derived from the current header gas limit.
+- Mainnet parameters are unchanged.

--- a/tips/tip-1083.md
+++ b/tips/tip-1083.md
@@ -2,7 +2,7 @@
 id: TIP-1083
 title: Ramp Testnet Block Gas Limit to 1 Gigagas
 description: Raise the Tempo Moderato/testnet block gas target to 1,000,000,000 gas using the existing parent-bounded gas limit adjustment.
-authors: Internal
+authors: @shekhirin
 status: Draft
 related: TIP-1010, TIP-1046
 protocolVersion: TBD

--- a/tips/tip-1083.md
+++ b/tips/tip-1083.md
@@ -1,46 +1,45 @@
 ---
 id: TIP-1083
 title: Ramp Testnet Block Gas Limit to 1 Gigagas
-description: Raise the Tempo Moderato/testnet block gas target to 1,000,000,000 gas using the existing parent-bounded gas limit adjustment.
+description: Track a testnet-only builder policy change that raises the block gas target to 1,000,000,000 gas using the existing parent-bounded gas limit rule.
 authors: @shekhirin
 status: Draft
 related: TIP-1010, TIP-1046
-protocolVersion: TBD
+protocolVersion: n/a
 ---
 
 # TIP-1083: Ramp Testnet Block Gas Limit to 1 Gigagas
 
 ## Abstract
 
-This TIP configures Tempo Moderato/testnet builders to target a 1,000,000,000 gas block limit. The change is testnet-only and uses the existing Ethereum parent gas-limit adjustment rule, so the block gas limit ramps gradually from the current 500,000,000 gas value instead of jumping to 1 gigagas in a single block.
+This TIP tracks a Tempo Moderato/testnet builder policy change that raises the block gas target from 500,000,000 to 1,000,000,000 gas. It is not a hardfork: builders use the existing Ethereum parent gas-limit adjustment rule, so the header gas limit ramps over roughly 710 blocks instead of jumping in one block.
 
-Post-T4 lane semantics are unchanged: shared gas remains 0, proposer transactions may use the full header gas limit, and non-payment transactions remain capped by the existing general gas limit.
+Mainnet parameters are unchanged. The testnet general gas limit remains 30,000,000 gas.
 
 ## Motivation
 
-Tempo testnet should be able to exercise higher payment-lane throughput than the current mainnet launch parameters while keeping the risk isolated from mainnet. Raising the Moderato/testnet block gas target to 1 gigagas doubles available block capacity for load generation, integration testing, and validator performance evaluation.
+Moderato/testnet load tests currently saturate the 500,000,000 gas block limit at around 10,000 TPS. Raising the builder target to 1,000,000,000 gas lets operators stress test up to roughly 20,000 TPS while keeping mainnet launch parameters unchanged.
 
-An instant 500,000,000 to 1,000,000,000 gas jump would require a consensus exception because the existing parent gas-limit rule rejects sudden increases. This TIP keeps that protection intact and changes only builder policy: upgraded builders move the header gas limit toward the 1 gigagas target by the maximum existing parent-bounded step.
+The gradual ramp keeps the existing protection against sudden gas-limit bumps intact. An immediate 500,000,000 to 1,000,000,000 gas child block remains invalid.
 
 ---
 
 # Specification
 
-At activation, upgraded Moderato/testnet builders target:
+When the policy is rolled out, upgraded Moderato/testnet builders target:
 
 | Parameter | Value |
 |---|---:|
 | Target block gas limit | 1,000,000,000 gas |
 | Gas limit bound divisor | 1,024 |
 | Shared gas limit | 0 gas |
-| Non-shared gas limit | Current header `gas_limit` |
-| General gas limit | Unchanged from the pre-activation testnet value |
+| General gas limit | Unchanged, currently 30,000,000 gas |
 
 Mainnet chainspecs and mainnet builder policy are unchanged.
 
 ## Ramp Rule
 
-For each new Moderato/testnet block after activation, an upgraded builder chooses the block header `gas_limit` by moving from the parent gas limit toward the target while staying within the existing parent gas-limit bound:
+For each new Moderato/testnet block after rollout, an upgraded builder chooses the block header `gas_limit` by moving from the parent gas limit toward the target while staying within the existing parent gas-limit bound:
 
 ```python
 target_block_gas_limit = 1_000_000_000
@@ -57,58 +56,29 @@ block_gas_limit = clamp(
 )
 ```
 
-From a 500,000,000 gas parent, the first upgraded child block has a gas limit of 500,488,280 gas. If every proposer applies the ramp rule and no blocks hold the parent value unchanged, the chain reaches the 1,000,000,000 gas target in roughly 710 blocks.
+From a 500,000,000 gas parent, the first upgraded child block has a gas limit of 500,488,280 gas. If every proposer applies the ramp rule and no blocks hold the parent value unchanged, the chain reaches the 1,000,000,000 gas target in roughly 710 blocks. Validators that have not updated builder policy still validate ramped blocks; when they propose, they may preserve the parent gas limit and only slow the ramp.
 
-Once the parent gas limit is 1,000,000,000 gas, upgraded builders continue proposing 1,000,000,000 gas unless a later TIP changes the target.
+## Gas Budget
 
-## Gas Budget Semantics
+The current post-T4 payment/general lane model is preserved: T4+ subblocks remain disabled, `shared_gas_limit = 0`, `non_shared_gas_limit` equals the current header `gas_limit`, and non-payment transactions remain capped by `general_gas_limit`.
 
-The current post-T4 payment/general lane model is preserved:
-
-1. T4+ subblocks remain disabled, so `shared_gas_limit = 0`.
-2. Proposer-selected payment and general transactions share the current block header gas limit.
-3. General transactions are additionally capped by `general_gas_limit`.
-4. Payment-lane transactions may consume the remaining block capacity after general transactions.
-
-During the ramp:
-
-```text
-payment-lane headroom = block_gas_limit - shared_gas_limit - general_gas_limit
-```
-
-If the testnet general gas limit is 30,000,000 gas and shared gas is 0, payment-lane headroom reaches 970,000,000 gas at the 1 gigagas target. For a 50,000 gas TIP-20 transfer, that target supports up to 20,000 transfers per block before the general reservation, or up to 19,400 proposer payment-lane transfers per block after reserving 30,000,000 gas for general transactions.
-
-## Block Validity
-
-This TIP does not add a new consensus exception. A block with a header gas limit below 1,000,000,000 gas is valid during the ramp if it satisfies existing consensus rules. A block that jumps directly from 500,000,000 gas to 1,000,000,000 gas is invalid.
-
-Validators that do not update builder policy still validate ramped blocks. When they propose, they may preserve the parent gas limit, slowing the ramp but not creating an incompatible block by itself.
+With a 30,000,000 gas general limit and 0 shared gas, payment-lane headroom reaches 970,000,000 gas at the 1 gigagas target. For a 50,000 gas TIP-20 transfer, that target supports up to 20,000 transfers per block before the general reservation, or up to 19,400 proposer payment-lane transfers per block after reserving 30,000,000 gas for general transactions.
 
 The transaction gas cap is unchanged by this TIP. Transactions that exceed the existing per-transaction gas cap continue to be rejected.
-
-## Rollout and Monitoring
-
-Operators should publish the activation time or block, the 1,000,000,000 gas target, and the expected ramp behavior.
-
-During the ramp, operators should monitor parent gas limit, proposed gas limit, target gas limit, builder stop reason, block propagation latency, execution time, RPC latency, indexing lag, and consensus validation errors labeled by gas-limit rule.
 
 ---
 
 # Invariants
 
 - Mainnet block gas parameters and builder policy are unchanged.
-- Upgraded Moderato/testnet builders target a 1,000,000,000 gas block limit after activation.
+- Upgraded Moderato/testnet builders target a 1,000,000,000 gas block limit after rollout.
 - Upgraded builders move toward the target only through the existing parent-bounded gas limit adjustment.
-- A child block does not jump directly from 500,000,000 gas to 1,000,000,000 gas.
+- A direct 500,000,000 to 1,000,000,000 gas child block remains invalid.
 - Testnet blocks below 1,000,000,000 gas remain valid during the ramp when they satisfy existing consensus rules.
-- Once the parent gas limit is 1,000,000,000 gas, upgraded builders keep proposing 1,000,000,000 gas unless a later TIP changes the target.
-- `shared_gas_limit` remains 0 on testnet after activation.
-- `non_shared_gas_limit` equals `block_gas_limit - shared_gas_limit`, producing the current header gas limit while shared gas is 0.
-- `general_gas_limit` remains unchanged unless another TIP explicitly changes it.
-- Non-payment transactions remain bounded by `general_gas_limit`.
-- The per-transaction gas cap remains unchanged.
+- `shared_gas_limit` remains 0 and `non_shared_gas_limit` equals the current header gas limit.
+- `general_gas_limit` and the per-transaction gas cap remain unchanged.
 
-## Test Cases
+## Test Coverage
 
 - Ramp-step calculation from a 500,000,000 gas parent produces 500,488,280 gas.
 - A direct 500,000,000 to 1,000,000,000 gas child block is rejected by existing parent gas-limit validation.

--- a/tips/tip-1083.md
+++ b/tips/tip-1083.md
@@ -2,7 +2,7 @@
 id: TIP-1083
 title: Ramp Testnet Block Gas Limit to 1 Gigagas
 description: Track a testnet-only builder policy change that raises the block gas target to 1,000,000,000 gas using the existing parent-bounded gas limit rule.
-authors: @shekhirin
+authors: Alexey Shekhirin (@shekhirin)
 status: Draft
 related: TIP-1010, TIP-1046
 protocolVersion: n/a

--- a/tips/tip-1083.md
+++ b/tips/tip-1083.md
@@ -1,6 +1,6 @@
 ---
 id: TIP-1083
-title: Ramp Testnet Block Gas Limit to 1 Gigagas
+title: Increase Testnet Block Gas Limit to 1 Gigagas
 description: Track a testnet-only builder policy change that raises the block gas target to 1,000,000,000 gas using the existing parent-bounded gas limit rule.
 authors: Alexey Shekhirin (@shekhirin)
 status: Draft
@@ -8,7 +8,7 @@ related: TIP-1010, TIP-1046
 protocolVersion: n/a
 ---
 
-# TIP-1083: Ramp Testnet Block Gas Limit to 1 Gigagas
+# TIP-1083: Increase Testnet Block Gas Limit to 1 Gigagas
 
 ## Abstract
 

--- a/tips/tip-1083.md
+++ b/tips/tip-1083.md
@@ -1,0 +1,161 @@
+---
+id: TIP-1083
+title: Ramp Testnet Block Gas Limit to 1 Gigagas
+description: Raise the Tempo Moderato/testnet block gas target to 1,000,000,000 gas using the existing parent-bounded gas limit adjustment.
+authors: Internal
+status: Draft
+related: TIP-1010, TIP-1046
+protocolVersion: TBD
+---
+
+# TIP-1083: Ramp Testnet Block Gas Limit to 1 Gigagas
+
+## Abstract
+
+This TIP configures Tempo Moderato/testnet builders to target a 1,000,000,000 gas block limit. The change is testnet-only and uses the existing Ethereum parent gas-limit adjustment rule, so block gas limit increases gradually from the current 500,000,000 gas value instead of jumping to 1 gigagas in a single block. Existing post-T4 lane semantics remain unchanged: shared gas remains 0, proposer transactions may use the full block budget, and non-payment transactions remain capped by the existing general gas limit.
+
+## Motivation
+
+Tempo testnet should be able to exercise higher payment-lane throughput than the current mainnet launch parameters while keeping the risk isolated from mainnet. Raising the Moderato/testnet block gas target to 1 gigagas doubles available block capacity for testnet load generation, integration testing, and validator performance evaluation without changing transaction semantics.
+
+An instant 500,000,000 to 1,000,000,000 gas jump would require a consensus exception because the existing parent gas-limit rule rejects sudden increases. This TIP instead keeps that protection intact and changes only builder policy: upgraded builders move the header gas limit toward the 1 gigagas target by the maximum existing parent-bounded step.
+
+The alternative is to continue testing at the 500,000,000 gas limit defined in TIP-1010. That keeps testnet aligned with mainnet but limits the ability to observe block propagation, payload construction, execution, and database behavior under the next capacity target.
+
+## Assumptions
+
+- This TIP applies only to the Tempo Moderato/testnet builder policy. Mainnet parameters remain governed by TIP-1010 or a future mainnet-specific TIP.
+- Existing consensus validation for parent gas-limit deltas remains active. A child block that jumps directly from 500,000,000 gas to 1,000,000,000 gas remains invalid.
+- The rollout is a coordinated testnet builder release or configuration change, not a consensus exception.
+- The activation point is post-T4, so `shared_gas_limit` remains 0 and explicit subblocks remain disabled.
+- The existing testnet general gas limit remains unchanged unless another TIP changes it. This proposal increases payment-lane headroom, not general-contract capacity.
+- Validators, RPC nodes, load generators, and indexers can be upgraded before or during the ramp. Validators that do not update builder policy still validate ramped blocks and, when proposing, preserve the parent gas limit; this slows the ramp but does not create an incompatible block by itself.
+- The target testnet validator set and hardware profile are representative enough to surface payload construction, execution, propagation, and indexing regressions before any mainnet capacity proposal.
+
+## Threat Model
+
+- **Validators and block builders** are trusted to run the scheduled Moderato/testnet builder policy. A stale builder may stop increasing the gas limit when it is leader, delaying the ramp, but should not fall out of consensus merely because other builders ramp within the parent-bound rule.
+- **Transaction submitters and load generators** may try to saturate the enlarged payment lane as capacity grows. This is in scope and should be used to measure whether execution, networking, and storage remain healthy through the ramp and at 1 gigagas.
+- **RPC providers and indexers** must tolerate gradually larger blocks and higher event volume. Resource exhaustion in those systems is in scope for testnet monitoring, but this TIP does not change RPC correctness rules.
+- **General-contract workloads** remain bounded by the existing general gas limit. Attempts to use the higher total block gas limit to run larger non-payment workloads are out of scope and must continue to be rejected by lane enforcement.
+
+---
+
+# Specification
+
+## Activation Scope
+
+At the activation time or block, Tempo Moderato/testnet builders MUST target:
+
+| Parameter | Value |
+|---|---:|
+| Target block gas limit | 1,000,000,000 gas |
+| Gas limit bound divisor | 1,024 |
+| Shared gas limit | 0 gas |
+| Non-shared gas limit | Current header `gas_limit` |
+| General gas limit | Unchanged from the pre-activation testnet value |
+
+Mainnet chainspecs and mainnet builder policy MUST NOT change as part of this TIP.
+
+## Ramp Rule
+
+For each new Moderato/testnet block after activation, an upgraded builder MUST choose the block header `gas_limit` by moving from the parent gas limit toward the target while staying within the existing parent gas-limit bound:
+
+```python
+target_block_gas_limit = 1_000_000_000
+gas_limit_bound_divisor = 1_024
+
+delta = max(parent_gas_limit // gas_limit_bound_divisor - 1, 0)
+min_gas_limit = parent_gas_limit - delta
+max_gas_limit = parent_gas_limit + delta
+
+block_gas_limit = clamp(
+    target_block_gas_limit,
+    min_gas_limit,
+    max_gas_limit,
+)
+```
+
+From a 500,000,000 gas parent, the first upgraded child block has a gas limit of 500,488,280 gas. If every proposer applies the ramp rule and no blocks hold the parent value unchanged, the chain reaches the 1,000,000,000 gas target in roughly 710 blocks.
+
+Once the parent gas limit is 1,000,000,000 gas, upgraded builders MUST keep proposing 1,000,000,000 gas unless a later TIP changes the target.
+
+## Gas Budget Semantics
+
+The enlarged block gas limit uses the current post-T4 payment/general lane model:
+
+1. T4+ subblocks remain disabled, so `shared_gas_limit = 0`.
+2. Proposer-selected payment and general transactions share the current block header gas limit.
+3. General transactions are additionally capped by `general_gas_limit`.
+4. Payment-lane transactions MAY consume the remaining block capacity after general transactions.
+
+During the ramp, payment-lane headroom grows with the current header gas limit:
+
+```text
+payment-lane headroom = block_gas_limit - shared_gas_limit - general_gas_limit
+```
+
+If the testnet general gas limit is 30,000,000 gas and shared gas is 0, the payment-lane headroom reaches 970,000,000 gas at the 1 gigagas target. For a 50,000 gas TIP-20 transfer, that target supports up to 20,000 transfers per block before the general reservation, or up to 19,400 proposer payment-lane transfers per block after reserving 30,000,000 gas for general transactions.
+
+## Block Validity
+
+This TIP does not add a new consensus exception. Testnet block validity continues to use the existing parent gas-limit rule and lane checks. A block MUST be invalid if any of the following hold:
+
+- The child header gas limit increase or decrease violates the existing parent gas-limit bound.
+- `shared_gas_limit` does not match the value derived from the active hardfork and header gas limit.
+- Total non-payment proposer gas used exceeds `general_gas_limit`.
+- Total block gas used exceeds the header `gas_limit`.
+
+A block with a header gas limit below 1,000,000,000 gas is valid during the ramp if it satisfies existing consensus rules. A block that jumps directly from 500,000,000 gas to 1,000,000,000 gas is invalid.
+
+The transaction gas cap is unchanged by this TIP. Transactions that exceed the existing per-transaction gas cap MUST continue to be rejected.
+
+## Rollout
+
+The change MUST activate through a scheduled Moderato/testnet builder policy rollout. Operators SHOULD publish release notes that state the activation time or block, the 1,000,000,000 gas target, the expected ramp behavior, and the resulting target total, shared, non-shared, and general gas limits.
+
+Before activation, testnet maintainers SHOULD run sustained load at or above the previous 500,000,000 gas limit to establish a baseline. During the ramp, maintainers SHOULD monitor each block's header gas limit and builder stop reason to confirm the network is moving toward the target. After the target is reached, maintainers SHOULD run sustained payment-lane load near the new block limit and compare block production, propagation, execution, RPC, and indexing behavior against the baseline.
+
+# Tooling
+
+Chainspec and payload-building tooling MUST expose both the current block header gas limit and the configured testnet target gas limit. Test helpers and fixtures that assert testnet block gas parameters MUST be updated to expect:
+
+- `target_block_gas_limit = 1,000,000,000`
+- First upgraded child from a 500,000,000 gas parent: `block_gas_limit = 500,488,280`
+- `shared_gas_limit = 0`
+- `non_shared_gas_limit = block_gas_limit`
+- `general_gas_limit` unchanged from the pre-activation testnet value
+
+Load-generation presets SHOULD add or update a 1 gigagas testnet profile so operators can fill the enlarged payment lane once the ramp reaches the target. Tools that decide whether the ramp has completed SHOULD compare the current header gas limit to the target rather than assuming the target is active immediately at rollout.
+
+# Observability
+
+N/A: no new event type is required. Existing block builder, execution, RPC, and node metrics MUST be sufficient to answer the following operational questions during the ramp and at 1 gigagas:
+
+| Question | Required signal |
+|---|---|
+| Are builders moving toward the target? | Parent gas limit, proposed gas limit, target gas limit, and ramp step per block |
+| Are builders filling the available block budget? | Total gas used, shared gas used, general gas used, payment-lane gas used, and builder stop reason per block |
+| Are blocks propagating within the expected testnet slot budget? | Block proposal, receive, validation, and import latency |
+| Is execution staying within resource budgets? | Block execution time, payload build time, database read/write latency, cache hit rates, CPU, memory, and disk I/O |
+| Are RPC and indexing systems keeping up? | RPC latency, pending queue depth, log/indexing lag, dropped connections, and error rates |
+| Are nodes rejecting blocks for gas-limit reasons? | Consensus validation errors labeled by gas-limit rule |
+
+Dashboards and alerts SHOULD compare pre-activation 500,000,000 gas behavior, in-ramp behavior, and post-ramp 1,000,000,000 gas behavior.
+
+# Invariants
+
+- Mainnet block gas parameters and builder policy MUST NOT change because of this TIP.
+- Upgraded Moderato/testnet builders MUST target a 1,000,000,000 gas block limit after activation.
+- Upgraded builders MUST move toward the target only through the existing parent-bounded gas limit adjustment.
+- A child block MUST NOT jump directly from 500,000,000 gas to 1,000,000,000 gas.
+- Testnet blocks below 1,000,000,000 gas MUST remain valid during the ramp when they satisfy existing consensus rules.
+- Once the parent gas limit is 1,000,000,000 gas, upgraded builders MUST keep proposing 1,000,000,000 gas unless a later TIP changes the target.
+- `shared_gas_limit` MUST remain 0 on testnet after activation.
+- `non_shared_gas_limit` MUST equal `block_gas_limit - shared_gas_limit`, producing the current header gas limit while shared gas is 0.
+- `general_gas_limit` MUST remain unchanged unless another TIP explicitly changes it.
+- Payment-lane transactions MUST be able to consume unused non-shared capacity after general transactions.
+- Non-payment transactions MUST remain bounded by `general_gas_limit`.
+- The per-transaction gas cap MUST remain unchanged.
+- Blocks that exceed any applicable total, shared, non-shared, or general gas limit MUST be rejected.
+- Test coverage MUST include ramp-step calculation, activation-boundary behavior, block validity under the parent gas-limit rule, shared and non-shared budget derivation, general-lane enforcement, target completion behavior, and unchanged mainnet parameters.


### PR DESCRIPTION
Adds TIP-1083, proposing a Moderato/testnet builder-policy ramp to a 1 gigagas block gas target using the existing parent-bounded gas-limit adjustment.

The draft keeps consensus gas-limit validation intact and preserves the current post-T4 lane semantics.