### PR TITLE
fix(rpc): detect AA transactions by `key_type`/`key_data` in gas estimation

### DIFF
--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -146,6 +146,8 @@ impl TryIntoTxEnv<TempoTxEnv, TempoHardfork, TempoBlockEnv> for TempoTransaction
                 || nonce_key.is_some()
                 || key_authorization.is_some()
                 || key_id.is_some()
+                || key_type.is_some()
+                || key_data.is_some()
                 || fee_payer.is_some()
                 || valid_before.is_some()
                 || valid_after.is_some()


### PR DESCRIPTION
#  detect AA transactions by `key_type`/`key_data` in gas estimation

There are two places that decide whether a request is an AA transaction, and they
disagreed.

| field | `output_tx_type` (canonical) | `try_into_tx_env` (gas est.) — before |
| ----- | :--------------------------: | :-----------------------------------: |
| calls / nonce_key / key_id / authz / valid_* | ✅ | ✅ |
| **key_type** | ✅ | ❌ ← gap |
| **key_data** | ✅ | ❌ ← gap |

`try_into_tx_env` powers `eth_estimateGas` / `eth_call`. When a request sets only
`key_type` (e.g. WebAuthn) — the field that *exists specifically* for gas
estimation (see its doc on `TempoTransactionRequest`) — the canonical classifier
calls it AA, but `try_into_tx_env` fell through to the plain Ethereum env. The
mock AA signature was never built, so the P256/WebAuthn verification gas (and its
calldata gas) was omitted and the estimate came back too low. A tx submitted with
that limit can hit out-of-gas.


## Fix
Add `key_type`/`key_data` to the `try_into_tx_env` AA predicate so the two paths
agree.


