### PR TITLE
perf(consensus): use recovered block lookups

### DIFF
--- a/crates/consensus/src/follow/resolver.rs
+++ b/crates/consensus/src/follow/resolver.rs
@@ -20,7 +20,6 @@ use commonware_utils::{
     vec::NonEmptyVec,
 };
 use eyre::Report;
-use reth_node_core::primitives::SealedBlock;
 use reth_provider::{BlockReader as _, BlockSource};
 use tempo_node::TempoFullNode;
 use tokio::select;
@@ -206,11 +205,12 @@ where
     }
 }
 
+/// Resolves an encoded block from the local execution layer.
 #[instrument(skip(execution_node))]
 fn resolve_block(execution_node: &TempoFullNode, block_digest: Digest) -> Result<Bytes, bool> {
     let Ok(Some(block)) = execution_node
         .provider
-        .find_block_by_hash(block_digest.0, BlockSource::Any)
+        .find_sealed_or_recovered_block(block_digest.0, BlockSource::Any)
         .map_err(Report::new)
         .inspect_err(
             |error| error!(%error, "unable to communicate with execution layer to lookup block"),
@@ -220,8 +220,7 @@ fn resolve_block(execution_node: &TempoFullNode, block_digest: Digest) -> Result
     };
     // Follow-mode recovery reads from the EL database, which persists only the block.
     // BAL is p2p side data, so it is unavailable here.
-    let consensus_block =
-        Block::from_execution_block_unchecked(SealedBlock::seal_slow(block), None);
+    let consensus_block = Block::from_execution_block_unchecked(block, None);
     Ok(consensus_block.encode())
 }
 

--- a/crates/consensus/src/storage/hybrid/mod.rs
+++ b/crates/consensus/src/storage/hybrid/mod.rs
@@ -174,10 +174,10 @@ where
         // `Canonical` (not `Any`) so the marshal can never be served a
         // block that lives only in reth's pending in-memory tree — see
         // [`Blocks::get`] on [`Hybrid`].
-        match self.find_block_by_hash(hash, BlockSource::Canonical) {
-            Ok(maybe_block) => Ok(maybe_block.map(|block| {
-                Block::from_execution_block_unchecked(SealedBlock::seal_slow(block), None)
-            })),
+        match self.find_sealed_or_recovered_block(hash, BlockSource::Canonical) {
+            Ok(maybe_block) => {
+                Ok(maybe_block.map(|block| Block::from_execution_block_unchecked(block, None)))
+            }
             Err(err @ ProviderError::BlockExpired { .. }) => {
                 info!(error = %eyre::Report::new(err), "cannot find block");
                 Ok(None)

--- a/crates/consensus/src/subblocks.rs
+++ b/crates/consensus/src/subblocks.rs
@@ -292,7 +292,7 @@ impl<TContext: Spawner + Metrics + Pacer> Actor<TContext> {
         let Ok(Some(header)) = self
             .node
             .provider
-            .find_block_by_hash(*tip, BlockSource::Any)
+            .find_sealed_or_recovered_block(*tip, BlockSource::Any)
         else {
             debug!(?tip, "missing header for the tip block at {tip}");
             return;
@@ -681,7 +681,7 @@ fn evm_at_block(
         .build();
     let header = node
         .provider
-        .find_block_by_hash(hash, BlockSource::Any)?
+        .find_sealed_or_recovered_block(hash, BlockSource::Any)?
         .ok_or(ProviderError::BestBlockNotFound)?;
 
     Ok(node.evm_config.evm_for_block(db, &header)?)


### PR DESCRIPTION
Follows #6203.

Uses sealed-or-recovered execution block lookups for follow resolver, subblock, and hybrid storage hash reads. This preserves recovered in-memory blocks without cloning or resealing when consensus resolves blocks by hash.