### PR TITLE
refactor(consensus): source epoch strategy from chainspec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13017,6 +13017,7 @@ dependencies = [
  "alloy-hardforks",
  "alloy-primitives",
  "commonware-codec",
+ "commonware-consensus",
  "commonware-cryptography",
  "eyre",
  "once_cell",

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -36,6 +36,7 @@ serde.workspace = true
 serde_json.workspace = true
 paste.workspace = true
 commonware-codec = { workspace = true, optional = true }
+commonware-consensus = { workspace = true, optional = true }
 commonware-cryptography = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -65,6 +66,7 @@ reth = [
     "std",
     "evm",
     "dep:commonware-codec",
+    "dep:commonware-consensus",
     "dep:commonware-cryptography",
     "dep:eyre",
     "dep:reth-chainspec",

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -10,6 +10,7 @@ use alloy_eips::eip7840::BlobParams;
 use alloy_evm::eth::spec::EthExecutorSpec;
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256, U256};
+use commonware_consensus::types::FixedEpocher;
 use once_cell as _;
 #[cfg(not(feature = "std"))]
 use once_cell::sync::Lazy as LazyLock;
@@ -195,6 +196,18 @@ impl TempoChainSpec {
     /// Returns the default RPC URL for following this chain.
     pub fn default_follow_url(&self) -> Option<&'static str> {
         self.default_follow_url
+    }
+
+    /// Returns the fixed epoch strategy configured by this chainspec.
+    pub fn epoch_strategy(&self) -> eyre::Result<FixedEpocher> {
+        let epoch_length = self
+            .info
+            .epoch_length()
+            .ok_or_else(|| eyre::eyre!("chainspec did not contain epochLength"))?;
+        let epoch_length = core::num::NonZeroU64::new(epoch_length)
+            .ok_or_else(|| eyre::eyre!("chainspec epochLength must be non-zero"))?;
+
+        Ok(FixedEpocher::new(epoch_length))
     }
 
     /// Converts the given [`Genesis`] into a [`TempoChainSpec`].

--- a/crates/consensus/src/consensus/engine.rs
+++ b/crates/consensus/src/consensus/engine.rs
@@ -5,10 +5,7 @@
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
 use commonware_broadcast::buffered;
-use commonware_consensus::{
-    Reporters, marshal,
-    types::{FixedEpocher, ViewDelta},
-};
+use commonware_consensus::{Reporters, marshal, types::ViewDelta};
 use commonware_cryptography::{
     Signer as _,
     bls12381::primitives::group::Share,
@@ -19,7 +16,7 @@ use commonware_runtime::{
     BufferPooler, Clock, ContextCell, Handle, Metrics, Network, Pacer, Spawner, Storage,
     buffer::paged::CacheRef, spawn_cell,
 };
-use commonware_utils::{NZU64, NZUsize};
+use commonware_utils::NZUsize;
 use eyre::{OptionExt as _, WrapErr as _};
 use futures::future::try_join_all;
 use rand_08::{CryptoRng, Rng};
@@ -119,13 +116,10 @@ where
             .clone()
             .ok_or_eyre("execution_node must be set using with_execution_node()")?;
 
-        let epoch_length = execution_node
+        let epoch_strategy = execution_node
             .chain_spec()
-            .info
-            .epoch_length()
-            .ok_or_eyre("chainspec did not contain epochLength; cannot go on without it")?;
-
-        let epoch_strategy = FixedEpocher::new(NZU64!(epoch_length));
+            .epoch_strategy()
+            .wrap_err("cannot go on without a valid chainspec epoch strategy")?;
 
         info!(
             identity = %self.signer.public_key(),

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -22,11 +22,9 @@ pub(crate) mod validators;
 
 use std::sync::Arc;
 
-use commonware_consensus::types::FixedEpocher;
 use commonware_cryptography::ed25519::{PrivateKey, PublicKey};
 use commonware_p2p::authenticated::lookup;
 use commonware_runtime::Metrics as _;
-use commonware_utils::NZU64;
 use eyre::{OptionExt, WrapErr as _, eyre};
 use tempo_consensus_config::SigningShare;
 use tempo_node::TempoFullNode;
@@ -177,11 +175,6 @@ pub async fn run_follow_stack(
 ) -> eyre::Result<()> {
     let chain_spec = execution_node.chain_spec();
 
-    let epoch_length = chain_spec
-        .info
-        .epoch_length()
-        .ok_or_eyre("chainspec did not contain epochLength")?;
-
     let chain_spec_network_identity = chain_spec
         .network_identity
         .clone()
@@ -205,7 +198,7 @@ pub async fn run_follow_stack(
         upstream_mailbox,
         network_identity,
         partition_prefix: PARTITION_PREFIX.into(),
-        epoch_strategy: FixedEpocher::new(NZU64!(epoch_length)),
+        epoch_strategy: chain_spec.epoch_strategy()?,
         mailbox_size: config.mailbox_size,
         fcu_heartbeat_interval: config.fcu_heartbeat_interval.into_duration(),
         finalized_blocks_retention: config.finalized_blocks_retention,


### PR DESCRIPTION
## Summary
- add `TempoChainSpec::epoch_strategy()` to construct the CL `FixedEpocher` from chainspec `epochLength`
- update consensus and follow stack initialization to use the chainspec-provided epoch strategy
- keep existing internal CL actor config types unchanged

## Validation
- `cargo fmt --check`
- `cargo check -p tempo-chainspec -p tempo-consensus --all-features`

Prompted by: @klkvr