### PR TITLE
Disable only TIP-1060 credit minting in fee hooks

### DIFF
--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -24,6 +24,7 @@ pub struct EvmPrecompileStorageProvider<'a> {
     is_static: bool,
     gas_params: GasParams,
     tip1060_storage_credits_enabled: bool,
+    tip1060_storage_credit_minting_enabled: bool,
     /// Debug-only LIFO checkpoint validator. See [`Self::assert_lifo`].
     #[cfg(debug_assertions)]
     checkpoint_stack: Vec<(usize, usize)>,
@@ -50,6 +51,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
             is_static,
             gas_params,
             tip1060_storage_credits_enabled: spec.is_t7(),
+            tip1060_storage_credit_minting_enabled: true,
             #[cfg(debug_assertions)]
             checkpoint_stack: Vec::new(),
             actions: StorageActions::disabled(),
@@ -269,6 +271,11 @@ impl crate::storage_credits::StorageCreditsBackend for EvmPrecompileStorageProvi
     #[inline]
     fn tstore(&mut self, address: Address, key: U256, value: U256) {
         self.internals.tstore(address, key, value);
+    }
+
+    #[inline]
+    fn tip1060_storage_credit_minting_enabled(&self) -> bool {
+        self.tip1060_storage_credit_minting_enabled
     }
 }
 
@@ -530,6 +537,11 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
     #[inline]
     fn set_tip1060_storage_credits(&mut self, enabled: bool) {
         self.tip1060_storage_credits_enabled = enabled && self.spec.is_t7();
+    }
+
+    #[inline]
+    fn set_tip1060_storage_credit_minting(&mut self, enabled: bool) {
+        self.tip1060_storage_credit_minting_enabled = enabled;
     }
 }
 

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -159,6 +159,13 @@ pub trait PrecompileStorageProvider {
     /// activate storage credits early.
     fn set_tip1060_storage_credits(&mut self, enabled: bool);
 
+    /// Enables or disables minting new TIP-1060 storage credits for subsequent storage clears.
+    ///
+    /// This leaves storage-credit accounting active for storage creation charges, redemptions, and
+    /// refund-mode settlement. Implementations that do not run TIP-1060 accounting may treat this
+    /// as a no-op.
+    fn set_tip1060_storage_credit_minting(&mut self, _enabled: bool) {}
+
     /// Computes keccak256 and charges the appropriate gas.
     ///
     /// Implementations should use this over naked `keccak256` call to ensure gas is accounted for.

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -228,6 +228,11 @@ impl StorageCtx {
         Self::with_storage(|s| s.set_tip1060_storage_credits(enabled))
     }
 
+    /// Enables or disables minting new TIP-1060 storage credits for subsequent storage clears.
+    pub fn set_tip1060_storage_credit_minting(&mut self, enabled: bool) {
+        Self::with_storage(|s| s.set_tip1060_storage_credit_minting(enabled))
+    }
+
     /// Creates a journal checkpoint and returns a RAII guard.
     ///
     /// All state mutations after this call will be atomically

--- a/crates/precompiles/src/storage_credits/accounting.rs
+++ b/crates/precompiles/src/storage_credits/accounting.rs
@@ -75,6 +75,12 @@ pub trait StorageCreditsBackend {
 
     /// TSTORE `address[key] = value`.
     fn tstore(&mut self, address: Address, key: U256, value: U256);
+
+    /// Returns whether x→0 storage clears should mint a persistent storage credit.
+    #[inline]
+    fn tip1060_storage_credit_minting_enabled(&self) -> bool {
+        true
+    }
 }
 
 #[inline]
@@ -128,8 +134,10 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
     let mut was_changed = false;
     if values.is_new_zero() {
         // x→0: storage deletion always mints a new credit.
-        credit = credit.saturating_add(1);
-        was_changed = true;
+        if backend.tip1060_storage_credit_minting_enabled() {
+            credit = credit.saturating_add(1);
+            was_changed = true;
+        }
     } else {
         // 0→x: storage creation.
         // This hook manages the 245k creditable gas, independent of the original value.


### PR DESCRIPTION
## Summary
- add a TIP-1060 storage-credit minting bool separate from full storage-credit accounting
- let the storage-credit hook suppress x-to-0 credit minting without disabling creation-side accounting
- expose a setter to flip credit minting, without adding `enter_evm_without_tip1060_credit_minting` or changing `enter_evm_without_tip1060_accounting` call sites

Prompted by: @klkvr

## Verification
- cargo fmt
- cargo check -p tempo-precompiles -p tempo-revm