### PR TITLE
Add rkrasiuk bench Slack mapping

### DIFF
--- a/.github/scripts/bench-slack-users.json
+++ b/.github/scripts/bench-slack-users.json
@@ -25,5 +25,6 @@
   "0xrusowsky": "U09FFDPBZ52",
   "howydev": "U09FB21B7FP",
   "decofe": "U09FATLPC30",
-  "Zygimantass": "U09FQNBAG11"
+  "Zygimantass": "U09FQNBAG11",
+  "rkrasiuk": "U0BAWJ7RLUE"
 }


### PR DESCRIPTION
Adds rkrasiuk to the benchmark Slack user mapping.

Prompted by: @shekhirin