### PR TITLE
ci: fix Release PR post-merge failures

### DIFF
--- a/.changelog/config.toml
+++ b/.changelog/config.toml
@@ -10,6 +10,7 @@ ignore = [
     "tempo-commonware-node",
     "tempo-commonware-node-config",
     "tempo-consensus",
+    "tempo-consensus-config",
     "tempo-dkg-onchain-artifacts",
     "tempo-e2e",
     "tempo-evm",

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -70,7 +70,7 @@ jobs:
               path.write_text("---\n" + "".join(kept) + "---\n" + body, encoding="utf-8")
           PY
 
-      - uses: tempoxyz/changelogs@b0179e7300997dfa5a631a6a7a2de248bf63310f # master @ 2026-04-08 (post-v0.6.3)
+      - uses: tempoxyz/changelogs@29ac40b71b3966761305991d99f21c5195d7466b # master @ 2026-06-09 (post-v0.6.3)
         id: changelogs
         with:
           conventional-commit: true


### PR DESCRIPTION
## Summary
- ignore `tempo-consensus-config` in the SDK release changelog config
- update `tempoxyz/changelogs` to a revision with the release-notes `grep`/`pipefail` hardening from tempoxyz/changelogs#111

## Evidence
- failing runs publish/tag `tempo-consensus-config@1.8.2`, then abort while creating its GitHub release
- config parse check confirms `tempo-consensus-config` is now ignored while the fixed SDK group remains unchanged

Prompted by: @0xrusowsky