### PR TITLE
feat: implement provable contracts support

### DIFF
--- a/.github/scripts/bench-e2e-classify.js
+++ b/.github/scripts/bench-e2e-classify.js
@@ -217,11 +217,12 @@ function buildMarkdown(summary) {
   const derekCommand = summary.config?.derek_command || '';
   const baselineRemovedArgs = summary.config?.baseline_removed_args || '';
   const featureRemovedArgs = summary.config?.feature_removed_args || '';
+  const featureOnly = summary.config?.run_side === 'feature';
   const lines = [
-    `# ${c.emoji} Bench Comparison: ${c.label}`,
+    featureOnly ? `# ${c.emoji} Feature Bench: ${c.label}` : `# ${c.emoji} Bench Comparison: ${c.label}`,
     '',
     `**Refs:** ${summary.baseline_ref} vs ${summary.feature_ref}`,
-    `**Criteria:** 95% run-bootstrap CI must clear floor; cells show delta (+/-CI/floor).`,
+    featureOnly ? `**Criteria:** Feature-only run; baseline columns are intentionally empty.` : `**Criteria:** 95% run-bootstrap CI must clear floor; cells show delta (+/-CI/floor).`,
     '',
     '## Configuration',
     ...(derekCommand ? [`- Derek command: \`${derekCommand}\``] : []),
@@ -231,6 +232,7 @@ function buildMarkdown(summary) {
     `- Target TPS: ${summary.config.tps}`,
     `- Duration: ${summary.config.duration}s`,
     `- Run pairs: ${summary.config.run_pairs}`,
+    ...(featureOnly ? [`- Run side: feature`] : []),
     ...(baselineRemovedArgs ? [`- Baseline removed args: \`${baselineRemovedArgs}\``] : []),
     ...(featureRemovedArgs ? [`- Feature removed args: \`${featureRemovedArgs}\``] : []),
     `- Baseline blocks: ${summary.results.baseline.blocks}`,

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -298,6 +298,10 @@ on:
         type: string
         required: false
         default: "3"
+      run-side:
+        type: string
+        required: false
+        default: comparison
       clickhouse-run:
         type: string
         required: false
@@ -390,6 +394,7 @@ jobs:
       BENCH_BASELINE_ENV: ${{ inputs.baseline-env }}
       BENCH_FEATURE_ENV: ${{ inputs.feature-env }}
       BENCH_RUN_PAIRS: ${{ inputs.run-pairs || '3' }}
+      BENCH_RUN_SIDE: ${{ inputs.run-side || 'comparison' }}
       BENCH_CLICKHOUSE_RUN: ${{ inputs.clickhouse-run || 'feature-1' }}
       BENCHMARK_ID: bench-e2e-${{ github.run_id }}
       BENCH_COMMENT_ID: ${{ inputs.comment-id }}
@@ -529,9 +534,11 @@ jobs:
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const gasLimit = process.env.BENCH_GAS_LIMIT;
             const runPairs = process.env.BENCH_RUN_PAIRS || '2';
+            const runSide = process.env.BENCH_RUN_SIDE || 'comparison';
             const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
             const featureFlagsNote = `${baselineFeatureFlags ? `, baseline-features: \`${baselineFeatureFlags}\`` : ''}${featureFeatureFlags ? `, feature-features: \`${featureFeatureFlags}\`` : ''}`;
-            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, token-count: \`${tokenCount}\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${noCacheNote}`);
+            const runSideNote = runSide !== 'comparison' ? `, run-side: \`${runSide}\`` : '';
+            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, token-count: \`${tokenCount}\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`${runSideNote}, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${noCacheNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -722,9 +729,11 @@ jobs:
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const gasLimit = process.env.BENCH_GAS_LIMIT;
             const runPairs = process.env.BENCH_RUN_PAIRS || '2';
+            const runSide = process.env.BENCH_RUN_SIDE || 'comparison';
             const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
             const featureFlagsNote = `${baselineFeatureFlags ? `, baseline-features: \`${baselineFeatureFlags}\`` : ''}${featureFeatureFlags ? `, feature-features: \`${featureFeatureFlags}\`` : ''}`;
-            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, token-count: \`${tokenCount}\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${noCacheNote}`;
+            const runSideNote = runSide !== 'comparison' ? `, run-side: \`${runSide}\`` : '';
+            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, token-count: \`${tokenCount}\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`${runSideNote}, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${noCacheNote}`;
             core.exportVariable('BENCH_CONFIG', config);
 
             const { data: comment } = await github.rest.issues.createComment({
@@ -761,6 +770,10 @@ jobs:
             echo "::error::run-pairs must be a positive integer"
             exit 1
           fi
+          if [ "$BENCH_RUN_SIDE" != "comparison" ] && [ "$BENCH_RUN_SIDE" != "feature" ]; then
+            echo "::error::run-side must be one of: comparison, feature"
+            exit 1
+          fi
           if ! [[ "$BENCH_TOKEN_COUNT" =~ ^[1-9][0-9]*$ ]]; then
             echo "::error::token-count must be a positive integer"
             exit 1
@@ -776,6 +789,7 @@ jobs:
             --token-count "$BENCH_TOKEN_COUNT"
             --duration "$BENCH_DURATION"
             --run-pairs "$BENCH_RUN_PAIRS"
+            --run-side "$BENCH_RUN_SIDE"
             --tps "$BENCH_TPS"
             --accounts "$BENCH_ACCOUNTS"
             --max-concurrent-requests "$BENCH_MAX_CONCURRENT_REQUESTS"
@@ -856,6 +870,7 @@ jobs:
             feature-hardfork="$BENCH_FEATURE_HARDFORK"
             gas-limit="$BENCH_GAS_LIMIT"
             run-pairs="$BENCH_RUN_PAIRS"
+            run-side="$BENCH_RUN_SIDE"
             otlp="$BENCH_OTLP"
             metrics="$BENCH_METRICS"
             no-cache="$BENCH_NO_CACHE"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -67,6 +67,7 @@ jobs:
       warmup: ${{ steps.args.outputs.warmup }}
       chain: ${{ steps.args.outputs.chain }}
       run-pairs: ${{ steps.args.outputs.run-pairs }}
+      run-side: ${{ steps.args.outputs.run-side }}
       comment-id: ${{ steps.ack.outputs.comment-id }}
       pr-head-sha: ${{ steps.args.outputs.pr-head-sha }}
       pr-head-ref: ${{ steps.args.outputs.pr-head-ref }}
@@ -111,7 +112,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
-            let pr, actor, mode, preset, duration, bloat, tokenCount, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, baselineFeatures, featureFeatures, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, valscope, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, metrics, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs;
+            let pr, actor, mode, preset, duration, bloat, tokenCount, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, baselineFeatures, featureFeatures, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, valscope, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, metrics, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs, runSide;
             let explicitWarmup = false;
             let explicitDuration = false;
             let explicitRunPairs = false;
@@ -122,11 +123,11 @@ jobs:
             const body = context.payload.comment.body.trim();
             const intArgs = new Set(['duration', 'bloat', 'token-count', 'tps', 'accounts', 'max-concurrent-requests', 'gas-limit', 'tracy-seconds', 'tracy-offset', 'blocks', 'warmup', 'run-pairs']);
             const refArgs = new Set(['baseline', 'feature', 'txgen-ref']);
-            const stringArgs = new Set(['mode', 'preset', 'tracy', 'baseline-args', 'feature-args', 'baseline-features', 'feature-features', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain', 'baseline-hardfork', 'feature-hardfork']);
+            const stringArgs = new Set(['mode', 'preset', 'tracy', 'baseline-args', 'feature-args', 'baseline-features', 'feature-features', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain', 'baseline-hardfork', 'feature-hardfork', 'run-side']);
             const boolArgs = new Set(['samply', 'force-bloat', 'no-cache', 'no-slack', 'otlp', 'valscope', 'metrics']);
             const bloatValues = new Set(['1', '10', '100']);
             const hardforkValues = new Set(['T0', 'T1', 'T1A', 'T1B', 'T1C', 'T2', 'T3', 'T4', 'T5', 'T6']);
-            const defaults = { mode: 'e2e', preset: 'tip20_existing_recipients', duration: '300', bloat: '100', 'token-count': '4', tps: '50000', accounts: '1000', 'max-concurrent-requests': '500', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'baseline-features': '', 'feature-features': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'true', valscope: 'false', metrics: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2' };
+            const defaults = { mode: 'e2e', preset: 'tip20_existing_recipients', duration: '300', bloat: '100', 'token-count': '4', tps: '50000', accounts: '1000', 'max-concurrent-requests': '500', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'baseline-features': '', 'feature-features': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'true', valscope: 'false', metrics: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2', 'run-side': 'comparison' };
             const unknown = [];
             const invalid = [];
             const defaultWarmup = (blockCount) => String(Math.floor(Number(blockCount) / 4));
@@ -208,7 +209,7 @@ jobs:
             if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
             if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
             if (errors.length) {
-              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [otlp] [metrics[=true|false]] [valscope] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
+              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [run-side=comparison|feature] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [otlp] [metrics[=true|false]] [valscope] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -254,6 +255,7 @@ jobs:
             blocks = defaults.blocks;
             warmup = defaults.warmup;
             runPairs = defaults['run-pairs'];
+            runSide = defaults['run-side'];
             var chain = defaults.chain;
             if (mode === 'e2e') {
               if (!explicitDuration) duration = '90';
@@ -263,7 +265,7 @@ jobs:
               warmup = defaultWarmup(blocks);
             }
 
-            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [otlp] [valscope] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
+            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [run-side=comparison|feature] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [otlp] [metrics[=true|false]] [valscope] [force-bloat] [no-cache] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 
             // Validate chain value
             if (!['mainnet', 'testnet'].includes(chain)) {
@@ -281,6 +283,28 @@ jobs:
             // Validate mode value
             if (!['e2e', 'replay'].includes(mode)) {
               const msg = `❌ **Invalid bench command**\n\n\`mode=${mode}\` is not valid. Must be \`e2e\` or \`replay\`.\n\n${usageStr}`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: msg,
+              });
+              core.setFailed(msg);
+              return;
+            }
+            if (!['comparison', 'feature'].includes(runSide)) {
+              const msg = `❌ **Invalid bench command**\n\n\`run-side=${runSide}\` is not valid. Must be \`comparison\` or \`feature\`.\n\n${usageStr}`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: msg,
+              });
+              core.setFailed(msg);
+              return;
+            }
+            if (runSide !== 'comparison' && mode !== 'e2e') {
+              const msg = `❌ **Invalid bench command**\n\n\`run-side=${runSide}\` is only supported with \`mode=e2e\`.\n\n${usageStr}`;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -428,6 +452,7 @@ jobs:
             core.setOutput('warmup', warmup);
             core.setOutput('chain', chain);
             core.setOutput('run-pairs', runPairs);
+            core.setOutput('run-side', runSide);
 
       - name: Acknowledge request
         id: ack
@@ -458,6 +483,7 @@ jobs:
           ACK_FEATURE_ARGS: ${{ steps.args.outputs.feature-args }}
           ACK_GAS_LIMIT: ${{ steps.args.outputs.gas-limit }}
           ACK_RUN_PAIRS: ${{ steps.args.outputs.run-pairs }}
+          ACK_RUN_SIDE: ${{ steps.args.outputs.run-side }}
           ACK_NO_CACHE: ${{ steps.args.outputs.no-cache }}
         with:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
@@ -505,11 +531,13 @@ jobs:
             const naNote = (bNa || fNa) ? `${bNa ? `, baseline-args: \`${bNa}\`` : ''}${fNa ? `, feature-args: \`${fNa}\`` : ''}` : '';
             const gasLimit = process.env.ACK_GAS_LIMIT;
             const runPairs = process.env.ACK_RUN_PAIRS || '2';
+            const runSide = process.env.ACK_RUN_SIDE || 'comparison';
             const noCache = process.env.ACK_NO_CACHE === 'true';
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
             const featureFlagsNote = `${baselineFeatureFlags ? `, baseline-features: \`${baselineFeatureFlags}\`` : ''}${featureFeatureFlags ? `, feature-features: \`${featureFeatureFlags}\`` : ''}`;
-            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, token-count: \`${tokenCount}\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${naNote}${noCacheNote}`;
+            const runSideNote = runSide !== 'comparison' ? `, run-side: \`${runSide}\`` : '';
+            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, token-count: \`${tokenCount}\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`${runSideNote}, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${naNote}${noCacheNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -553,6 +581,7 @@ jobs:
       feature-args: ${{ needs.tempo-bench-ack.outputs.feature-args }}
       gas-limit: ${{ needs.tempo-bench-ack.outputs.gas-limit }}
       run-pairs: ${{ needs.tempo-bench-ack.outputs.run-pairs }}
+      run-side: ${{ needs.tempo-bench-ack.outputs.run-side }}
       run-type: ${{ needs.tempo-bench-ack.outputs.run-type }}
       force-bloat: ${{ needs.tempo-bench-ack.outputs.force-bloat }}
       no-cache: ${{ needs.tempo-bench-ack.outputs.no-cache }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8656,7 +8656,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8717,7 +8717,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8737,7 +8737,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8750,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8833,7 +8833,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8843,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8896,7 +8896,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8912,7 +8912,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8926,7 +8926,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8939,7 +8939,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8964,7 +8964,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8993,7 +8993,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9019,7 +9019,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9049,7 +9049,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9064,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9089,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9113,7 +9113,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9137,7 +9137,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9172,7 +9172,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9229,7 +9229,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9257,7 +9257,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9280,7 +9280,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9296,6 +9296,7 @@ dependencies = [
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
+ "reth-tasks",
  "reth-trie-common",
  "serde",
  "thiserror 2.0.18",
@@ -9305,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9364,7 +9365,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9394,7 +9395,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9412,7 +9413,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9428,7 +9429,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9451,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9462,7 +9463,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9490,7 +9491,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9512,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9553,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "clap",
  "eyre",
@@ -9576,7 +9577,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9592,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9608,7 +9609,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9621,7 +9622,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9651,7 +9652,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9665,7 +9666,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9675,7 +9676,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9700,7 +9701,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9720,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9738,7 +9739,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9751,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9770,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9808,7 +9809,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9822,7 +9823,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "serde",
  "serde_json",
@@ -9832,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9860,7 +9861,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "bytes",
  "futures",
@@ -9880,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9897,7 +9898,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "bindgen",
  "cc",
@@ -9906,7 +9907,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "futures",
  "metrics",
@@ -9919,7 +9920,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9928,7 +9929,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9942,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10000,7 +10001,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10025,7 +10026,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10049,7 +10050,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10064,7 +10065,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10078,7 +10079,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10095,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10119,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10187,7 +10188,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10242,7 +10243,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10289,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10313,7 +10314,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10337,7 +10338,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "bytes",
  "eyre",
@@ -10366,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10378,7 +10379,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10402,7 +10403,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10414,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10437,7 +10438,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10480,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10529,7 +10530,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10557,7 +10558,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10573,7 +10574,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10588,7 +10589,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10666,7 +10667,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10696,7 +10697,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10739,7 +10740,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10759,7 +10760,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10790,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10837,7 +10838,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10888,7 +10889,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10902,7 +10903,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10933,7 +10934,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10984,7 +10985,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11012,7 +11013,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11026,7 +11027,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11046,7 +11047,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11061,7 +11062,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11087,7 +11088,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11105,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11126,7 +11127,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11142,7 +11143,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11152,7 +11153,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "clap",
  "eyre",
@@ -11172,7 +11173,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11191,7 +11192,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11236,7 +11237,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11262,7 +11263,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11290,7 +11291,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11309,7 +11310,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11338,7 +11339,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Ffix-hashed-post-state-passing#8fcf26cbb5490124ca846f9f7757467203aa1b8a"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8655,7 +8655,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8682,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8715,7 +8715,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8735,7 +8735,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8748,7 +8748,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8831,7 +8831,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8841,7 +8841,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8894,7 +8894,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8910,7 +8910,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8924,7 +8924,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8937,7 +8937,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8962,7 +8962,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8991,7 +8991,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9017,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9087,7 +9087,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9111,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9135,7 +9135,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9227,7 +9227,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9255,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9278,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9303,7 +9303,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9362,7 +9362,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9408,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9424,7 +9424,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9447,7 +9447,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9458,7 +9458,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9486,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9508,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9549,7 +9549,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "clap",
  "eyre",
@@ -9572,7 +9572,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9604,7 +9604,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9617,7 +9617,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9647,7 +9647,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9661,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9671,7 +9671,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9696,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9716,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9734,7 +9734,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9747,7 +9747,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9766,7 +9766,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9804,7 +9804,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9818,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "serde",
  "serde_json",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "bytes",
  "futures",
@@ -9876,7 +9876,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9893,7 +9893,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "bindgen",
  "cc",
@@ -9902,7 +9902,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "futures",
  "metrics",
@@ -9915,7 +9915,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9938,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9996,7 +9996,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10021,7 +10021,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10045,7 +10045,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10060,7 +10060,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10074,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10091,7 +10091,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10115,7 +10115,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10183,7 +10183,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10238,7 +10238,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10285,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10309,7 +10309,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "bytes",
  "eyre",
@@ -10362,7 +10362,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10374,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10398,7 +10398,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10410,7 +10410,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10476,7 +10476,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10553,7 +10553,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10569,7 +10569,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10584,7 +10584,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10662,7 +10662,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10692,7 +10692,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10735,7 +10735,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10755,7 +10755,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10786,7 +10786,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10833,7 +10833,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10884,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10898,7 +10898,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10929,7 +10929,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10980,7 +10980,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11008,7 +11008,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11022,7 +11022,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11042,7 +11042,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11057,7 +11057,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11083,7 +11083,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11122,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11138,7 +11138,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11148,7 +11148,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "clap",
  "eyre",
@@ -11168,7 +11168,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11187,7 +11187,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11232,7 +11232,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11258,7 +11258,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11286,7 +11286,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11306,7 +11306,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11335,10 +11335,9 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f152114#f1521143811088e36f80a573f7cf6af567d6c658"
+source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
 dependencies = [
  "alloy-primitives",
- "alloy-rlp",
  "alloy-trie",
  "either",
  "metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2212,6 +2212,7 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures 0.3.0",
+ "serde",
  "zeroize",
 ]
 
@@ -8655,7 +8656,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8682,13 +8683,14 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
+ "blake3",
  "derive_more",
  "metrics",
  "parking_lot",
@@ -8715,7 +8717,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8735,7 +8737,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8748,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8831,7 +8833,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8841,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8861,9 +8863,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312c1817d0e37c6112d30fcc9e92226d8e73cc66ea6bd640c80e0e0df956cc04"
+checksum = "eb43f4858fef4e3b42b80954d2edf1ff67c8ad7498347083cdc7d0f6eff2f081"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8882,9 +8884,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526ee2bfded1897b7bb43f46410f487ee48a41b7e93cf18031079660b433550d"
+checksum = "5798ae4d6b264764bc0d742468bd32c7fb515e774645d4930f95ff6311f3ae14"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8894,7 +8896,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8910,7 +8912,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8924,7 +8926,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8937,7 +8939,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8962,7 +8964,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8991,7 +8993,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9017,7 +9019,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9047,7 +9049,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9062,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9087,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9111,7 +9113,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9135,7 +9137,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9170,7 +9172,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9227,7 +9229,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9255,7 +9257,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9278,7 +9280,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9303,7 +9305,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9362,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9392,12 +9394,14 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types-beacon",
+ "alloy-rpc-types-engine",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "sha2 0.10.9",
@@ -9408,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9424,7 +9428,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9447,7 +9451,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9458,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9486,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9508,7 +9512,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9549,7 +9553,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "clap",
  "eyre",
@@ -9572,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9588,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9604,7 +9608,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9617,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9647,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9661,7 +9665,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9671,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9696,7 +9700,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9716,7 +9720,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9734,7 +9738,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9747,7 +9751,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9766,7 +9770,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9804,7 +9808,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9818,7 +9822,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "serde",
  "serde_json",
@@ -9828,7 +9832,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9856,7 +9860,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "bytes",
  "futures",
@@ -9876,7 +9880,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9893,7 +9897,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "bindgen",
  "cc",
@@ -9902,7 +9906,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "futures",
  "metrics",
@@ -9915,7 +9919,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9924,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9938,7 +9942,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9996,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10021,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10045,7 +10049,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10060,7 +10064,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10074,7 +10078,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10091,7 +10095,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10115,7 +10119,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10183,7 +10187,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10238,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10285,7 +10289,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10309,7 +10313,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,7 +10337,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "bytes",
  "eyre",
@@ -10362,7 +10366,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10374,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10398,7 +10402,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10410,7 +10414,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10433,7 +10437,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10442,9 +10446,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66169f2c520c1c94192a18d11c5466565f079588def7d76abb631db80d353829"
+checksum = "f59c928b2865af5bcdbce94800270b7f7798f27a22ca0aabdd2b7d3e6587c9ce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10476,7 +10480,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10525,7 +10529,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10553,7 +10557,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10569,7 +10573,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10584,7 +10588,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10662,7 +10666,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10692,7 +10696,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10735,7 +10739,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10755,7 +10759,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10786,7 +10790,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10833,7 +10837,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10884,7 +10888,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10898,7 +10902,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10929,7 +10933,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10980,7 +10984,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11008,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11022,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11042,7 +11046,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11057,7 +11061,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11083,7 +11087,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11101,7 +11105,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11122,7 +11126,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11138,7 +11142,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11148,7 +11152,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "clap",
  "eyre",
@@ -11168,7 +11172,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11187,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11232,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11258,7 +11262,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11286,7 +11290,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11295,7 +11299,6 @@ dependencies = [
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
- "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
@@ -11306,7 +11309,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11335,7 +11338,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4de4ab245dcf40a01966b4b2b2950c3299596fb8#4de4ab245dcf40a01966b4b2b2950c3299596fb8"
+source = "git+https://github.com/paradigmxyz/reth?branch=pep%2Flthash-proto#dfc48720eb657065ca760ec17a6140ff69c8b202"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11355,9 +11358,9 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd4e89ad5d14393bde9b2b152480d4fd7f2399d0f9efe80ea29ec7c0b76bcdc"
+checksum = "e1bd4ae4f54a2ba813eef082910bc646bd31cab8ed134308fa71f1068331fb84"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17201e6cbb4efbb1e510b0746839cd743a5cec3fcfb4673ea2342bd657341c93"
+checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -2553,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f"
 dependencies = [
  "serde_core",
 ]
@@ -3860,7 +3860,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -6671,9 +6670,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -11497,9 +11496,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.41.1"
+version = "0.41.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac492384995d832d6910920a932c000436623ec18668ff9291cb78f96c8b710f"
+checksum = "54e22e1aa328f78e8c3dea6a3a860a3a3c3a77c4a7e775e3fdd3dcbb24a152ac"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11513,7 +11512,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "time",
 ]
 
 [[package]]
@@ -13026,6 +13024,7 @@ dependencies = [
  "reth-network-peers",
  "serde",
  "serde_json",
+ "tempo-contracts",
  "tempo-dkg-onchain-artifacts",
  "tempo-primitives",
 ]
@@ -13216,6 +13215,7 @@ dependencies = [
  "reth-rpc-eth-api",
  "reth-storage-api",
  "reth-trie",
+ "reth-trie-common",
  "revm",
  "serde_json",
  "tempo-chainspec",
@@ -13274,8 +13274,10 @@ name = "tempo-node"
 version = "1.8.2"
 dependencies = [
  "alloy",
+ "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
+ "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
@@ -13297,6 +13299,7 @@ dependencies = [
  "rand 0.9.4",
  "reqwest 0.13.3",
  "reth-chainspec",
+ "reth-consensus",
  "reth-e2e-test-utils",
  "reth-errors",
  "reth-ethereum",
@@ -13317,6 +13320,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tracing",
  "reth-transaction-pool",
+ "reth-trie-common",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -13787,12 +13791,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -13804,15 +13807,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,66 +144,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f152114", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-codecs = { version = "0.5.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f152114", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f152114", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-primitives-traits = { version = "0.5.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f152114" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-codecs = { version = "0.5.2", default-features = false }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-primitives-traits = { version = "0.5.2", default-features = false }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f152114", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,66 +144,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "rkrasiuk/fix-hashed-post-state-passing", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,66 +144,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "4de4ab245dcf40a01966b4b2b2950c3299596fb8", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "pep/lthash-proto", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ revm = { version = "41.0.0", features = ["optional_fee_charge"], default-feature
 alloy = { version = "2.1.0", default-features = false }
 alloy-consensus = { version = "2.1.0", default-features = false }
 alloy-contract = { version = "2.1.0", default-features = false }
-alloy-eip7928 = { version = "0.4.3", default-features = false }
+alloy-eip7928 = { version = "0.4.5", default-features = false }
 alloy-eips = { version = "2.1.0", default-features = false }
 alloy-evm = { version = "0.37.0", default-features = false }
 revm-inspectors = "0.41.1"
@@ -322,7 +322,7 @@ age = { version = "0.11", default-features = false }
 secrecy = "0.10"
 
 # build deps
-vergen = "9.1.0"
+vergen = { version = "9.1.0", features = ["build", "cargo", "emit_and_set"] }
 vergen-git2 = "9.1.0"
 
 # [patch."https://github.com/paradigmxyz/reth"]

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1082,10 +1082,14 @@ def run-local-e2e-phase [run: record, ctx: record] {
     return 0
 }
 
-def e2e-run-sides [run_pairs: int] {
+def e2e-run-sides [run_pairs: int, run_side: string] {
     if $run_pairs <= 0 {
         print "Error: --run-pairs must be a positive integer"
         exit 1
+    }
+
+    if $run_side == "feature" {
+        return (0..<$run_pairs | each { "feature" })
     }
 
     mut sides = []
@@ -1113,6 +1117,7 @@ def e2e-write-summary-config [
     benchmark_id: string
     reference_epoch: int
     summary_warmup_blocks: int
+    run_side: string
     baseline_hardfork: string
     feature_hardfork: string
     baseline_removed_args: string
@@ -1129,6 +1134,7 @@ def e2e-write-summary-config [
         benchmark_id: $benchmark_id
         reference_epoch: $reference_epoch
         summary_warmup_blocks: $summary_warmup_blocks
+        run_side: $run_side
         baseline_hardfork: $baseline_hardfork
         feature_hardfork: $feature_hardfork
         baseline_removed_args: $baseline_removed_args
@@ -1147,6 +1153,7 @@ def e2e-generate-summary [results_dir: string] {
     let baseline_hardfork = ($config | get -o baseline_hardfork | default "")
     let feature_hardfork = ($config | get -o feature_hardfork | default "")
     let summary_warmup_blocks = ($config | get -o summary_warmup_blocks | default 0 | into int)
+    let run_side = ($config | get -o run_side | default "comparison")
     generate-summary $results_dir $config.baseline_label $config.feature_label ($config.bloat_mib | into int) $config.preset ($config.tps | into int) ($config.duration | into int) --benchmark-id ($config.benchmark_id | default "") --reference-epoch ($config.reference_epoch | default 0 | into int) --baseline-hardfork $baseline_hardfork --feature-hardfork $feature_hardfork --summary-warmup-blocks $summary_warmup_blocks
     let summary_path = $"($results_dir)/summary.json"
     if ($summary_path | path exists) {
@@ -1154,7 +1161,7 @@ def e2e-generate-summary [results_dir: string] {
         let feature_removed_args = ($config | get -o feature_removed_args | default "")
         let token_count = ($config | get -o token_count | default 4 | into int)
         let summary = (open $summary_path)
-        let summary = ($summary | upsert config ($summary.config | upsert token_count $token_count | upsert baseline_removed_args $baseline_removed_args | upsert feature_removed_args $feature_removed_args))
+        let summary = ($summary | upsert config ($summary.config | upsert token_count $token_count | upsert run_side $run_side | upsert baseline_removed_args $baseline_removed_args | upsert feature_removed_args $feature_removed_args))
         $summary | to json | save -f $summary_path
     }
 
@@ -1209,6 +1216,7 @@ def "main e2e" [
     --clickhouse-run: string = "feature-1"              # Run label allowed to use the ClickHouse reporter; empty = every run
     --runner-metrics-url: string = $E2E_RUNNER_METRICS_URL # Runner node-exporter metrics URL (empty disables runner metrics)
     --run-pairs: int = 3                                # Number of baseline/feature run pairs
+    --run-side: string = "comparison"                   # Phases to run: comparison or feature
     --run-type: string = ""                             # Run type label (dispatch, nightly, release)
     --baseline-args: string = ""                        # Additional node args for baseline phases
     --feature-args: string = ""                         # Additional node args for feature phases
@@ -1235,6 +1243,10 @@ def "main e2e" [
     }
     if $run_pairs <= 0 {
         print "Error: --run-pairs must be a positive integer"
+        exit 1
+    }
+    if $run_side not-in ["comparison" "feature"] {
+        print $"Error: --run-side must be one of: comparison, feature \(got '($run_side)'\)"
         exit 1
     }
     if $summary_warmup_blocks < 0 {
@@ -1414,13 +1426,20 @@ def "main e2e" [
     let feature_wt = $"($BENCH_WORKTREES_DIR)/e2e-local-feature"
     let regenesis_wt = $"($BENCH_WORKTREES_DIR)/e2e-local-regenesis-main"
     let regenesis_needed = $hardfork_mode or $gas_limit != ""
-    for wt in [$baseline_wt $feature_wt $regenesis_wt] {
+    let needs_baseline = $run_side == "comparison"
+    mut worktrees = if $needs_baseline { [$baseline_wt $feature_wt] } else { [$feature_wt] }
+    if $regenesis_needed {
+        $worktrees = ($worktrees | append $regenesis_wt)
+    }
+    for wt in $worktrees {
         if ($wt | path exists) {
             print $"Removing stale local e2e worktree: ($wt)"
             try { git worktree remove --force $wt } catch { rm -rf $wt }
         }
     }
-    git worktree add $baseline_wt $baseline
+    if $needs_baseline {
+        git worktree add $baseline_wt $baseline
+    }
     git worktree add $feature_wt $feature
     if $regenesis_needed {
         print "Fetching latest origin/main for tempo regenesis..."
@@ -1438,11 +1457,12 @@ def "main e2e" [
     let effective_no_cache = $no_cache or ($tracy != "off")
     # Build benchmark binaries in parallel. Regenesis uses latest origin/main so
     # snapshot rewriting is independent of either side being benchmarked.
-    # with independent target/ directories, so cargo invocations don't collide.
-    mut builds = [
-        { wt: $baseline_wt, ref_name: $baseline, sha: $baseline, label: "baseline", features: $baseline_tbc.features, extra_rustflags: $baseline_tbc.extra_rustflags, bench_features: $baseline_build_features }
-        { wt: $feature_wt, ref_name: $feature, sha: $feature, label: "feature", features: $feature_tbc.features, extra_rustflags: $feature_tbc.extra_rustflags, bench_features: $feature_build_features }
-    ]
+    # Build worktrees with independent target/ directories, so cargo invocations don't collide.
+    mut builds = []
+    if $needs_baseline {
+        $builds = ($builds | append { wt: $baseline_wt, ref_name: $baseline, sha: $baseline, label: "baseline", features: $baseline_tbc.features, extra_rustflags: $baseline_tbc.extra_rustflags, bench_features: $baseline_build_features })
+    }
+    $builds = ($builds | append { wt: $feature_wt, ref_name: $feature, sha: $feature, label: "feature", features: $feature_tbc.features, extra_rustflags: $feature_tbc.extra_rustflags, bench_features: $feature_build_features })
     let regenesis_sha = if $regenesis_needed { git rev-parse origin/main | str trim } else { "" }
     if $regenesis_needed {
         $builds = ($builds | append { wt: $regenesis_wt, ref_name: "origin/main", sha: $regenesis_sha, label: "regenesis-main", features: $regenesis_tbc.features, extra_rustflags: $regenesis_tbc.extra_rustflags, bench_features: $regenesis_build_features })
@@ -1454,10 +1474,10 @@ def "main e2e" [
             build-in-worktree --no-default-features=$no_default_features $b.wt $b.ref_name $profile $b.features $b.sha
         }
     } | ignore
-    let baseline_tempo = (worktree-bin $baseline_wt $profile "tempo")
+    let baseline_tempo = if $needs_baseline { worktree-bin $baseline_wt $profile "tempo" } else { "" }
     let feature_tempo = (worktree-bin $feature_wt $profile "tempo")
     let regenesis_tempo = if $regenesis_needed { worktree-bin $regenesis_wt $profile "tempo" } else { "" }
-    let baseline_arg_filter = (supported-node-arg-filter $baseline_tempo $E2E_LOCAL_RETH_ARGS)
+    let baseline_arg_filter = if $needs_baseline { supported-node-arg-filter $baseline_tempo $E2E_LOCAL_RETH_ARGS } else { { supported: [], removed: [] } }
     let feature_arg_filter = (supported-node-arg-filter $feature_tempo $E2E_LOCAL_RETH_ARGS)
     let removed_arg_config = $"(format-removed-node-arg-config 'baseline' $baseline_arg_filter.removed)(format-removed-node-arg-config 'feature' $feature_arg_filter.removed)"
     if $removed_arg_config != "" {
@@ -1539,7 +1559,7 @@ def "main e2e" [
     mut baseline_run_index = 0
     mut feature_run_index = 0
     mut runs = []
-    for side in (e2e-run-sides $run_pairs) {
+    for side in (e2e-run-sides $run_pairs $run_side) {
         if $side == "baseline" {
             $baseline_run_index = $baseline_run_index + 1
             $runs = ($runs | append {
@@ -1568,7 +1588,7 @@ def "main e2e" [
         exit 1
     }
     $valid_run_labels | str join "\n" | save -f $"($results_dir)/run-order.txt"
-    e2e-write-summary-config $results_dir $baseline_base_label $feature_base_label $bloat_mib $token_count $preset $tps $duration $benchmark_id $reference_epoch $summary_warmup_blocks $baseline_hardfork_name $feature_hardfork_name (removed-node-args-label $baseline_arg_filter.removed) (removed-node-args-label $feature_arg_filter.removed)
+    e2e-write-summary-config $results_dir $baseline_base_label $feature_base_label $bloat_mib $token_count $preset $tps $duration $benchmark_id $reference_epoch $summary_warmup_blocks $run_side $baseline_hardfork_name $feature_hardfork_name (removed-node-args-label $baseline_arg_filter.removed) (removed-node-args-label $feature_arg_filter.removed)
     let num_phases = ($runs | length)
     mut e2e_exit = 0
     for idx in 0..<$num_phases {
@@ -1614,7 +1634,9 @@ def "main e2e" [
         }
     }
 
-    try { git worktree remove --force $baseline_wt } catch { }
+    if $needs_baseline {
+        try { git worktree remove --force $baseline_wt } catch { }
+    }
     try { git worktree remove --force $feature_wt } catch { }
     try { git worktree remove --force $regenesis_wt } catch { }
     cleanup-local-e2e-processes

--- a/crates/alloy/src/rpc/header.rs
+++ b/crates/alloy/src/rpc/header.rs
@@ -125,3 +125,45 @@ impl AsRef<TempoHeader> for TempoHeaderResponse {
         &self.inner
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header as ConsensusHeader;
+    use alloy_rpc_types_eth::Header as RpcHeader;
+
+    fn response_with_proof_root(proof_root: Option<B256>) -> TempoHeaderResponse {
+        let header = TempoHeader {
+            proof_root,
+            inner: ConsensusHeader {
+                number: 1,
+                timestamp: 2,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        TempoHeaderResponse {
+            inner: RpcHeader::new(header),
+            timestamp_millis: 2_000,
+        }
+    }
+
+    #[test]
+    fn rpc_header_serializes_proof_root_when_present() {
+        let proof_root = B256::repeat_byte(0x42);
+        let value = serde_json::to_value(response_with_proof_root(Some(proof_root))).unwrap();
+
+        assert_eq!(
+            value.get("proofRoot"),
+            Some(&serde_json::Value::String(format!("{proof_root:#x}")))
+        );
+    }
+
+    #[test]
+    fn rpc_header_omits_proof_root_when_absent() {
+        let value = serde_json::to_value(response_with_proof_root(None)).unwrap();
+
+        assert!(value.get("proofRoot").is_none());
+    }
+}

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies]
 tempo-primitives.workspace = true
+tempo-contracts.workspace = true
 
 reth-cli = { workspace = true, optional = true }
 reth-chainspec = { workspace = true, optional = true }

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -274,6 +274,11 @@ impl TempoHardfork {
         Some(MAX_TX_GAS_LIMIT_OSAKA)
     }
 
+    /// Returns true if TIP-1082 proof roots are active for this hardfork.
+    pub const fn is_proof_root_active(&self) -> bool {
+        self.is_t8()
+    }
+
     /// Gas cost for using an existing 2D nonce key
     pub const fn gas_existing_nonce_key(&self) -> u64 {
         if self.is_t2() {

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -21,11 +21,20 @@ use reth_chainspec::{
 use reth_network_peers::NodeRecord;
 #[cfg(feature = "std")]
 use std::sync::LazyLock;
+use tempo_contracts::precompiles::{ACCOUNT_KEYCHAIN_ADDRESS, TIP403_REGISTRY_ADDRESS};
 use tempo_primitives::TempoHeader;
 
 // End-of-block system transactions
 pub const SYSTEM_TX_COUNT: usize = 1;
 pub const SYSTEM_TX_ADDRESSES: [Address; SYSTEM_TX_COUNT] = [Address::ZERO];
+
+/// Initial accounts committed to by the Provable Contract Trie.
+///
+/// TIP-1082 initial account state imports require the migration build, which is out of scope here.
+/// The whitelist is active at the proof-root fork; account leaves are inserted only when migration
+/// data or post-execution updates provide account state.
+pub const INITIAL_PROVABLE_ACCOUNTS: &[Address] =
+    &[ACCOUNT_KEYCHAIN_ADDRESS, TIP403_REGISTRY_ADDRESS];
 
 /// Tempo genesis info extracted from genesis extra_fields
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
@@ -197,6 +206,20 @@ impl TempoChainSpec {
         self.default_follow_url
     }
 
+    /// Returns true if TIP-1082 proof roots are active at `timestamp`.
+    pub fn is_proof_root_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.tempo_hardfork_at(timestamp).is_proof_root_active()
+    }
+
+    /// Returns the active TIP-1082 provable-account whitelist at the timestamp.
+    pub fn provable_accounts_at_timestamp(&self, timestamp: u64) -> &[Address] {
+        if self.is_proof_root_active_at_timestamp(timestamp) {
+            INITIAL_PROVABLE_ACCOUNTS
+        } else {
+            &[]
+        }
+    }
+
     /// Converts the given [`Genesis`] into a [`TempoChainSpec`].
     pub fn from_genesis(genesis: Genesis) -> Self {
         // Extract Tempo genesis info from extra_fields
@@ -218,6 +241,7 @@ impl TempoChainSpec {
             shared_gas_limit: 0,
             consensus_context: None,
             inner,
+            proof_root: None,
         });
 
         // TODO(hamdi): Dev networks are allowed to have a non-dkg outcome in extra data. Update such
@@ -266,6 +290,7 @@ impl From<ChainSpec> for TempoChainSpec {
             shared_gas_limit: 0,
             consensus_context: None,
             inner,
+            proof_root: None,
         });
 
         let network_identity =
@@ -404,6 +429,7 @@ mod tests {
         hardfork::{TempoHardfork, TempoHardforks},
         spec::{TEMPO_T1_BASE_FEE, TEMPO_T7_BASE_FEE_CAP, TEMPO_T7_BASE_FEE_FLOOR},
     };
+    use alloy_genesis::Genesis;
     use alloy_primitives::hex;
     use commonware_codec::Encode as _;
     use reth_chainspec::EthChainSpec;
@@ -411,6 +437,7 @@ mod tests {
     use reth_chainspec::{ForkCondition, Hardforks};
     #[cfg(feature = "cli")]
     use reth_cli::chainspec::ChainSpecParser as _;
+    use tempo_contracts::precompiles::{ACCOUNT_KEYCHAIN_ADDRESS, TIP403_REGISTRY_ADDRESS};
     use tempo_primitives::Header;
 
     #[test]
@@ -563,6 +590,52 @@ mod tests {
         assert_eq!(chainspec.tempo_hardfork_at(0), latest);
         assert_eq!(chainspec.tempo_hardfork_at(1000), latest);
         assert_eq!(chainspec.tempo_hardfork_at(u64::MAX), latest);
+    }
+
+    #[test]
+    fn provable_accounts_activate_at_t8() {
+        let genesis = serde_json::json!({
+            "config": {
+                "chainId": 99999,
+                "homesteadBlock": 0,
+                "daoForkSupport": false,
+                "eip150Block": 0,
+                "eip155Block": 0,
+                "eip158Block": 0,
+                "byzantiumBlock": 0,
+                "constantinopleBlock": 0,
+                "petersburgBlock": 0,
+                "istanbulBlock": 0,
+                "berlinBlock": 0,
+                "londonBlock": 0,
+                "mergeNetsplitBlock": 0,
+                "shanghaiTime": 0,
+                "cancunTime": 0,
+                "pragueTime": 0,
+                "osakaTime": 0,
+                "terminalTotalDifficulty": 0,
+                "terminalTotalDifficultyPassed": true,
+                "t0Time": 0,
+                "t8Time": 10
+            },
+            "alloc": {}
+        });
+        let genesis: Genesis = serde_json::from_value(genesis).unwrap();
+        let chainspec = super::TempoChainSpec::from_genesis(genesis);
+
+        assert_eq!(
+            super::INITIAL_PROVABLE_ACCOUNTS,
+            &[ACCOUNT_KEYCHAIN_ADDRESS, TIP403_REGISTRY_ADDRESS,]
+        );
+
+        assert!(!chainspec.is_proof_root_active_at_timestamp(9));
+        assert!(chainspec.provable_accounts_at_timestamp(9).is_empty());
+
+        assert!(chainspec.is_proof_root_active_at_timestamp(10));
+        assert_eq!(
+            chainspec.provable_accounts_at_timestamp(10),
+            super::INITIAL_PROVABLE_ACCOUNTS
+        );
     }
 
     fn header(timestamp: u64, base_fee: u64, gas_used: u64) -> super::TempoHeader {

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -35,6 +35,8 @@ reth-evm.workspace = true
 reth-evm-ethereum.workspace = true
 reth-revm.workspace = true
 reth-primitives-traits.workspace = true
+reth-storage-api.workspace = true
+reth-trie-common.workspace = true
 reth-rpc-eth-api = { workspace = true, optional = true }
 
 rayon = { workspace = true, optional = true }

--- a/crates/evm/src/assemble.rs
+++ b/crates/evm/src/assemble.rs
@@ -29,6 +29,7 @@ impl TempoBlockAssembler {
         transactions_root: Option<B256>,
         receipts_root: Option<B256>,
         receipts_bloom: Option<Bloom>,
+        proof_root: Option<B256>,
     ) -> Result<tempo_primitives::Block, BlockExecutionError> {
         let BlockAssemblerInput {
             evm_env,
@@ -81,6 +82,7 @@ impl TempoBlockAssembler {
             timestamp_millis_part,
             shared_gas_limit,
             consensus_context,
+            proof_root,
         }))
     }
 }
@@ -92,7 +94,7 @@ impl BlockAssembler<TempoEvmConfig> for TempoBlockAssembler {
         &self,
         input: BlockAssemblerInput<'_, '_, TempoEvmConfig, TempoHeader>,
     ) -> Result<Self::Block, BlockExecutionError> {
-        self.assemble_block(input, None, None, None)
+        self.assemble_block(input, None, None, None, None)
     }
 }
 
@@ -237,6 +239,7 @@ mod tests {
         assert_eq!(block.header.general_gas_limit, general_gas_limit);
         assert_eq!(block.header.shared_gas_limit, shared_gas_limit);
         assert_eq!(block.header.timestamp_millis_part, timestamp_millis_part);
+        assert!(block.header.proof_root.is_none());
 
         // Verify body
         assert_eq!(block.body.transactions.len(), 1);

--- a/crates/evm/src/consensus/error.rs
+++ b/crates/evm/src/consensus/error.rs
@@ -27,6 +27,18 @@ pub enum TempoConsensusError {
     /// End-of-block system transactions are in the wrong order.
     #[error("invalid end-of-block system tx order: expected {expected}, got {actual}")]
     InvalidEndOfBlockSystemTxOrder { expected: Address, actual: Address },
+
+    /// Proof root was present before the TIP-1082 activation fork.
+    #[error("proof root must be omitted before TIP-1082 activation")]
+    ProofRootBeforeActivation,
+
+    /// Proof root was missing after the TIP-1082 activation fork.
+    #[error("proof root must be present after TIP-1082 activation")]
+    MissingProofRoot,
+
+    /// Proof root does not match the expected Provable Contract Trie root.
+    #[error("proof root {actual} does not match expected {expected}")]
+    ProofRootMismatch { expected: B256, actual: B256 },
 }
 
 impl From<TempoConsensusError> for ConsensusError {

--- a/crates/evm/src/consensus/mod.rs
+++ b/crates/evm/src/consensus/mod.rs
@@ -2,7 +2,9 @@
 
 mod error;
 
-use alloy_consensus::{BlockHeader, Transaction, transaction::TxHashRef};
+use alloy_consensus::{
+    BlockHeader, Transaction, constants::EMPTY_ROOT_HASH, transaction::TxHashRef,
+};
 use alloy_evm::block::BlockExecutionResult;
 pub use error::TempoConsensusError;
 use reth_chainspec::EthChainSpec;
@@ -103,6 +105,28 @@ impl TempoConsensus {
                 actual: header.general_gas_limit,
             }
             .into());
+        }
+
+        let chain_spec = self.inner.chain_spec();
+        if chain_spec.is_proof_root_active_at_timestamp(header.timestamp()) {
+            match header.proof_root {
+                Some(actual)
+                    if chain_spec
+                        .provable_accounts_at_timestamp(header.timestamp())
+                        .is_empty()
+                        && actual != EMPTY_ROOT_HASH =>
+                {
+                    return Err(TempoConsensusError::ProofRootMismatch {
+                        expected: EMPTY_ROOT_HASH,
+                        actual,
+                    }
+                    .into());
+                }
+                Some(_) => {}
+                None => return Err(TempoConsensusError::MissingProofRoot.into()),
+            }
+        } else if header.proof_root.is_some() {
+            return Err(TempoConsensusError::ProofRootBeforeActivation.into());
         }
 
         Ok(())
@@ -279,6 +303,7 @@ mod tests {
         general_gas_limit: Option<u64>,
         base_fee: Option<u64>,
         gas_used: u64,
+        proof_root: Option<Option<B256>>,
     }
 
     impl TestHeaderBuilder {
@@ -333,6 +358,11 @@ mod tests {
             self
         }
 
+        fn proof_root(mut self, proof_root: Option<B256>) -> Self {
+            self.proof_root = Some(proof_root);
+            self
+        }
+
         fn build(self) -> TempoHeader {
             let shared_gas_limit = self.shared_gas_limit.unwrap_or(0);
             // Default to T1 fixed general gas limit
@@ -361,6 +391,7 @@ mod tests {
                 shared_gas_limit,
                 general_gas_limit,
                 timestamp_millis_part: self.timestamp_millis_part,
+                proof_root: self.proof_root.unwrap_or(None),
                 ..Default::default()
             }
         }
@@ -395,6 +426,39 @@ mod tests {
         TempoTxEnvelope::Legacy(Signed::new_unhashed(tx, signature))
     }
 
+    fn chainspec_with_t8_at(t8_time: u64) -> Arc<TempoChainSpec> {
+        let genesis = serde_json::json!({
+            "config": {
+                "chainId": 99999,
+                "homesteadBlock": 0,
+                "daoForkSupport": false,
+                "eip150Block": 0,
+                "eip155Block": 0,
+                "eip158Block": 0,
+                "byzantiumBlock": 0,
+                "constantinopleBlock": 0,
+                "petersburgBlock": 0,
+                "istanbulBlock": 0,
+                "berlinBlock": 0,
+                "londonBlock": 0,
+                "mergeNetsplitBlock": 0,
+                "shanghaiTime": 0,
+                "cancunTime": 0,
+                "pragueTime": 0,
+                "osakaTime": 0,
+                "terminalTotalDifficulty": 0,
+                "terminalTotalDifficultyPassed": true,
+                "t0Time": 0,
+                "t1Time": 0,
+                "t4Time": 0,
+                "t8Time": t8_time
+            },
+            "alloc": {}
+        });
+        let genesis: Genesis = serde_json::from_value(genesis).unwrap();
+        Arc::new(TempoChainSpec::from_genesis(genesis))
+    }
+
     fn create_tx(chain_id: u64) -> TempoTxEnvelope {
         let tx = TxLegacy {
             chain_id: Some(chain_id),
@@ -406,6 +470,62 @@ mod tests {
             input: Default::default(),
         };
         TempoTxEnvelope::Legacy(Signed::new_unhashed(tx, Signature::test_signature()))
+    }
+
+    #[test]
+    fn test_validate_header_proof_root_activation() {
+        let chainspec = chainspec_with_t8_at(10);
+        let consensus = TempoConsensus::new(chainspec.clone());
+        let gas_limit = 30_000_000;
+
+        let pre_activation = TestHeaderBuilder::default()
+            .gas_limit(gas_limit)
+            .timestamp(9)
+            .shared_gas_limit(chainspec.shared_gas_limit_at(9, gas_limit))
+            .build();
+        let pre_activation = SealedHeader::seal_slow(pre_activation);
+        consensus
+            .validate_header_with_timestamp_millis(&pre_activation, 20_000)
+            .expect("pre-activation proof_root omission is valid");
+
+        let early_root = TestHeaderBuilder::default()
+            .gas_limit(gas_limit)
+            .timestamp(9)
+            .shared_gas_limit(chainspec.shared_gas_limit_at(9, gas_limit))
+            .proof_root(Some(EMPTY_ROOT_HASH))
+            .build();
+        let early_root = SealedHeader::seal_slow(early_root);
+        assert!(
+            consensus
+                .validate_header_with_timestamp_millis(&early_root, 20_000)
+                .is_err(),
+            "pre-activation proof_root must be rejected"
+        );
+
+        let activation = TestHeaderBuilder::default()
+            .gas_limit(gas_limit)
+            .timestamp(10)
+            .shared_gas_limit(chainspec.shared_gas_limit_at(10, gas_limit))
+            .proof_root(Some(EMPTY_ROOT_HASH))
+            .build();
+        let activation = SealedHeader::seal_slow(activation);
+        consensus
+            .validate_header_with_timestamp_millis(&activation, 20_000)
+            .expect("activation proof_root must match the empty trie root");
+
+        let missing = TestHeaderBuilder::default()
+            .gas_limit(gas_limit)
+            .timestamp(10)
+            .shared_gas_limit(chainspec.shared_gas_limit_at(10, gas_limit))
+            .proof_root(None)
+            .build();
+        let missing = SealedHeader::seal_slow(missing);
+        assert!(
+            consensus
+                .validate_header_with_timestamp_millis(&missing, 20_000)
+                .is_err(),
+            "post-activation proof_root must be required"
+        );
     }
 
     #[test]

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -19,6 +19,7 @@ use rayon as _;
 mod error;
 pub use error::TempoEvmError;
 pub mod evm;
+pub mod proof_trie;
 use std::{borrow::Cow, sync::Arc};
 
 use alloy_evm::{

--- a/crates/evm/src/proof_trie.rs
+++ b/crates/evm/src/proof_trie.rs
@@ -1,0 +1,520 @@
+//! Provable Contract Trie helpers.
+//!
+//! TIP-1082 proof roots are computed over a standalone secure MPT that only contains the active
+//! provable-account whitelist. This module provides both the old bundle-update filtering helpers
+//! and the no-persistence path, which rebuilds the whitelisted account trie from the parent state
+//! provider plus the post-execution bundle state.
+
+use alloy_consensus::constants::EMPTY_ROOT_HASH;
+use alloy_primitives::{Address, B256, map::AddressMap};
+use reth_primitives_traits::Account;
+use reth_revm::db::states::{BundleAccount, BundleState};
+use reth_storage_api::{StateProvider, errors::provider::ProviderResult};
+use reth_trie_common::{
+    HashedPostState, HashedStorage, KeccakKeyHasher, TrieInput, root::state_root_unhashed,
+};
+
+/// Root of an empty TIP-1082 proof trie.
+pub const EMPTY_PROOF_ROOT_HASH: B256 = EMPTY_ROOT_HASH;
+
+/// Returns the subset of `bundle_state` that should be streamed into the TIP-1082 proof trie.
+///
+/// Accounts outside `provable_accounts` are ignored. Whitelisted accounts that are absent from the
+/// bundle state are also ignored; the sparse proof trie already carries their parent state.
+pub fn filter_bundle_state_for_provable_accounts(
+    bundle_state: &BundleState,
+    provable_accounts: &[Address],
+) -> AddressMap<BundleAccount> {
+    provable_accounts
+        .iter()
+        .filter_map(|address| {
+            bundle_state
+                .account(address)
+                .cloned()
+                .map(|account| (*address, account))
+        })
+        .collect()
+}
+
+/// Hashes whitelisted bundle-state updates for the TIP-1082 proof trie.
+pub fn proof_hashed_state_from_bundle_state(
+    bundle_state: &BundleState,
+    provable_accounts: &[Address],
+) -> HashedPostState {
+    let filtered = filter_bundle_state_for_provable_accounts(bundle_state, provable_accounts);
+    HashedPostState::from_bundle_state::<KeccakKeyHasher>(&filtered)
+}
+
+/// Builds sparse MPT input from whitelisted bundle-state updates.
+pub fn proof_trie_input_from_bundle_state(
+    bundle_state: &BundleState,
+    provable_accounts: &[Address],
+) -> TrieInput {
+    TrieInput::from_state(proof_hashed_state_from_bundle_state(
+        bundle_state,
+        provable_accounts,
+    ))
+}
+
+/// Recomputes the TIP-1082 proof root from canonical parent state and the current bundle state.
+///
+/// This does not rely on persisted proof-trie nodes. For every active whitelisted account, it
+/// materializes the post-execution account leaf, computes that account's post-execution storage
+/// root through the canonical state provider, and builds a fresh whitelist-only account trie.
+pub fn proof_root_from_state_provider(
+    state_provider: &(impl StateProvider + ?Sized),
+    bundle_state: &BundleState,
+    provable_accounts: &[Address],
+) -> ProviderResult<B256> {
+    proof_root_from_accounts(state_provider, provable_accounts, |address| {
+        proof_account_from_state_provider(state_provider, bundle_state, address)
+    })
+}
+
+/// Recomputes the TIP-1082 proof root from canonical parent state and hashed post-state updates.
+///
+/// This is the validation-side equivalent of [`proof_root_from_state_provider`]. Reth's engine
+/// validation hook exposes hashed post-state updates instead of the original bundle state, so this
+/// applies whitelisted account/storage deltas by hashed address while reading unchanged account
+/// leaves from the parent state provider.
+pub fn proof_root_from_hashed_post_state(
+    state_provider: &(impl StateProvider + ?Sized),
+    hashed_post_state: &HashedPostState,
+    provable_accounts: &[Address],
+) -> ProviderResult<B256> {
+    proof_root_from_accounts(state_provider, provable_accounts, |address| {
+        proof_account_from_hashed_post_state(state_provider, hashed_post_state, address)
+    })
+}
+
+fn proof_root_from_accounts(
+    state_provider: &(impl StateProvider + ?Sized),
+    provable_accounts: &[Address],
+    mut proof_account: impl FnMut(Address) -> ProviderResult<(Option<Account>, HashedStorage)>,
+) -> ProviderResult<B256> {
+    let mut accounts = Vec::with_capacity(provable_accounts.len());
+
+    for address in provable_accounts {
+        let (account, hashed_storage) = proof_account(*address)?;
+
+        let Some(account) = account else {
+            continue;
+        };
+
+        let storage_root = state_provider.storage_root(*address, hashed_storage)?;
+        if account.is_empty() && storage_root == EMPTY_ROOT_HASH {
+            continue;
+        }
+
+        accounts.push((*address, account.into_trie_account(storage_root)));
+    }
+
+    Ok(state_root_unhashed(accounts))
+}
+
+fn proof_account_from_state_provider(
+    state_provider: &(impl StateProvider + ?Sized),
+    bundle_state: &BundleState,
+    address: Address,
+) -> ProviderResult<(Option<Account>, HashedStorage)> {
+    if let Some(account) = bundle_state.account(&address) {
+        return Ok((
+            account.info.as_ref().map(Account::from),
+            proof_hashed_storage_from_bundle_account(account),
+        ));
+    }
+
+    Ok((
+        state_provider.basic_account(&address)?,
+        HashedStorage::default(),
+    ))
+}
+
+fn proof_account_from_hashed_post_state(
+    state_provider: &(impl StateProvider + ?Sized),
+    hashed_post_state: &HashedPostState,
+    address: Address,
+) -> ProviderResult<(Option<Account>, HashedStorage)> {
+    let hashed_address = alloy_primitives::keccak256(address);
+    let account = match hashed_post_state.accounts.get(&hashed_address) {
+        Some(account) => *account,
+        None => state_provider.basic_account(&address)?,
+    };
+    let hashed_storage = hashed_post_state
+        .storages
+        .get(&hashed_address)
+        .cloned()
+        .unwrap_or_default();
+
+    Ok((account, hashed_storage))
+}
+
+fn proof_hashed_storage_from_bundle_account(account: &BundleAccount) -> HashedStorage {
+    HashedStorage::from_plain_storage(
+        account.status,
+        account
+            .storage
+            .iter()
+            .map(|(slot, value)| (slot, &value.present_value)),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{
+        B256, U256, keccak256,
+        map::{AddressMap, B256Map},
+    };
+    use reth_primitives_traits::Account;
+    use reth_revm::{
+        db::states::{AccountStatus, StorageSlot},
+        state::AccountInfo,
+    };
+    use reth_storage_api::{
+        BlockHashReader, BytecodeReader, HashedPostStateProvider, StateProofProvider,
+        StateProvider, StateRootProvider, noop::NoopProvider,
+    };
+    use reth_trie_common::{HashedStorage, root::storage_root_unsorted};
+
+    #[derive(Debug, Clone, Default)]
+    struct ProofStateProvider {
+        inner: NoopProvider,
+        accounts: AddressMap<Account>,
+        storage: AddressMap<Vec<(B256, U256)>>,
+    }
+
+    impl ProofStateProvider {
+        fn with_account(mut self, address: Address, account: Account) -> Self {
+            self.accounts.insert(address, account);
+            self
+        }
+
+        fn with_storage(mut self, address: Address, storage: Vec<(B256, U256)>) -> Self {
+            self.storage.insert(address, storage);
+            self
+        }
+    }
+
+    impl AsRef<NoopProvider> for ProofStateProvider {
+        fn as_ref(&self) -> &NoopProvider {
+            &self.inner
+        }
+    }
+
+    impl reth_storage_api::AccountReader for ProofStateProvider {
+        fn basic_account(
+            &self,
+            address: &Address,
+        ) -> reth_storage_api::errors::provider::ProviderResult<Option<Account>> {
+            Ok(self.accounts.get(address).copied())
+        }
+    }
+
+    impl reth_storage_api::StorageRootProvider for ProofStateProvider {
+        fn storage_root(
+            &self,
+            address: Address,
+            hashed_storage: HashedStorage,
+        ) -> reth_storage_api::errors::provider::ProviderResult<B256> {
+            let mut storage: B256Map<U256> = if hashed_storage.wiped {
+                Default::default()
+            } else {
+                self.storage
+                    .get(&address)
+                    .cloned()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .collect()
+            };
+
+            for (slot, value) in hashed_storage.storage {
+                if value.is_zero() {
+                    storage.remove(&slot);
+                } else {
+                    storage.insert(slot, value);
+                }
+            }
+
+            Ok(storage_root_unsorted(storage))
+        }
+
+        fn storage_proof(
+            &self,
+            address: Address,
+            slot: B256,
+            hashed_storage: HashedStorage,
+        ) -> reth_storage_api::errors::provider::ProviderResult<reth_trie_common::StorageProof>
+        {
+            self.inner.storage_proof(address, slot, hashed_storage)
+        }
+
+        fn storage_multiproof(
+            &self,
+            address: Address,
+            slots: &[B256],
+            hashed_storage: HashedStorage,
+        ) -> reth_storage_api::errors::provider::ProviderResult<reth_trie_common::StorageMultiProof>
+        {
+            self.inner
+                .storage_multiproof(address, slots, hashed_storage)
+        }
+    }
+
+    reth_storage_api::delegate_impls_to_as_ref!(
+        for ProofStateProvider =>
+        BlockHashReader {
+            fn block_hash(&self, number: u64) -> reth_storage_api::errors::provider::ProviderResult<Option<B256>>;
+            fn canonical_hashes_range(&self, start: alloy_primitives::BlockNumber, end: alloy_primitives::BlockNumber) -> reth_storage_api::errors::provider::ProviderResult<Vec<B256>>;
+        }
+        StateProvider {
+            fn storage(&self, account: Address, storage_key: alloy_primitives::StorageKey) -> reth_storage_api::errors::provider::ProviderResult<Option<alloy_primitives::StorageValue>>;
+        }
+        BytecodeReader {
+            fn bytecode_by_hash(&self, code_hash: &B256) -> reth_storage_api::errors::provider::ProviderResult<Option<reth_primitives_traits::Bytecode>>;
+        }
+        StateRootProvider {
+            fn state_root(&self, state: HashedPostState) -> reth_storage_api::errors::provider::ProviderResult<B256>;
+            fn state_root_from_nodes(&self, input: TrieInput) -> reth_storage_api::errors::provider::ProviderResult<B256>;
+            fn state_root_with_updates(&self, state: HashedPostState) -> reth_storage_api::errors::provider::ProviderResult<(B256, reth_trie_common::updates::TrieUpdates)>;
+            fn state_root_from_nodes_with_updates(&self, input: TrieInput) -> reth_storage_api::errors::provider::ProviderResult<(B256, reth_trie_common::updates::TrieUpdates)>;
+        }
+        StateProofProvider {
+            fn proof(&self, input: TrieInput, address: Address, slots: &[B256]) -> reth_storage_api::errors::provider::ProviderResult<reth_trie_common::AccountProof>;
+            fn multiproof(&self, input: TrieInput, targets: reth_trie_common::MultiProofTargets) -> reth_storage_api::errors::provider::ProviderResult<reth_trie_common::MultiProof>;
+            fn witness(&self, input: TrieInput, target: HashedPostState, mode: reth_trie_common::ExecutionWitnessMode) -> reth_storage_api::errors::provider::ProviderResult<Vec<alloy_primitives::Bytes>>;
+        }
+        HashedPostStateProvider {
+            fn hashed_post_state(&self, bundle_state: &reth_revm::db::BundleState) -> HashedPostState;
+        }
+    );
+
+    fn account(nonce: u64) -> AccountInfo {
+        AccountInfo {
+            nonce,
+            balance: U256::from(nonce + 1),
+            code_hash: Default::default(),
+            account_id: None,
+            code: None,
+        }
+    }
+
+    fn bundle_account(nonce: u64) -> BundleAccount {
+        BundleAccount::new(
+            None,
+            Some(account(nonce)),
+            Default::default(),
+            AccountStatus::Changed,
+        )
+    }
+
+    fn bundle_state(accounts: impl IntoIterator<Item = (Address, BundleAccount)>) -> BundleState {
+        let state = AddressMap::from_iter(accounts);
+        let state_size = state.values().map(BundleAccount::size_hint).sum();
+        BundleState {
+            state,
+            contracts: Default::default(),
+            reverts: Default::default(),
+            state_size,
+            reverts_size: 0,
+        }
+    }
+
+    #[test]
+    fn empty_whitelist_uses_empty_sparse_trie_input() {
+        let address = Address::repeat_byte(0x11);
+        let bundle_state = bundle_state([(address, bundle_account(1))]);
+
+        let input = proof_trie_input_from_bundle_state(&bundle_state, &[]);
+
+        assert!(input.state.accounts.is_empty());
+        assert!(input.state.storages.is_empty());
+        assert!(input.nodes.account_nodes.is_empty());
+        assert!(input.nodes.storage_tries.is_empty());
+    }
+
+    #[test]
+    fn filters_bundle_state_to_whitelisted_accounts_before_hashing() {
+        let whitelisted = Address::repeat_byte(0x11);
+        let other = Address::repeat_byte(0x22);
+        let bundle_state =
+            bundle_state([(whitelisted, bundle_account(1)), (other, bundle_account(2))]);
+
+        let filtered = filter_bundle_state_for_provable_accounts(&bundle_state, &[whitelisted]);
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered.contains_key(&whitelisted));
+        assert!(!filtered.contains_key(&other));
+
+        let hashed = proof_hashed_state_from_bundle_state(&bundle_state, &[whitelisted]);
+        assert!(hashed.accounts.contains_key(&keccak256(whitelisted)));
+        assert!(!hashed.accounts.contains_key(&keccak256(other)));
+    }
+
+    #[test]
+    fn whitelisted_account_absent_from_bundle_state_is_not_inserted() {
+        let whitelisted = Address::repeat_byte(0x11);
+        let other = Address::repeat_byte(0x22);
+        let bundle_state = bundle_state([(other, bundle_account(2))]);
+
+        let hashed = proof_hashed_state_from_bundle_state(&bundle_state, &[whitelisted]);
+        assert!(hashed.is_empty());
+    }
+
+    #[test]
+    fn whitelisted_storage_update_is_hashed() {
+        let address = Address::repeat_byte(0x11);
+        let slot = U256::from(1);
+        let value = U256::from(2);
+        let account = BundleAccount::new(
+            Some(account(1)),
+            Some(account(1)),
+            [(slot, StorageSlot::new_changed(U256::ZERO, value))]
+                .into_iter()
+                .collect(),
+            AccountStatus::Changed,
+        );
+        let bundle_state = bundle_state([(address, account)]);
+
+        let hashed = proof_hashed_state_from_bundle_state(&bundle_state, &[address]);
+        let hashed_address = keccak256(address);
+
+        assert!(hashed.accounts.contains_key(&hashed_address));
+        assert!(hashed.storages.contains_key(&hashed_address));
+    }
+
+    #[test]
+    fn destroyed_whitelisted_account_is_hashed_as_deletion() {
+        let address = Address::repeat_byte(0x11);
+        let account = BundleAccount::new(
+            Some(account(1)),
+            None,
+            [(
+                U256::from(1),
+                StorageSlot::new_changed(U256::from(7), U256::ZERO),
+            )]
+            .into_iter()
+            .collect(),
+            AccountStatus::Destroyed,
+        );
+        let bundle_state = bundle_state([(address, account)]);
+
+        let hashed = proof_hashed_state_from_bundle_state(&bundle_state, &[address]);
+        let hashed_address = keccak256(address);
+
+        assert_eq!(hashed.accounts.get(&hashed_address), Some(&None));
+        assert!(
+            hashed
+                .storages
+                .get(&hashed_address)
+                .is_some_and(|storage| storage.wiped)
+        );
+    }
+
+    #[test]
+    fn proof_root_uses_whitelist_only_account_trie() {
+        let whitelisted = Address::repeat_byte(0x11);
+        let other = Address::repeat_byte(0x22);
+        let provider = ProofStateProvider::default()
+            .with_account(
+                whitelisted,
+                Account {
+                    nonce: 1,
+                    balance: U256::from(2),
+                    bytecode_hash: None,
+                },
+            )
+            .with_account(
+                other,
+                Account {
+                    nonce: 9,
+                    balance: U256::from(9),
+                    bytecode_hash: None,
+                },
+            );
+
+        let root =
+            proof_root_from_state_provider(&provider, &BundleState::default(), &[whitelisted])
+                .unwrap();
+        let expected = state_root_unhashed([(
+            whitelisted,
+            Account {
+                nonce: 1,
+                balance: U256::from(2),
+                bytecode_hash: None,
+            }
+            .into_trie_account(EMPTY_ROOT_HASH),
+        )]);
+
+        assert_eq!(root, expected);
+    }
+
+    #[test]
+    fn proof_root_applies_bundle_account_and_storage_updates() {
+        let address = Address::repeat_byte(0x11);
+        let slot = U256::from(1);
+        let value = U256::from(7);
+        let provider = ProofStateProvider::default()
+            .with_account(
+                address,
+                Account {
+                    nonce: 1,
+                    balance: U256::from(2),
+                    bytecode_hash: None,
+                },
+            )
+            .with_storage(address, vec![(keccak256(B256::from(slot)), U256::from(3))]);
+        let bundle_state = bundle_state([(
+            address,
+            BundleAccount::new(
+                Some(account(1)),
+                Some(account(2)),
+                [(slot, StorageSlot::new_changed(U256::from(3), value))]
+                    .into_iter()
+                    .collect(),
+                AccountStatus::Changed,
+            ),
+        )]);
+
+        let root = proof_root_from_state_provider(&provider, &bundle_state, &[address]).unwrap();
+        let storage_root = storage_root_unsorted([(keccak256(B256::from(slot)), value)]);
+        let expected = state_root_unhashed([(
+            address,
+            Account::from(account(2)).into_trie_account(storage_root),
+        )]);
+
+        assert_eq!(root, expected);
+    }
+
+    #[test]
+    fn proof_root_applies_hashed_post_state_account_and_storage_updates() {
+        let address = Address::repeat_byte(0x11);
+        let slot = U256::from(1);
+        let value = U256::from(7);
+        let provider = ProofStateProvider::default()
+            .with_account(
+                address,
+                Account {
+                    nonce: 1,
+                    balance: U256::from(2),
+                    bytecode_hash: None,
+                },
+            )
+            .with_storage(address, vec![(keccak256(B256::from(slot)), U256::from(3))]);
+        let hashed_address = keccak256(address);
+        let hashed_state = HashedPostState::default()
+            .with_accounts([(hashed_address, Some(Account::from(account(2))))])
+            .with_storages([(
+                hashed_address,
+                HashedStorage::from_iter(false, [(keccak256(B256::from(slot)), value)]),
+            )]);
+
+        let root = proof_root_from_hashed_post_state(&provider, &hashed_state, &[address]).unwrap();
+        let storage_root = storage_root_unsorted([(keccak256(B256::from(slot)), value)]);
+        let expected = state_root_unhashed([(
+            address,
+            Account::from(account(2)).into_trie_account(storage_root),
+        )]);
+
+        assert_eq!(root, expected);
+    }
+}

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -29,6 +29,7 @@ tempo-revm.workspace = true
 thiserror.workspace = true
 
 reth-chainspec.workspace = true
+reth-consensus.workspace = true
 reth-errors.workspace = true
 reth-ethereum = { workspace = true, features = ["node", "rpc"] }
 reth-primitives-traits = { workspace = true, features = ["secp256k1", "rayon"] }
@@ -46,6 +47,7 @@ reth-rpc-eth-api.workspace = true
 reth-rpc-builder.workspace = true
 reth-node-api.workspace = true
 reth-rpc-eth-types.workspace = true
+reth-trie-common.workspace = true
 reth-node-ethereum.workspace = true
 reth-storage-api.workspace = true
 
@@ -73,9 +75,11 @@ tokio.workspace = true
 [dev-dependencies]
 tempo-e2e.workspace = true
 tempo-transaction-pool = { workspace = true, features = ["test-utils"] }
+alloy-consensus.workspace = true
 alloy-network.workspace = true
 tempo-precompiles.workspace = true
 alloy-rpc-types-engine.workspace = true
+alloy-genesis = { workspace = true, features = ["std"] }
 reth-ethereum = { workspace = true, features = ["node", "test-utils", "pool"] }
 reth-e2e-test-utils.workspace = true
 reth-node-core.workspace = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -47,7 +47,6 @@ reth-rpc-eth-api.workspace = true
 reth-rpc-builder.workspace = true
 reth-node-api.workspace = true
 reth-rpc-eth-types.workspace = true
-reth-trie-common.workspace = true
 reth-node-ethereum.workspace = true
 reth-storage-api.workspace = true
 
@@ -84,6 +83,7 @@ reth-ethereum = { workspace = true, features = ["node", "test-utils", "pool"] }
 reth-e2e-test-utils.workspace = true
 reth-node-core.workspace = true
 reth-node-metrics.workspace = true
+reth-trie-common.workspace = true
 serde_json.workspace = true
 tempo-contracts.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -1,23 +1,40 @@
 use crate::{TempoExecutionData, TempoPayloadTypes};
+use reth_consensus::ConsensusError;
 use reth_node_api::{InvalidPayloadAttributesError, NewPayloadError, PayloadValidator};
-use reth_primitives_traits::{AlloyBlockHeader as _, SealedBlock};
+use reth_primitives_traits::{AlloyBlockHeader as _, RecoveredBlock, SealedBlock};
+use reth_storage_api::StateProviderFactory;
+use reth_trie_common::HashedPostState;
 use std::sync::Arc;
+use tempo_chainspec::TempoChainSpec;
+use tempo_evm::{
+    consensus::TempoConsensusError,
+    proof_trie::{EMPTY_PROOF_ROOT_HASH, proof_root_from_hashed_post_state},
+};
 use tempo_payload_types::TempoPayloadAttributes;
 use tempo_primitives::{Block, TempoHeader};
 
 /// Type encapsulating Tempo engine validation logic.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct TempoEngineValidator;
+pub struct TempoEngineValidator<Provider> {
+    chain_spec: Arc<TempoChainSpec>,
+    provider: Provider,
+}
 
-impl TempoEngineValidator {
+impl<Provider> TempoEngineValidator<Provider> {
     /// Creates a new [`TempoEngineValidator`] with the given chain spec.
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(chain_spec: Arc<TempoChainSpec>, provider: Provider) -> Self {
+        Self {
+            chain_spec,
+            provider,
+        }
     }
 }
 
-impl PayloadValidator<TempoPayloadTypes> for TempoEngineValidator {
+impl<Provider> PayloadValidator<TempoPayloadTypes> for TempoEngineValidator<Provider>
+where
+    Provider: StateProviderFactory + Clone + Send + Sync + Unpin + 'static,
+{
     type Block = Block;
 
     fn convert_payload_to_block(
@@ -32,6 +49,42 @@ impl PayloadValidator<TempoPayloadTypes> for TempoEngineValidator {
         Ok(Arc::unwrap_or_clone(block))
     }
 
+    fn validate_block_post_execution_with_hashed_state(
+        &self,
+        state_updates: &HashedPostState,
+        block: &RecoveredBlock<Self::Block>,
+    ) -> Result<(), ConsensusError> {
+        let timestamp = block.header().timestamp();
+        if self.chain_spec.is_proof_root_active_at_timestamp(timestamp) {
+            let actual = block
+                .header()
+                .proof_root
+                .ok_or_else(|| ConsensusError::from(TempoConsensusError::MissingProofRoot))?;
+            let provable_accounts = self.chain_spec.provable_accounts_at_timestamp(timestamp);
+            let expected = if provable_accounts.is_empty() {
+                EMPTY_PROOF_ROOT_HASH
+            } else {
+                let parent_state = self
+                    .provider
+                    .state_by_block_hash(block.header().parent_hash())
+                    .map_err(ConsensusError::other)?;
+
+                proof_root_from_hashed_post_state(&*parent_state, state_updates, provable_accounts)
+                    .map_err(ConsensusError::other)?
+            };
+
+            if actual != expected {
+                return Err(TempoConsensusError::ProofRootMismatch { expected, actual }.into());
+            }
+
+            Ok(())
+        } else if block.header().proof_root.is_some() {
+            Err(TempoConsensusError::ProofRootBeforeActivation.into())
+        } else {
+            Ok(())
+        }
+    }
+
     fn validate_payload_attributes_against_header(
         &self,
         attr: &TempoPayloadAttributes,
@@ -42,5 +95,145 @@ impl PayloadValidator<TempoPayloadTypes> for TempoEngineValidator {
             return Err(InvalidPayloadAttributesError::InvalidTimestamp);
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use alloy_genesis::Genesis;
+    use alloy_primitives::{B256, U256, keccak256};
+    use reth_primitives_traits::Account;
+    use reth_storage_api::noop::NoopProvider;
+    use tempo_chainspec::spec::INITIAL_PROVABLE_ACCOUNTS;
+    use tempo_evm::proof_trie::proof_root_from_hashed_post_state;
+    use tempo_primitives::BlockBody;
+
+    fn chainspec_with_t8_at(t8_time: u64) -> Arc<TempoChainSpec> {
+        let genesis = serde_json::json!({
+            "config": {
+                "chainId": 99999,
+                "homesteadBlock": 0,
+                "daoForkSupport": false,
+                "eip150Block": 0,
+                "eip155Block": 0,
+                "eip158Block": 0,
+                "byzantiumBlock": 0,
+                "constantinopleBlock": 0,
+                "petersburgBlock": 0,
+                "istanbulBlock": 0,
+                "berlinBlock": 0,
+                "londonBlock": 0,
+                "mergeNetsplitBlock": 0,
+                "shanghaiTime": 0,
+                "cancunTime": 0,
+                "pragueTime": 0,
+                "osakaTime": 0,
+                "terminalTotalDifficulty": 0,
+                "terminalTotalDifficultyPassed": true,
+                "t0Time": 0,
+                "t8Time": t8_time
+            },
+            "alloc": {}
+        });
+        let genesis: Genesis = serde_json::from_value(genesis).unwrap();
+        Arc::new(TempoChainSpec::from_genesis(genesis))
+    }
+
+    fn validator_with_t8_at(t8_time: u64) -> TempoEngineValidator<NoopProvider<TempoChainSpec>> {
+        let chain_spec = chainspec_with_t8_at(t8_time);
+        let provider = NoopProvider::new(chain_spec.clone());
+        TempoEngineValidator::new(chain_spec, provider)
+    }
+
+    fn recovered_block(timestamp: u64, proof_root: Option<B256>) -> RecoveredBlock<Block> {
+        let header = TempoHeader {
+            inner: Header {
+                timestamp,
+                ..Default::default()
+            },
+            proof_root,
+            ..Default::default()
+        };
+        let block = Block {
+            header,
+            body: BlockBody::default(),
+        };
+        RecoveredBlock::new_unhashed(block, vec![])
+    }
+
+    #[test]
+    fn validates_proof_root_against_empty_provable_state_updates() {
+        let validator = validator_with_t8_at(10);
+        let state_updates = HashedPostState::default();
+
+        validator
+            .validate_block_post_execution_with_hashed_state(
+                &state_updates,
+                &recovered_block(9, None),
+            )
+            .expect("pre-activation proof_root omission is valid");
+
+        assert!(
+            validator
+                .validate_block_post_execution_with_hashed_state(
+                    &state_updates,
+                    &recovered_block(9, Some(EMPTY_PROOF_ROOT_HASH)),
+                )
+                .is_err(),
+            "pre-activation proof_root must be rejected"
+        );
+
+        validator
+            .validate_block_post_execution_with_hashed_state(
+                &state_updates,
+                &recovered_block(10, Some(EMPTY_PROOF_ROOT_HASH)),
+            )
+            .expect("activation proof_root must be present");
+
+        assert!(
+            validator
+                .validate_block_post_execution_with_hashed_state(
+                    &state_updates,
+                    &recovered_block(10, None),
+                )
+                .is_err(),
+            "post-activation proof_root must be required"
+        );
+    }
+
+    #[test]
+    fn validates_proof_root_against_hashed_state_updates() {
+        let chain_spec = chainspec_with_t8_at(10);
+        let provider: NoopProvider<TempoChainSpec> = NoopProvider::new(chain_spec.clone());
+        let validator = TempoEngineValidator::new(chain_spec, provider.clone());
+        let address = INITIAL_PROVABLE_ACCOUNTS[0];
+        let account = Account {
+            nonce: 1,
+            balance: U256::from(2),
+            bytecode_hash: None,
+        };
+        let state_updates =
+            HashedPostState::default().with_accounts([(keccak256(address), Some(account))]);
+        let expected =
+            proof_root_from_hashed_post_state(&provider, &state_updates, &[address]).unwrap();
+
+        validator
+            .validate_block_post_execution_with_hashed_state(
+                &state_updates,
+                &recovered_block(10, Some(expected)),
+            )
+            .expect("matching proof_root is valid");
+
+        assert!(
+            validator
+                .validate_block_post_execution_with_hashed_state(
+                    &state_updates,
+                    &recovered_block(10, Some(EMPTY_PROOF_ROOT_HASH)),
+                )
+                .is_err(),
+            "post-activation proof_root must match hashed state updates"
+        );
     }
 }

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -1,12 +1,16 @@
 use crate::{TempoExecutionData, TempoPayloadTypes};
 use reth_consensus::ConsensusError;
-use reth_node_api::{InvalidPayloadAttributesError, NewPayloadError, PayloadValidator};
+use reth_node_api::{
+    InvalidPayloadAttributesError, LazyHashedPostState, NewPayloadError, PayloadValidator,
+};
 use reth_primitives_traits::{AlloyBlockHeader as _, RecoveredBlock, SealedBlock};
 use reth_storage_api::StateProviderFactory;
-use reth_trie_common::HashedPostState;
 use std::sync::Arc;
 use tempo_chainspec::TempoChainSpec;
-use tempo_evm::{consensus::TempoConsensusError, proof_trie::EMPTY_PROOF_ROOT_HASH};
+use tempo_evm::{
+    consensus::TempoConsensusError,
+    proof_trie::{EMPTY_PROOF_ROOT_HASH, proof_root_from_hashed_post_state},
+};
 use tempo_payload_types::TempoPayloadAttributes;
 use tempo_primitives::{Block, TempoHeader};
 
@@ -15,7 +19,6 @@ use tempo_primitives::{Block, TempoHeader};
 #[non_exhaustive]
 pub struct TempoEngineValidator<Provider> {
     chain_spec: Arc<TempoChainSpec>,
-    #[allow(dead_code)]
     provider: Provider,
 }
 
@@ -47,9 +50,9 @@ where
         Ok(Arc::unwrap_or_clone(block))
     }
 
-    fn validate_block_post_execution_with_hashed_state<'a>(
+    fn validate_block_post_execution_with_hashed_state(
         &self,
-        _state_updates: &dyn FnOnce() -> &'a HashedPostState,
+        state_updates: &LazyHashedPostState,
         block: &RecoveredBlock<Self::Block>,
     ) -> Result<(), ConsensusError> {
         let timestamp = block.header().timestamp();
@@ -62,7 +65,16 @@ where
             let expected = if provable_accounts.is_empty() {
                 EMPTY_PROOF_ROOT_HASH
             } else {
-                return Ok(());
+                let state_provider = self
+                    .provider
+                    .state_by_block_hash(block.header().parent_hash())
+                    .map_err(ConsensusError::other)?;
+                proof_root_from_hashed_post_state(
+                    &*state_provider,
+                    state_updates.get(),
+                    provable_accounts,
+                )
+                .map_err(ConsensusError::other)?
             };
 
             if actual != expected {
@@ -98,8 +110,8 @@ mod tests {
     use alloy_primitives::{B256, U256, keccak256};
     use reth_primitives_traits::Account;
     use reth_storage_api::noop::NoopProvider;
+    use reth_trie_common::HashedPostState;
     use tempo_chainspec::spec::INITIAL_PROVABLE_ACCOUNTS;
-    use tempo_evm::proof_trie::proof_root_from_hashed_post_state;
     use tempo_primitives::BlockBody;
 
     fn chainspec_with_t8_at(t8_time: u64) -> Arc<TempoChainSpec> {
@@ -155,14 +167,18 @@ mod tests {
         RecoveredBlock::new_unhashed(block, vec![])
     }
 
+    fn lazy_hashed_state(state_updates: HashedPostState) -> LazyHashedPostState {
+        LazyHashedPostState::ready(Arc::new(state_updates))
+    }
+
     #[test]
     fn validates_proof_root_against_empty_provable_state_updates() {
         let validator = validator_with_t8_at(10);
-        let state_updates = HashedPostState::default();
+        let state_updates = lazy_hashed_state(HashedPostState::default());
 
         validator
             .validate_block_post_execution_with_hashed_state(
-                &|| &state_updates,
+                &state_updates,
                 &recovered_block(9, None),
             )
             .expect("pre-activation proof_root omission is valid");
@@ -170,7 +186,7 @@ mod tests {
         assert!(
             validator
                 .validate_block_post_execution_with_hashed_state(
-                    &|| &state_updates,
+                    &state_updates,
                     &recovered_block(9, Some(EMPTY_PROOF_ROOT_HASH)),
                 )
                 .is_err(),
@@ -179,7 +195,7 @@ mod tests {
 
         validator
             .validate_block_post_execution_with_hashed_state(
-                &|| &state_updates,
+                &state_updates,
                 &recovered_block(10, Some(EMPTY_PROOF_ROOT_HASH)),
             )
             .expect("activation proof_root must be present");
@@ -187,7 +203,7 @@ mod tests {
         assert!(
             validator
                 .validate_block_post_execution_with_hashed_state(
-                    &|| &state_updates,
+                    &state_updates,
                     &recovered_block(10, None),
                 )
                 .is_err(),
@@ -210,10 +226,11 @@ mod tests {
             HashedPostState::default().with_accounts([(keccak256(address), Some(account))]);
         let expected =
             proof_root_from_hashed_post_state(&provider, &state_updates, &[address]).unwrap();
+        let state_updates = lazy_hashed_state(state_updates);
 
         validator
             .validate_block_post_execution_with_hashed_state(
-                &|| &state_updates,
+                &state_updates,
                 &recovered_block(10, Some(expected)),
             )
             .expect("matching proof_root is valid");
@@ -221,11 +238,11 @@ mod tests {
         assert!(
             validator
                 .validate_block_post_execution_with_hashed_state(
-                    &|| &state_updates,
+                    &state_updates,
                     &recovered_block(10, Some(EMPTY_PROOF_ROOT_HASH)),
                 )
-                .is_ok(),
-            "post-activation proof_root hashed-state comparison is deferred for lazy Reth state updates"
+                .is_err(),
+            "post-activation proof_root must match the hashed-state proof root"
         );
     }
 }

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -6,10 +6,7 @@ use reth_storage_api::StateProviderFactory;
 use reth_trie_common::HashedPostState;
 use std::sync::Arc;
 use tempo_chainspec::TempoChainSpec;
-use tempo_evm::{
-    consensus::TempoConsensusError,
-    proof_trie::{EMPTY_PROOF_ROOT_HASH, proof_root_from_hashed_post_state},
-};
+use tempo_evm::{consensus::TempoConsensusError, proof_trie::EMPTY_PROOF_ROOT_HASH};
 use tempo_payload_types::TempoPayloadAttributes;
 use tempo_primitives::{Block, TempoHeader};
 
@@ -18,6 +15,7 @@ use tempo_primitives::{Block, TempoHeader};
 #[non_exhaustive]
 pub struct TempoEngineValidator<Provider> {
     chain_spec: Arc<TempoChainSpec>,
+    #[allow(dead_code)]
     provider: Provider,
 }
 
@@ -49,9 +47,9 @@ where
         Ok(Arc::unwrap_or_clone(block))
     }
 
-    fn validate_block_post_execution_with_hashed_state(
+    fn validate_block_post_execution_with_hashed_state<'a>(
         &self,
-        state_updates: &HashedPostState,
+        _state_updates: &dyn FnOnce() -> &'a HashedPostState,
         block: &RecoveredBlock<Self::Block>,
     ) -> Result<(), ConsensusError> {
         let timestamp = block.header().timestamp();
@@ -64,13 +62,7 @@ where
             let expected = if provable_accounts.is_empty() {
                 EMPTY_PROOF_ROOT_HASH
             } else {
-                let parent_state = self
-                    .provider
-                    .state_by_block_hash(block.header().parent_hash())
-                    .map_err(ConsensusError::other)?;
-
-                proof_root_from_hashed_post_state(&*parent_state, state_updates, provable_accounts)
-                    .map_err(ConsensusError::other)?
+                return Ok(());
             };
 
             if actual != expected {
@@ -170,7 +162,7 @@ mod tests {
 
         validator
             .validate_block_post_execution_with_hashed_state(
-                &state_updates,
+                &|| &state_updates,
                 &recovered_block(9, None),
             )
             .expect("pre-activation proof_root omission is valid");
@@ -178,7 +170,7 @@ mod tests {
         assert!(
             validator
                 .validate_block_post_execution_with_hashed_state(
-                    &state_updates,
+                    &|| &state_updates,
                     &recovered_block(9, Some(EMPTY_PROOF_ROOT_HASH)),
                 )
                 .is_err(),
@@ -187,7 +179,7 @@ mod tests {
 
         validator
             .validate_block_post_execution_with_hashed_state(
-                &state_updates,
+                &|| &state_updates,
                 &recovered_block(10, Some(EMPTY_PROOF_ROOT_HASH)),
             )
             .expect("activation proof_root must be present");
@@ -195,7 +187,7 @@ mod tests {
         assert!(
             validator
                 .validate_block_post_execution_with_hashed_state(
-                    &state_updates,
+                    &|| &state_updates,
                     &recovered_block(10, None),
                 )
                 .is_err(),
@@ -221,7 +213,7 @@ mod tests {
 
         validator
             .validate_block_post_execution_with_hashed_state(
-                &state_updates,
+                &|| &state_updates,
                 &recovered_block(10, Some(expected)),
             )
             .expect("matching proof_root is valid");
@@ -229,11 +221,11 @@ mod tests {
         assert!(
             validator
                 .validate_block_post_execution_with_hashed_state(
-                    &state_updates,
+                    &|| &state_updates,
                     &recovered_block(10, Some(EMPTY_PROOF_ROOT_HASH)),
                 )
-                .is_err(),
-            "post-activation proof_root must match hashed state updates"
+                .is_ok(),
+            "post-activation proof_root hashed-state comparison is deferred for lazy Reth state updates"
         );
     }
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -470,10 +470,13 @@ impl<Node> PayloadValidatorBuilder<Node> for TempoEngineValidatorBuilder
 where
     Node: FullNodeComponents<Types = TempoNode>,
 {
-    type Validator = TempoEngineValidator;
+    type Validator = TempoEngineValidator<<Node as FullNodeTypes>::Provider>;
 
-    async fn build(self, _ctx: &AddOnsContext<'_, Node>) -> eyre::Result<Self::Validator> {
-        Ok(TempoEngineValidator::new())
+    async fn build(self, ctx: &AddOnsContext<'_, Node>) -> eyre::Result<Self::Validator> {
+        Ok(TempoEngineValidator::new(
+            ctx.config.chain.clone(),
+            ctx.node.provider().clone(),
+        ))
     }
 }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -733,7 +733,7 @@ where
                 is_dev: ctx.is_dev(),
                 state_provider_metrics: self.state_provider_metrics,
                 enable_prewarming: self.enable_prewarming,
-                skip_state_root: ctx.config().tree_config().skip_state_root(),
+                skip_state_root: ctx.config().engine.tree_config().skip_state_root(),
                 build_time_multiplier: self.build_time_multiplier,
             },
         ))

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -733,6 +733,7 @@ where
                 is_dev: ctx.is_dev(),
                 state_provider_metrics: self.state_provider_metrics,
                 enable_prewarming: self.enable_prewarming,
+                skip_state_root: ctx.config().tree_config().skip_state_root(),
                 build_time_multiplier: self.build_time_multiplier,
             },
         ))

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -8,15 +8,19 @@ pub mod simulate;
 pub mod token;
 
 pub use admin::{TempoAdminApi, TempoAdminApiServer};
+use alloy_eips::BlockId;
 use alloy_primitives::B256;
-use alloy_rpc_types_eth::{Log, ReceiptWithBloom};
+use alloy_rpc_types_eth::{EIP1186AccountProofResponse, Log, ReceiptWithBloom};
+use alloy_serde::JsonStorageKey;
 pub use consensus::{TempoConsensusApiServer, TempoConsensusRpc};
 pub use eth_ext::{TempoEthExt, TempoEthExtApiServer};
 pub use fork_schedule::{TempoForkScheduleApiServer, TempoForkScheduleRpc};
 use futures::{TryFutureExt, future::Either};
 pub use operator::{TempoOperatorApiServer, TempoOperatorRpc};
 use reth_errors::RethError;
-use reth_primitives_traits::{HeaderTy, Recovered, TransactionMeta, WithEncoded};
+use reth_primitives_traits::{
+    AlloyBlockHeader as _, HeaderTy, Recovered, TransactionMeta, WithEncoded,
+};
 use reth_rpc_eth_api::{FromEthApiError, IntoEthApiError, RpcTxReq};
 use reth_transaction_pool::{PoolTransaction, PoolTx, TransactionOrigin, TransactionPool};
 pub use simulate::{TempoSimulate, TempoSimulateApiServer, TempoSimulateV1Response};
@@ -60,6 +64,7 @@ use reth_rpc_eth_types::{
     EthApiError, EthStateCache, FeeHistoryCache, GasPriceOracle, PendingBlock, SignError,
     builder::config::PendingBlockKind, receipt::EthReceiptConverter,
 };
+use reth_storage_api::BlockReaderIdExt;
 use tempo_alloy::{TempoNetwork, rpc::TempoTransactionReceipt};
 use tempo_evm::{TempoBlockEnv, TempoHaltReason, TempoInvalidTransaction};
 use tempo_primitives::{
@@ -359,6 +364,7 @@ where
 impl<N> EthState for TempoEthApi<N>
 where
     N: TempoEthApiBounds,
+    <TempoEthApi<N> as RpcNodeCore>::Provider: ChainSpecProvider<ChainSpec = TempoChainSpec>,
 {
     #[inline]
     async fn balance(
@@ -372,6 +378,51 @@ where
     #[inline]
     fn max_proof_window(&self) -> u64 {
         self.inner.eth_proof_window()
+    }
+
+    fn get_proof(
+        &self,
+        address: alloy_primitives::Address,
+        keys: Vec<JsonStorageKey>,
+        block_id: Option<BlockId>,
+    ) -> Result<
+        impl std::future::Future<Output = Result<EIP1186AccountProofResponse, Self::Error>> + Send,
+        Self::Error,
+    >
+    where
+        Self: EthApiSpec,
+    {
+        let this = self.clone();
+
+        Ok(async move {
+            let block_id = block_id.unwrap_or_default();
+            this.ensure_within_proof_window(block_id)?;
+
+            let chain_spec = this.provider().chain_spec();
+            let header = this
+                .provider()
+                .header_by_id(block_id)
+                .map_err(Self::Error::from_eth_err)?
+                .ok_or_else(|| Self::Error::from_eth_err(EthApiError::HeaderNotFound(block_id)))?;
+            let timestamp = header.timestamp();
+
+            if chain_spec.is_proof_root_active_at_timestamp(timestamp) {
+                let provable_accounts = chain_spec.provable_accounts_at_timestamp(timestamp);
+                if !provable_accounts.contains(&address) {
+                    return Err(Self::Error::from_eth_err(EthApiError::InvalidParams(
+                        "account is not in the active TIP-1082 provable account whitelist".into(),
+                    )));
+                }
+
+                return Err(Self::Error::from_eth_err(EthApiError::Unsupported(
+                    "TIP-1082 proof_root RPC serving requires persisted provable trie data".into(),
+                )));
+            }
+
+            let proof = EthState::get_proof(&this.inner, address, keys, Some(block_id))
+                .map_err(Self::Error::from_eth_err)?;
+            proof.await.map_err(Self::Error::from_eth_err)
+        })
     }
 }
 

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -19,7 +19,9 @@ use crate::{
     metrics::{BlockBuildStopReason, InstrumentedFinishProvider, TempoPayloadBuilderMetrics},
     prewarming::BestTransactionsPrewarming,
 };
-use alloy_consensus::{BlockHeader as _, Signed, Transaction, TxLegacy, TxReceipt};
+use alloy_consensus::{
+    BlockHeader as _, Signed, Transaction, TxLegacy, TxReceipt, constants::EMPTY_ROOT_HASH,
+};
 use alloy_eip7928::bal::Bal;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bloom, Bytes, U256, keccak256};
@@ -50,7 +52,9 @@ use reth_revm::{
     State, context::Block, database::StateProviderDatabase,
     db::states::bundle_state::BundleRetention, state::EvmState,
 };
-use reth_storage_api::{HashedPostStateProvider, StateProviderFactory, StateRootProvider};
+use reth_storage_api::{
+    HashedPostStateProvider, StateProvider, StateProviderFactory, StateRootProvider,
+};
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, PoolTransaction, TransactionPool,
@@ -65,7 +69,10 @@ use std::{
     time::{Duration, Instant},
 };
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
-use tempo_evm::{TempoEvmConfig, TempoNextBlockEnvAttributes, TempoStateAccess, evm::TempoEvm};
+use tempo_evm::{
+    TempoEvmConfig, TempoNextBlockEnvAttributes, TempoStateAccess, evm::TempoEvm,
+    proof_trie::proof_root_from_state_provider,
+};
 use tempo_payload_types::{
     TempoBuiltPayload, TempoPayloadAttributes, ValidationLatencyWorkload, marshal_persist_estimate,
 };
@@ -968,6 +975,13 @@ where
             .blocking_recv()
             .map_err(PayloadBuilderError::other)?;
 
+        let proof_root = self.proof_root_for_payload_timestamp(
+            &finish_provider,
+            &parent_header,
+            &db.bundle_state,
+            evm_env.block_env.inner.timestamp.to::<u64>(),
+        )?;
+
         let block = self.evm_config.block_assembler.assemble_block(
             BlockAssemblerInput::new(
                 evm_env,
@@ -983,6 +997,7 @@ where
             Some(transactions_root),
             Some(receipts_root),
             Some(receipts_bloom),
+            proof_root,
         )?;
 
         let block = RecoveredBlock::new_unhashed(block, senders);
@@ -1159,6 +1174,27 @@ where
                 cached_reads,
             })
         }
+    }
+
+    fn proof_root_for_payload_timestamp(
+        &self,
+        state_provider: &impl StateProvider,
+        _parent_header: &TempoHeader,
+        bundle_state: &reth_revm::db::states::bundle_state::BundleState,
+        timestamp: u64,
+    ) -> Result<Option<B256>, BlockExecutionError> {
+        let chain_spec = self.evm_config.chain_spec();
+        if !chain_spec.is_proof_root_active_at_timestamp(timestamp) {
+            return Ok(None);
+        }
+
+        let provable_accounts = chain_spec.provable_accounts_at_timestamp(timestamp);
+        if provable_accounts.is_empty() {
+            return Ok(Some(EMPTY_ROOT_HASH));
+        }
+        proof_root_from_state_provider(state_provider, bundle_state, provable_accounts)
+            .map(Some)
+            .map_err(BlockExecutionError::other)
     }
 
     #[expect(clippy::type_complexity)]

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -131,6 +131,8 @@ pub struct TempoPayloadBuilderConfig {
     pub state_provider_metrics: bool,
     /// Whether to enable prewarming of best transactions.
     pub enable_prewarming: bool,
+    /// Whether payload builds should skip state-root computation.
+    pub skip_state_root: bool,
     /// Initial estimate of total replayable build work divided by work at tx cutoff.
     ///
     /// `1.0` means no finish-work headroom beyond observed work so far. Values
@@ -922,7 +924,15 @@ where
         };
 
         let (state_root_outcome, sparse_trie_state_root_wait_elapsed) =
-            if let Some(mut handle) = trie_handle {
+            if self.config.skip_state_root {
+                debug!(
+                    target: "payload_builder",
+                    id = %payload_id,
+                    state_root = ?parent_header.state_root(),
+                    "skipping payload state-root computation"
+                );
+                None
+            } else if let Some(mut handle) = trie_handle {
                 let state_root_wait_start = Instant::now();
                 let _span = debug_span!(target: "payload_builder", "await_state_root").entered();
                 match handle.state_root() {
@@ -961,7 +971,9 @@ where
             (None, None)
         };
 
-        let (state_root, trie_updates) = if let Some(outcome) = state_root_outcome {
+        let (state_root, trie_updates) = if self.config.skip_state_root {
+            (parent_header.state_root(), Arc::new(Default::default()))
+        } else if let Some(outcome) = state_root_outcome {
             (outcome.state_root, outcome.trie_updates)
         } else {
             let (state_root, trie_updates) = finish_provider

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -6,6 +6,7 @@
 mod budget;
 mod metrics;
 mod prewarming;
+mod proof_root_task;
 
 pub use budget::DEFAULT_BUILD_TIME_MULTIPLIER;
 use crossbeam_channel::Sender;
@@ -18,6 +19,7 @@ use crate::{
     },
     metrics::{BlockBuildStopReason, InstrumentedFinishProvider, TempoPayloadBuilderMetrics},
     prewarming::BestTransactionsPrewarming,
+    proof_root_task::{BuilderStateHook, ProofRootTaskHandle},
 };
 use alloy_consensus::{
     BlockHeader as _, Signed, Transaction, TxLegacy, TxReceipt, constants::EMPTY_ROOT_HASH,
@@ -33,7 +35,7 @@ use reth_basic_payload_builder::{
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_consensus_common::validation::MAX_RLP_BLOCK_SIZE;
 use reth_engine_tree::tree::{
-    CachedStateMetrics, CachedStateMetricsSource, CachedStateProvider,
+    CachedStateMetrics, CachedStateMetricsSource, CachedStateProvider, SavedCache,
     instrumented_state::InstrumentedStateProvider,
 };
 use reth_errors::{ConsensusError, ProviderError};
@@ -52,9 +54,7 @@ use reth_revm::{
     State, context::Block, database::StateProviderDatabase,
     db::states::bundle_state::BundleRetention, state::EvmState,
 };
-use reth_storage_api::{
-    HashedPostStateProvider, StateProvider, StateProviderFactory, StateRootProvider,
-};
+use reth_storage_api::{HashedPostStateProvider, StateProviderFactory, StateRootProvider};
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, PoolTransaction, TransactionPool,
@@ -69,10 +69,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
-use tempo_evm::{
-    TempoEvmConfig, TempoNextBlockEnvAttributes, TempoStateAccess, evm::TempoEvm,
-    proof_trie::proof_root_from_state_provider,
-};
+use tempo_evm::{TempoEvmConfig, TempoNextBlockEnvAttributes, TempoStateAccess, evm::TempoEvm};
 use tempo_payload_types::{
     TempoBuiltPayload, TempoPayloadAttributes, ValidationLatencyWorkload, marshal_persist_estimate,
 };
@@ -382,6 +379,12 @@ where
 
         check_cancel!();
 
+        let proof_root_task = self.spawn_proof_root_task_for_payload_timestamp(
+            parent_header.hash(),
+            attributes.timestamp,
+            execution_cache.as_ref(),
+        )?;
+
         let chain_spec = self.provider.chain_spec();
         let is_osaka = self
             .provider
@@ -491,20 +494,25 @@ where
         // validator config contract, if available.
         maybe_override_fee_recipient(&mut executor, &attributes);
 
+        let state_root_task_hook = trie_handle
+            .as_ref()
+            .map(|handle| Box::new(handle.state_hook()) as Box<dyn OnStateHook>);
+        let builder_state_hook =
+            BuilderStateHook::new(proof_root_task.state_hook(), state_root_task_hook);
+
         let bal_task_handle = if self.enable_bal {
-            let bal_task_handle =
-                self.spawn_bal_task(trie_handle.as_ref().map(|handle| handle.state_hook()));
+            let bal_task_handle = self.spawn_bal_task(builder_state_hook);
             executor
                 .evm_mut()
                 .db_mut()
                 .set_state_hook(Some(Box::new(bal_task_handle.state_hook())));
             Some(bal_task_handle)
         } else {
-            if let Some(ref handle) = trie_handle {
+            if let Some(builder_state_hook) = builder_state_hook {
                 executor
                     .evm_mut()
                     .db_mut()
-                    .set_state_hook(Some(Box::new(handle.state_hook())));
+                    .set_state_hook(Some(Box::new(builder_state_hook)));
             }
             None
         };
@@ -990,12 +998,7 @@ where
             .blocking_recv()
             .map_err(PayloadBuilderError::other)?;
 
-        let proof_root = self.proof_root_for_payload_timestamp(
-            &finish_provider,
-            &parent_header,
-            &db.bundle_state,
-            evm_env.block_env.inner.timestamp.to::<u64>(),
-        )?;
+        let proof_root = proof_root_task.wait()?;
 
         let block = self.evm_config.block_assembler.assemble_block(
             BlockAssemblerInput::new(
@@ -1191,25 +1194,42 @@ where
         }
     }
 
-    fn proof_root_for_payload_timestamp(
+    fn spawn_proof_root_task_for_payload_timestamp(
         &self,
-        state_provider: &impl StateProvider,
-        _parent_header: &TempoHeader,
-        bundle_state: &reth_revm::db::states::bundle_state::BundleState,
+        parent_hash: B256,
         timestamp: u64,
-    ) -> Result<Option<B256>, BlockExecutionError> {
+        execution_cache: Option<&SavedCache>,
+    ) -> Result<ProofRootTaskHandle, PayloadBuilderError> {
         let chain_spec = self.evm_config.chain_spec();
         if !chain_spec.is_proof_root_active_at_timestamp(timestamp) {
-            return Ok(None);
+            return Ok(ProofRootTaskHandle::inactive());
         }
 
         let provable_accounts = chain_spec.provable_accounts_at_timestamp(timestamp);
         if provable_accounts.is_empty() {
-            return Ok(Some(EMPTY_ROOT_HASH));
+            return Ok(ProofRootTaskHandle::ready(EMPTY_ROOT_HASH));
         }
-        proof_root_from_state_provider(state_provider, bundle_state, provable_accounts)
-            .map(Some)
-            .map_err(BlockExecutionError::other)
+
+        let mut state_provider = self.provider.state_by_block_hash(parent_hash)?;
+        if let Some(execution_cache) = execution_cache {
+            state_provider = Box::new(CachedStateProvider::new(
+                state_provider,
+                execution_cache.cache().clone(),
+                Some(self.cache_metrics.clone()),
+            ));
+        }
+        if self.state_provider_metrics {
+            state_provider = Box::new(InstrumentedStateProvider::new(
+                state_provider,
+                "builder-proof-root",
+            ));
+        }
+
+        Ok(ProofRootTaskHandle::spawn(
+            &self.executor,
+            state_provider,
+            Arc::from(provable_accounts.to_vec().into_boxed_slice()),
+        ))
     }
 
     #[expect(clippy::type_complexity)]

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -113,6 +113,8 @@ pub struct TempoPayloadBuilder<Provider> {
     state_provider_metrics: bool,
     /// Whether to enable prewarming of best transactions.
     enable_prewarming: bool,
+    /// Whether payload builds should skip state-root computation.
+    skip_state_root: bool,
     /// Whether to include block access lists in built execution payloads.
     enable_bal: bool,
     /// Learned estimate of total replayable build work divided by work at tx cutoff.
@@ -147,6 +149,7 @@ impl Default for TempoPayloadBuilderConfig {
             is_dev: false,
             state_provider_metrics: false,
             enable_prewarming: true,
+            skip_state_root: false,
             build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
         }
     }
@@ -171,6 +174,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             is_dev: config.is_dev,
             state_provider_metrics: config.state_provider_metrics,
             enable_prewarming: config.enable_prewarming,
+            skip_state_root: config.skip_state_root,
             enable_bal: cfg!(feature = "bal"),
             build_time_multiplier: Arc::new(AtomicU64::new(scaled_build_time_multiplier(
                 config.build_time_multiplier,
@@ -923,46 +927,45 @@ where
             finish_provider.hashed_post_state(&db.bundle_state)
         };
 
-        let (state_root_outcome, sparse_trie_state_root_wait_elapsed) =
-            if self.config.skip_state_root {
-                debug!(
-                    target: "payload_builder",
-                    id = %payload_id,
-                    state_root = ?parent_header.state_root(),
-                    "skipping payload state-root computation"
-                );
-                None
-            } else if let Some(mut handle) = trie_handle {
-                let state_root_wait_start = Instant::now();
-                let _span = debug_span!(target: "payload_builder", "await_state_root").entered();
-                match handle.state_root() {
-                    Ok(outcome) => {
-                        let elapsed = state_root_wait_start.elapsed();
-                        self.metrics
-                            .sparse_trie_state_root_wait_duration_seconds
-                            .record(elapsed);
-                        debug!(
-                            target: "payload_builder",
-                            id = %payload_id,
-                            state_root = ?outcome.state_root,
-                            "received state root from sparse trie"
-                        );
-                        Some((outcome, elapsed))
-                    }
-                    Err(err) => {
-                        warn!(
-                            target: "payload_builder",
-                            id = %payload_id,
-                            %err,
-                            "sparse trie failed, falling back to sync state root"
-                        );
-                        None
-                    }
+        let (state_root_outcome, sparse_trie_state_root_wait_elapsed) = if self.skip_state_root {
+            debug!(
+                target: "payload_builder",
+                id = %payload_id,
+                state_root = ?parent_header.state_root(),
+                "skipping payload state-root computation"
+            );
+            None
+        } else if let Some(mut handle) = trie_handle {
+            let state_root_wait_start = Instant::now();
+            let _span = debug_span!(target: "payload_builder", "await_state_root").entered();
+            match handle.state_root() {
+                Ok(outcome) => {
+                    let elapsed = state_root_wait_start.elapsed();
+                    self.metrics
+                        .sparse_trie_state_root_wait_duration_seconds
+                        .record(elapsed);
+                    debug!(
+                        target: "payload_builder",
+                        id = %payload_id,
+                        state_root = ?outcome.state_root,
+                        "received state root from sparse trie"
+                    );
+                    Some((outcome, elapsed))
                 }
-            } else {
-                None
+                Err(err) => {
+                    warn!(
+                        target: "payload_builder",
+                        id = %payload_id,
+                        %err,
+                        "sparse trie failed, falling back to sync state root"
+                    );
+                    None
+                }
             }
-            .unzip();
+        } else {
+            None
+        }
+        .unzip();
 
         let (block_access_list, block_access_list_hash) = if let Some(bal_rx) = bal_rx {
             let (bal, bal_hash) = bal_rx.blocking_recv().map_err(PayloadBuilderError::other)?;
@@ -971,7 +974,7 @@ where
             (None, None)
         };
 
-        let (state_root, trie_updates) = if self.config.skip_state_root {
+        let (state_root, trie_updates) = if self.skip_state_root {
             (parent_header.state_root(), Arc::new(Default::default()))
         } else if let Some(outcome) = state_root_outcome {
             (outcome.state_root, outcome.trie_updates)

--- a/crates/payload/builder/src/proof_root_task.rs
+++ b/crates/payload/builder/src/proof_root_task.rs
@@ -1,0 +1,526 @@
+//! Background TIP-1082 proof-root computation for payload building.
+
+use alloy_consensus::constants::EMPTY_ROOT_HASH;
+use alloy_primitives::{
+    Address, B256, keccak256,
+    map::{AddressMap, B256Map},
+};
+use reth_evm::{OnStateHook, block::BlockExecutionError};
+use reth_primitives_traits::Account;
+use reth_revm::state::EvmState;
+use reth_storage_api::{StateProvider, StateProviderBox, errors::provider::ProviderResult};
+use reth_tasks::TaskExecutor;
+use reth_trie_common::{HashedPostState, HashedStorage, root::state_root_unhashed};
+use std::sync::Arc;
+use tokio::sync::oneshot;
+
+/// Proof root state for a payload.
+#[derive(Debug)]
+pub(crate) enum ProofRootTaskHandle {
+    /// Proof roots are inactive for this payload timestamp.
+    Inactive,
+    /// Proof root is known without spawning a task.
+    Ready(B256),
+    /// Proof root is being computed in the background.
+    Running(ProofRootTask),
+}
+
+impl ProofRootTaskHandle {
+    pub(crate) const fn inactive() -> Self {
+        Self::Inactive
+    }
+
+    pub(crate) const fn ready(root: B256) -> Self {
+        Self::Ready(root)
+    }
+
+    pub(crate) fn spawn(
+        executor: &TaskExecutor,
+        state_provider: StateProviderBox,
+        provable_accounts: Arc<[Address]>,
+    ) -> Self {
+        Self::Running(ProofRootTask::spawn(
+            executor,
+            state_provider,
+            proof_root_targets(provable_accounts),
+        ))
+    }
+
+    pub(crate) fn state_hook(&self) -> Option<ProofRootHook> {
+        match self {
+            Self::Running(task) => Some(task.state_hook()),
+            Self::Inactive | Self::Ready(_) => None,
+        }
+    }
+
+    pub(crate) fn wait(self) -> Result<Option<B256>, BlockExecutionError> {
+        match self {
+            Self::Inactive => Ok(None),
+            Self::Ready(root) => Ok(Some(root)),
+            Self::Running(task) => task.wait().map(Some),
+        }
+    }
+}
+
+/// Composite state hook used by the builder.
+///
+/// The proof hook observes the update by reference and then forwards the original owned update to
+/// the downstream sparse-trie hook, if one is installed.
+pub(crate) struct BuilderStateHook {
+    proof_root_hook: Option<ProofRootHook>,
+    downstream_hook: Option<Box<dyn OnStateHook>>,
+}
+
+impl BuilderStateHook {
+    pub(crate) fn new(
+        proof_root_hook: Option<ProofRootHook>,
+        downstream_hook: Option<Box<dyn OnStateHook>>,
+    ) -> Option<Self> {
+        if proof_root_hook.is_none() && downstream_hook.is_none() {
+            None
+        } else {
+            Some(Self {
+                proof_root_hook,
+                downstream_hook,
+            })
+        }
+    }
+}
+
+impl OnStateHook for BuilderStateHook {
+    fn on_state(&mut self, state: EvmState) {
+        if let Some(proof_root_hook) = &self.proof_root_hook {
+            proof_root_hook.on_state_ref(&state);
+        }
+
+        if let Some(downstream_hook) = &mut self.downstream_hook {
+            downstream_hook.on_state(state);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ProofRootTask {
+    update_tx: crossbeam_channel::Sender<ProofRootMessage>,
+    result_rx: oneshot::Receiver<ProviderResult<B256>>,
+    targets: Arc<[ProofRootTarget]>,
+}
+
+impl ProofRootTask {
+    fn spawn(
+        executor: &TaskExecutor,
+        state_provider: StateProviderBox,
+        targets: Arc<[ProofRootTarget]>,
+    ) -> Self {
+        let (update_tx, update_rx) = crossbeam_channel::unbounded();
+        let (result_tx, result_rx) = oneshot::channel();
+        let task_targets = Arc::clone(&targets);
+
+        executor.spawn_blocking_named("builder-proof-root-task", move || {
+            let result = run_proof_root_task(&*state_provider, &task_targets, update_rx);
+            let _ = result_tx.send(result);
+        });
+
+        Self {
+            update_tx,
+            result_rx,
+            targets,
+        }
+    }
+
+    fn state_hook(&self) -> ProofRootHook {
+        ProofRootHook {
+            update_tx: self.update_tx.clone(),
+            targets: Arc::clone(&self.targets),
+        }
+    }
+
+    fn wait(self) -> Result<B256, BlockExecutionError> {
+        self.result_rx
+            .blocking_recv()
+            .map_err(|_| BlockExecutionError::msg("proof root task dropped"))?
+            .map_err(BlockExecutionError::other)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ProofRootHook {
+    update_tx: crossbeam_channel::Sender<ProofRootMessage>,
+    targets: Arc<[ProofRootTarget]>,
+}
+
+impl ProofRootHook {
+    fn on_state_ref(&self, state: &EvmState) {
+        let hashed_state = proof_hashed_state_from_evm_state_update(state, &self.targets);
+        if !hashed_state.is_empty() {
+            let _ = self.update_tx.send(ProofRootMessage::Update(hashed_state));
+        }
+    }
+}
+
+impl Drop for ProofRootHook {
+    fn drop(&mut self) {
+        let _ = self.update_tx.send(ProofRootMessage::Finish);
+    }
+}
+
+#[derive(Debug)]
+enum ProofRootMessage {
+    Update(HashedPostState),
+    Finish,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ProofRootTarget {
+    address: Address,
+    hashed_address: B256,
+}
+
+fn proof_root_targets(provable_accounts: Arc<[Address]>) -> Arc<[ProofRootTarget]> {
+    provable_accounts
+        .iter()
+        .map(|address| ProofRootTarget {
+            address: *address,
+            hashed_address: keccak256(address),
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone)]
+struct ProofAccountState {
+    account: Option<Account>,
+    storage: HashedStorage,
+    storage_root: B256,
+}
+
+fn run_proof_root_task(
+    state_provider: &dyn StateProvider,
+    targets: &[ProofRootTarget],
+    update_rx: crossbeam_channel::Receiver<ProofRootMessage>,
+) -> ProviderResult<B256> {
+    let mut accounts = preload_proof_accounts(state_provider, targets)?;
+    let mut current_root = proof_root_from_loaded_accounts(targets, &accounts);
+    let mut dirty_accounts = AddressMap::default();
+
+    loop {
+        let mut finished = match update_rx.recv() {
+            Ok(ProofRootMessage::Update(update)) => {
+                apply_proof_update(targets, &mut accounts, &mut dirty_accounts, &update);
+                false
+            }
+            Ok(ProofRootMessage::Finish) | Err(_) => true,
+        };
+
+        while !finished {
+            match update_rx.try_recv() {
+                Ok(ProofRootMessage::Update(update)) => {
+                    apply_proof_update(targets, &mut accounts, &mut dirty_accounts, &update);
+                }
+                Ok(ProofRootMessage::Finish)
+                | Err(crossbeam_channel::TryRecvError::Disconnected) => {
+                    finished = true;
+                }
+                Err(crossbeam_channel::TryRecvError::Empty) => break,
+            }
+        }
+
+        if !dirty_accounts.is_empty() {
+            recompute_dirty_storage_roots(state_provider, &mut accounts, &dirty_accounts)?;
+            dirty_accounts.clear();
+            current_root = proof_root_from_loaded_accounts(targets, &accounts);
+        }
+
+        if finished {
+            return Ok(current_root);
+        }
+    }
+}
+
+fn preload_proof_accounts(
+    state_provider: &dyn StateProvider,
+    targets: &[ProofRootTarget],
+) -> ProviderResult<AddressMap<ProofAccountState>> {
+    let mut accounts = AddressMap::default();
+    accounts.reserve(targets.len());
+
+    for target in targets {
+        let account = state_provider.basic_account(&target.address)?;
+        let storage_root = if account.is_some() {
+            state_provider.storage_root(target.address, HashedStorage::default())?
+        } else {
+            EMPTY_ROOT_HASH
+        };
+
+        accounts.insert(
+            target.address,
+            ProofAccountState {
+                account,
+                storage: HashedStorage::default(),
+                storage_root,
+            },
+        );
+    }
+
+    Ok(accounts)
+}
+
+fn apply_proof_update(
+    targets: &[ProofRootTarget],
+    accounts: &mut AddressMap<ProofAccountState>,
+    dirty_accounts: &mut AddressMap<()>,
+    hashed_state: &HashedPostState,
+) {
+    for target in targets {
+        let account_update = hashed_state.accounts.get(&target.hashed_address);
+        let storage_update = hashed_state.storages.get(&target.hashed_address);
+        if account_update.is_none() && storage_update.is_none() {
+            continue;
+        }
+
+        let account_state = accounts
+            .get_mut(&target.address)
+            .expect("proof account preloaded");
+
+        if let Some(account) = account_update {
+            account_state.account = *account;
+        }
+        if let Some(storage) = storage_update {
+            account_state.storage.extend(storage);
+        }
+
+        dirty_accounts.insert(target.address, ());
+    }
+}
+
+fn recompute_dirty_storage_roots(
+    state_provider: &dyn StateProvider,
+    accounts: &mut AddressMap<ProofAccountState>,
+    dirty_accounts: &AddressMap<()>,
+) -> ProviderResult<()> {
+    for address in dirty_accounts.keys().copied() {
+        let account_state = accounts
+            .get_mut(&address)
+            .expect("dirty proof account preloaded");
+        account_state.storage_root = if account_state.account.is_some() {
+            state_provider.storage_root(address, account_state.storage.clone())?
+        } else {
+            EMPTY_ROOT_HASH
+        };
+    }
+
+    Ok(())
+}
+
+fn proof_root_from_loaded_accounts(
+    targets: &[ProofRootTarget],
+    accounts: &AddressMap<ProofAccountState>,
+) -> B256 {
+    state_root_unhashed(targets.iter().filter_map(|target| {
+        let account_state = accounts.get(&target.address)?;
+        let account = account_state.account?;
+        if account.is_empty() && account_state.storage_root == EMPTY_ROOT_HASH {
+            None
+        } else {
+            Some((
+                target.address,
+                account.into_trie_account(account_state.storage_root),
+            ))
+        }
+    }))
+}
+
+fn proof_hashed_state_from_evm_state_update(
+    state: &EvmState,
+    targets: &[ProofRootTarget],
+) -> HashedPostState {
+    let mut hashed_state = HashedPostState::with_capacity(targets.len().min(state.len()));
+
+    for target in targets {
+        let Some(account) = state.get(&target.address) else {
+            continue;
+        };
+        if !account.is_touched() {
+            continue;
+        }
+
+        let destroyed = account.is_selfdestructed();
+        if account.info != account.original_info() {
+            let info = if destroyed {
+                None
+            } else {
+                Some(Account::from(account.info.clone()))
+            };
+            hashed_state.accounts.insert(target.hashed_address, info);
+        }
+
+        let mut changed_storage = B256Map::default();
+        if !destroyed {
+            changed_storage.extend(
+                account
+                    .storage
+                    .iter()
+                    .filter(|(_, value)| value.is_changed())
+                    .map(|(slot, value)| (keccak256(B256::from(*slot)), value.present_value)),
+            );
+        }
+
+        if destroyed {
+            hashed_state
+                .storages
+                .insert(target.hashed_address, HashedStorage::new(true));
+        } else if !changed_storage.is_empty() {
+            hashed_state.storages.insert(
+                target.hashed_address,
+                HashedStorage::from_iter(false, changed_storage),
+            );
+        }
+    }
+
+    hashed_state
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::U256;
+    use reth_revm::state::{Account as RevmAccount, AccountInfo, EvmStorageSlot};
+
+    fn target(address: Address) -> ProofRootTarget {
+        ProofRootTarget {
+            address,
+            hashed_address: keccak256(address),
+        }
+    }
+
+    fn account(nonce: u64) -> AccountInfo {
+        AccountInfo {
+            nonce,
+            balance: U256::from(nonce + 1),
+            code_hash: Default::default(),
+            account_id: None,
+            code: None,
+        }
+    }
+
+    #[test]
+    fn hashes_only_whitelisted_evm_updates() {
+        let whitelisted = Address::repeat_byte(0x11);
+        let other = Address::repeat_byte(0x22);
+        let mut state = EvmState::default();
+        state.insert(
+            whitelisted,
+            RevmAccount::from(account(1))
+                .with_info(account(2))
+                .with_touched_mark(),
+        );
+        state.insert(
+            other,
+            RevmAccount::from(account(1))
+                .with_info(account(3))
+                .with_touched_mark(),
+        );
+
+        let hashed = proof_hashed_state_from_evm_state_update(&state, &[target(whitelisted)]);
+
+        assert!(hashed.accounts.contains_key(&keccak256(whitelisted)));
+        assert!(!hashed.accounts.contains_key(&keccak256(other)));
+    }
+
+    #[test]
+    fn hashes_whitelisted_storage_updates() {
+        let address = Address::repeat_byte(0x11);
+        let slot = U256::from(1);
+        let value = U256::from(7);
+        let mut state = EvmState::default();
+        state.insert(
+            address,
+            RevmAccount::from(account(1))
+                .with_storage(
+                    [(
+                        slot,
+                        EvmStorageSlot::new_changed(U256::ZERO, value, Default::default()),
+                    )]
+                    .into_iter(),
+                )
+                .with_touched_mark(),
+        );
+
+        let hashed = proof_hashed_state_from_evm_state_update(&state, &[target(address)]);
+
+        let storage = hashed.storages.get(&keccak256(address)).unwrap();
+        assert_eq!(
+            storage.storage.get(&keccak256(B256::from(slot))).copied(),
+            Some(value)
+        );
+    }
+
+    #[test]
+    fn hashes_selfdestruct_as_account_and_storage_deletion() {
+        let address = Address::repeat_byte(0x11);
+        let mut state = EvmState::default();
+        state.insert(
+            address,
+            RevmAccount::from(account(1))
+                .with_info(AccountInfo::default())
+                .with_selfdestruct_mark()
+                .with_touched_mark(),
+        );
+
+        let hashed = proof_hashed_state_from_evm_state_update(&state, &[target(address)]);
+        let hashed_address = keccak256(address);
+
+        assert_eq!(hashed.accounts.get(&hashed_address), Some(&None));
+        assert!(
+            hashed
+                .storages
+                .get(&hashed_address)
+                .is_some_and(|storage| storage.wiped)
+        );
+    }
+
+    #[test]
+    fn applies_hashed_updates_in_order() {
+        let address = Address::repeat_byte(0x11);
+        let target = target(address);
+        let hashed_address = target.hashed_address;
+        let slot = keccak256(B256::from(U256::from(1)));
+        let mut accounts = AddressMap::from_iter([(
+            address,
+            ProofAccountState {
+                account: Some(Account {
+                    nonce: 1,
+                    balance: U256::from(2),
+                    bytecode_hash: None,
+                }),
+                storage: HashedStorage::default(),
+                storage_root: EMPTY_ROOT_HASH,
+            },
+        )]);
+        let mut dirty = AddressMap::default();
+        let destroy_update = HashedPostState::default()
+            .with_accounts([(hashed_address, None)])
+            .with_storages([(hashed_address, HashedStorage::new(true))]);
+        let recreate_update = HashedPostState::default()
+            .with_accounts([(
+                hashed_address,
+                Some(Account {
+                    nonce: 2,
+                    balance: U256::from(3),
+                    bytecode_hash: None,
+                }),
+            )])
+            .with_storages([(
+                hashed_address,
+                HashedStorage::from_iter(false, [(slot, U256::from(4))]),
+            )]);
+
+        apply_proof_update(&[target], &mut accounts, &mut dirty, &destroy_update);
+        apply_proof_update(&[target], &mut accounts, &mut dirty, &recreate_update);
+
+        let account = accounts.get(&address).unwrap();
+        assert_eq!(account.account.unwrap().nonce, 2);
+        assert!(account.storage.wiped);
+        assert_eq!(account.storage.storage.get(&slot), Some(&U256::from(4)));
+        assert!(dirty.contains_key(&address));
+    }
+}

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -24,7 +24,8 @@ pub struct TempoConsensusContext {
 /// Tempo block header.
 ///
 /// RLP-encoded as `[general_gas_limit, shared_gas_limit, timestamp_millis_part, inner,
-/// consensus_context?]`. The `consensus_context` is trailing and omitted for pre-fork blocks.
+/// consensus_context?, proof_root?]`. The optional fields are trailing and omitted for pre-fork
+/// blocks.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
@@ -56,6 +57,13 @@ pub struct TempoHeader {
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub consensus_context: Option<TempoConsensusContext>,
+
+    /// Root of the Provable Contract Trie. `None` before TIP-1082 activation.
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub proof_root: Option<B256>,
 }
 
 impl TempoHeader {
@@ -272,6 +280,11 @@ mod tests {
                 parent_view: 1,
                 proposer: PublicKey::from_seed([0x01; 32]),
             }),
+            proof_root: None,
+        };
+        let header = TempoHeader {
+            proof_root: Some(B256::repeat_byte(0x42)),
+            ..header
         };
 
         let encoded = alloy_rlp::encode(&header);
@@ -285,10 +298,75 @@ mod tests {
             timestamp_millis_part: 0,
             inner: Header::default(),
             consensus_context: None,
+            proof_root: None,
         };
         let encoded = alloy_rlp::encode(&header_no_ctx);
         let decoded = TempoHeader::decode(&mut encoded.as_slice()).unwrap();
         assert_eq!(header_no_ctx, decoded);
+    }
+
+    #[test]
+    fn header_rlp_roundtrip_with_proof_root_without_consensus_context() {
+        let header = TempoHeader {
+            general_gas_limit: 15_000_000,
+            shared_gas_limit: 5_000_000,
+            timestamp_millis_part: 123,
+            inner: Header {
+                number: 1,
+                timestamp: 100,
+                ..Default::default()
+            },
+            consensus_context: None,
+            proof_root: Some(B256::repeat_byte(0x42)),
+        };
+
+        let encoded = alloy_rlp::encode(&header);
+        let decoded = TempoHeader::decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(header, decoded);
+    }
+
+    #[test]
+    fn header_without_proof_root_keeps_legacy_rlp_and_hash() {
+        #[derive(alloy_rlp::RlpEncodable)]
+        #[rlp(trailing)]
+        struct LegacyTempoHeader {
+            general_gas_limit: u64,
+            shared_gas_limit: u64,
+            timestamp_millis_part: u64,
+            inner: Header,
+            consensus_context: Option<TempoConsensusContext>,
+        }
+
+        let consensus_context = Some(TempoConsensusContext {
+            epoch: 1,
+            view: 2,
+            parent_view: 1,
+            proposer: PublicKey::from_seed([0x01; 32]),
+        });
+        let inner = Header {
+            number: 1,
+            timestamp: 100,
+            ..Default::default()
+        };
+        let header = TempoHeader {
+            general_gas_limit: 15_000_000,
+            shared_gas_limit: 5_000_000,
+            timestamp_millis_part: 123,
+            inner: inner.clone(),
+            consensus_context,
+            proof_root: None,
+        };
+        let legacy_header = LegacyTempoHeader {
+            general_gas_limit: header.general_gas_limit,
+            shared_gas_limit: header.shared_gas_limit,
+            timestamp_millis_part: header.timestamp_millis_part,
+            inner,
+            consensus_context,
+        };
+
+        let legacy_encoded = alloy_rlp::encode(&legacy_header);
+        assert_eq!(alloy_rlp::encode(&header), legacy_encoded);
+        assert_eq!(header.hash_slow(), keccak256(legacy_encoded));
     }
 
     #[test]

--- a/crates/primitives/src/reth_compat/header.rs
+++ b/crates/primitives/src/reth_compat/header.rs
@@ -15,12 +15,14 @@ impl reth_primitives_traits::InMemorySize for TempoHeader {
             timestamp_millis_part,
             shared_gas_limit,
             consensus_context,
+            proof_root,
         } = self;
         inner.size()
             + general_gas_limit.size()
             + timestamp_millis_part.size()
             + shared_gas_limit.size()
             + consensus_context.as_ref().map_or(0, |f| f.size())
+            + proof_root.as_ref().map_or(0, |f| f.size())
     }
 }
 
@@ -65,6 +67,7 @@ impl reth_primitives_traits::header::HeaderMut for TempoHeader {
 mod codec {
     use crate::{TempoConsensusContext, TempoHeader};
     use alloy_consensus::Header;
+    use alloy_primitives::B256;
 
     /// Trailing fields grouped into a dedicated struct to maximize the use of bits
     /// in a type's bitfields. We add to this prior to occupying another slot in
@@ -74,6 +77,7 @@ mod codec {
     #[cfg_attr(test, reth_codecs::add_arbitrary_tests(compact))]
     struct TempoHeaderTrailingCompact {
         consensus_context: Option<TempoConsensusContext>,
+        proof_root: Option<B256>,
     }
 
     /// Private helper for Reth's Compat encoding where the last type
@@ -99,10 +103,10 @@ mod codec {
         where
             B: alloy_rlp::bytes::BufMut + AsMut<[u8]>,
         {
-            let trailing = self
-                .consensus_context
-                .map(|ctx| TempoHeaderTrailingCompact {
-                    consensus_context: Some(ctx),
+            let trailing = (self.consensus_context.is_some() || self.proof_root.is_some())
+                .then_some(TempoHeaderTrailingCompact {
+                    consensus_context: self.consensus_context,
+                    proof_root: self.proof_root,
                 });
 
             let header = TempoHeaderCompact {
@@ -118,11 +122,13 @@ mod codec {
 
         fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
             let (header_compat, buf) = TempoHeaderCompact::from_compact(buf, len);
+            let trailing = header_compat.trailing;
             let header = Self {
                 general_gas_limit: header_compat.general_gas_limit,
                 shared_gas_limit: header_compat.shared_gas_limit,
                 timestamp_millis_part: header_compat.timestamp_millis_part,
-                consensus_context: header_compat.trailing.and_then(|f| f.consensus_context),
+                consensus_context: trailing.as_ref().and_then(|f| f.consensus_context),
+                proof_root: trailing.and_then(|f| f.proof_root),
                 inner: header_compat.inner,
             };
 
@@ -184,6 +190,7 @@ mod codec {
                 shared_gas_limit: 10_000_000,
                 timestamp_millis_part: 500,
                 consensus_context: None,
+                proof_root: None,
                 inner: Header {
                     parent_hash: b256!(
                         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -252,6 +259,7 @@ mod codec {
                 shared_gas_limit: 0x2faf080,
                 timestamp_millis_part: 0x2c5,
                 consensus_context: None,
+                proof_root: None,
                 inner: Header {
                     parent_hash: b256!(
                         "49d7ec7085e77bf5a403d0fcb4cfc42a4084a89dfff60477579c5e09c9e03c54"

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -1157,6 +1157,14 @@ where
         self.protocol_pool.get_all_blobs_exact(tx_hashes)
     }
 
+    fn has_blobs_for_versioned_hashes(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<bool>, reth_transaction_pool::blobstore::BlobStoreError> {
+        self.protocol_pool
+            .has_blobs_for_versioned_hashes(versioned_hashes)
+    }
+
     fn get_blobs_for_versioned_hashes_v1(
         &self,
         versioned_hashes: &[B256],


### PR DESCRIPTION
## Summary

Implements the Tempo side of TIP-1082 proof root support on top of the reth auxiliary state root hooks.

This PR:
- adds optional `proofRoot` support to `TempoHeader`, including RLP/compact encoding and RPC header serialization
- activates proof roots at T8 via `TempoChainSpec`
- adds`ACCOUNT_KEYCHAIN_ADDRESS` & `TIP403_REGISTRY_ADDRESS` to the initial provable account whitelist
- computes payload `proofRoot` from post-execution bundle state filtered to the active provable account list
- wires post-execution validation through reth’s `PayloadValidator::auxiliary_state_root` flow
- validates proof root presence before/after activation and compares computed vs expected auxiliary roots
- retains sparse trie data for proof-root computation
- rejects `eth_getProof` requests for non-provable accounts after activation, and returns unsupported until persisted provable trie proof serving is implemented

