### PR TITLE
fix(consensus): lower cut-short event levels

### DIFF
--- a/crates/consensus/src/consensus/application/actor.rs
+++ b/crates/consensus/src/consensus/application/actor.rs
@@ -739,6 +739,17 @@ impl Inner<Init> {
         ))
     }
 
+    #[instrument(
+        skip_all,
+        fields(
+            %parent_view,
+            %parent_digest,
+            %round,
+            proposal = %payload,
+            %proposer,
+        ),
+        err(level = Level::WARN),
+    )]
     async fn verify<TContext: Pacer>(
         self,
         context: TContext,

--- a/crates/consensus/src/consensus/application/actor.rs
+++ b/crates/consensus/src/consensus/application/actor.rs
@@ -452,7 +452,7 @@ impl Inner<Init> {
             parent.digest = %verify.parent.1,
             proposer = %verify.proposer,
         ),
-        err,
+        err(level = Level::INFO),
     )]
     async fn handle_verify<TContext: Pacer>(
         self,


### PR DESCRIPTION
Lowers cut-short verification events from ERROR to INFO through the `handle_verify` instrumentation, while `verify` now emits WARN for real verification errors. Proposal cut-short errors continue to use WARN through the existing instrument macro configuration.

Tests: `cargo +nightly fmt`; `cargo check -p tempo-consensus`; `cargo test -p tempo-consensus`