### PR TITLE
fix(test): restore testnet T6 gas estimate

### DIFF
--- a/crates/node/tests/it/eth_call.rs
+++ b/crates/node/tests/it/eth_call.rs
@@ -296,7 +296,7 @@ async fn test_eth_estimate_gas(schedule: ForkSchedule) -> eyre::Result<()> {
     let expected_gas = if schedule.is_active(TempoHardfork::T8) {
         547407
     } else if schedule.is_active(TempoHardfork::T6) {
-        545190
+        553657
     } else if schedule.is_active(TempoHardfork::T3) {
         551540
     } else {


### PR DESCRIPTION
Restores the T6 expected gas for the testnet `eth_estimateGas` integration case to the value observed after moderato crossed T6.

The merge queue failure was caused by the wall-clock-driven testnet schedule entering the T6 branch after the June 18 rollout while the assertion still used a stale snapshot from #5433.