### PR TITLE
fix(consensus): initialize marshal from archive floor

### DIFF
--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -14,10 +14,11 @@ pub(crate) mod marshal {
     use commonware_runtime::{
         BufferPooler, Clock, Metrics, Spawner, Storage, buffer::paged::CacheRef,
     };
-    use commonware_storage::archive::immutable;
+    use commonware_storage::archive::{Archive as _, Identifier, immutable};
     use commonware_utils::acknowledgement::Exact;
     use eyre::WrapErr as _;
     use rand_08::{CryptoRng, Rng};
+    use reth_ethereum::chainspec::EthChainSpec;
     use reth_ethereum::provider::db::DatabaseEnv;
     use reth_node_builder::NodeTypesWithDBAdapter;
     use reth_provider::providers::BlockchainProvider;
@@ -87,17 +88,25 @@ pub(crate) mod marshal {
         /// Mailbox for sending messages to [`Self::actor`].
         pub mailbox: Mailbox,
 
-        /// `max(marshal_stored_height, reth_finalized_height)` after
-        /// advancing marshal's sync floor to that height. The engine uses
-        /// this to seed the executor and other actors that need to know
-        /// where the chain starts replaying from.
-        pub last_finalized_height: Height,
+        /// The local consensus finalized tip used to seed actors that need to
+        /// read startup state. When the finalization archive is absent, this
+        /// preserves the legacy `max(marshal_stored_height,
+        /// reth_finalized_height)` behavior.
+        pub finalized_tip: Height,
+
+        /// The local consensus height after which startup backfill should
+        /// resume. This is the archive floor for snapshot/archive starts, or
+        /// marshal's stored processed height otherwise.
+        pub finalized_backfill_start: Height,
+
+        /// The finalized tip known at startup, including the digest to
+        /// canonicalize once startup backfill is complete.
+        pub latest_observed_finalized_tip: (Height, Digest),
     }
 
     /// Initialize the marshal actor and its backing finalized-blocks store
     /// (the finalizations-by-height archive plus the [`Hybrid`] finalized
-    /// blocks store), and advance marshal's sync floor to
-    /// `max(marshal_stored_height, reth_finalized_height)`.
+    /// blocks store), and advance marshal's sync floor.
     ///
     /// Both the consensus and follow engines must initialize marshal in
     /// exactly the same way so that nodes can switch modes without data
@@ -144,6 +153,8 @@ pub(crate) mod marshal {
         .await
         .wrap_err("failed to initialize hybrid finalized blocks store")?;
 
+        let archive_bounds = archive_finalization_bounds(&finalizations_by_height).await?;
+
         let (actor, mailbox, marshal_stored_height) = core::Actor::init(
             context.with_label("marshal"),
             finalizations_by_height,
@@ -167,30 +178,182 @@ pub(crate) mod marshal {
         )
         .await;
 
-        // Floor marshal at reth's last finalized block so we don't try to
-        // re-sync history that the execution layer already finalized. The
-        // mailbox message is buffered until the actor starts; `set_floor` only
-        // ever advances, so sending it unconditionally is safe.
+        // When a consensus archive exists, it is the startup source of truth:
+        // floor marshal at the first local finalization and seed the other
+        // actors from the local CL tip. For existing nodes, the floor may be
+        // below the processed height restored from marshal metadata;
+        // commonware ignores stale floors, so sending it unconditionally is
+        // safe. If the archive is absent, preserve the legacy EL-driven
+        // fallback.
         let reth_finalized_height = execution_node
             .provider
             .canonical_in_memory_state()
             .get_finalized_num_hash()
             .map(|nh| nh.number)
             .unwrap_or(0);
-        let last_finalized_height = marshal_stored_height.max(Height::new(reth_finalized_height));
-        if last_finalized_height > marshal_stored_height {
+        let finalized_tip =
+            initial_finalized_height(archive_bounds, marshal_stored_height, reth_finalized_height);
+        let finalized_backfill_start =
+            initial_backfill_start(archive_bounds, marshal_stored_height);
+        let latest_observed_finalized_tip = archive_bounds
+            .map(|bounds| (bounds.tip, bounds.tip_digest))
+            .unwrap_or_else(|| {
+                (
+                    Height::zero(),
+                    Digest(execution_node.chain_spec().genesis_hash()),
+                )
+            });
+
+        if let Some(ArchiveFinalizationBounds {
+            floor: archive_floor_height,
+            tip: archive_tip_height,
+            tip_digest: archive_tip_digest,
+        }) = archive_bounds
+        {
+            info!(
+                marshal_stored = %marshal_stored_height,
+                archive_floor = %archive_floor_height,
+                archive_tip = %archive_tip_height,
+                archive_tip_digest = %archive_tip_digest,
+                "setting marshal sync floor to first archived finalization certificate"
+            );
+            mailbox.set_floor(archive_floor_height).await;
+        } else if finalized_tip > marshal_stored_height {
             info!(
                 marshal_stored = %marshal_stored_height,
                 reth_finalized = reth_finalized_height,
                 "advancing marshal sync floor to reth's finalized block"
             );
-            mailbox.set_floor(last_finalized_height).await;
+            mailbox.set_floor(finalized_tip).await;
         }
 
         Ok(Initialized {
             actor,
             mailbox,
-            last_finalized_height,
+            finalized_tip,
+            finalized_backfill_start,
+            latest_observed_finalized_tip,
         })
+    }
+
+    #[derive(Clone, Copy)]
+    struct ArchiveFinalizationBounds {
+        floor: Height,
+        tip: Height,
+        tip_digest: Digest,
+    }
+
+    async fn archive_finalization_bounds<TContext>(
+        finalizations_by_height: &immutable::Archive<
+            TContext,
+            Digest,
+            Finalization<Scheme<PublicKey, MinSig>, Digest>,
+        >,
+    ) -> eyre::Result<Option<ArchiveFinalizationBounds>>
+    where
+        TContext: Clock + Metrics + Spawner + Storage + BufferPooler + Clone + Send + 'static,
+    {
+        let Some(floor) = finalizations_by_height
+            .ranges_from(0)
+            .next()
+            .map(|(start, _)| Height::new(start))
+        else {
+            return Ok(None);
+        };
+        let Some(tip) = finalizations_by_height.last_index().map(Height::new) else {
+            return Ok(None);
+        };
+        let finalization = finalizations_by_height
+            .get(Identifier::Index(tip.get()))
+            .await
+            .wrap_err_with(|| {
+                format!("failed reading finalization certificate at archive tip `{tip}`")
+            })?
+            .ok_or_else(|| {
+                eyre::eyre!(
+                    "finalization archive reported tip `{tip}` but no certificate was present"
+                )
+            })?;
+        let tip_digest = finalization.proposal.payload;
+        Ok(Some(ArchiveFinalizationBounds {
+            floor,
+            tip,
+            tip_digest,
+        }))
+    }
+
+    fn initial_finalized_height(
+        archive_bounds: Option<ArchiveFinalizationBounds>,
+        marshal_stored_height: Height,
+        reth_finalized_height: u64,
+    ) -> Height {
+        archive_bounds
+            .map(|bounds| bounds.tip)
+            .unwrap_or_else(|| marshal_stored_height.max(Height::new(reth_finalized_height)))
+    }
+
+    fn initial_backfill_start(
+        archive_bounds: Option<ArchiveFinalizationBounds>,
+        marshal_stored_height: Height,
+    ) -> Height {
+        archive_bounds
+            .map(|bounds| bounds.floor)
+            .unwrap_or(marshal_stored_height)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn initial_finalized_height_uses_archive_tip_when_present() {
+            assert_eq!(
+                initial_finalized_height(
+                    Some(ArchiveFinalizationBounds {
+                        floor: Height::new(7),
+                        tip: Height::new(9),
+                        tip_digest: Digest(alloy_primitives::B256::ZERO),
+                    }),
+                    Height::new(10),
+                    12,
+                ),
+                Height::new(9),
+            );
+        }
+
+        #[test]
+        fn initial_finalized_height_preserves_existing_fallback_without_archive() {
+            assert_eq!(
+                initial_finalized_height(None, Height::new(10), 12),
+                Height::new(12),
+            );
+            assert_eq!(
+                initial_finalized_height(None, Height::new(14), 12),
+                Height::new(14),
+            );
+        }
+
+        #[test]
+        fn initial_backfill_start_uses_archive_floor_when_present() {
+            assert_eq!(
+                initial_backfill_start(
+                    Some(ArchiveFinalizationBounds {
+                        floor: Height::new(7),
+                        tip: Height::new(9),
+                        tip_digest: Digest(alloy_primitives::B256::ZERO),
+                    }),
+                    Height::new(10),
+                ),
+                Height::new(7),
+            );
+        }
+
+        #[test]
+        fn initial_backfill_start_uses_marshal_stored_height_without_archive() {
+            assert_eq!(
+                initial_backfill_start(None, Height::new(10)),
+                Height::new(10)
+            );
+        }
     }
 }

--- a/crates/consensus/src/consensus/engine.rs
+++ b/crates/consensus/src/consensus/engine.rs
@@ -143,7 +143,9 @@ where
         let alias::marshal::Initialized {
             actor: marshal,
             mailbox: marshal_mailbox,
-            last_finalized_height,
+            finalized_tip,
+            finalized_backfill_start,
+            latest_observed_finalized_tip,
         } = alias::marshal::init(
             context.clone(),
             page_cache_ref.clone(),
@@ -168,7 +170,9 @@ where
             context.with_label("executor"),
             crate::executor::Config {
                 execution_node: execution_node.clone(),
-                last_finalized_height,
+                finalized_tip,
+                finalized_backfill_start,
+                latest_observed_finalized_tip: Some(latest_observed_finalized_tip),
                 marshal: marshal_mailbox.clone(),
                 fcu_heartbeat_interval: self.fcu_heartbeat_interval,
                 public_key: Some(self.signer.public_key()),
@@ -182,7 +186,7 @@ where
                 execution_node: execution_node.clone(),
                 oracle: self.peer_manager.clone(),
                 epoch_strategy: epoch_strategy.clone(),
-                last_finalized_height,
+                last_finalized_height: finalized_tip,
             },
         );
 

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -104,7 +104,8 @@ pub(crate) struct Actor<TContext> {
     /// and to update the canonical chain by sending forkchoice updates.
     execution_node: Arc<TempoFullNode>,
 
-    last_consensus_finalized_height: Height,
+    finalized_tip: Height,
+    finalized_backfill_start: Height,
     last_execution_finalized_height: Height,
 
     /// The channel over which the agent will receive new commands from the
@@ -189,7 +190,9 @@ where
     ) -> eyre::Result<Self> {
         let Config {
             execution_node,
-            last_finalized_height,
+            finalized_tip,
+            finalized_backfill_start,
+            latest_observed_finalized_tip,
             marshal,
             fcu_heartbeat_interval,
             public_key,
@@ -203,12 +206,13 @@ where
 
         let fcu_heartbeat_timer = OptionFuture::some(context.sleep(fcu_heartbeat_interval).boxed());
         let last_execution_finalized_height = Height::new(finalized_num_hash.number);
-        let finalized_heights_to_backfill =
-            (last_execution_finalized_height.get() + 1)..=last_finalized_height.get();
+        let backfill_floor = last_execution_finalized_height.max(finalized_backfill_start);
+        let finalized_heights_to_backfill = (backfill_floor.get() + 1)..=finalized_tip.get();
         Ok(Self {
             context: ContextCell::new(context),
             execution_node,
-            last_consensus_finalized_height: last_finalized_height,
+            finalized_tip,
+            finalized_backfill_start,
             last_execution_finalized_height,
             mailbox,
             marshal,
@@ -230,7 +234,7 @@ where
             execution_task: OptionFuture::none(),
             payload_jobs: FuturesUnordered::new(),
 
-            latest_observed_finalized_tip: None,
+            latest_observed_finalized_tip,
 
             public_key,
             metrics,
@@ -244,9 +248,10 @@ where
     async fn run(mut self) {
         info_span!("start").in_scope(|| {
             info!(
-                last_finalized_consensus_height = %self.last_consensus_finalized_height,
+                finalized_tip = %self.finalized_tip,
+                finalized_backfill_start = %self.finalized_backfill_start,
                 last_finalized_execution_height = %self.last_execution_finalized_height,
-                "consensus and execution layers reported last finalized heights; \
+                "consensus layer reported finalized tip and startup backfill start; \
                 backfilling blocks from consensus to execution if necessary",
             );
         });

--- a/crates/consensus/src/executor/mod.rs
+++ b/crates/consensus/src/executor/mod.rs
@@ -14,6 +14,8 @@ use futures::channel::mpsc;
 pub(crate) use ingress::Mailbox;
 use tempo_node::TempoFullNode;
 
+use crate::consensus::Digest;
+
 pub(crate) fn init<TContext>(
     context: TContext,
     config: Config,
@@ -32,11 +34,17 @@ pub(crate) struct Config {
     /// and to update the canonical chain by sending forkchoice updates.
     pub(crate) execution_node: Arc<TempoFullNode>,
 
-    /// The last finalized height according to the consensus layer.
+    /// The known finalized tip according to the consensus layer.
     /// If on startup there is a mismatch between the execution layer and the
-    /// consensus, then the node will fill the gap by backfilling blocks to
-    /// the execution layer until `last_finalized_height` is reached.
-    pub(crate) last_finalized_height: Height,
+    /// consensus layer, the node will fill the gap by backfilling blocks to
+    /// the execution layer until `finalized_tip` is reached.
+    pub(crate) finalized_tip: Height,
+
+    /// The local consensus height after which startup backfill should resume.
+    pub(crate) finalized_backfill_start: Height,
+
+    /// The finalized tip known at startup, if any.
+    pub(crate) latest_observed_finalized_tip: Option<(Height, Digest)>,
 
     /// The mailbox of the marshal actor. Used to backfill blocks.
     pub(crate) marshal: crate::alias::marshal::Mailbox,

--- a/crates/consensus/src/follow/engine.rs
+++ b/crates/consensus/src/follow/engine.rs
@@ -105,7 +105,9 @@ impl<TUpstream> Config<TUpstream> {
         let alias::marshal::Initialized {
             actor: marshal_actor,
             mailbox: marshal_mailbox,
-            last_finalized_height,
+            finalized_tip,
+            finalized_backfill_start,
+            latest_observed_finalized_tip,
         } = alias::marshal::init(
             context.clone(),
             page_cache_ref,
@@ -123,12 +125,8 @@ impl<TUpstream> Config<TUpstream> {
         .await
         .wrap_err("failed to initialize marshal")?;
 
-        info_span!("follow_engine").in_scope(|| {
-            info!(
-                last_finalized_height = last_finalized_height.get(),
-                "initialized marshal"
-            )
-        });
+        info_span!("follow_engine")
+            .in_scope(|| info!(finalized_tip = finalized_tip.get(), "initialized marshal"));
 
         let (resolver, resolver_mailbox, resolver_rx) = resolver::try_init(
             context.with_label("resolver"),
@@ -151,7 +149,9 @@ impl<TUpstream> Config<TUpstream> {
             context.with_label("executor"),
             executor::Config {
                 execution_node: self.execution_node.clone(),
-                last_finalized_height,
+                finalized_tip,
+                finalized_backfill_start,
+                latest_observed_finalized_tip: Some(latest_observed_finalized_tip),
                 marshal: marshal_mailbox.clone(),
                 fcu_heartbeat_interval: self.fcu_heartbeat_interval,
                 public_key: None,
@@ -168,7 +168,7 @@ impl<TUpstream> Config<TUpstream> {
                 execution_node: self.execution_node.clone(),
                 scheme_provider: scheme_provider.clone(),
                 network_identity: self.network_identity,
-                last_finalized_height,
+                last_finalized_height: finalized_tip,
                 marshal: marshal_mailbox,
                 feed: feed_mailbox,
                 epoch_strategy: epoch_strategy.clone(),


### PR DESCRIPTION
## Summary
- initialize marshal from the first available archived finalization certificate when consensus archive storage is present
- expose the highest local archived finalization certificate as `finalized_tip` for startup actor state
- expose a separate `finalized_backfill_start` so executor backfill starts after the archive floor, or after marshal's stored processed height when no archive exists
- seed executor `latest_observed_finalized_tip` from the highest archived finalization cert, or genesis when the archive has no certs
- keep the previous reth-finalized fallback for nodes without consensus archive storage
- rely on pinned commonware marshal metadata to ignore stale floors on existing nodes

Prompted by: @SuperFluffy

## Commonware notes
- Pinned commonware rev `2a7dd423f0a241276a5a38db8cc3d05f11de0c03` persists last processed height in marshal application metadata and ignores `set_floor` when the requested floor is at or below that height.
- Latest commonware main inspected at `2606c97223d2ef546a53e7d6aa396faa25bbb7ab`; latest release tag found was `v2026.5.0` at `b8b0a8d8919a66b5649c9fdaceb881a55fbe5876`. In that API marshal starts from a `Start::Floor(finalization)` certificate and still reads the same legacy application metadata. A future upgrade should verify that processed-round recovery from local finalization metadata remains available before relying on an older startup floor cert.

## Testing
- `cargo fmt --check`
- `cargo test -p tempo-consensus alias::marshal::tests --lib`
- `cargo check -p tempo-consensus`