### PR TITLE
ci(bench): revert Tracy and txgen CPU pinning

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -12,10 +12,8 @@ const E2E_B_MOUNT = "/reth-bench-b"
 const BENCH_SCHELK_SCRIPT = "bench-schelk.nu"
 const E2E_VALIDATORS = "127.0.0.2:8000,127.0.0.3:8100"
 const E2E_SEED = 42
-const E2E_A_CPUS = "0-14"
-const E2E_B_CPUS = "15-29"
-const E2E_TRACY_CAPTURE_CPUS = "30"
-const E2E_TXGEN_CPUS = "31"
+const E2E_A_CPUS = "0-7,16-23"
+const E2E_B_CPUS = "8-15,24-31"
 const E2E_A_MEMORY = "60G"
 const E2E_B_MEMORY = "60G"
 const E2E_GAS_LIMIT = "1000000000"
@@ -1012,16 +1010,16 @@ def run-local-e2e-phase [run: record, ctx: record] {
         let seconds_flag = if $ctx.tracy_seconds > 0 { $"-s ($ctx.tracy_seconds)" } else { "" }
         let limit_msg = if $ctx.tracy_seconds > 0 { $" \(($ctx.tracy_seconds)s limit\)" } else { "" }
         let capture_path = ($env.PATH | str join (char esep))
-        let capture_cmd = $"sudo env PATH=($capture_path) TRACY_SAMPLING_HZ=($TRACY_SAMPLING_HZ) taskset -c ($ctx.tracy_capture_cpus) tracy-capture -f -o ($tracy_output) ($seconds_flag) >($tracy_log) 2>&1"
+        let capture_cmd = $"sudo env PATH=($capture_path) TRACY_SAMPLING_HZ=($TRACY_SAMPLING_HZ) tracy-capture -f -o ($tracy_output) ($seconds_flag) >($tracy_log) 2>&1"
         if $ctx.tracy_offset > 0 {
-            print $"  Tracy-capture will start on CPUs ($ctx.tracy_capture_cpus) after ($ctx.tracy_offset) seconds($limit_msg)..."
+            print $"  Tracy-capture will start after ($ctx.tracy_offset) seconds($limit_msg)..."
             $tracy_capture_job = (job spawn {
                 sleep ($"($ctx.tracy_offset)sec" | into duration)
                 let result = (sh -c $capture_cmd | complete)
                 { phase: $phase, exit_code: $result.exit_code } | job send --tag 18999 0
             })
         } else {
-            print $"  Starting tracy-capture on CPUs ($ctx.tracy_capture_cpus) ($limit_msg)..."
+            print $"  Starting tracy-capture($limit_msg)..."
             $tracy_capture_job = (job spawn {
                 let result = (sh -c $capture_cmd | complete)
                 { phase: $phase, exit_code: $result.exit_code } | job send --tag 18999 0
@@ -1058,7 +1056,6 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --max-concurrent-requests $ctx.max_concurrent_requests
                 --bench-args $ctx.bench_args
                 --bench-env $ctx.bench_env
-                --taskset-cpus $ctx.txgen_cpus
                 --git-ref $run.ref
                 --git-ref-label ($run | get -o ref_label | default $run.ref)
                 --build-profile $ctx.profile
@@ -1566,8 +1563,6 @@ def "main e2e" [
         tracy_filter: $tracy_filter
         tracy_seconds: $tracy_seconds
         tracy_offset: $tracy_offset
-        tracy_capture_cpus: $E2E_TRACY_CAPTURE_CPUS
-        txgen_cpus: $E2E_TXGEN_CPUS
         baseline_args: $baseline_args
         feature_args: $feature_args
         bench_args: $bench_args

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -252,7 +252,6 @@ def txgen-run-preset-pipeline [
     --max-concurrent-requests: int
     --bench-args: string = ""
     --bench-env: string = ""
-    --taskset-cpus: string = ""
     --git-ref: string = ""
     --git-ref-label: string = ""
     --build-profile: string = ""
@@ -285,9 +284,7 @@ def txgen-run-preset-pipeline [
 
     let tx_count = [($tps * $duration) 1] | math max
     let txgen_duration = $"($duration)s"
-    let taskset_prefix = if $taskset_cpus != "" { ["taskset" "-c" $taskset_cpus] } else { [] }
     let txgen_cmd = [
-        ...$taskset_prefix
         $txgen_tempo_bin
         "generate"
         "-s" $spec_path
@@ -298,7 +295,6 @@ def txgen-run-preset-pipeline [
     ]
     let metrics_url_args = ($metrics_url | each { |url| ["--metrics-url" $url] } | flatten)
     let bench_base_cmd = [
-        ...$taskset_prefix
         $txgen_bench_bin
         "send"
         "--rpc-url" $submit_rpc_url


### PR DESCRIPTION
## Summary
- restore local e2e validator CPU ranges from before 1ab56a4c98f536f4f791f723ff49af5ec91fe135
- run tracy-capture without taskset CPU pinning
- remove txgen taskset CPU pin support from the e2e sender path

## Validation
- nu --commands 'source bench-e2e.nu; source contrib/bench/txgen/helpers.nu'\n- git diff --check\n\nPrompted by: @shekhirin