### PR TITLE
test(node): cover upcoming devnet hardforks

### DIFF
--- a/crates/node/tests/it/eth_call.rs
+++ b/crates/node/tests/it/eth_call.rs
@@ -1,4 +1,4 @@
-use crate::utils::{ForkSchedule, TestNodeBuilder, setup_test_token};
+use crate::utils::{ForkSchedule, TestNodeBuilder, run_schedule_cases, setup_test_token};
 use alloy::{
     primitives::{Address, B256, Bytes, U256},
     providers::{Provider, ProviderBuilder, ext::TraceApi},
@@ -62,44 +62,47 @@ fn state_diff(address: Address, diffs: &[(B256, U256)]) -> StateOverride {
 #[test_case(ForkSchedule::Mainnet ; "mainnet")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_eth_call(schedule: ForkSchedule) -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
+    run_schedule_cases(schedule, |schedule| async move {
+        reth_tracing::init_test_tracing();
 
-    let setup = TestNodeBuilder::new()
-        .with_schedule(schedule)
-        .build_http_only()
-        .await?;
-    let http_url = setup.http_url;
+        let setup = TestNodeBuilder::new()
+            .with_schedule(schedule)
+            .build_http_only()
+            .await?;
+        let http_url = setup.http_url;
 
-    let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
-    let caller = wallet.address();
-    let provider = ProviderBuilder::new().wallet(wallet).connect_http(http_url);
+        let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
+        let caller = wallet.address();
+        let provider = ProviderBuilder::new().wallet(wallet).connect_http(http_url);
 
-    // Setup test token
-    let token = setup_test_token(provider.clone(), caller).await?;
+        // Setup test token
+        let token = setup_test_token(provider.clone(), caller).await?;
 
-    // First, mint some tokens to the caller for testing
-    let mint_amount = U256::from(rand::random::<u128>());
-    token
-        .mint(caller, mint_amount)
-        .gas_price(TEMPO_T1_BASE_FEE as u128)
-        .gas(1_000_000)
-        .send()
-        .await?
-        .get_receipt()
-        .await?;
+        // First, mint some tokens to the caller for testing
+        let mint_amount = U256::from(rand::random::<u128>());
+        token
+            .mint(caller, mint_amount)
+            .gas_price(TEMPO_T1_BASE_FEE as u128)
+            .gas(1_000_000)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
 
-    let recipient = Address::random();
-    let calldata = token.transfer(recipient, mint_amount).calldata().clone();
-    let tx = TransactionRequest::default()
-        .to(*token.address())
-        .gas_price(0)
-        .input(TransactionInput::new(calldata));
+        let recipient = Address::random();
+        let calldata = token.transfer(recipient, mint_amount).calldata().clone();
+        let tx = TransactionRequest::default()
+            .to(*token.address())
+            .gas_price(0)
+            .input(TransactionInput::new(calldata));
 
-    let res = provider.call(tx).await?;
-    let success = transferCall::abi_decode_returns(&res)?;
-    assert!(success);
+        let res = provider.call(tx).await?;
+        let success = transferCall::abi_decode_returns(&res)?;
+        assert!(success);
 
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 #[test_case(ForkSchedule::Devnet ; "devnet")]
@@ -107,99 +110,102 @@ async fn test_eth_call(schedule: ForkSchedule) -> eyre::Result<()> {
 #[test_case(ForkSchedule::Mainnet ; "mainnet")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_eth_trace_call(schedule: ForkSchedule) -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
+    run_schedule_cases(schedule, |schedule| async move {
+        reth_tracing::init_test_tracing();
 
-    let setup = TestNodeBuilder::new()
-        .with_schedule(schedule)
-        .build_http_only()
-        .await?;
-    let http_url = setup.http_url;
+        let setup = TestNodeBuilder::new()
+            .with_schedule(schedule)
+            .build_http_only()
+            .await?;
+        let http_url = setup.http_url;
 
-    let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
-    let caller = wallet.address();
-    let provider = ProviderBuilder::new().wallet(wallet).connect_http(http_url);
+        let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
+        let caller = wallet.address();
+        let provider = ProviderBuilder::new().wallet(wallet).connect_http(http_url);
 
-    // Setup test token
-    let token = setup_test_token(provider.clone(), caller).await?;
-    let token_address = *token.address();
+        // Setup test token
+        let token = setup_test_token(provider.clone(), caller).await?;
+        let token_address = *token.address();
 
-    // First, mint some tokens to the caller for testing
-    let mint_amount = U256::from(rand::random::<u128>());
-    token
-        .mint(caller, mint_amount)
-        .gas_price(TEMPO_T1_BASE_FEE as u128)
-        .gas(1_000_000)
-        .send()
-        .await?
-        .get_receipt()
-        .await?;
+        // First, mint some tokens to the caller for testing
+        let mint_amount = U256::from(rand::random::<u128>());
+        token
+            .mint(caller, mint_amount)
+            .gas_price(TEMPO_T1_BASE_FEE as u128)
+            .gas(1_000_000)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
 
-    let recipient = Address::random();
-    let calldata = token.transfer(recipient, mint_amount).calldata().clone();
-    let tx = TransactionRequest::default()
-        .from(caller)
-        .to(*token.address())
-        .input(TransactionInput::new(calldata));
+        let recipient = Address::random();
+        let calldata = token.transfer(recipient, mint_amount).calldata().clone();
+        let tx = TransactionRequest::default()
+            .from(caller)
+            .to(*token.address())
+            .input(TransactionInput::new(calldata));
 
-    let res = provider.call(tx.clone()).await?;
-    let success = transferCall::abi_decode_returns(&res)?;
-    assert!(success);
+        let res = provider.call(tx.clone()).await?;
+        let success = transferCall::abi_decode_returns(&res)?;
+        assert!(success);
 
-    let trace_res = provider.trace_call(&tx).state_diff().await?;
+        let trace_res = provider.trace_call(&tx).state_diff().await?;
 
-    let success = transferCall::abi_decode_returns(&trace_res.output)?;
-    assert!(success);
+        let success = transferCall::abi_decode_returns(&trace_res.output)?;
+        assert!(success);
 
-    let state_diff = trace_res.state_diff.expect("Could not get state diff");
-    let caller_diff = state_diff.get(&caller).expect("Could not get caller diff");
-    assert!(caller_diff.nonce.is_changed());
-    assert!(caller_diff.balance.is_unchanged());
-    assert!(caller_diff.code.is_unchanged());
-    assert!(caller_diff.storage.is_empty());
+        let state_diff = trace_res.state_diff.expect("Could not get state diff");
+        let caller_diff = state_diff.get(&caller).expect("Could not get caller diff");
+        assert!(caller_diff.nonce.is_changed());
+        assert!(caller_diff.balance.is_unchanged());
+        assert!(caller_diff.code.is_unchanged());
+        assert!(caller_diff.storage.is_empty());
 
-    let token_diff = state_diff
-        .get(token.address())
-        .expect("Could not get token diff");
+        let token_diff = state_diff
+            .get(token.address())
+            .expect("Could not get token diff");
 
-    assert!(token_diff.balance.is_unchanged());
-    assert!(token_diff.code.is_unchanged());
-    assert!(token_diff.nonce.is_unchanged());
+        assert!(token_diff.balance.is_unchanged());
+        assert!(token_diff.code.is_unchanged());
+        assert!(token_diff.nonce.is_unchanged());
 
-    let token_storage_diff = token_diff.storage.clone();
-    // Assert sender token balance has changed
-    let slot = TIP20Token::from_address(token_address)
-        .expect("valid TIP20 address")
-        .balances[caller]
-        .slot();
-    let sender_balance = token_storage_diff
-        .get(&B256::from(slot))
-        .expect("Could not get recipient balance delta");
+        let token_storage_diff = token_diff.storage.clone();
+        // Assert sender token balance has changed
+        let slot = TIP20Token::from_address(token_address)
+            .expect("valid TIP20 address")
+            .balances[caller]
+            .slot();
+        let sender_balance = token_storage_diff
+            .get(&B256::from(slot))
+            .expect("Could not get recipient balance delta");
 
-    assert!(sender_balance.is_changed());
+        assert!(sender_balance.is_changed());
 
-    let Delta::Changed(ChangedType { from, to }) = sender_balance else {
-        panic!("Unexpected delta");
-    };
-    assert_eq!(from.into_u256(), mint_amount);
-    assert_eq!(to.into_u256(), U256::ZERO);
+        let Delta::Changed(ChangedType { from, to }) = sender_balance else {
+            panic!("Unexpected delta");
+        };
+        assert_eq!(from.into_u256(), mint_amount);
+        assert_eq!(to.into_u256(), U256::ZERO);
 
-    // Assert recipient token balance is changed
-    let slot = TIP20Token::from_address(token_address)
-        .expect("valid TIP20 address")
-        .balances[recipient]
-        .slot();
-    let recipient_balance = token_storage_diff
-        .get(&B256::from(slot))
-        .expect("Could not get recipient balance delta");
-    assert!(recipient_balance.is_changed());
+        // Assert recipient token balance is changed
+        let slot = TIP20Token::from_address(token_address)
+            .expect("valid TIP20 address")
+            .balances[recipient]
+            .slot();
+        let recipient_balance = token_storage_diff
+            .get(&B256::from(slot))
+            .expect("Could not get recipient balance delta");
+        assert!(recipient_balance.is_changed());
 
-    let Delta::Changed(ChangedType { from, to }) = recipient_balance else {
-        panic!("Unexpected delta");
-    };
-    assert_eq!(from.into_u256(), U256::ZERO);
-    assert_eq!(to.into_u256(), mint_amount);
+        let Delta::Changed(ChangedType { from, to }) = recipient_balance else {
+            panic!("Unexpected delta");
+        };
+        assert_eq!(from.into_u256(), U256::ZERO);
+        assert_eq!(to.into_u256(), mint_amount);
 
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 #[test_case(ForkSchedule::Devnet ; "devnet")]
@@ -207,64 +213,67 @@ async fn test_eth_trace_call(schedule: ForkSchedule) -> eyre::Result<()> {
 #[test_case(ForkSchedule::Mainnet ; "mainnet")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_eth_get_logs(schedule: ForkSchedule) -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
+    run_schedule_cases(schedule, |schedule| async move {
+        reth_tracing::init_test_tracing();
 
-    let setup = TestNodeBuilder::new()
-        .with_schedule(schedule)
-        .build_http_only()
-        .await?;
-    let http_url = setup.http_url;
+        let setup = TestNodeBuilder::new()
+            .with_schedule(schedule)
+            .build_http_only()
+            .await?;
+        let http_url = setup.http_url;
 
-    let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
-    let caller = wallet.address();
-    let provider = ProviderBuilder::new().wallet(wallet).connect_http(http_url);
+        let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
+        let caller = wallet.address();
+        let provider = ProviderBuilder::new().wallet(wallet).connect_http(http_url);
 
-    // Setup test token
-    let token = setup_test_token(provider.clone(), caller).await?;
+        // Setup test token
+        let token = setup_test_token(provider.clone(), caller).await?;
 
-    let mint_amount = U256::from(rand::random::<u128>());
-    let mint_receipt = token
-        .mint(caller, mint_amount)
-        .gas_price(TEMPO_T1_BASE_FEE as u128)
-        .gas(1_000_000)
-        .send()
-        .await?
-        .get_receipt()
-        .await?;
+        let mint_amount = U256::from(rand::random::<u128>());
+        let mint_receipt = token
+            .mint(caller, mint_amount)
+            .gas_price(TEMPO_T1_BASE_FEE as u128)
+            .gas(1_000_000)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
 
-    let recipient = Address::random();
-    token
-        .transfer(recipient, mint_amount)
-        .gas_price(TEMPO_T1_BASE_FEE as u128)
-        .gas(1_000_000)
-        .send()
-        .await?
-        .get_receipt()
-        .await?;
+        let recipient = Address::random();
+        token
+            .transfer(recipient, mint_amount)
+            .gas_price(TEMPO_T1_BASE_FEE as u128)
+            .gas(1_000_000)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
 
-    let filter = Filter::new()
-        .address(*token.address())
-        .from_block(mint_receipt.block_number.unwrap());
-    let logs = provider.get_logs(&filter).await?;
-    assert_eq!(logs.len(), 3);
+        let filter = Filter::new()
+            .address(*token.address())
+            .from_block(mint_receipt.block_number.unwrap());
+        let logs = provider.get_logs(&filter).await?;
+        assert_eq!(logs.len(), 3);
 
-    // NOTE: this currently reflects the event emission from the reference contract. Double check
-    // this is the expected behavior
-    let transfer_event = ITIP20::Transfer::decode_log(&logs[0].inner)?;
-    assert_eq!(transfer_event.from, Address::ZERO);
-    assert_eq!(transfer_event.to, caller);
-    assert_eq!(transfer_event.amount, mint_amount);
+        // NOTE: this currently reflects the event emission from the reference contract. Double check
+        // this is the expected behavior
+        let transfer_event = ITIP20::Transfer::decode_log(&logs[0].inner)?;
+        assert_eq!(transfer_event.from, Address::ZERO);
+        assert_eq!(transfer_event.to, caller);
+        assert_eq!(transfer_event.amount, mint_amount);
 
-    let mint_event = ITIP20::Mint::decode_log(&logs[1].inner)?;
-    assert_eq!(mint_event.to, caller);
-    assert_eq!(mint_event.amount, mint_amount);
+        let mint_event = ITIP20::Mint::decode_log(&logs[1].inner)?;
+        assert_eq!(mint_event.to, caller);
+        assert_eq!(mint_event.amount, mint_amount);
 
-    let transfer_event = ITIP20::Transfer::decode_log(&logs[2].inner)?;
-    assert_eq!(transfer_event.from, caller);
-    assert_eq!(transfer_event.to, recipient);
-    assert_eq!(transfer_event.amount, mint_amount);
+        let transfer_event = ITIP20::Transfer::decode_log(&logs[2].inner)?;
+        assert_eq!(transfer_event.from, caller);
+        assert_eq!(transfer_event.to, recipient);
+        assert_eq!(transfer_event.amount, mint_amount);
 
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 #[test_case(ForkSchedule::Devnet ; "devnet")]
@@ -272,49 +281,52 @@ async fn test_eth_get_logs(schedule: ForkSchedule) -> eyre::Result<()> {
 #[test_case(ForkSchedule::Mainnet ; "mainnet")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_eth_estimate_gas(schedule: ForkSchedule) -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
+    run_schedule_cases(schedule, |schedule| async move {
+        reth_tracing::init_test_tracing();
 
-    let setup = TestNodeBuilder::new()
-        .with_schedule(schedule)
-        .build_http_only()
-        .await?;
-    let http_url = setup.http_url;
+        let setup = TestNodeBuilder::new()
+            .with_schedule(schedule)
+            .build_http_only()
+            .await?;
+        let http_url = setup.http_url;
 
-    let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
-    let caller = wallet.address();
-    let provider = ProviderBuilder::new().wallet(wallet).connect_http(http_url);
+        let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
+        let caller = wallet.address();
+        let provider = ProviderBuilder::new().wallet(wallet).connect_http(http_url);
 
-    let token = setup_test_token(provider.clone(), caller).await?;
-    let calldata = token.mint(caller, U256::from(1000)).calldata().clone();
-    let tx = TransactionRequest::default()
-        .to(*token.address())
-        .input(calldata.into());
+        let token = setup_test_token(provider.clone(), caller).await?;
+        let calldata = token.mint(caller, U256::from(1000)).calldata().clone();
+        let tx = TransactionRequest::default()
+            .to(*token.address())
+            .input(calldata.into());
 
-    let gas = provider.estimate_gas(tx.clone()).await?;
-    // gas estimation is calldata dependent, but should be consistent with same calldata
-    // TIP-1000 (T1): gas includes 250k new account cost when nonce=0
-    let expected_gas = if schedule.is_active(TempoHardfork::T8) {
-        547407
-    } else if schedule.is_active(TempoHardfork::T7) {
-        545190
-    } else if schedule.is_active(TempoHardfork::T6) {
-        553657
-    } else if schedule.is_active(TempoHardfork::T3) {
-        551540
-    } else {
-        549423
-    };
-    assert_eq!(gas, expected_gas);
+        let gas = provider.estimate_gas(tx.clone()).await?;
+        // gas estimation is calldata dependent, but should be consistent with same calldata
+        // TIP-1000 (T1): gas includes 250k new account cost when nonce=0
+        let expected_gas = if schedule.is_active(TempoHardfork::T8) {
+            547407
+        } else if schedule.is_active(TempoHardfork::T7) {
+            555874
+        } else if schedule.is_active(TempoHardfork::T6) {
+            553657
+        } else if schedule.is_active(TempoHardfork::T3) {
+            551540
+        } else {
+            549423
+        };
+        assert_eq!(gas, expected_gas);
 
-    // ensure we can successfully send the tx with that gas
-    let receipt = provider
-        .send_transaction(tx.gas_limit(gas))
-        .await?
-        .get_receipt()
-        .await?;
-    assert!(receipt.gas_used <= gas);
+        // ensure we can successfully send the tx with that gas
+        let receipt = provider
+            .send_transaction(tx.gas_limit(gas))
+            .await?
+            .get_receipt()
+            .await?;
+        assert!(receipt.gas_used <= gas);
 
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -638,38 +650,41 @@ async fn test_eth_estimate_gas_preseeded_zero_address_validator_token() -> eyre:
 #[test_case(ForkSchedule::Mainnet ; "mainnet")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_selector_error_via_rpc(schedule: ForkSchedule) -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
+    run_schedule_cases(schedule, |schedule| async move {
+        reth_tracing::init_test_tracing();
 
-    let setup = TestNodeBuilder::new()
-        .with_schedule(schedule)
-        .build_http_only()
-        .await?;
-    let http_url = setup.http_url;
+        let setup = TestNodeBuilder::new()
+            .with_schedule(schedule)
+            .build_http_only()
+            .await?;
+        let http_url = setup.http_url;
 
-    let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
-    let provider = ProviderBuilder::new().wallet(wallet).connect_http(http_url);
+        let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
+        let provider = ProviderBuilder::new().wallet(wallet).connect_http(http_url);
 
-    // Call with an unknown function selector (0x12345678)
-    let unknown_selector = [0x12u8, 0x34, 0x56, 0x78];
-    let mut calldata = unknown_selector.to_vec();
-    // Add some dummy data
-    calldata.extend_from_slice(&[0u8; 64]);
+        // Call with an unknown function selector (0x12345678)
+        let unknown_selector = [0x12u8, 0x34, 0x56, 0x78];
+        let mut calldata = unknown_selector.to_vec();
+        // Add some dummy data
+        calldata.extend_from_slice(&[0u8; 64]);
 
-    let tx = TransactionRequest::default()
-        .to(TIP20_FACTORY_ADDRESS)
-        .input(TransactionInput::new(Bytes::from(calldata)));
+        let tx = TransactionRequest::default()
+            .to(TIP20_FACTORY_ADDRESS)
+            .input(TransactionInput::new(Bytes::from(calldata)));
 
-    // The call should fail with UnknownFunctionSelector containing the unknown selector
-    let err = provider.call(tx).await.unwrap_err();
-    let expected = Bytes::from(
-        UnknownFunctionSelector {
-            selector: unknown_selector.into(),
-        }
-        .abi_encode(),
-    );
-    assert_eq!(extract_revert_data(&err), expected);
+        // The call should fail with UnknownFunctionSelector containing the unknown selector
+        let err = provider.call(tx).await.unwrap_err();
+        let expected = Bytes::from(
+            UnknownFunctionSelector {
+                selector: unknown_selector.into(),
+            }
+            .abi_encode(),
+        );
+        assert_eq!(extract_revert_data(&err), expected);
 
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/node/tests/it/tempo_transaction/mod.rs
+++ b/crates/node/tests/it/tempo_transaction/mod.rs
@@ -37,7 +37,7 @@
 //! - Expiring nonce replay protection.
 //! - Keychain spending limit TOCTOU DoS.
 
-use crate::utils::ForkSchedule;
+use crate::utils::{ForkSchedule, run_schedule_cases};
 use test_case::test_case;
 
 pub(crate) mod helpers;
@@ -72,7 +72,12 @@ async fn run_all_matrices(env: &mut impl TestEnv) -> eyre::Result<()> {
 #[test_case(ForkSchedule::Mainnet ; "mainnet")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_matrices_local(schedule: ForkSchedule) -> eyre::Result<()> {
-    run_all_matrices(&mut local::Localnet::with_schedule(schedule).await?).await
+    run_schedule_cases(schedule, |schedule| async move {
+        run_all_matrices(&mut local::Localnet::with_schedule(schedule).await?).await?;
+
+        Ok(())
+    })
+    .await
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -9,8 +9,10 @@
 /// overlays hardfork timestamps from the corresponding network config.
 /// Forks whose activation timestamp is in the future (relative to the current wall-clock time)
 /// are deactivated (`u64::MAX`); forks already active are activated at t=0.
+/// `DevnetAt` schedules activate all Tempo hardforks through the given latest active fork.
 ///
-/// This lets the same test run against different fork schedules via `#[test_case]`:
+/// Tests that use `ForkSchedule::Devnet` can wrap their body in [`run_schedule_cases`] to
+/// dynamically fan out to one devnet run per hardfork ahead of testnet:
 ///
 /// ```ignore
 /// #[test_case(ForkSchedule::Devnet ; "devnet")]
@@ -18,17 +20,23 @@
 /// #[test_case(ForkSchedule::Mainnet ; "mainnet")]
 /// #[tokio::test(flavor = "multi_thread")]
 /// async fn test_estimate_gas(schedule: ForkSchedule) -> eyre::Result<()> {
-///     let setup = TestNodeBuilder::new()
-///         .with_schedule(schedule)
-///         .build_http_only()
-///         .await?;
-///     // ...
+///     run_schedule_cases(schedule, |schedule| async move {
+///         let setup = TestNodeBuilder::new()
+///             .with_schedule(schedule)
+///             .build_http_only()
+///             .await?;
+///         // ...
+///         Ok(())
+///     })
+///     .await
 /// }
 /// ```
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum ForkSchedule {
-    /// Preserves test dev genesis hardfork schedule: typically all active at t=0.
+    /// Preserves the latest test dev genesis hardfork schedule.
     Devnet,
+    /// Activates all test dev genesis Tempo hardforks through the given hardfork at t=0.
+    DevnetAt(TempoHardfork),
     /// Fork schedule matching testnet (moderato): only forks active *now* are set to t=0.
     Testnet,
     /// Fork schedule matching mainnet (presto): only forks active *now* are set to t=0.
@@ -36,11 +44,68 @@ pub(crate) enum ForkSchedule {
 }
 
 impl ForkSchedule {
+    const TESTNET_REFERENCE_GENESIS: &'static str =
+        include_str!("../../../chainspec/src/genesis/moderato.json");
+
+    /// Resolves this schedule into the concrete schedules a test should run.
+    ///
+    /// `Devnet` expands to every declared hardfork that is ahead of the hardfork currently active
+    /// on testnet. If testnet has already caught up to the latest hardfork, this still returns one
+    /// latest-devnet schedule so devnet coverage does not disappear.
+    fn cases(self) -> Vec<Self> {
+        match self {
+            Self::Devnet => Self::devnet_cases(),
+            schedule => vec![schedule],
+        }
+    }
+
+    /// Returns one devnet schedule for each hardfork ahead of the hardfork active on testnet.
+    ///
+    /// This fills the coverage gap between testnet and latest-devnet. If testnet is already at the
+    /// latest declared hardfork, returns a single latest-devnet schedule so devnet still runs.
+    fn devnet_cases() -> Vec<Self> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let reference: serde_json::Value = serde_json::from_str(Self::TESTNET_REFERENCE_GENESIS)
+            .expect("reference genesis must parse");
+        let active = TempoHardfork::VARIANTS
+            .iter()
+            .rev()
+            .copied()
+            .find(|fork| {
+                if *fork == TempoHardfork::Genesis {
+                    return true;
+                }
+
+                let key = format!("{}Time", fork.to_string().to_lowercase());
+                matches!(reference["config"][&key].as_u64(), Some(ts) if ts <= now)
+            })
+            .unwrap_or(TempoHardfork::Genesis);
+        let cases: Vec<_> = TempoHardfork::VARIANTS
+            .iter()
+            .copied()
+            .filter(|fork| *fork > active)
+            .map(Self::DevnetAt)
+            .collect();
+
+        if cases.is_empty() {
+            vec![Self::DevnetAt(
+                *TempoHardfork::VARIANTS
+                    .last()
+                    .expect("TempoHardfork must have at least Genesis"),
+            )]
+        } else {
+            cases
+        }
+    }
+
     /// Returns the reference genesis JSON whose fork timestamps should be used.
     fn reference_genesis(&self) -> Option<&'static str> {
         match self {
-            Self::Devnet => None,
-            Self::Testnet => Some(include_str!("../../../chainspec/src/genesis/moderato.json")),
+            Self::Devnet | Self::DevnetAt(_) => None,
+            Self::Testnet => Some(Self::TESTNET_REFERENCE_GENESIS),
             Self::Mainnet => Some(include_str!("../../../chainspec/src/genesis/presto.json")),
         }
     }
@@ -48,11 +113,18 @@ impl ForkSchedule {
     /// Returns whether the given Tempo hardfork is active for this schedule.
     ///
     /// For [`Devnet`](Self::Devnet) all forks from the dev genesis are active.
+    /// For [`DevnetAt`](Self::DevnetAt), only forks through the selected hardfork are active.
     /// For other schedules, a fork is active only if its timestamp in the
     /// reference genesis is in the past.
     pub(crate) fn is_active(&self, fork: TempoHardfork) -> bool {
+        match self {
+            Self::Devnet => return true,
+            Self::DevnetAt(last_active) => return fork <= *last_active,
+            _ => {}
+        }
+
         let Some(reference_json) = self.reference_genesis() else {
-            return true; // devnet: all forks active
+            return true; // unreachable for current variants
         };
         let reference: serde_json::Value =
             serde_json::from_str(reference_json).expect("reference genesis must parse");
@@ -60,8 +132,12 @@ impl ForkSchedule {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        let time_key = format!("{}Time", fork.to_string().to_lowercase());
-        matches!(reference["config"][&time_key].as_u64(), Some(ts) if ts <= now)
+        if fork == TempoHardfork::Genesis {
+            return true;
+        }
+
+        let key = format!("{}Time", fork.to_string().to_lowercase());
+        matches!(reference["config"][&key].as_u64(), Some(ts) if ts <= now)
     }
 
     /// Apply this profile's fork timestamps to a test genesis JSON value.
@@ -70,7 +146,28 @@ impl ForkSchedule {
     /// against the reference network genesis. Forks active *now* on the
     /// reference network are set to `0`; forks that are still in the future
     /// or absent from the reference are set to `u64::MAX`.
+    ///
+    /// Devnet schedules are special because the test genesis normally enables every declared
+    /// Tempo hardfork. `DevnetAt` rewrites that genesis so tests can run with only the selected
+    /// hardfork and earlier forks active.
     pub(crate) fn apply(&self, genesis: &mut serde_json::Value) {
+        match self {
+            Self::Devnet => {
+                Self::apply_devnet(
+                    genesis,
+                    *TempoHardfork::VARIANTS
+                        .last()
+                        .expect("TempoHardfork must have at least Genesis"),
+                );
+                return;
+            }
+            Self::DevnetAt(last_active) => {
+                Self::apply_devnet(genesis, *last_active);
+                return;
+            }
+            _ => {}
+        }
+
         let Some(reference_json) = self.reference_genesis() else {
             return; // keep test genesis timestamps unchanged
         };
@@ -95,6 +192,48 @@ impl ForkSchedule {
             *value = serde_json::json!(ts);
         }
     }
+
+    /// Rewrites devnet fork timestamps so only forks through `last_active` are enabled.
+    ///
+    /// The shared test genesis enables all declared Tempo forks; `DevnetAt` needs this clamp to
+    /// exercise intermediate upcoming hardfork states instead of always running latest-devnet.
+    fn apply_devnet(genesis: &mut serde_json::Value, last_active: TempoHardfork) {
+        let config = genesis["config"]
+            .as_object_mut()
+            .expect("genesis must have config");
+
+        for &fork in TempoHardfork::VARIANTS {
+            if fork == TempoHardfork::Genesis {
+                continue;
+            }
+
+            let key = format!("{}Time", fork.to_string().to_lowercase());
+            if let Some(value) = config.get_mut(&key) {
+                *value = serde_json::json!(if fork <= last_active { 0 } else { u64::MAX });
+            }
+        }
+    }
+}
+
+/// Runs a test body once for every concrete schedule represented by `schedule`.
+///
+/// This is mainly used for `ForkSchedule::Devnet`, which expands at runtime to one
+/// `DevnetAt` run per declared hardfork ahead of testnet. Testnet and mainnet run once.
+pub(crate) async fn run_schedule_cases<F, Fut>(
+    schedule: ForkSchedule,
+    mut run: F,
+) -> eyre::Result<()>
+where
+    F: FnMut(ForkSchedule) -> Fut,
+    Fut: std::future::Future<Output = eyre::Result<()>>,
+{
+    for schedule in schedule.cases() {
+        run(schedule)
+            .await
+            .wrap_err_with(|| format!("fork schedule case {schedule:?} failed"))?;
+    }
+
+    Ok(())
 }
 
 /// Build a genesis JSON string from `test-genesis.json` with only forks up to
@@ -140,6 +279,7 @@ use alloy::{
 };
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::PayloadAttributes;
+use eyre::WrapErr;
 use reth_e2e_test_utils::setup;
 use reth_ethereum::tasks::Runtime;
 use reth_node_api::FullNodeComponents;


### PR DESCRIPTION
Adds runtime devnet hardfork fan-out for integration tests that are parameterized over `ForkSchedule`. `ForkSchedule::Devnet` resolves to one `DevnetAt(T*)` run per hardfork ahead of the currently active testnet hardfork, with a latest-devnet fallback once testnet catches up.

This keeps normal `#[test_case(ForkSchedule::Devnet ; "devnet")]` callsites and avoids maintaining hardfork-specific test cases or adding build-script generation.