### PR TITLE
refactor(consensus): preserve recovered finalized blocks

### DIFF
--- a/crates/consensus/src/consensus/block.rs
+++ b/crates/consensus/src/consensus/block.rs
@@ -169,10 +169,15 @@ impl Block {
         self.execution_block
     }
 
-    /// Consumes the block and returns the execution-layer block plus optional BAL.
-    pub(crate) fn into_parts(self) -> (SealedBlock<tempo_primitives::Block>, Option<Bytes>) {
+    /// Consumes the block and returns the execution-layer block handle plus optional BAL.
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        SealedOrRecoveredBlock<tempo_primitives::Block>,
+        Option<Bytes>,
+    ) {
         (
-            self.execution_block.into_sealed_block(),
+            self.execution_block,
             #[cfg(feature = "bal")]
             {
                 self.block_access_list

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -883,7 +883,7 @@ async fn forward_finalized<TContext: Pacer>(
         .add_ons_handle
         .beacon_engine_handle
         .new_payload(TempoExecutionData {
-            block: block.into(),
+            block,
             block_access_list,
             // can be omitted for finalized blocks
             validator_set: None,


### PR DESCRIPTION
Keeps consensus `Block::into_parts` returning its `SealedOrRecoveredBlock` handle instead of degrading to `SealedBlock`. Finalized payload submission now forwards that handle directly, preserving recovered sender data for the execution engine.