### PR TITLE
tests: add T7 gas estimate expectation

### DIFF
--- a/crates/node/tests/it/eth_call.rs
+++ b/crates/node/tests/it/eth_call.rs
@@ -295,8 +295,10 @@ async fn test_eth_estimate_gas(schedule: ForkSchedule) -> eyre::Result<()> {
     // TIP-1000 (T1): gas includes 250k new account cost when nonce=0
     let expected_gas = if schedule.is_active(TempoHardfork::T8) {
         547407
-    } else if schedule.is_active(TempoHardfork::T6) {
+    } else if schedule.is_active(TempoHardfork::T7) {
         545190
+    } else if schedule.is_active(TempoHardfork::T6) {
+        553657
     } else if schedule.is_active(TempoHardfork::T3) {
         551540
     } else {


### PR DESCRIPTION
## Summary
- add explicit T7 and T6 branches to the eth_estimateGas expected gas ladder
- target main with T7 expected gas set to 545190 and T6 expected gas set to 553657

## Testing
- cargo test -p tempo-node --test it test_eth_estimate_gas -- --nocapture

Prompted by: @0xrusowsky
Prompted by: @mattsse