### PR TITLE
fix(pool): derive fee_token_cost directly from gas spending

### DIFF
--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -102,10 +102,9 @@ impl TempoPooledTransaction {
     ) -> Self {
         let is_payment = transaction.is_payment_v2();
         let value = transaction.value();
-        let cost =
-            calc_gas_balance_spending(transaction.gas_limit(), transaction.max_fee_per_gas())
-                .saturating_add(value);
-        let fee_token_cost = cost - value;
+        let fee_token_cost =
+            calc_gas_balance_spending(transaction.gas_limit(), transaction.max_fee_per_gas());
+        let cost = fee_token_cost.saturating_add(value);
         Self {
             inner: EthPooledTransaction {
                 cost,


### PR DESCRIPTION
# fix(pool): derive fee_token_cost directly from gas spending

So here's the thing. When a `TempoPooledTransaction` is built, we compute the
total `cost` as `gas_spending.saturating_add(value)`, and then we recover the
fee-token portion by subtracting `value` back out:


```rust
let cost = calc_gas_balance_spending(..).saturating_add(value);
let fee_token_cost = cost - value;   // <- 
```

That round-trip is fine right up until `value` is big enough to saturate `cost`.
Once `cost` pins at `U256::MAX`, `cost - value` no longer gives you back the gas
spending — it gives you something near zero. And `fee_token_cost` isn't cosmetic:
it feeds transaction ordering, AMM liquidity admission, and the state-aware
eviction check. A tx could look like it costs ~0 to run.



The fix just stops going through `cost`. Compute the gas spending once, use it as
`fee_token_cost`, and build `cost` from it instead:


```rust
let fee_token_cost = calc_gas_balance_spending(..);
let cost = fee_token_cost.saturating_add(value);
```

Identical for every normal transaction; only the saturating corner changes.

