### PR TITLE
test(pool): cover `evict_timed_out` in the paused pool

### DIFF
--- a/crates/transaction-pool/src/paused.rs
+++ b/crates/transaction-pool/src/paused.rs
@@ -406,6 +406,52 @@ mod tests {
     }
 
     #[test]
+    fn test_evict_timed_out() {
+        use std::time::Duration;
+
+        let mut pool = PausedFeeTokenPool::new();
+
+        // A token paused longer ago than the timeout should be evicted wholesale.
+        let stale_token = Address::random();
+        let stale_at = Instant::now()
+            .checked_sub(PAUSED_TX_TIMEOUT + Duration::from_secs(1))
+            .expect("monotonic clock has enough history for the test");
+        pool.by_token.insert(
+            stale_token,
+            PausedTokenMeta {
+                paused_at: stale_at,
+                entries: vec![
+                    PausedEntry {
+                        tx: create_valid_tx(Address::random()),
+                        valid_before: None,
+                    },
+                    PausedEntry {
+                        tx: create_valid_tx(Address::random()),
+                        valid_before: None,
+                    },
+                ],
+            },
+        );
+
+        // A freshly paused token is within the timeout and must be retained.
+        let fresh_token = Address::random();
+        pool.insert_batch(
+            fresh_token,
+            vec![PausedEntry {
+                tx: create_valid_tx(Address::random()),
+                valid_before: None,
+            }],
+        );
+
+        let removed = pool.evict_timed_out();
+
+        assert_eq!(removed, 2, "both stale entries should be evicted");
+        assert_eq!(pool.count_for_token(&stale_token), 0);
+        assert_eq!(pool.count_for_token(&fresh_token), 1);
+        assert!(!pool.is_empty());
+    }
+
+    #[test]
     fn test_global_cap_evicts_oldest() {
         let mut pool = PausedFeeTokenPool::new();
 


### PR DESCRIPTION
# test(pool): cover `evict_timed_out` in the paused pool

`PausedFeeTokenPool::evict_timed_out` drops every transaction of a fee token that
has stayed paused longer than `PAUSED_TX_TIMEOUT` (30 min) — a memory-safety
guard — but it had no direct test. This adds one.


## What the test asserts
- A token whose `paused_at` is older than the timeout is evicted **wholesale**
  (all its entries) and the returned count matches. 
- A token paused just now is **retained**. 
- The pool is not emptied when only some tokens time out. 

The stale entry is injected by constructing `PausedTokenMeta` with a back-dated
`Instant` (same-module test access), since wall-clock time can't be advanced in a
unit test. 

Test-only change.
