### PR TITLE
Record e2e bench setup metadata

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -194,6 +194,27 @@ def df-available-mib [path: string] {
     $row | get 3 | into int
 }
 
+def e2e-db-size-bytes [datadir: string] {
+    let paths = [
+        $"($datadir)/db"
+        $"($datadir)/static_files"
+    ] | where { |path| $path | path exists }
+    if ($paths | is-empty) {
+        return 0
+    }
+
+    let result = (^du -sb ...$paths | complete)
+    if $result.exit_code != 0 {
+        if $result.stderr != "" { print $result.stderr }
+        return 0
+    }
+
+    $result.stdout
+        | lines
+        | each { |line| $line | split row --regex '\s+' | first | into int }
+        | math sum
+}
+
 def ensure-bloat-space [bloat: int] {
     if $bloat <= 0 {
         return
@@ -1041,6 +1062,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
 
     if $phase_exit == 0 {
         let phase_started_ms = ((date now | into int) / 1_000_000 | into int)
+        let initial_db_size_bytes = (e2e-db-size-bytes $ctx.a.datadir)
         let sender_exit = (try {
             let bench_result = (txgen-run-preset-pipeline
                 --txgen-tempo-bin $ctx.txgen.txgen_tempo_bin
@@ -1069,6 +1091,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --bloat-mib $ctx.bloat
                 --tip20-token-count $ctx.token_count
                 --bloat-token-count ($TIP20_TOKEN_IDS | length)
+                --initial-db-size-bytes $initial_db_size_bytes
                 --victoriametrics-url $ctx.victoriametrics_url
                 --clickhouse-url $phase_clickhouse_url
                 --skip-funding=($ctx.bloat > 0))

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -267,6 +267,7 @@ def txgen-run-preset-pipeline [
     --bloat-mib: int = 0
     --tip20-token-count: int = 0
     --bloat-token-count: int = 4
+    --initial-db-size-bytes: int = 0
     --skip-funding                                   # Skip faucet funding (accounts already funded at genesis via state bloat)
 ] {
     let chain_id = (txgen-fetch-chain-id $generate_rpc_url)
@@ -278,6 +279,14 @@ def txgen-run-preset-pipeline [
     let tx_token_count = if $tip20_token_count > 0 { $tip20_token_count } else { $bloat_token_count }
     txgen-configure-tip20-token-env $tx_token_count
     txgen-configure-existing-recipients-env $spec_path $bloat_mib $bloat_token_count
+    let existing_recipient_start = ($env | get --optional TXGEN_EXISTING_RECIPIENTS_START | default "0" | into int)
+    let existing_recipient_end = ($env | get --optional TXGEN_EXISTING_RECIPIENTS_END | default "0" | into int)
+    let recipient_accounts = if $existing_recipient_end > $existing_recipient_start {
+        $existing_recipient_end - $existing_recipient_start
+    } else {
+        0
+    }
+    let total_accounts = $accounts + $recipient_accounts
     if not $skip_funding {
         txgen-fund-accounts $txgen_tempo_bin $spec_path $generate_rpc_url
     }
@@ -315,8 +324,11 @@ def txgen-run-preset-pipeline [
         "-m" $"chain_id=($chain_id)"
         "-m" $"target_tps=($tps)"
         "-m" $"run_duration_secs=($duration)"
-        "-m" $"accounts=($accounts)"
+        "-m" $"accounts=($total_accounts)"
         "-m" $"total_connections=($max_concurrent_requests)"
+        "-m" $"bloat_mib=($bloat_mib)"
+        "-m" $"tip20_token_count=($tx_token_count)"
+        "-m" $"bloat_token_count=($bloat_token_count)"
         "-m" "tip20_weight=1.0"
         "-m" "place_order_weight=0.0"
         "-m" "swap_weight=0.0"
@@ -333,6 +345,7 @@ def txgen-run-preset-pipeline [
         | append (if $platform != "" { ["-m" $"platform=($platform)"] } else { [] })
         | append (if $scenario != "" { ["-m" $"scenario=($scenario)"] } else { [] })
         | append (if $pr_number != "" { ["-m" $"pr_number=($pr_number)"] } else { [] })
+        | append (if $initial_db_size_bytes > 0 { ["-m" $"initial_db_size_bytes=($initial_db_size_bytes)"] } else { [] })
     let bench_cmd = $bench_base_cmd | append $report_args | append $metadata_args
 
     let bench_env_export = if $bench_env != "" { $"export ($bench_env) && " } else { "" }


### PR DESCRIPTION
## Summary
- add e2e run metadata for total account count, bloat size, TIP20 token counts, and initial state size
- make `accounts` the dashboard value: txgen sender accounts plus existing recipient accounts when a preset uses bloat recipients
- measure initial state size from the restored datadir MDBX db plus static files before txgen starts
- forward the setup metadata through txgen existing ClickHouse metadata path so perf dashboards can read it from `txgen_runs.metadata`

## Code links
- e2e measurement and phase wiring: bench-e2e.nu
- txgen ClickHouse metadata emission: contrib/bench/txgen/helpers.nu

## Tests
- nu --commands 'source contrib/bench/txgen/helpers.nu; source bench-e2e.nu'
- git diff --check