### PR TITLE
ci(bench): restore Tracy, txgen, and bench CPU pinning

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -14,6 +14,9 @@ const E2E_VALIDATORS = "127.0.0.2:8000,127.0.0.3:8100"
 const E2E_SEED = 42
 const E2E_A_CPUS = "0-7,16-23"
 const E2E_B_CPUS = "8-15,24-31"
+const E2E_TRACY_CAPTURE_CPUS = "32"
+const E2E_TXGEN_CPUS = "33"
+const E2E_BENCH_CPUS = "34"
 const E2E_A_MEMORY = "60G"
 const E2E_B_MEMORY = "60G"
 const E2E_GAS_LIMIT = "1000000000"
@@ -505,6 +508,32 @@ def taskset-command [cmd: list<string>, cpus: string] {
         ["taskset" "-c" $cpus ...$cmd]
     } else {
         $cmd
+    }
+}
+
+def validate-e2e-cpus [cpu_sets: list<string>] {
+    if (^uname | str trim) != "Linux" {
+        return
+    }
+
+    let online = (try { ^nproc | str trim | into int } catch { 0 })
+    if $online <= 0 {
+        return
+    }
+
+    let max_cpu = (
+        $cpu_sets
+        | split row ","
+        | each { |part|
+            let bounds = ($part | split row "-")
+            if ($bounds | length) == 2 { $bounds | last } else { $part }
+        }
+        | each { |cpu| $cpu | into int }
+        | math max
+    )
+
+    if $max_cpu >= $online {
+        error make { msg: $"e2e CPU pinning requires CPU ($max_cpu), but only ($online) logical CPUs are online" }
     }
 }
 
@@ -1010,16 +1039,16 @@ def run-local-e2e-phase [run: record, ctx: record] {
         let seconds_flag = if $ctx.tracy_seconds > 0 { $"-s ($ctx.tracy_seconds)" } else { "" }
         let limit_msg = if $ctx.tracy_seconds > 0 { $" \(($ctx.tracy_seconds)s limit\)" } else { "" }
         let capture_path = ($env.PATH | str join (char esep))
-        let capture_cmd = $"sudo env PATH=($capture_path) TRACY_SAMPLING_HZ=($TRACY_SAMPLING_HZ) tracy-capture -f -o ($tracy_output) ($seconds_flag) >($tracy_log) 2>&1"
+        let capture_cmd = $"sudo env PATH=($capture_path) TRACY_SAMPLING_HZ=($TRACY_SAMPLING_HZ) taskset -c ($ctx.tracy_capture_cpus) tracy-capture -f -o ($tracy_output) ($seconds_flag) >($tracy_log) 2>&1"
         if $ctx.tracy_offset > 0 {
-            print $"  Tracy-capture will start after ($ctx.tracy_offset) seconds($limit_msg)..."
+            print $"  Tracy-capture will start on CPUs ($ctx.tracy_capture_cpus) after ($ctx.tracy_offset) seconds($limit_msg)..."
             $tracy_capture_job = (job spawn {
                 sleep ($"($ctx.tracy_offset)sec" | into duration)
                 let result = (sh -c $capture_cmd | complete)
                 { phase: $phase, exit_code: $result.exit_code } | job send --tag 18999 0
             })
         } else {
-            print $"  Starting tracy-capture($limit_msg)..."
+            print $"  Starting tracy-capture on CPUs ($ctx.tracy_capture_cpus) ($limit_msg)..."
             $tracy_capture_job = (job spawn {
                 let result = (sh -c $capture_cmd | complete)
                 { phase: $phase, exit_code: $result.exit_code } | job send --tag 18999 0
@@ -1056,6 +1085,8 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --max-concurrent-requests $ctx.max_concurrent_requests
                 --bench-args $ctx.bench_args
                 --bench-env $ctx.bench_env
+                --txgen-taskset-cpus $ctx.txgen_cpus
+                --bench-taskset-cpus $ctx.bench_cpus
                 --git-ref $run.ref
                 --git-ref-label ($run | get -o ref_label | default $run.ref)
                 --build-profile $ctx.profile
@@ -1303,6 +1334,7 @@ def "main e2e" [
         print "Error: tracy-capture not found. Install tracy and ensure tracy-capture is in PATH."
         exit 1
     }
+    validate-e2e-cpus [$E2E_A_CPUS $E2E_B_CPUS $E2E_TRACY_CAPTURE_CPUS $E2E_TXGEN_CPUS $E2E_BENCH_CPUS]
     let hardfork_mode = $baseline_hardfork != "" or $feature_hardfork != ""
     if $hardfork_mode and ($baseline_hardfork == "" or $feature_hardfork == "") {
         print "Error: --baseline-hardfork and --feature-hardfork must both be provided"
@@ -1563,6 +1595,9 @@ def "main e2e" [
         tracy_filter: $tracy_filter
         tracy_seconds: $tracy_seconds
         tracy_offset: $tracy_offset
+        tracy_capture_cpus: $E2E_TRACY_CAPTURE_CPUS
+        txgen_cpus: $E2E_TXGEN_CPUS
+        bench_cpus: $E2E_BENCH_CPUS
         baseline_args: $baseline_args
         feature_args: $feature_args
         bench_args: $bench_args

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -252,6 +252,8 @@ def txgen-run-preset-pipeline [
     --max-concurrent-requests: int
     --bench-args: string = ""
     --bench-env: string = ""
+    --txgen-taskset-cpus: string = ""
+    --bench-taskset-cpus: string = ""
     --git-ref: string = ""
     --git-ref-label: string = ""
     --build-profile: string = ""
@@ -284,7 +286,10 @@ def txgen-run-preset-pipeline [
 
     let tx_count = [($tps * $duration) 1] | math max
     let txgen_duration = $"($duration)s"
+    let txgen_taskset_prefix = if $txgen_taskset_cpus != "" { ["taskset" "-c" $txgen_taskset_cpus] } else { [] }
+    let bench_taskset_prefix = if $bench_taskset_cpus != "" { ["taskset" "-c" $bench_taskset_cpus] } else { [] }
     let txgen_cmd = [
+        ...$txgen_taskset_prefix
         $txgen_tempo_bin
         "generate"
         "-s" $spec_path
@@ -295,6 +300,7 @@ def txgen-run-preset-pipeline [
     ]
     let metrics_url_args = ($metrics_url | each { |url| ["--metrics-url" $url] } | flatten)
     let bench_base_cmd = [
+        ...$bench_taskset_prefix
         $txgen_bench_bin
         "send"
         "--rpc-url" $submit_rpc_url


### PR DESCRIPTION
## Summary
- keep local e2e A/B validator CPU ranges unchanged at `0-7,16-23` and `8-15,24-31`
- pin tracy-capture, txgen generation, and txgen bench/send onto separate CPUs `32`, `33`, and `34`
- validate that the runner has enough online logical CPUs before starting e2e work

## Core availability
A/B nodes currently consume CPUs `0..31`, so this needs at least 35 online logical CPUs to provide free CPUs `32`, `33`, and `34` for the tools. I could not verify the bare-metal runner CPU count from repo state; the local sandbox has only 12 CPUs, and the new validation correctly fails there.

## Validation
- `nu --commands 'source bench-e2e.nu; source contrib/bench/txgen/helpers.nu'`\n- `git diff --check`\n- `nu --commands 'source bench-e2e.nu; validate-e2e-cpus ["0-7,16-23" "8-15,24-31" "32" "33" "34"]'` fails locally as expected with `e2e CPU pinning requires CPU 34, but only 12 logical CPUs are online`\n\nPrompted by: @shekhirin