### PR TITLE
docs(tip-1060): specify non-creditable bookkeeping slots

### DIFF
--- a/tips/tip-1060.md
+++ b/tips/tip-1060.md
@@ -1,0 +1,149 @@
+---
+id: TIP-1060
+title: Gas Credits Primitive
+description: Replaces SSTORE clearing refunds with account-local storage credits for future storage creation.
+authors: Tempo
+status: Scheduled
+related: TIP-1000, TIP-1016
+protocolVersion: T7
+---
+
+# TIP-1060: Gas Credits Primitive
+
+## Abstract
+
+This TIP replaces the legacy SSTORE clear refund with an account-local storage credit. Clearing an occupied storage slot mints one credit for the storage-owning account. Creating a new storage slot can then spend, preserve, or later refund against that account's credits according to the account's selected credit mode.
+
+At T7, a zero-to-nonzero SSTORE still pays the 5,000 gas residual set cost. The remaining 245,000 gas creditable portion is governed by TIP-1060.
+
+## Motivation
+
+TIP-1000 makes permanent state creation expensive enough to price storage growth, but the legacy clear-refund model is awkward for users who delete state before creating replacement state. TIP-1060 keeps the state-growth price signal while letting accounts reuse the economic value of storage they free.
+
+The primitive is account-local. A credit minted by clearing one account's storage can only offset future storage creation by that same storage-owning account.
+
+---
+
+# Specification
+
+## Parameters
+
+At the T7 hardfork, introduce the following parameters:
+
+| Parameter | Value | Meaning |
+| --- | ---: | --- |
+| SSTORE creation cost | 250,000 gas | TIP-1000 zero-to-nonzero storage creation cost |
+| SSTORE residual set cost | 5,000 gas | Gas always charged by the SSTORE gas table for a clean zero-to-nonzero write |
+| Storage credit value | 245,000 gas | Creditable portion of storage creation, equal to creation cost minus residual |
+| Storage credits precompile | `0x1060000000000000000000000000000000000000` | Precompile that exposes account credit state |
+
+## Credit State
+
+For each storage-owning account, the protocol tracks:
+
+- `balance`: the persistent number of storage credits owned by the account.
+- `mode`: the transaction-local storage creation mode for the account.
+- `budget`: the transaction-local number of credits that may be spent directly in `Direct` mode.
+- `pendingRefunds`: the transaction-local number of Refund-mode storage creations awaiting settlement.
+
+Persistent credit balances are stored in the storage credits precompile at key `uint256(bytes32(account))`, where `account` is the 20-byte address left-padded to 32 bytes.
+
+`mode`, `budget`, and `pendingRefunds` are transient and MUST NOT persist after the transaction.
+
+## Credit Modes
+
+Each account's transaction-local mode is one of:
+
+- `Refund`: storage creation pays the creditable portion up front and records a pending refund-eligible creation.
+- `Preserve`: storage creation pays the creditable portion up front and does not consume credits.
+- `Direct`: storage creation spends an available credit immediately, subject to the account's direct-spend budget.
+
+The default mode is `Refund` with budget `0`.
+
+Calling `setMode(Direct)` sets the direct-spend budget to `uint64::MAX`. Calling `setMode(Refund)` or `setMode(Preserve)` sets the budget to `0`. Calling `setBudget(n)` sets mode to `Direct` and sets the budget to `n`.
+
+## SSTORE Accounting
+
+TIP-1060 accounting applies only when a storage write crosses the zero boundary:
+
+- `x -> 0`: mint one storage credit for the storage-owning account.
+- `0 -> x`: apply the storage creation rules for the storage-owning account.
+- `0 -> 0` and `x -> y`: no TIP-1060 credit accounting.
+
+The storage credits precompile's own storage is protocol bookkeeping and MUST NOT recursively mint, consume, or settle storage credits for itself.
+
+For a `0 -> x` storage creation:
+
+1. The SSTORE gas table charges the 5,000 gas residual set cost for a clean creation.
+2. In `Direct` mode, if the account has a positive credit balance and positive direct-spend budget, consume one credit and decrement the budget unless the budget is `uint64::MAX`.
+3. In `Direct` mode without a spendable credit or budget, charge the 245,000 gas creditable portion.
+4. In `Preserve` mode, charge the 245,000 gas creditable portion.
+5. In `Refund` mode, charge the 245,000 gas creditable portion and increment `pendingRefunds`.
+
+At end of transaction, `Refund`-mode settlement consumes `min(pendingRefunds, balance)` credits for each account and refunds 245,000 gas per consumed credit. Settlement MUST NOT use transient mode state as persistent credit balance.
+
+## Disabled Accounting Contexts
+
+Some protocol paths run storage-provider logic with TIP-1060 accounting disabled because their gas is charged externally or they are protocol bookkeeping. Writes in such contexts MUST NOT mint, consume, or settle storage credits. If those writes create persistent storage, the external charge MUST include the 245,000 gas creditable portion unless the slot is explicitly exempt.
+
+Protocol bookkeeping slots that can be cleared during metered execution and recreated later in a TIP-1060-disabled context are non-creditable for the duration of that transaction. Clearing one of these slots MUST NOT mint a storage credit, because the later disabled-context recreation would not consume a credit or pay the storage creation charge.
+
+The non-creditable slot set is transaction-local and contains the concrete `(owner, slot)` pairs for:
+
+1. the fee payer's TIP-20 fee-token balance slot;
+2. the keychain spending-limit slot for the transaction access key, when limits are enforced;
+3. the fee manager collected-fees slot for the beneficiary and validator token.
+
+Only the `x -> 0` mint path is affected by this non-creditable-slot rule. `0 -> x` storage creation remains accounted normally when it occurs in a TIP-1060-enabled context.
+
+## Legacy Refund Changes
+
+At T7:
+
+- `SSTORE_CLEARS_SCHEDULE` is `0`; nonzero-to-zero clears mint storage credits instead of receiving the legacy clear refund.
+- The restore-to-original-zero refund is capped at the 5,000 gas residual set cost so `0 -> x -> 0` cannot become refund-positive.
+- Existing restore-to-original-nonzero reset refunds remain otherwise unchanged.
+
+## Precompile Interface
+
+The storage credits precompile exposes:
+
+```solidity
+enum Mode {
+    Refund,
+    Preserve,
+    Direct
+}
+
+function balanceOf(address account) external view returns (uint64);
+function modeOf(address account) external view returns (Mode);
+function budgetOf(address account) external view returns (uint64);
+function setMode(Mode mode) external;
+function setBudget(uint64 creditBudget) external;
+```
+
+## Invariants
+
+- Storage credits are account-local and cannot subsidize another account's storage creation.
+- Clearing an occupied creditable slot mints at most one credit.
+- Creating a slot consumes or refunds against at most one credit.
+- Non-creditable protocol bookkeeping slots do not mint credits when cleared.
+- TIP-1060 disabled-context writes do not mint, consume, or settle credits.
+- The storage credits precompile does not recursively account for its own storage.
+- Transient mode, budget, and pending-refund state do not persist across transactions.
+
+---
+
+# Alternatives Considered
+
+## Keep legacy SSTORE refunds
+
+This preserves EVM familiarity, but it keeps refunds coupled to gas spent in the same transaction and does not provide a reusable account-local credit for future storage creation.
+
+## Global storage credits
+
+Global credits would be easier to spend, but they would let one account's state deletion subsidize another account's state growth. TIP-1060 keeps credits tied to the account that owns the storage.
+
+## Account for every protocol bookkeeping write
+
+Charging every protocol bookkeeping recreation through TIP-1060 would make the accounting model more uniform, but some of these writes occur in contexts where gas is charged externally or where pre/post-transaction settlement must not run the regular storage-credit hook. The non-creditable-slot rule keeps those paths explicit and prevents unbacked credits.


### PR DESCRIPTION
## Summary
- add the TIP-1060 gas credits primitive spec
- document the transaction-local non-creditable bookkeeping slots from the unbacked credits fix
- specify disabled-accounting context behavior, credit modes, settlement, and precompile surface

Prompted by: @klkvr