### PR TITLE
fix(primitives): saturate `AASigned::value` sum to match `TempoTransaction`

### DIFF
--- a/crates/primitives/src/transaction/tt_signed.rs
+++ b/crates/primitives/src/transaction/tt_signed.rs
@@ -348,11 +348,11 @@ impl Transaction for AASigned {
 
     #[inline]
     fn value(&self) -> U256 {
-        // Return sum of all call values
+        // Return sum of all call values, saturating to U256::MAX on overflow
         self.tx
             .calls
             .iter()
-            .fold(U256::ZERO, |acc, call| acc + call.value)
+            .fold(U256::ZERO, |acc, call| acc.saturating_add(call.value))
     }
 
     #[inline]


### PR DESCRIPTION
# fix(primitives): saturate `AASigned::value` sum to match `TempoTransaction`

## What 

`AASigned::value()` sums per-call values with an unchecked `+`. Switched to
`saturating_add`, matching the sibling impl on `TempoTransaction::value()`.


```diff
- // Return sum of all call values
- .fold(U256::ZERO, |acc, call| acc + call.value)
+ // Return sum of all call values, saturating to U256::MAX on overflow
+ .fold(U256::ZERO, |acc, call| acc.saturating_add(call.value))
```

## Why it matters 

`Call::value` is a `U256` decoded straight from the wire — there is no per-call
upper bound, and `validate_calls` only checks CREATE placement / emptiness. A
structurally valid AA transaction with e.g. two calls of `value = U256::MAX`
makes the sum overflow:


| build profile | old behaviour |  
| ------------- | ------------- | 
| debug / tests (`overflow-checks`) | **panic** `attempt to add with overflow` | 
| release / maxperf | silently **wraps** to a small value | 

Worse, the *same* logical transaction returns a different `value()` depending on
whether it is read through `AASigned` (the variant actually held in
`TempoTxEnvelope::AA`) or its inner `TempoTransaction`.



## Risk 

Behaviour changes only on the overflow path (now returns `U256::MAX` instead of
panicking/wrapping). No change for any non-overflowing transaction.


`crates/primitives/src/transaction/tt_signed.rs`
