### PR TITLE
Extract block epoch conversion to chainspec

### DIFF
--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -20,13 +20,13 @@ use alloy_signer_trezor::{HDPath as TrezorHDPath, TrezorSigner};
 use alloy_sol_types::SolCall;
 use clap::Subcommand;
 use commonware_codec::{DecodeExt as _, Encode as _, ReadExt as _};
-use commonware_consensus::types::{Epocher as _, FixedEpocher, Height};
+use commonware_consensus::types::Height;
 use commonware_cryptography::{
     Signer as _,
     ed25519::{PrivateKey, PublicKey},
 };
 use commonware_math::algebra::Random as _;
-use commonware_utils::{NZU64, ordered};
+use commonware_utils::ordered;
 use eyre::{OptionExt as _, Report, WrapErr as _, bail, eyre};
 use reth_chainspec::EthChainSpec;
 use reth_cli_runner::CliRunner;
@@ -1100,11 +1100,6 @@ impl ValidatorInfo {
                 .ok_or_else(|| eyre!("unknown chain id {chain_id}, pass --chain explicitly"))?,
         };
 
-        let epoch_length = chain
-            .info
-            .epoch_length()
-            .ok_or_eyre("epochLength not found in chainspec")?;
-
         let validator = read_validator_from_contract(&provider, self.id).await?;
         let pubkey_bytes = validator.publicKey.0;
 
@@ -1113,12 +1108,10 @@ impl ValidatorInfo {
             .await
             .wrap_err("failed to get latest block number")?;
 
-        let epoch_strategy = FixedEpocher::new(NZU64!(epoch_length));
         let current_height = Height::new(latest_block_number);
-        let current_epoch_info = epoch_strategy
-            .containing(current_height)
+        let current_epoch = chain
+            .epoch_at_block(latest_block_number)
             .ok_or_else(|| eyre!("failed to determine epoch for height {latest_block_number}"))?;
-        let current_epoch = current_epoch_info.epoch();
 
         let mut is_dkg_dealer = None;
         let mut is_dkg_player = None;
@@ -1127,20 +1120,16 @@ impl ValidatorInfo {
         if !self.no_dkg_information {
             use alloy_consensus::BlockHeader;
 
-            let boundary_height = current_epoch
-                .previous()
-                .map(|epoch| epoch_strategy.last(epoch).expect("valid epoch"))
-                .unwrap_or_default();
+            let boundary_height = chain
+                .previous_epoch_boundary_block(latest_block_number)
+                .ok_or_eyre("epochLength not found in chainspec")?;
 
             let boundary_block = provider
-                .get_block_by_number(boundary_height.get().into())
+                .get_block_by_number(boundary_height.into())
                 .hashes()
                 .await
                 .wrap_err_with(|| {
-                    format!(
-                        "failed to get block header at height {}",
-                        boundary_height.get()
-                    )
+                    format!("failed to get block header at height {boundary_height}")
                 })?
                 .ok_or_eyre("boundary block not found")?;
 
@@ -1148,7 +1137,7 @@ impl ValidatorInfo {
             if extra_data.is_empty() {
                 return Err(eyre!(
                     "boundary block at height {} has no DKG outcome in extra_data",
-                    boundary_height.get()
+                    boundary_height
                 ));
             }
 
@@ -1165,7 +1154,7 @@ impl ValidatorInfo {
         }
 
         let output = ValidatorInfoOutput {
-            current_epoch: current_epoch.get(),
+            current_epoch,
             current_height: current_height.get(),
             validator: ValidatorOutput {
                 validator,
@@ -1250,35 +1239,27 @@ impl Info {
             .await
             .wrap_err("failed to get latest block number")?;
 
-        let epoch_strategy = FixedEpocher::new(NZU64!(epoch_length));
         let current_height = Height::new(latest_block_number);
-        let current_epoch_info = epoch_strategy
-            .containing(current_height)
+        let current_epoch = chain
+            .epoch_at_block(latest_block_number)
             .ok_or_else(|| eyre!("failed to determine epoch for height {latest_block_number}"))?;
 
-        let current_epoch = current_epoch_info.epoch();
-        let boundary_height = current_epoch
-            .previous()
-            .map(|epoch| epoch_strategy.last(epoch).expect("valid epoch"))
-            .unwrap_or_default();
+        let boundary_height = chain
+            .previous_epoch_boundary_block(latest_block_number)
+            .ok_or_eyre("epochLength not found in chainspec")?;
 
         let boundary_block = provider
-            .get_block_by_number(boundary_height.get().into())
+            .get_block_by_number(boundary_height.into())
             .hashes()
             .await
-            .wrap_err_with(|| {
-                format!(
-                    "failed to get block header at height {}",
-                    boundary_height.get()
-                )
-            })?
+            .wrap_err_with(|| format!("failed to get block header at height {boundary_height}"))?
             .ok_or_eyre("boundary block not found")?;
 
         let extra_data = boundary_block.header.extra_data();
         if extra_data.is_empty() {
             return Err(eyre!(
                 "boundary block at height {} has no DKG outcome in extra_data",
-                boundary_height.get()
+                boundary_height
             ));
         }
 
@@ -1373,9 +1354,9 @@ impl Info {
 
         let output = InfoOutput {
             validators,
-            current_epoch: current_epoch.get(),
+            current_epoch,
             current_height: current_height.get(),
-            last_boundary: boundary_height.get(),
+            last_boundary: boundary_height,
             epoch_length,
             is_next_full_dkg: dkg_outcome.is_next_full_dkg,
             next_full_dkg_epoch,

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -106,6 +106,48 @@ impl TempoGenesisInfo {
     }
 }
 
+/// Block-to-epoch conversion parameters for a Tempo chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TempoEpochs {
+    epoch_length: core::num::NonZeroU64,
+}
+
+impl TempoEpochs {
+    /// Creates epoch conversion parameters from a non-zero epoch length.
+    pub const fn new(epoch_length: core::num::NonZeroU64) -> Self {
+        Self { epoch_length }
+    }
+
+    /// Returns the epoch length in blocks.
+    pub const fn epoch_length(self) -> core::num::NonZeroU64 {
+        self.epoch_length
+    }
+
+    /// Returns the epoch containing `block_number`.
+    pub const fn epoch_at_block(self, block_number: u64) -> u64 {
+        block_number / self.epoch_length.get()
+    }
+
+    /// Returns the last block in `epoch`.
+    pub const fn last_block_in_epoch(self, epoch: u64) -> Option<u64> {
+        match epoch.checked_add(1) {
+            Some(next_epoch) => match next_epoch.checked_mul(self.epoch_length.get()) {
+                Some(next_epoch_first_block) => next_epoch_first_block.checked_sub(1),
+                None => None,
+            },
+            None => None,
+        }
+    }
+
+    /// Returns the last block of the epoch preceding the block's epoch, or genesis for epoch 0.
+    pub const fn previous_epoch_boundary_block(self, block_number: u64) -> Option<u64> {
+        match self.epoch_at_block(block_number).checked_sub(1) {
+            Some(epoch) => self.last_block_in_epoch(epoch),
+            None => Some(0),
+        }
+    }
+}
+
 /// Tempo chain specification parser.
 #[derive(Debug, Clone, Default)]
 pub struct TempoChainSpecParser;
@@ -253,6 +295,28 @@ impl TempoChainSpec {
     /// Returns the mainnet chainspec.
     pub fn mainnet() -> Self {
         PRESTO.as_ref().clone()
+    }
+
+    /// Returns the block-to-epoch conversion parameters for this chain.
+    pub fn epochs(&self) -> Option<TempoEpochs> {
+        Some(TempoEpochs::new(core::num::NonZeroU64::new(
+            self.info.epoch_length()?,
+        )?))
+    }
+
+    /// Returns the epoch containing `block_number`.
+    pub fn epoch_at_block(&self, block_number: u64) -> Option<u64> {
+        Some(self.epochs()?.epoch_at_block(block_number))
+    }
+
+    /// Returns the last block in `epoch`.
+    pub fn last_block_in_epoch(&self, epoch: u64) -> Option<u64> {
+        self.epochs()?.last_block_in_epoch(epoch)
+    }
+
+    /// Returns the last block of the epoch preceding the block's epoch, or genesis for epoch 0.
+    pub fn previous_epoch_boundary_block(&self, block_number: u64) -> Option<u64> {
+        self.epochs()?.previous_epoch_boundary_block(block_number)
     }
 }
 

--- a/crates/consensus/src/consensus/engine.rs
+++ b/crates/consensus/src/consensus/engine.rs
@@ -19,7 +19,7 @@ use commonware_runtime::{
     BufferPooler, Clock, ContextCell, Handle, Metrics, Network, Pacer, Spawner, Storage,
     buffer::paged::CacheRef, spawn_cell,
 };
-use commonware_utils::{NZU64, NZUsize};
+use commonware_utils::NZUsize;
 use eyre::{OptionExt as _, WrapErr as _};
 use futures::future::try_join_all;
 use rand_08::{CryptoRng, Rng};
@@ -119,13 +119,12 @@ where
             .clone()
             .ok_or_eyre("execution_node must be set using with_execution_node()")?;
 
-        let epoch_length = execution_node
+        let epochs = execution_node
             .chain_spec()
-            .info
-            .epoch_length()
+            .epochs()
             .ok_or_eyre("chainspec did not contain epochLength; cannot go on without it")?;
 
-        let epoch_strategy = FixedEpocher::new(NZU64!(epoch_length));
+        let epoch_strategy = FixedEpocher::new(epochs.epoch_length());
 
         info!(
             identity = %self.signer.public_key(),

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -26,7 +26,6 @@ use commonware_consensus::types::FixedEpocher;
 use commonware_cryptography::ed25519::{PrivateKey, PublicKey};
 use commonware_p2p::authenticated::lookup;
 use commonware_runtime::Metrics as _;
-use commonware_utils::NZU64;
 use eyre::{OptionExt, WrapErr as _, eyre};
 use tempo_consensus_config::SigningShare;
 use tempo_node::TempoFullNode;
@@ -177,11 +176,6 @@ pub async fn run_follow_stack(
 ) -> eyre::Result<()> {
     let chain_spec = execution_node.chain_spec();
 
-    let epoch_length = chain_spec
-        .info
-        .epoch_length()
-        .ok_or_eyre("chainspec did not contain epochLength")?;
-
     let chain_spec_network_identity = chain_spec
         .network_identity
         .clone()
@@ -205,7 +199,12 @@ pub async fn run_follow_stack(
         upstream_mailbox,
         network_identity,
         partition_prefix: PARTITION_PREFIX.into(),
-        epoch_strategy: FixedEpocher::new(NZU64!(epoch_length)),
+        epoch_strategy: FixedEpocher::new(
+            chain_spec
+                .epochs()
+                .ok_or_eyre("chainspec did not contain epochLength")?
+                .epoch_length(),
+        ),
         mailbox_size: config.mailbox_size,
         fcu_heartbeat_interval: config.fcu_heartbeat_interval.into_duration(),
         finalized_blocks_retention: config.finalized_blocks_retention,

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -182,6 +182,16 @@ where
         }
     }
 
+    /// Returns the epoch containing the block currently being executed.
+    pub fn current_epoch(&self) -> Option<u64> {
+        Some(
+            self.inner
+                .spec
+                .epochs()?
+                .epoch_at_block(self.inner.evm.block().number.to::<u64>()),
+        )
+    }
+
     /// Deploys `0xEF` marker bytecode to a precompile address if it doesn't already have code.
     ///
     /// This also dispatches the state change to the system caller's state hook so that the


### PR DESCRIPTION
## Summary
- add commonware-free `TempoEpochs` conversion parameters to `TempoChainSpec` for block-to-epoch, epoch-to-last-block, and previous epoch boundary conversion
- update consensus CLI callers and `TempoBlockExecutor::current_epoch()` to use the shared chainspec epoch derivation
- keep commonware confined to CL by adapting `TempoEpochs::epoch_length()` into `FixedEpocher` at CL boundaries

## Testing
- `cargo fmt --check`
- `cargo check -p tempo-chainspec --no-default-features`
- `cargo check -p tempo-chainspec -p tempo-evm -p tempo-consensus -p tempo --all-features`

Prompted by: @klkvr