### PR TITLE
chore(release): v1.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12884,7 +12884,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13032,7 +13032,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13093,7 +13093,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13122,7 +13122,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13136,7 +13136,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13187,7 +13187,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13231,7 +13231,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13250,7 +13250,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "eyre",
  "indenter",
@@ -13258,7 +13258,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13271,7 +13271,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13341,7 +13341,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -13379,7 +13379,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13399,7 +13399,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13431,7 +13431,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13479,7 +13479,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13513,7 +13513,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "clap",
@@ -13538,7 +13538,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "eyre",
  "jiff",
@@ -13547,7 +13547,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13589,7 +13589,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13601,7 +13601,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.8.2"
+version = "1.9.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]


### PR DESCRIPTION
Bumps the Cargo workspace release version to v1.9.1 after the release artifacts were created.

Created manually because the release workflow automated bump PR job failed. Validated with `cargo metadata --locked --no-deps --format-version 1`.