### PR TITLE
Fix provable proof root carry-forward

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -9,7 +9,7 @@ mod prewarming;
 
 pub use budget::DEFAULT_BUILD_TIME_MULTIPLIER;
 use crossbeam_channel::Sender;
-use reth_trie_common::ordered_root::OrderedTrieRootEncodedBuilder;
+use reth_trie_common::{Nibbles, ordered_root::OrderedTrieRootEncodedBuilder};
 
 use crate::{
     budget::{
@@ -973,6 +973,7 @@ where
 
         let proof_root = self.proof_root_for_payload_timestamp(
             &finish_provider,
+            &parent_header,
             &db.bundle_state,
             evm_env.block_env.inner.timestamp.to::<u64>(),
         )?;
@@ -1174,6 +1175,7 @@ where
     fn proof_root_for_payload_timestamp(
         &self,
         state_root_provider: &impl StateRootProvider,
+        parent_header: &TempoHeader,
         bundle_state: &reth_revm::db::states::bundle_state::BundleState,
         timestamp: u64,
     ) -> Result<Option<B256>, BlockExecutionError> {
@@ -1183,7 +1185,21 @@ where
         }
 
         let provable_accounts = chain_spec.provable_accounts_at_timestamp(timestamp);
-        let proof_trie_input = proof_trie_input_from_bundle_state(bundle_state, provable_accounts);
+        let mut proof_trie_input =
+            proof_trie_input_from_bundle_state(bundle_state, provable_accounts);
+
+        if proof_trie_input.state.is_empty() {
+            if let Some(parent_root) = parent_header.proof_root {
+                return Ok(Some(parent_root));
+            }
+
+            for address in provable_accounts {
+                proof_trie_input
+                    .prefix_sets
+                    .account_prefix_set
+                    .insert(Nibbles::unpack(keccak256(address)));
+            }
+        }
 
         // Compute the proof root through the same provider path used by the serial state-root
         // fallback after filtering and hashing the bundle state into proof-trie input.


### PR DESCRIPTION
## Summary
- carry forward the parent proof root when a TIP-1082 payload has no provable trie updates
- keep non-empty proof trie inputs on the existing state-root provider path
- add a regression test proving empty proof trie input does not touch the normal state provider

## Validation
- cargo fmt --check
- cargo test -p tempo-payload-builder empty_proof_trie_input_carries_forward_parent_proof_root --lib