### PR TITLE
feat(consensus): add marshal persistence metrics

### DIFF
--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -27,7 +27,7 @@ pub(crate) mod marshal {
     use crate::{
         consensus::{Digest, block::Block},
         epoch::SchemeProvider,
-        storage::{self, Hybrid, MeasuredBlocks, MeasuredCertificates},
+        storage::{self, Hybrid, MeasuredCertificates},
     };
 
     type FinalizationsByHeight<TContext> = MeasuredCertificates<
@@ -35,10 +35,8 @@ pub(crate) mod marshal {
         immutable::Archive<TContext, Digest, Finalization<Scheme<PublicKey, MinSig>, Digest>>,
     >;
 
-    type FinalizedBlocks<TContext> = MeasuredBlocks<
-        TContext,
-        Hybrid<TContext, BlockchainProvider<NodeTypesWithDBAdapter<TempoNode, DatabaseEnv>>>,
-    >;
+    type FinalizedBlocks<TContext> =
+        Hybrid<TContext, BlockchainProvider<NodeTypesWithDBAdapter<TempoNode, DatabaseEnv>>>;
 
     pub(crate) type Actor<TContext> = core::Actor<
         TContext,
@@ -158,11 +156,6 @@ pub(crate) mod marshal {
         )
         .await
         .wrap_err("failed to initialize hybrid finalized blocks store")?;
-        let finalized_blocks = MeasuredBlocks::new(
-            finalized_blocks,
-            context.with_label("marshal").with_label("finalized_blocks"),
-            "marshal finalized block store",
-        );
 
         let (actor, mailbox, marshal_stored_height) = core::Actor::init(
             context.with_label("marshal"),

--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -27,15 +27,25 @@ pub(crate) mod marshal {
     use crate::{
         consensus::{Digest, block::Block},
         epoch::SchemeProvider,
-        storage::{self, Hybrid},
+        storage::{self, Hybrid, MeasuredBlocks, MeasuredCertificates},
     };
+
+    type FinalizationsByHeight<TContext> = MeasuredCertificates<
+        TContext,
+        immutable::Archive<TContext, Digest, Finalization<Scheme<PublicKey, MinSig>, Digest>>,
+    >;
+
+    type FinalizedBlocks<TContext> = MeasuredBlocks<
+        TContext,
+        Hybrid<TContext, BlockchainProvider<NodeTypesWithDBAdapter<TempoNode, DatabaseEnv>>>,
+    >;
 
     pub(crate) type Actor<TContext> = core::Actor<
         TContext,
         Standard<Block>,
         SchemeProvider,
-        immutable::Archive<TContext, Digest, Finalization<Scheme<PublicKey, MinSig>, Digest>>,
-        Hybrid<TContext, BlockchainProvider<NodeTypesWithDBAdapter<TempoNode, DatabaseEnv>>>,
+        FinalizationsByHeight<TContext>,
+        FinalizedBlocks<TContext>,
         FixedEpocher,
         Sequential,
         Exact,
@@ -133,6 +143,11 @@ pub(crate) mod marshal {
         )
         .await
         .wrap_err("failed to initialize finalizations by height archive")?;
+        let finalizations_by_height = MeasuredCertificates::new(
+            finalizations_by_height,
+            context.with_label("marshal").with_label("finalizations"),
+            "marshal finalization certificate store",
+        );
 
         let finalized_blocks = storage::init_finalized_blocks(
             &context,
@@ -143,6 +158,11 @@ pub(crate) mod marshal {
         )
         .await
         .wrap_err("failed to initialize hybrid finalized blocks store")?;
+        let finalized_blocks = MeasuredBlocks::new(
+            finalized_blocks,
+            context.with_label("marshal").with_label("finalized_blocks"),
+            "marshal finalized block store",
+        );
 
         let (actor, mailbox, marshal_stored_height) = core::Actor::init(
             context.with_label("marshal"),

--- a/crates/consensus/src/storage/hybrid/mod.rs
+++ b/crates/consensus/src/storage/hybrid/mod.rs
@@ -75,13 +75,19 @@
 //!
 //! [`alias::marshal::init`]: crate::alias::marshal::init
 
+use std::sync::Arc;
+
 use alloy_primitives::B256;
 use commonware_consensus::{Heightable as _, marshal::store::Blocks, types::Height};
-use commonware_runtime::{BufferPooler, Clock, Metrics, Storage};
+use commonware_runtime::{
+    BufferPooler, Clock, Metrics, Storage,
+    telemetry::metrics::histogram::{self, Timed},
+};
 use commonware_storage::{
     archive::{self, Identifier, prunable},
     translator::TwoCap,
 };
+use prometheus_client::metrics::histogram::Histogram;
 use reth_node_core::primitives::SealedBlock;
 use reth_provider::{
     BlockReader, BlockSource, ProviderError, ProviderResult,
@@ -220,6 +226,9 @@ where
     /// older is dropped from the cache and served out of
     /// [`Self::execution_block_provider`] instead.
     pub(crate) retention_blocks: u64,
+
+    /// Metrics context used for marshal-facing finalized block store latency.
+    pub(crate) metrics_context: TContext,
 }
 
 /// Finalized blocks store backed by a prunable archive (a hot cache of
@@ -244,6 +253,9 @@ where
     /// older is dropped from the cache and served out of
     /// [`Self::execution_block_provider`] instead.
     retention_blocks: u64,
+
+    /// Duration histograms for marshal-facing store calls.
+    durations: OperationDurations<TContext>,
 }
 
 impl<TContext, P> Hybrid<TContext, P>
@@ -256,11 +268,13 @@ where
             prunable,
             execution_block_provider: provider,
             retention_blocks,
+            metrics_context,
         } = config;
         Self {
             prunable,
             execution_block_provider: provider,
             retention_blocks,
+            durations: OperationDurations::init(metrics_context),
         }
     }
 
@@ -291,18 +305,8 @@ where
         let prune_floor = min_to_keep.saturating_add(1);
         prunable::Archive::prune(&mut self.prunable, prune_floor).await
     }
-}
 
-impl<TContext, TExecutionBlockProvider> Blocks for Hybrid<TContext, TExecutionBlockProvider>
-where
-    TContext: BufferPooler + Storage + Metrics + Clock + Send + Sync + 'static,
-    TExecutionBlockProvider: FinalizedBlocksProvider + 'static,
-{
-    type Block = Block;
-    type Error = Error;
-
-    #[instrument(skip_all, err)]
-    async fn put(&mut self, block: Self::Block) -> Result<(), Self::Error> {
+    async fn put_inner(&mut self, block: Block) -> Result<(), Error> {
         let height = block.height();
         let digest = block.digest();
         match archive::Archive::put(&mut self.prunable, height.get(), digest, block).await {
@@ -345,10 +349,33 @@ where
         }
         Ok(())
     }
+}
+
+impl<TContext, TExecutionBlockProvider> Blocks for Hybrid<TContext, TExecutionBlockProvider>
+where
+    TContext: BufferPooler + Storage + Metrics + Clock + Send + Sync + 'static,
+    TExecutionBlockProvider: FinalizedBlocksProvider + 'static,
+{
+    type Block = Block;
+    type Error = Error;
+
+    #[instrument(skip_all, err)]
+    async fn put(&mut self, block: Self::Block) -> Result<(), Self::Error> {
+        let mut timer = self.durations.put.timer();
+        let result = self.put_inner(block).await;
+        timer.observe();
+        result
+    }
 
     async fn sync(&mut self) -> Result<(), Self::Error> {
-        archive::Archive::sync(&mut self.prunable).await?;
-        Ok(())
+        let mut timer = self.durations.sync.timer();
+        let result = async {
+            archive::Archive::sync(&mut self.prunable).await?;
+            Ok(())
+        }
+        .await;
+        timer.observe();
+        result
     }
 
     /// Attempts to read `id` from the prunable archive, falling back to EL on miss.
@@ -377,6 +404,8 @@ where
 
     /// No-op: Cache eviction is EL-driven (see [`Self::evict_below_execution_finalized_floor`]).
     async fn prune(&mut self, _min: Height) -> Result<(), Self::Error> {
+        let mut timer = self.durations.prune.timer();
+        timer.observe();
         Ok(())
     }
 
@@ -402,5 +431,50 @@ where
         // EL here would mask gaps the marshal needs to fill via the
         // resolver.
         archive::Archive::last_index(&self.prunable).map(Height::new)
+    }
+}
+
+/// Duration histograms for marshal-facing finalized block store calls.
+struct OperationDurations<TContext>
+where
+    TContext: Clock,
+{
+    put: Timed<TContext>,
+    sync: Timed<TContext>,
+    prune: Timed<TContext>,
+}
+
+impl<TContext> OperationDurations<TContext>
+where
+    TContext: Clock + Metrics,
+{
+    fn init(context: TContext) -> Self {
+        let put = Histogram::new(histogram::Buckets::LOCAL);
+        context.register(
+            "put_duration",
+            "Histogram of marshal finalized block store put calls, in seconds",
+            put.clone(),
+        );
+
+        let sync = Histogram::new(histogram::Buckets::LOCAL);
+        context.register(
+            "sync_duration",
+            "Histogram of marshal finalized block store sync calls, in seconds",
+            sync.clone(),
+        );
+
+        let prune = Histogram::new(histogram::Buckets::LOCAL);
+        context.register(
+            "prune_duration",
+            "Histogram of marshal finalized block store prune calls, in seconds",
+            prune.clone(),
+        );
+
+        let clock = Arc::new(context);
+        Self {
+            put: Timed::new(put, Arc::clone(&clock)),
+            sync: Timed::new(sync, Arc::clone(&clock)),
+            prune: Timed::new(prune, clock),
+        }
     }
 }

--- a/crates/consensus/src/storage/hybrid/mod.rs
+++ b/crates/consensus/src/storage/hybrid/mod.rs
@@ -75,19 +75,13 @@
 //!
 //! [`alias::marshal::init`]: crate::alias::marshal::init
 
-use std::sync::Arc;
-
 use alloy_primitives::B256;
 use commonware_consensus::{Heightable as _, marshal::store::Blocks, types::Height};
-use commonware_runtime::{
-    BufferPooler, Clock, Metrics, Storage,
-    telemetry::metrics::histogram::{self, Timed},
-};
+use commonware_runtime::{BufferPooler, Clock, Metrics, Storage};
 use commonware_storage::{
     archive::{self, Identifier, prunable},
     translator::TwoCap,
 };
-use prometheus_client::metrics::histogram::Histogram;
 use reth_node_core::primitives::SealedBlock;
 use reth_provider::{
     BlockReader, BlockSource, ProviderError, ProviderResult,
@@ -96,6 +90,8 @@ use reth_provider::{
 use tracing::{debug, info, instrument, warn};
 
 use crate::consensus::{Digest, block::Block};
+
+use super::measured::OperationDurations;
 
 #[cfg(test)]
 mod test;
@@ -274,7 +270,7 @@ where
             prunable,
             execution_block_provider: provider,
             retention_blocks,
-            durations: OperationDurations::init(metrics_context),
+            durations: OperationDurations::init(metrics_context, "marshal finalized block store"),
         }
     }
 
@@ -431,50 +427,5 @@ where
         // EL here would mask gaps the marshal needs to fill via the
         // resolver.
         archive::Archive::last_index(&self.prunable).map(Height::new)
-    }
-}
-
-/// Duration histograms for marshal-facing finalized block store calls.
-struct OperationDurations<TContext>
-where
-    TContext: Clock,
-{
-    put: Timed<TContext>,
-    sync: Timed<TContext>,
-    prune: Timed<TContext>,
-}
-
-impl<TContext> OperationDurations<TContext>
-where
-    TContext: Clock + Metrics,
-{
-    fn init(context: TContext) -> Self {
-        let put = Histogram::new(histogram::Buckets::LOCAL);
-        context.register(
-            "put_duration",
-            "Histogram of marshal finalized block store put calls, in seconds",
-            put.clone(),
-        );
-
-        let sync = Histogram::new(histogram::Buckets::LOCAL);
-        context.register(
-            "sync_duration",
-            "Histogram of marshal finalized block store sync calls, in seconds",
-            sync.clone(),
-        );
-
-        let prune = Histogram::new(histogram::Buckets::LOCAL);
-        context.register(
-            "prune_duration",
-            "Histogram of marshal finalized block store prune calls, in seconds",
-            prune.clone(),
-        );
-
-        let clock = Arc::new(context);
-        Self {
-            put: Timed::new(put, Arc::clone(&clock)),
-            sync: Timed::new(sync, Arc::clone(&clock)),
-            prune: Timed::new(prune, clock),
-        }
     }
 }

--- a/crates/consensus/src/storage/hybrid/test/mod.rs
+++ b/crates/consensus/src/storage/hybrid/test/mod.rs
@@ -59,6 +59,7 @@ impl SetupHybrid {
             prunable,
             execution_block_provider: provider.clone(),
             retention_blocks: self.retention,
+            metrics_context: context.with_label("marshal").with_label("finalized_blocks"),
         });
         (hybrid, provider)
     }

--- a/crates/consensus/src/storage/measured.rs
+++ b/crates/consensus/src/storage/measured.rs
@@ -1,4 +1,4 @@
-//! Tempo-side metrics wrappers for certificate stores passed to Commonware marshal.
+//! Tempo-side metrics helpers for stores passed to Commonware marshal.
 
 use std::sync::Arc;
 
@@ -13,23 +13,20 @@ use commonware_storage::archive::Identifier;
 use prometheus_client::metrics::histogram::Histogram;
 
 /// Duration histograms for one marshal store.
-struct OperationDurations<TContext>
+pub(in crate::storage) struct OperationDurations<TContext>
 where
     TContext: Clock,
 {
-    put: Timed<TContext>,
-    sync: Timed<TContext>,
-    prune: Timed<TContext>,
+    pub(in crate::storage) put: Timed<TContext>,
+    pub(in crate::storage) sync: Timed<TContext>,
+    pub(in crate::storage) prune: Timed<TContext>,
 }
 
 impl<TContext> OperationDurations<TContext>
 where
     TContext: Clock + RuntimeMetrics,
 {
-    fn init(context: TContext, store: &str) -> Self
-    where
-        TContext: RuntimeMetrics,
-    {
+    pub(in crate::storage) fn init(context: TContext, store: &str) -> Self {
         let put = Histogram::new(histogram::Buckets::LOCAL);
         context.register(
             "put_duration",
@@ -60,13 +57,49 @@ where
     }
 }
 
+/// Duration histograms for certificate store calls where only sync/prune matter.
+struct CertificateDurations<TContext>
+where
+    TContext: Clock,
+{
+    sync: Timed<TContext>,
+    prune: Timed<TContext>,
+}
+
+impl<TContext> CertificateDurations<TContext>
+where
+    TContext: Clock + RuntimeMetrics,
+{
+    fn init(context: TContext, store: &str) -> Self {
+        let sync = Histogram::new(histogram::Buckets::LOCAL);
+        context.register(
+            "sync_duration",
+            format!("Histogram of {store} sync calls, in seconds"),
+            sync.clone(),
+        );
+
+        let prune = Histogram::new(histogram::Buckets::LOCAL);
+        context.register(
+            "prune_duration",
+            format!("Histogram of {store} prune calls, in seconds"),
+            prune.clone(),
+        );
+
+        let clock = Arc::new(context);
+        Self {
+            sync: Timed::new(sync, Arc::clone(&clock)),
+            prune: Timed::new(prune, clock),
+        }
+    }
+}
+
 /// Measured wrapper for marshal finalization certificate stores.
 pub(crate) struct MeasuredCertificates<TContext, TStore>
 where
     TContext: Clock,
 {
     inner: TStore,
-    durations: OperationDurations<TContext>,
+    durations: CertificateDurations<TContext>,
 }
 
 impl<TContext, TStore> MeasuredCertificates<TContext, TStore>
@@ -80,7 +113,7 @@ where
     {
         Self {
             inner,
-            durations: OperationDurations::init(context, store),
+            durations: CertificateDurations::init(context, store),
         }
     }
 }
@@ -101,10 +134,7 @@ where
         digest: Self::BlockDigest,
         finalization: Finalization<Self::Scheme, Self::Commitment>,
     ) -> Result<(), Self::Error> {
-        let mut timer = self.durations.put.timer();
-        let result = self.inner.put(height, digest, finalization).await;
-        timer.observe();
-        result
+        self.inner.put(height, digest, finalization).await
     }
 
     async fn sync(&mut self) -> Result<(), Self::Error> {

--- a/crates/consensus/src/storage/measured.rs
+++ b/crates/consensus/src/storage/measured.rs
@@ -1,13 +1,10 @@
-//! Tempo-side metrics wrappers for the stores passed to Commonware marshal.
+//! Tempo-side metrics wrappers for certificate stores passed to Commonware marshal.
 
 use std::sync::Arc;
 
 use commonware_consensus::{
-    marshal::store::{Blocks, Certificates},
-    simplex::types::Finalization,
-    types::Height,
+    marshal::store::Certificates, simplex::types::Finalization, types::Height,
 };
-use commonware_cryptography::Digestible;
 use commonware_runtime::{
     Clock, Metrics as RuntimeMetrics,
     telemetry::metrics::histogram::{self, Timed},
@@ -137,79 +134,5 @@ where
 
     fn ranges_from(&self, from: Height) -> impl Iterator<Item = (Height, Height)> {
         self.inner.ranges_from(from)
-    }
-}
-
-/// Measured wrapper for marshal finalized block stores.
-pub(crate) struct MeasuredBlocks<TContext, TStore>
-where
-    TContext: Clock,
-{
-    inner: TStore,
-    durations: OperationDurations<TContext>,
-}
-
-impl<TContext, TStore> MeasuredBlocks<TContext, TStore>
-where
-    TContext: Clock,
-{
-    /// Wrap a finalized block store and register per-operation duration histograms.
-    pub(crate) fn new(inner: TStore, context: TContext, store: &str) -> Self
-    where
-        TContext: RuntimeMetrics,
-    {
-        Self {
-            inner,
-            durations: OperationDurations::init(context, store),
-        }
-    }
-}
-
-impl<TContext, TStore> Blocks for MeasuredBlocks<TContext, TStore>
-where
-    TContext: Clock + Send + Sync + 'static,
-    TStore: Blocks,
-{
-    type Block = TStore::Block;
-    type Error = TStore::Error;
-
-    async fn put(&mut self, block: Self::Block) -> Result<(), Self::Error> {
-        let mut timer = self.durations.put.timer();
-        let result = self.inner.put(block).await;
-        timer.observe();
-        result
-    }
-
-    async fn sync(&mut self) -> Result<(), Self::Error> {
-        let mut timer = self.durations.sync.timer();
-        let result = self.inner.sync().await;
-        timer.observe();
-        result
-    }
-
-    async fn get(
-        &self,
-        id: Identifier<'_, <Self::Block as Digestible>::Digest>,
-    ) -> Result<Option<Self::Block>, Self::Error> {
-        self.inner.get(id).await
-    }
-
-    async fn prune(&mut self, min: Height) -> Result<(), Self::Error> {
-        let mut timer = self.durations.prune.timer();
-        let result = self.inner.prune(min).await;
-        timer.observe();
-        result
-    }
-
-    fn missing_items(&self, start: Height, max: usize) -> Vec<Height> {
-        self.inner.missing_items(start, max)
-    }
-
-    fn next_gap(&self, value: Height) -> (Option<Height>, Option<Height>) {
-        self.inner.next_gap(value)
-    }
-
-    fn last_index(&self) -> Option<Height> {
-        self.inner.last_index()
     }
 }

--- a/crates/consensus/src/storage/measured.rs
+++ b/crates/consensus/src/storage/measured.rs
@@ -1,0 +1,215 @@
+//! Tempo-side metrics wrappers for the stores passed to Commonware marshal.
+
+use std::sync::Arc;
+
+use commonware_consensus::{
+    marshal::store::{Blocks, Certificates},
+    simplex::types::Finalization,
+    types::Height,
+};
+use commonware_cryptography::Digestible;
+use commonware_runtime::{
+    Clock, Metrics as RuntimeMetrics,
+    telemetry::metrics::histogram::{self, Timed},
+};
+use commonware_storage::archive::Identifier;
+use prometheus_client::metrics::histogram::Histogram;
+
+/// Duration histograms for one marshal store.
+struct OperationDurations<TContext>
+where
+    TContext: Clock,
+{
+    put: Timed<TContext>,
+    sync: Timed<TContext>,
+    prune: Timed<TContext>,
+}
+
+impl<TContext> OperationDurations<TContext>
+where
+    TContext: Clock + RuntimeMetrics,
+{
+    fn init(context: TContext, store: &str) -> Self
+    where
+        TContext: RuntimeMetrics,
+    {
+        let put = Histogram::new(histogram::Buckets::LOCAL);
+        context.register(
+            "put_duration",
+            format!("Histogram of {store} put calls, in seconds"),
+            put.clone(),
+        );
+
+        let sync = Histogram::new(histogram::Buckets::LOCAL);
+        context.register(
+            "sync_duration",
+            format!("Histogram of {store} sync calls, in seconds"),
+            sync.clone(),
+        );
+
+        let prune = Histogram::new(histogram::Buckets::LOCAL);
+        context.register(
+            "prune_duration",
+            format!("Histogram of {store} prune calls, in seconds"),
+            prune.clone(),
+        );
+
+        let clock = Arc::new(context);
+        Self {
+            put: Timed::new(put, Arc::clone(&clock)),
+            sync: Timed::new(sync, Arc::clone(&clock)),
+            prune: Timed::new(prune, clock),
+        }
+    }
+}
+
+/// Measured wrapper for marshal finalization certificate stores.
+pub(crate) struct MeasuredCertificates<TContext, TStore>
+where
+    TContext: Clock,
+{
+    inner: TStore,
+    durations: OperationDurations<TContext>,
+}
+
+impl<TContext, TStore> MeasuredCertificates<TContext, TStore>
+where
+    TContext: Clock,
+{
+    /// Wrap a certificate store and register per-operation duration histograms.
+    pub(crate) fn new(inner: TStore, context: TContext, store: &str) -> Self
+    where
+        TContext: RuntimeMetrics,
+    {
+        Self {
+            inner,
+            durations: OperationDurations::init(context, store),
+        }
+    }
+}
+
+impl<TContext, TStore> Certificates for MeasuredCertificates<TContext, TStore>
+where
+    TContext: Clock + Send + Sync + 'static,
+    TStore: Certificates,
+{
+    type BlockDigest = TStore::BlockDigest;
+    type Commitment = TStore::Commitment;
+    type Scheme = TStore::Scheme;
+    type Error = TStore::Error;
+
+    async fn put(
+        &mut self,
+        height: Height,
+        digest: Self::BlockDigest,
+        finalization: Finalization<Self::Scheme, Self::Commitment>,
+    ) -> Result<(), Self::Error> {
+        let mut timer = self.durations.put.timer();
+        let result = self.inner.put(height, digest, finalization).await;
+        timer.observe();
+        result
+    }
+
+    async fn sync(&mut self) -> Result<(), Self::Error> {
+        let mut timer = self.durations.sync.timer();
+        let result = self.inner.sync().await;
+        timer.observe();
+        result
+    }
+
+    async fn get(
+        &self,
+        id: Identifier<'_, Self::BlockDigest>,
+    ) -> Result<Option<Finalization<Self::Scheme, Self::Commitment>>, Self::Error> {
+        self.inner.get(id).await
+    }
+
+    async fn prune(&mut self, min: Height) -> Result<(), Self::Error> {
+        let mut timer = self.durations.prune.timer();
+        let result = self.inner.prune(min).await;
+        timer.observe();
+        result
+    }
+
+    fn last_index(&self) -> Option<Height> {
+        self.inner.last_index()
+    }
+
+    fn ranges_from(&self, from: Height) -> impl Iterator<Item = (Height, Height)> {
+        self.inner.ranges_from(from)
+    }
+}
+
+/// Measured wrapper for marshal finalized block stores.
+pub(crate) struct MeasuredBlocks<TContext, TStore>
+where
+    TContext: Clock,
+{
+    inner: TStore,
+    durations: OperationDurations<TContext>,
+}
+
+impl<TContext, TStore> MeasuredBlocks<TContext, TStore>
+where
+    TContext: Clock,
+{
+    /// Wrap a finalized block store and register per-operation duration histograms.
+    pub(crate) fn new(inner: TStore, context: TContext, store: &str) -> Self
+    where
+        TContext: RuntimeMetrics,
+    {
+        Self {
+            inner,
+            durations: OperationDurations::init(context, store),
+        }
+    }
+}
+
+impl<TContext, TStore> Blocks for MeasuredBlocks<TContext, TStore>
+where
+    TContext: Clock + Send + Sync + 'static,
+    TStore: Blocks,
+{
+    type Block = TStore::Block;
+    type Error = TStore::Error;
+
+    async fn put(&mut self, block: Self::Block) -> Result<(), Self::Error> {
+        let mut timer = self.durations.put.timer();
+        let result = self.inner.put(block).await;
+        timer.observe();
+        result
+    }
+
+    async fn sync(&mut self) -> Result<(), Self::Error> {
+        let mut timer = self.durations.sync.timer();
+        let result = self.inner.sync().await;
+        timer.observe();
+        result
+    }
+
+    async fn get(
+        &self,
+        id: Identifier<'_, <Self::Block as Digestible>::Digest>,
+    ) -> Result<Option<Self::Block>, Self::Error> {
+        self.inner.get(id).await
+    }
+
+    async fn prune(&mut self, min: Height) -> Result<(), Self::Error> {
+        let mut timer = self.durations.prune.timer();
+        let result = self.inner.prune(min).await;
+        timer.observe();
+        result
+    }
+
+    fn missing_items(&self, start: Height, max: usize) -> Vec<Height> {
+        self.inner.missing_items(start, max)
+    }
+
+    fn next_gap(&self, value: Height) -> (Option<Height>, Option<Height>) {
+        self.inner.next_gap(value)
+    }
+
+    fn last_index(&self) -> Option<Height> {
+        self.inner.last_index()
+    }
+}

--- a/crates/consensus/src/storage/mod.rs
+++ b/crates/consensus/src/storage/mod.rs
@@ -27,9 +27,11 @@ use crate::{
 };
 
 pub(crate) mod hybrid;
+mod measured;
 pub mod snapshot;
 
 pub(crate) use hybrid::{FinalizedBlocksProvider, Hybrid};
+pub(crate) use measured::{MeasuredBlocks, MeasuredCertificates};
 
 const FINALIZATIONS_BY_HEIGHT: &str = "finalizations-by-height";
 const PRUNABLE_FINALIZED_BLOCKS: &str = "finalized-blocks-prunable";

--- a/crates/consensus/src/storage/mod.rs
+++ b/crates/consensus/src/storage/mod.rs
@@ -31,7 +31,7 @@ mod measured;
 pub mod snapshot;
 
 pub(crate) use hybrid::{FinalizedBlocksProvider, Hybrid};
-pub(crate) use measured::{MeasuredBlocks, MeasuredCertificates};
+pub(crate) use measured::MeasuredCertificates;
 
 const FINALIZATIONS_BY_HEIGHT: &str = "finalizations-by-height";
 const PRUNABLE_FINALIZED_BLOCKS: &str = "finalized-blocks-prunable";
@@ -149,6 +149,7 @@ where
         prunable,
         execution_block_provider: provider,
         retention_blocks,
+        metrics_context: context.with_label("marshal").with_label("finalized_blocks"),
     }))
 }
 


### PR DESCRIPTION
Adds Tempo-side wrappers around the Commonware Marshal finalization and finalized-block stores to record put, sync, and prune duration histograms. This gives valscope real Marshal persistence latency signals without patching Commonware or scraping logs.

Validated with:
- cargo +nightly fmt
- cargo check -p tempo-consensus
- cargo test -p tempo-consensus storage::hybrid