### PR TITLE
fix(payload): avoid u64 underflow in block-time metric

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -347,8 +347,10 @@ where
 
         let start = Instant::now();
 
-        let block_time_millis =
-            (attributes.timestamp_millis() - parent_header.timestamp_millis()) as f64;
+        let block_time_millis = attributes
+            .timestamp_millis()
+            .saturating_sub(parent_header.timestamp_millis())
+            as f64;
         self.metrics.block_time_millis.record(block_time_millis);
         self.metrics.block_time_millis_last.set(block_time_millis);
 


### PR DESCRIPTION
# fix(payload): avoid u64 underflow in block-time metric

**Problem**
`block_time_millis` is computed as a raw `u64` subtraction:
```rust
let block_time_millis =
    (attributes.timestamp_millis() - parent_header.timestamp_millis()) as f64;
```
If `attributes.timestamp_millis() < parent_header.timestamp_millis()` — clock
skew, or an attribute timestamp not rejected on this path — the subtraction
underflows.


**Root cause**
Unchecked `-` on `u64`. Notably the rest of this file already guards timing math
with `saturating_sub` (e.g. lines ~771, ~1087) — this site is the inconsistency.


**Fix**
```rust
let block_time_millis = attributes
    .timestamp_millis()
    .saturating_sub(parent_header.timestamp_millis())
    as f64;
```

**Impact**
- debug: removes a potential panic
- release: histogram no longer polluted by a ~u64::MAX outlier 
- normal monotonic timestamps: identical 

