### PR TITLE
fix(serde): serialize sealed blocks as plain blocks

### DIFF
--- a/crates/node/src/rpc/consensus/types.rs
+++ b/crates/node/src/rpc/consensus/types.rs
@@ -209,3 +209,50 @@ pub trait ConsensusFeed: Send + Sync + 'static {
         full: bool,
     ) -> impl Future<Output = Result<IdentityTransitionResponse, IdentityProofError>> + Send;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn certified_block_roundtrips_legacy_plain_block_json() {
+        let fixture = serde_json::json!({
+            "epoch": 7,
+            "view": 11,
+            "digest": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "certificate": "0x1234",
+            "block": {
+                "body": {
+                    "ommers": [],
+                    "transactions": [],
+                    "withdrawals": null
+                },
+                "header": {
+                    "difficulty": "0x0",
+                    "extraData": "0x",
+                    "gasLimit": "0x0",
+                    "gasUsed": "0x0",
+                    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "mainBlockGeneralGasLimit": "0x0",
+                    "miner": "0x0000000000000000000000000000000000000000",
+                    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "nonce": "0x0000000000000000",
+                    "number": "0x0",
+                    "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "sharedGasLimit": "0x0",
+                    "stateRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                    "timestamp": "0x0",
+                    "timestampMillisPart": "0x0",
+                    "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+                }
+            }
+        });
+
+        let certified: CertifiedBlock = serde_json::from_value(fixture.clone()).unwrap();
+        let roundtripped = serde_json::to_value(certified).unwrap();
+
+        assert_eq!(roundtripped, fixture);
+    }
+}

--- a/crates/node/src/rpc/consensus/types.rs
+++ b/crates/node/src/rpc/consensus/types.rs
@@ -7,6 +7,7 @@ use futures::Future;
 use reth_primitives_traits::SealedOrRecoveredBlock;
 use serde::{Deserialize, Serialize};
 use tempo_alloy::rpc::TempoHeaderResponse;
+use tempo_payload_types::serde_sealed_or_recovered_block;
 use tempo_primitives::Block;
 use tokio::sync::broadcast;
 
@@ -22,6 +23,7 @@ pub struct CertifiedBlock {
     pub certificate: String,
 
     /// The Tempo block.
+    #[serde(with = "serde_sealed_or_recovered_block")]
     pub block: SealedOrRecoveredBlock<Block>,
 }
 

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -313,20 +313,8 @@ impl EncodedBlock {
 mod tests {
     use super::*;
 
-    #[derive(Deserialize)]
-    struct OwnedWrappedBlock {
-        #[serde(with = "crate::serde_sealed_or_recovered_block")]
-        block: SealedOrRecoveredBlock<Block>,
-    }
-
-    #[derive(Serialize)]
-    struct BorrowedWrappedBlock<'a> {
-        #[serde(with = "crate::serde_sealed_or_recovered_block")]
-        block: &'a SealedOrRecoveredBlock<Block>,
-    }
-
     #[test]
-    fn sealed_or_recovered_block_roundtrips_legacy_plain_block_json() {
+    fn execution_data_roundtrips_legacy_plain_block_json() {
         let fixture = serde_json::json!({
             "block": {
                 "body": {
@@ -354,14 +342,13 @@ mod tests {
                     "timestampMillisPart": "0x0",
                     "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
                 }
-            }
+            },
+            "block_access_list": null,
+            "validator_set": null
         });
 
-        let wrapped: OwnedWrappedBlock = serde_json::from_value(fixture.clone()).unwrap();
-        let roundtripped = serde_json::to_value(BorrowedWrappedBlock {
-            block: &wrapped.block,
-        })
-        .unwrap();
+        let execution_data: TempoExecutionData = serde_json::from_value(fixture.clone()).unwrap();
+        let roundtripped = serde_json::to_value(execution_data).unwrap();
 
         assert_eq!(roundtripped, fixture);
     }

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -164,21 +164,39 @@ pub struct TempoExecutionData {
 
 pub mod serde_sealed_block {
     use reth_primitives_traits::SealedBlock;
-    use serde::{Deserialize, Serialize};
     use tempo_primitives::Block;
 
     pub fn serialize<S>(block: &SealedBlock<Block>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        block.clone_block().serialize(serializer)
+        #[derive(serde::Serialize)]
+        struct BlockRef<'a> {
+            header: &'a tempo_primitives::TempoHeader,
+            body: &'a tempo_primitives::BlockBody,
+        }
+
+        serde::Serialize::serialize(
+            &BlockRef {
+                header: block.header(),
+                body: block.body(),
+            },
+            serializer,
+        )
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<SealedBlock<Block>, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        Block::deserialize(deserializer).map(SealedBlock::seal_slow)
+        #[derive(serde::Deserialize)]
+        struct BlockParts {
+            header: tempo_primitives::TempoHeader,
+            body: tempo_primitives::BlockBody,
+        }
+
+        let BlockParts { header, body } = serde::Deserialize::deserialize(deserializer)?;
+        Ok(SealedBlock::seal_slow(Block { header, body }))
     }
 }
 

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -154,11 +154,54 @@ impl BuiltPayload for TempoBuiltPayload {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TempoExecutionData {
     /// The built block.
+    #[serde(with = "serde_sealed_or_recovered_block")]
     pub block: SealedOrRecoveredBlock<Block>,
     /// RLP-encoded EIP-7928 block access list, when supplied with the payload.
     pub block_access_list: Option<Bytes>,
     /// Validator set active at the time this block was built.
     pub validator_set: Option<Vec<B256>>,
+}
+
+pub mod serde_sealed_block {
+    use reth_primitives_traits::SealedBlock;
+    use serde::{Deserialize, Serialize};
+    use tempo_primitives::Block;
+
+    pub fn serialize<S>(block: &SealedBlock<Block>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        block.clone_block().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<SealedBlock<Block>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Block::deserialize(deserializer).map(SealedBlock::seal_slow)
+    }
+}
+
+pub mod serde_sealed_or_recovered_block {
+    use reth_primitives_traits::SealedOrRecoveredBlock;
+    use tempo_primitives::Block;
+
+    pub fn serialize<S>(
+        block: &SealedOrRecoveredBlock<Block>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        super::serde_sealed_block::serialize(block.sealed_block(), serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<SealedOrRecoveredBlock<Block>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        super::serde_sealed_block::deserialize(deserializer).map(SealedOrRecoveredBlock::from)
+    }
 }
 
 impl ExecutionPayload for TempoExecutionData {
@@ -264,5 +307,58 @@ impl EncodedBlock {
     /// Returns cached encoded bytes, filling the cache with `encode` if it is empty.
     pub fn get_or_encode_with(&self, encode: impl FnOnce() -> Bytes) -> &Bytes {
         self.0.get_or_init(encode)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Serialize)]
+    struct WrappedBlock<'a> {
+        #[serde(with = "crate::serde_sealed_or_recovered_block")]
+        block: &'a SealedOrRecoveredBlock<Block>,
+    }
+
+    #[derive(Deserialize)]
+    struct OwnedWrappedBlock {
+        #[serde(with = "crate::serde_sealed_or_recovered_block")]
+        block: SealedOrRecoveredBlock<Block>,
+    }
+
+    #[test]
+    fn sealed_or_recovered_block_serializes_as_plain_block() {
+        let plain_block = Block::default();
+        let sealed_block = SealedBlock::seal_slow(plain_block.clone());
+        let block = SealedOrRecoveredBlock::from(sealed_block);
+
+        let wrapped = serde_json::to_value(WrappedBlock { block: &block }).unwrap();
+
+        assert_eq!(wrapped["block"], serde_json::to_value(plain_block).unwrap());
+        assert!(wrapped["block"]["header"]["parentHash"].is_string());
+        assert!(wrapped["block"]["header"]["header"].is_null());
+    }
+
+    #[test]
+    fn recovered_block_serializes_as_plain_block() {
+        let plain_block = Block::default();
+        let recovered_block = SealedBlock::seal_slow(plain_block.clone()).with_senders(Vec::new());
+        let block = SealedOrRecoveredBlock::from(recovered_block);
+
+        let wrapped = serde_json::to_value(WrappedBlock { block: &block }).unwrap();
+
+        assert_eq!(wrapped["block"], serde_json::to_value(plain_block).unwrap());
+        assert!(wrapped["block"]["header"]["parentHash"].is_string());
+        assert!(wrapped["block"]["header"]["header"].is_null());
+    }
+
+    #[test]
+    fn sealed_or_recovered_block_deserializes_from_plain_block() {
+        let plain_block = Block::default();
+        let value = serde_json::json!({ "block": plain_block });
+
+        let wrapped: OwnedWrappedBlock = serde_json::from_value(value).unwrap();
+
+        assert_eq!(wrapped.block.sealed_block().clone_block(), Block::default());
     }
 }

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -162,6 +162,11 @@ pub struct TempoExecutionData {
     pub validator_set: Option<Vec<B256>>,
 }
 
+/// Serde helper for preserving the legacy plain block JSON shape.
+///
+/// `SealedOrRecoveredBlock` normally serializes through `SealedBlock`, which exposes the
+/// `SealedHeader` wrapper as an extra nested `header`. Consensus RPC and execution payload JSON
+/// historically used `tempo_primitives::Block`, so this keeps those wire formats stable.
 pub mod serde_sealed_or_recovered_block {
     use reth_primitives_traits::{SealedBlock, SealedOrRecoveredBlock};
     use tempo_primitives::Block;

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -162,11 +162,14 @@ pub struct TempoExecutionData {
     pub validator_set: Option<Vec<B256>>,
 }
 
-pub mod serde_sealed_block {
-    use reth_primitives_traits::SealedBlock;
+pub mod serde_sealed_or_recovered_block {
+    use reth_primitives_traits::{SealedBlock, SealedOrRecoveredBlock};
     use tempo_primitives::Block;
 
-    pub fn serialize<S>(block: &SealedBlock<Block>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(
+        block: &SealedOrRecoveredBlock<Block>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -185,7 +188,7 @@ pub mod serde_sealed_block {
         )
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<SealedBlock<Block>, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<SealedOrRecoveredBlock<Block>, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -196,29 +199,7 @@ pub mod serde_sealed_block {
         }
 
         let BlockParts { header, body } = serde::Deserialize::deserialize(deserializer)?;
-        Ok(SealedBlock::seal_slow(Block { header, body }))
-    }
-}
-
-pub mod serde_sealed_or_recovered_block {
-    use reth_primitives_traits::SealedOrRecoveredBlock;
-    use tempo_primitives::Block;
-
-    pub fn serialize<S>(
-        block: &SealedOrRecoveredBlock<Block>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        super::serde_sealed_block::serialize(block.sealed_block(), serializer)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<SealedOrRecoveredBlock<Block>, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        super::serde_sealed_block::deserialize(deserializer).map(SealedOrRecoveredBlock::from)
+        Ok(SealedBlock::seal_slow(Block { header, body }).into())
     }
 }
 
@@ -332,51 +313,56 @@ impl EncodedBlock {
 mod tests {
     use super::*;
 
-    #[derive(Serialize)]
-    struct WrappedBlock<'a> {
-        #[serde(with = "crate::serde_sealed_or_recovered_block")]
-        block: &'a SealedOrRecoveredBlock<Block>,
-    }
-
     #[derive(Deserialize)]
     struct OwnedWrappedBlock {
         #[serde(with = "crate::serde_sealed_or_recovered_block")]
         block: SealedOrRecoveredBlock<Block>,
     }
 
-    #[test]
-    fn sealed_or_recovered_block_serializes_as_plain_block() {
-        let plain_block = Block::default();
-        let sealed_block = SealedBlock::seal_slow(plain_block.clone());
-        let block = SealedOrRecoveredBlock::from(sealed_block);
-
-        let wrapped = serde_json::to_value(WrappedBlock { block: &block }).unwrap();
-
-        assert_eq!(wrapped["block"], serde_json::to_value(plain_block).unwrap());
-        assert!(wrapped["block"]["header"]["parentHash"].is_string());
-        assert!(wrapped["block"]["header"]["header"].is_null());
+    #[derive(Serialize)]
+    struct BorrowedWrappedBlock<'a> {
+        #[serde(with = "crate::serde_sealed_or_recovered_block")]
+        block: &'a SealedOrRecoveredBlock<Block>,
     }
 
     #[test]
-    fn recovered_block_serializes_as_plain_block() {
-        let plain_block = Block::default();
-        let recovered_block = SealedBlock::seal_slow(plain_block.clone()).with_senders(Vec::new());
-        let block = SealedOrRecoveredBlock::from(recovered_block);
+    fn sealed_or_recovered_block_roundtrips_legacy_plain_block_json() {
+        let fixture = serde_json::json!({
+            "block": {
+                "body": {
+                    "ommers": [],
+                    "transactions": [],
+                    "withdrawals": null
+                },
+                "header": {
+                    "difficulty": "0x0",
+                    "extraData": "0x",
+                    "gasLimit": "0x0",
+                    "gasUsed": "0x0",
+                    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "mainBlockGeneralGasLimit": "0x0",
+                    "miner": "0x0000000000000000000000000000000000000000",
+                    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "nonce": "0x0000000000000000",
+                    "number": "0x0",
+                    "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "sharedGasLimit": "0x0",
+                    "stateRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                    "timestamp": "0x0",
+                    "timestampMillisPart": "0x0",
+                    "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+                }
+            }
+        });
 
-        let wrapped = serde_json::to_value(WrappedBlock { block: &block }).unwrap();
+        let wrapped: OwnedWrappedBlock = serde_json::from_value(fixture.clone()).unwrap();
+        let roundtripped = serde_json::to_value(BorrowedWrappedBlock {
+            block: &wrapped.block,
+        })
+        .unwrap();
 
-        assert_eq!(wrapped["block"], serde_json::to_value(plain_block).unwrap());
-        assert!(wrapped["block"]["header"]["parentHash"].is_string());
-        assert!(wrapped["block"]["header"]["header"].is_null());
-    }
-
-    #[test]
-    fn sealed_or_recovered_block_deserializes_from_plain_block() {
-        let plain_block = Block::default();
-        let value = serde_json::json!({ "block": plain_block });
-
-        let wrapped: OwnedWrappedBlock = serde_json::from_value(value).unwrap();
-
-        assert_eq!(wrapped.block.sealed_block().clone_block(), Block::default());
+        assert_eq!(roundtripped, fixture);
     }
 }


### PR DESCRIPTION
## Summary
- add shared serde helpers that serialize `SealedBlock<Block>` through the plain Tempo block shape
- apply the helper to `SealedOrRecoveredBlock<Block>` fields used by consensus RPC and execution data
- add regression coverage for sealed/recovered JSON round trips

Prompted by: @klkvr

## Tests
- cargo test -p tempo-payload-types
- cargo check -p tempo-node
