### PR TITLE
chore(release): v1.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12884,7 +12884,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13032,7 +13032,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13093,7 +13093,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13122,7 +13122,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13136,7 +13136,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13187,7 +13187,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13231,7 +13231,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13250,7 +13250,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "eyre",
  "indenter",
@@ -13258,7 +13258,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13271,7 +13271,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13341,7 +13341,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -13379,7 +13379,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13399,7 +13399,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13431,7 +13431,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13479,7 +13479,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13513,7 +13513,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "clap",
@@ -13538,7 +13538,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "eyre",
  "jiff",
@@ -13547,7 +13547,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13589,7 +13589,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13601,7 +13601,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.8.2"
+version = "1.9.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]

--- a/scripts/foundry-patch.sh
+++ b/scripts/foundry-patch.sh
@@ -30,10 +30,9 @@ if [[ ! -f "$FOUNDRY_CARGO" ]]; then
   exit 1
 fi
 
-# Already patched – nothing to do
+has_tempo_git_patch=false
 if grep -q '^\[patch\."https://github.com/tempoxyz/tempo"\]' "$FOUNDRY_CARGO"; then
-  echo "Foundry Cargo.toml already contains tempo git patch section – skipping."
-  exit 0
+  has_tempo_git_patch=true
 fi
 
 # ── 1. Discover tempo-* workspace crates that have local paths ──────────────
@@ -54,16 +53,42 @@ if [[ -z "$PATCHES" ]]; then
   exit 1
 fi
 
-# ── 2. Patch [patch."https://github.com/tempoxyz/tempo"] ────────────────────
-{
-  printf '\n[patch."https://github.com/tempoxyz/tempo"]\n'
-  while IFS=$'\t' read -r crate path; do
-    [[ -n "$crate" ]] || continue
-    printf '%s = { path = "%s/%s" }\n' "$crate" "$TEMPO_ROOT" "$path"
-  done <<< "$PATCHES"
-} >> "$FOUNDRY_CARGO"
+# ── 2. Replace Foundry's direct Tempo git dependencies ──────────────────────
+# [patch] entries do not always dislodge old git-sourced lockfile packages when
+# the local checkout has a different crate version. Rewrite Foundry's direct
+# tempo-* dependencies to local paths first, preserving any feature flags.
+while IFS=$'\t' read -r crate path; do
+  [[ -n "$crate" ]] || continue
+  local_path="${TEMPO_ROOT}/${path}"
+  tmp_cargo="$(mktemp "${FOUNDRY_CARGO}.XXXXXX")"
+  awk -v crate="$crate" -v local_path="$local_path" '
+    index($0, crate " = {") == 1 && index($0, "git = \"https://github.com/tempoxyz/tempo\"") {
+      sub(/\{[[:space:]]*/, "{ path = \"" local_path "\", ")
+      gsub(/[[:space:]]*git = "https:\/\/github.com\/tempoxyz\/tempo",[[:space:]]*/, "")
+      gsub(/[[:space:]]*rev = "[^"]+",?[[:space:]]*/, "")
+      gsub(/,[[:space:]]*}/, " }")
+      print
+      next
+    }
+    { print }
+  ' "$FOUNDRY_CARGO" > "$tmp_cargo"
+  mv "$tmp_cargo" "$FOUNDRY_CARGO"
+done <<< "$PATCHES"
 
-# ── 3. Patch [patch.crates-io] ──────────────────────────────────────────────
+# ── 3. Patch [patch."https://github.com/tempoxyz/tempo"] ────────────────────
+if [[ "$has_tempo_git_patch" == "true" ]]; then
+  echo "Foundry Cargo.toml already contains tempo git patch section – keeping existing section."
+else
+  {
+    printf '\n[patch."https://github.com/tempoxyz/tempo"]\n'
+    while IFS=$'\t' read -r crate path; do
+      [[ -n "$crate" ]] || continue
+      printf '%s = { path = "%s/%s" }\n' "$crate" "$TEMPO_ROOT" "$path"
+    done <<< "$PATCHES"
+  } >> "$FOUNDRY_CARGO"
+fi
+
+# ── 4. Patch [patch.crates-io] ──────────────────────────────────────────────
 # Upstream foundry pins some tempo crates to git revisions in [patch.crates-io].
 # Replace those with local paths so Cargo doesn't conflict.
 while IFS=$'\t' read -r crate path; do
@@ -156,7 +181,7 @@ update_stale_tempo_git_packages() {
   cargo update "${update_args[@]}" >/dev/null
 }
 
-# ── 4. Re-resolve the lockfile without upgrading unrelated crates ──────────
+# ── 5. Re-resolve the lockfile without upgrading unrelated crates ──────────
 # `cargo update` can pull newer upstream deps from Foundry's workspace, which is non-deterministic.
 # A normal resolver pass is enough to rewrite the lockfile entries for the tempo path overrides.
 # Keep this aligned with the CI Forge build so Optimism-only dependencies do not re-enter resolution.


### PR DESCRIPTION
Bumps the Cargo workspace release version to v1.9.1 after the release artifacts were created.

Created manually because the release workflow automated bump PR job failed. Validated with `cargo metadata --locked --no-deps --format-version 1`.