### PR TITLE
chore: increase stale PR operations per run

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,5 +20,6 @@ jobs:
           close-pr-message: "Closed due to inactivity. Reopen if still needed."
           stale-pr-label: stale
           exempt-draft-pr: false
+          operations-per-run: 120
           days-before-issue-stale: -1
           days-before-issue-close: -1


### PR DESCRIPTION
## Summary
- Set `operations-per-run` to 120 for the stale PR workflow.

## Testing
- Not run; workflow config-only change.

Prompted by: @sds