### PR TITLE
fix(cli): hide and silence snapshot skip-consensus overrides

### DIFF
--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -30,6 +30,7 @@ pub(crate) struct Args {
         long,
         default_value_t = true,
         default_missing_value = "true",
+        hide = true,
         num_args = 0..=1,
         require_equals = true
     )]
@@ -140,6 +141,14 @@ fn write_bootstrap_finalization(
 mod tests {
     use super::*;
     use alloy_primitives::{B256, Bytes};
+    use clap::CommandFactory;
+
+    #[test]
+    fn help_hides_skip_consensus_override() {
+        let help = Args::command().render_long_help().to_string();
+
+        assert!(!help.contains("--skip-consensus"));
+    }
 
     #[test]
     fn args_parses_mixed_reth_and_tempo_flags() {

--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -68,7 +68,6 @@ pub(crate) fn run_with_runner(matches: &ArgMatches, runner: CliRunner) -> eyre::
         );
 
         if args.skip_consensus {
-            info!("--skip-consensus set. skipping consensus layer");
             return Ok(());
         }
 

--- a/bin/tempo/src/snapshot_manifest.rs
+++ b/bin/tempo/src/snapshot_manifest.rs
@@ -55,6 +55,7 @@ pub(crate) struct Args {
         long,
         default_value_t = true,
         default_missing_value = "true",
+        hide = true,
         num_args = 0..=1,
         require_equals = true
     )]
@@ -239,6 +240,14 @@ fn execution_provider(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn help_hides_skip_consensus_override() {
+        let help = Args::command().render_long_help().to_string();
+
+        assert!(!help.contains("--skip-consensus"));
+    }
 
     #[test]
     fn args_defaults_to_skip_consensus() {

--- a/bin/tempo/src/snapshot_manifest.rs
+++ b/bin/tempo/src/snapshot_manifest.rs
@@ -116,7 +116,6 @@ impl Args {
         );
 
         if skip_consensus {
-            eprintln!("--skip-consensus set. skipping consensus layer");
             return Ok(());
         }
 


### PR DESCRIPTION
Marks the Tempo snapshot manifest and download `--skip-consensus` overrides as hidden while keeping explicit parsing available. Also stops announcing to the world that these are set by default (this caused confusion for operators).

We will make them public once we actually start using these.