### PR TITLE
ci: ignore pending Review check in reth updater

### DIFF
--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -514,7 +514,7 @@ jobs:
               fi
 
               # All done with no failures = success
-              PENDING=$(echo "$STATUS" | jq -r '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS")] | length')
+              PENDING=$(echo "$STATUS" | jq -r '[.[] | select((.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS") and .name != "Review")] | length')
               if [ "$PENDING" = "0" ] 2>/dev/null; then
                 echo "All CI checks passed!"
                 exit 0
@@ -524,7 +524,7 @@ jobs:
               ELAPSED=$(( (SECONDS - WAIT_START) / 60 ))
               if [ "$ELAPSED" -ge "$CI_TIMEOUT_MINUTES" ]; then
                 echo "CI checks stuck for ${ELAPSED}m — investigating with Amp..."
-                STUCK_NAMES=$(echo "$STATUS" | jq -r '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS")] | map(.name) | join(", ")')
+                STUCK_NAMES=$(echo "$STATUS" | jq -r '[.[] | select((.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS") and .name != "Review")] | map(.name) | join(", ")')
 
                 # Fetch logs from in-progress runs for the current HEAD commit
                 HEAD_SHA=$(gh pr view "$PR_BRANCH" --json headRefOid --jq '.headRefOid')


### PR DESCRIPTION
## Summary
- Ignore the external `Review` check while it is pending/in progress in the reth updater CI polling loop.
- Keep failing `Review` checks visible as failures.

## Validation
- `uv run --with pyyaml python -c "import yaml; yaml.safe_load(open('.github/workflows/update-reth.yml')); print('yaml ok')"`
- `gh pr checks 6211 --repo tempoxyz/tempo --json bucket,name,state | jq -r ...` returned `0` pending checks after excluding `Review`.

Prompted by: @shekhirin