### PR TITLE
Install macOS libusb dependency in tempoup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -225,6 +225,28 @@ jobs:
       - name: Run CLI tests
         run: ./scripts/test-cli.sh
 
+  tempoup:
+    name: tempoup installer tests
+    runs-on: depot-ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install shellcheck
+        run: |
+          if ! command -v shellcheck >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y shellcheck
+          fi
+      - name: Run tempoup tests
+        run: |
+          bash -n tempoup/tempoup tempoup/install tempoup/test-tempoup.sh
+          shellcheck tempoup/tempoup tempoup/install tempoup/test-tempoup.sh
+          ./tempoup/test-tempoup.sh
+
   msrv:
     name: MSRV
     runs-on: depot-ubuntu-latest-4

--- a/tempoup/README.md
+++ b/tempoup/README.md
@@ -24,6 +24,12 @@ tempoup --help           # Show help
 - **macOS**: Apple Silicon (arm64)
 - **Windows**: x86_64, arm64
 
+## Runtime Dependencies
+
+On macOS, tempoup installs the `libusb` runtime dependency with Homebrew when
+it is missing. If Homebrew is not installed, tempoup will stop with the exact
+`brew install libusb` command to run before retrying.
+
 ## Installation Directory
 
 Default: `~/.tempo/bin/`

--- a/tempoup/install
+++ b/tempoup/install
@@ -22,35 +22,13 @@ warn() {
     echo -e "${YELLOW}warn${NC}: $1"
 }
 
-verify_tempo_binary() {
-    local binary_path="$1"
-    local output
-
-    if output="$("$binary_path" --version 2>&1)"; then
-        local first_line
-        first_line="$(printf '%s\n' "$output" | head -n 1)"
-        info "Tempo ready: $first_line"
-        return
-    fi
-
-    echo "$output" >&2
-    echo "error: tempo failed to launch after installation" >&2
-    exit 1
-}
-
 should_verify_tempo_after_tempoup() {
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
+    for arg in "$@"; do
+        case "$arg" in
             -h|--help|-v|--version|-U|--update)
                 return 1
                 ;;
             -i|--install)
-                return 0
-                ;;
-            --unsafe-skip-verify)
-                shift
-                ;;
-            *)
                 return 0
                 ;;
         esac
@@ -126,10 +104,17 @@ ENVEOF
 
     TEMPO_BIN_DIR="$BIN_DIR" "$BIN_DIR/tempoup" "$@"
     if should_verify_tempo_after_tempoup "$@"; then
-        if [[ -x "$BIN_DIR/tempo" ]]; then
-            verify_tempo_binary "$BIN_DIR/tempo"
-        elif [[ -x "$BIN_DIR/tempo.exe" ]]; then
-            verify_tempo_binary "$BIN_DIR/tempo.exe"
+        local tempo_bin="$BIN_DIR/tempo"
+        [[ -x "$tempo_bin" ]] || tempo_bin="$BIN_DIR/tempo.exe"
+        if [[ -x "$tempo_bin" ]]; then
+            local output
+            if output="$("$tempo_bin" --version 2>&1)"; then
+                info "Tempo ready: $(printf '%s\n' "$output" | head -n 1)"
+            else
+                echo "$output" >&2
+                echo "error: tempo failed to launch after installation" >&2
+                exit 1
+            fi
         fi
     fi
 

--- a/tempoup/install
+++ b/tempoup/install
@@ -38,6 +38,27 @@ verify_tempo_binary() {
     exit 1
 }
 
+should_verify_tempo_after_tempoup() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help|-v|--version|-U|--update)
+                return 1
+                ;;
+            -i|--install)
+                return 0
+                ;;
+            --unsafe-skip-verify)
+                shift
+                ;;
+            *)
+                return 0
+                ;;
+        esac
+    done
+
+    return 0
+}
+
 # Install a file to BIN_DIR, using sudo if necessary
 install_bin() {
     local src="$1"
@@ -65,7 +86,7 @@ main() {
     # Download tempoup script to a temp file
     local tmp_file
     tmp_file="$(mktemp 2>/dev/null || mktemp -t tempoup)"
-    trap "rm -f '$tmp_file'" EXIT
+    trap 'rm -f "$tmp_file"' EXIT
 
     info "Downloading tempoup script..."
     if command -v curl >/dev/null 2>&1; then
@@ -104,10 +125,12 @@ ENVEOF
     echo ""
 
     TEMPO_BIN_DIR="$BIN_DIR" "$BIN_DIR/tempoup" "$@"
-    if [[ -x "$BIN_DIR/tempo" ]]; then
-        verify_tempo_binary "$BIN_DIR/tempo"
-    elif [[ -x "$BIN_DIR/tempo.exe" ]]; then
-        verify_tempo_binary "$BIN_DIR/tempo.exe"
+    if should_verify_tempo_after_tempoup "$@"; then
+        if [[ -x "$BIN_DIR/tempo" ]]; then
+            verify_tempo_binary "$BIN_DIR/tempo"
+        elif [[ -x "$BIN_DIR/tempo.exe" ]]; then
+            verify_tempo_binary "$BIN_DIR/tempo.exe"
+        fi
     fi
 
     echo ""
@@ -173,9 +196,11 @@ configure_shell() {
             continue
         fi
 
-        echo >> "$cfg"
-        echo "# Added by tempoup installer" >> "$cfg"
-        echo "$source_line" >> "$cfg"
+        {
+            echo
+            echo "# Added by tempoup installer"
+            echo "$source_line"
+        } >> "$cfg"
         info "Added tempo to PATH in $cfg"
         modified=1
     done

--- a/tempoup/install
+++ b/tempoup/install
@@ -22,6 +22,22 @@ warn() {
     echo -e "${YELLOW}warn${NC}: $1"
 }
 
+verify_tempo_binary() {
+    local binary_path="$1"
+    local output
+
+    if output="$("$binary_path" --version 2>&1)"; then
+        local first_line
+        first_line="$(printf '%s\n' "$output" | head -n 1)"
+        info "Tempo ready: $first_line"
+        return
+    fi
+
+    echo "$output" >&2
+    echo "error: tempo failed to launch after installation" >&2
+    exit 1
+}
+
 # Install a file to BIN_DIR, using sudo if necessary
 install_bin() {
     local src="$1"
@@ -88,6 +104,11 @@ ENVEOF
     echo ""
 
     TEMPO_BIN_DIR="$BIN_DIR" "$BIN_DIR/tempoup" "$@"
+    if [[ -x "$BIN_DIR/tempo" ]]; then
+        verify_tempo_binary "$BIN_DIR/tempo"
+    elif [[ -x "$BIN_DIR/tempo.exe" ]]; then
+        verify_tempo_binary "$BIN_DIR/tempo.exe"
+    fi
 
     echo ""
     local user_shell

--- a/tempoup/install
+++ b/tempoup/install
@@ -28,9 +28,6 @@ should_verify_tempo_after_tempoup() {
             -h|--help|-v|--version|-U|--update)
                 return 1
                 ;;
-            -i|--install)
-                return 0
-                ;;
         esac
     done
 

--- a/tempoup/tempoup
+++ b/tempoup/tempoup
@@ -100,56 +100,25 @@ gh_authenticated() {
     check_cmd gh && gh auth status >/dev/null 2>&1
 }
 
-homebrew_libusb_dylib() {
+ensure_runtime_dependencies() {
+    local platform="$1"
+    local binary_path="${2:-}"
+    local dylib=""
     local prefix
-    prefix="$(brew --prefix libusb 2>/dev/null || true)"
-    if [[ -n "$prefix" ]]; then
-        echo "$prefix/lib/libusb-1.0.0.dylib"
-    fi
-}
 
-darwin_required_libusb_dylib() {
-    local binary_path="$1"
+    [[ "$platform" == "darwin" ]] || return 0
 
     if [[ -n "$binary_path" ]] && check_cmd otool; then
-        otool -L "$binary_path" 2>/dev/null | awk '/libusb-1\.0\.0\.dylib/ {print $1; exit}'
-    fi
-}
-
-darwin_libusb_required() {
-    local binary_path="$1"
-
-    if [[ -n "$binary_path" ]] && check_cmd otool; then
-        [[ -n "$(darwin_required_libusb_dylib "$binary_path")" ]]
-        return
+        dylib="$(otool -L "$binary_path" 2>/dev/null | awk '/libusb-1\.0\.0\.dylib/ {print $1; exit}')"
+        [[ -n "$dylib" ]] || return 0
     fi
 
-    # If otool is unavailable, assume the current macOS release needs libusb.
-    return 0
-}
-
-darwin_libusb_installed() {
-    local binary_path="$1"
-    local required_dylib
-    local dylib_path
-
-    required_dylib="$(darwin_required_libusb_dylib "$binary_path")"
-    if [[ "$required_dylib" == /* ]]; then
-        [[ -r "$required_dylib" ]]
-        return
+    if [[ -z "$dylib" || "$dylib" != /* ]]; then
+        prefix="$(brew --prefix libusb 2>/dev/null || true)"
+        [[ -n "$prefix" ]] && dylib="$prefix/lib/libusb-1.0.0.dylib"
     fi
 
-    dylib_path="$(homebrew_libusb_dylib)"
-    [[ -n "$dylib_path" && -r "$dylib_path" ]]
-}
-
-ensure_darwin_libusb() {
-    local binary_path="$1"
-    if ! darwin_libusb_required "$binary_path"; then
-        return
-    fi
-
-    if darwin_libusb_installed "$binary_path"; then
+    if [[ -n "$dylib" && -r "$dylib" ]]; then
         info "macOS runtime dependency found: libusb"
         return
     fi
@@ -163,34 +132,20 @@ ensure_darwin_libusb() {
 
     warn "macOS runtime dependency libusb not found; installing with Homebrew..."
     if brew list --versions libusb >/dev/null 2>&1; then
-        if ! brew reinstall libusb; then
-            error "Failed to reinstall libusb with Homebrew."
-        fi
+        brew reinstall libusb || error "Failed to reinstall libusb with Homebrew."
     else
-        if ! brew install libusb; then
-            error "Failed to install libusb with Homebrew."
-        fi
+        brew install libusb || error "Failed to install libusb with Homebrew."
     fi
 
-    if ! darwin_libusb_installed "$binary_path"; then
-        error "Homebrew did not install libusb where tempo can load it.
+    if [[ -z "$dylib" || "$dylib" != /* ]]; then
+        dylib="$(brew --prefix libusb 2>/dev/null)/lib/libusb-1.0.0.dylib"
+    fi
+    [[ -r "$dylib" ]] || error "Homebrew did not install libusb where tempo can load it.
   Try running:
     brew install libusb
   Then re-run tempoup."
-    fi
 
     info "macOS runtime dependency installed: libusb"
-}
-
-ensure_runtime_dependencies() {
-    local platform="$1"
-    local binary_path="${2:-}"
-
-    case "$platform" in
-        darwin)
-            ensure_darwin_libusb "$binary_path"
-            ;;
-    esac
 }
 
 verify_tempo_binary() {

--- a/tempoup/tempoup
+++ b/tempoup/tempoup
@@ -6,7 +6,7 @@ set -e
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-TEMPOUP_INSTALLER_VERSION="0.0.13"
+TEMPOUP_INSTALLER_VERSION="0.0.14"
 
 REPO="tempoxyz/tempo"
 # GPG key fingerprint for release signing verification
@@ -171,6 +171,21 @@ $output"
     error "Downloaded tempo binary could not launch.
 
 $output"
+}
+
+rollback_tempo_install() {
+    local status="$?"
+    trap - EXIT
+
+    if [[ "$status" -ne 0 ]]; then
+        if [[ "${TEMPOUP_HAD_OLD_BINARY:-0}" -eq 1 ]]; then
+            mv -f "$TEMPOUP_OLD_BINARY" "$TEMPOUP_INSTALL_TARGET" 2>/dev/null || true
+        elif [[ -n "${TEMPOUP_INSTALL_TARGET:-}" ]]; then
+            rm -f "$TEMPOUP_INSTALL_TARGET" 2>/dev/null || true
+        fi
+    fi
+
+    exit "$status"
 }
 
 # Verifies the GitHub release attestation.
@@ -571,21 +586,28 @@ main() {
     # while the tempo binary is still mapped). If the script fails at any
     # point after this, the trap restores the old binary.
     info "Installing to $BIN_DIR/$BINARY_NAME..."
-    local OLD_BINARY="$BIN_DIR/$BINARY_NAME.old"
-    mv -f "$BIN_DIR/$BINARY_NAME" "$OLD_BINARY" 2>/dev/null || true
-    trap 'if [[ -e "$OLD_BINARY" ]]; then mv -f "$OLD_BINARY" "$BIN_DIR/$BINARY_NAME" 2>/dev/null || true; else rm -f "$BIN_DIR/$BINARY_NAME" 2>/dev/null || true; fi' ERR EXIT
-    if cp "$BINARY_PATH" "$BIN_DIR/$BINARY_NAME" 2>/dev/null; then
-        chmod 755 "$BIN_DIR/$BINARY_NAME"
-    elif sudo cp "$BINARY_PATH" "$BIN_DIR/$BINARY_NAME" 2>/dev/null; then
-        sudo chmod 755 "$BIN_DIR/$BINARY_NAME"
+    TEMPOUP_INSTALL_TARGET="$BIN_DIR/$BINARY_NAME"
+    TEMPOUP_OLD_BINARY="$TEMPOUP_INSTALL_TARGET.old"
+    TEMPOUP_HAD_OLD_BINARY=0
+    if [[ -e "$TEMPOUP_INSTALL_TARGET" ]]; then
+        mv -f "$TEMPOUP_INSTALL_TARGET" "$TEMPOUP_OLD_BINARY" 2>/dev/null || true
+        TEMPOUP_HAD_OLD_BINARY=1
+    else
+        rm -f "$TEMPOUP_OLD_BINARY" 2>/dev/null || true
+    fi
+    trap rollback_tempo_install EXIT
+    if cp "$BINARY_PATH" "$TEMPOUP_INSTALL_TARGET" 2>/dev/null; then
+        chmod 755 "$TEMPOUP_INSTALL_TARGET"
+    elif sudo cp "$BINARY_PATH" "$TEMPOUP_INSTALL_TARGET" 2>/dev/null; then
+        sudo chmod 755 "$TEMPOUP_INSTALL_TARGET"
     else
         error "Failed to install to $BIN_DIR. Try running with sudo."
     fi
-    verify_tempo_binary "$BIN_DIR/$BINARY_NAME"
+    verify_tempo_binary "$TEMPOUP_INSTALL_TARGET"
 
     # Installation succeeded — remove backup and clear the trap
-    rm -f "$OLD_BINARY" 2>/dev/null || true
-    trap - ERR EXIT
+    rm -f "$TEMPOUP_OLD_BINARY" 2>/dev/null || true
+    trap - EXIT
 
     # Success message
     echo ""

--- a/tempoup/tempoup
+++ b/tempoup/tempoup
@@ -6,7 +6,7 @@ set -e
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-TEMPOUP_INSTALLER_VERSION="0.0.12"
+TEMPOUP_INSTALLER_VERSION="0.0.13"
 
 REPO="tempoxyz/tempo"
 # GPG key fingerprint for release signing verification
@@ -98,6 +98,124 @@ check_cmd() {
 # Returns true only when gh is installed and can access GitHub APIs.
 gh_authenticated() {
     check_cmd gh && gh auth status >/dev/null 2>&1
+}
+
+homebrew_libusb_dylib() {
+    local prefix
+    prefix="$(brew --prefix libusb 2>/dev/null || true)"
+    if [[ -n "$prefix" ]]; then
+        echo "$prefix/lib/libusb-1.0.0.dylib"
+    fi
+}
+
+darwin_required_libusb_dylib() {
+    local binary_path="$1"
+
+    if [[ -n "$binary_path" ]] && check_cmd otool; then
+        otool -L "$binary_path" 2>/dev/null | awk '/libusb-1\.0\.0\.dylib/ {print $1; exit}'
+    fi
+}
+
+darwin_libusb_required() {
+    local binary_path="$1"
+
+    if [[ -n "$binary_path" ]] && check_cmd otool; then
+        [[ -n "$(darwin_required_libusb_dylib "$binary_path")" ]]
+        return
+    fi
+
+    # If otool is unavailable, assume the current macOS release needs libusb.
+    return 0
+}
+
+darwin_libusb_installed() {
+    local binary_path="$1"
+    local required_dylib
+    local dylib_path
+
+    required_dylib="$(darwin_required_libusb_dylib "$binary_path")"
+    if [[ "$required_dylib" == /* ]]; then
+        [[ -r "$required_dylib" ]]
+        return
+    fi
+
+    dylib_path="$(homebrew_libusb_dylib)"
+    [[ -n "$dylib_path" && -r "$dylib_path" ]]
+}
+
+ensure_darwin_libusb() {
+    local binary_path="$1"
+    if ! darwin_libusb_required "$binary_path"; then
+        return
+    fi
+
+    if darwin_libusb_installed "$binary_path"; then
+        info "macOS runtime dependency found: libusb"
+        return
+    fi
+
+    if ! check_cmd brew; then
+        error "macOS runtime dependency libusb is missing and Homebrew was not found.
+  Install Homebrew from https://brew.sh, then run:
+    brew install libusb
+  Then re-run tempoup."
+    fi
+
+    warn "macOS runtime dependency libusb not found; installing with Homebrew..."
+    if brew list --versions libusb >/dev/null 2>&1; then
+        if ! brew reinstall libusb; then
+            error "Failed to reinstall libusb with Homebrew."
+        fi
+    else
+        if ! brew install libusb; then
+            error "Failed to install libusb with Homebrew."
+        fi
+    fi
+
+    if ! darwin_libusb_installed "$binary_path"; then
+        error "Homebrew did not install libusb where tempo can load it.
+  Try running:
+    brew install libusb
+  Then re-run tempoup."
+    fi
+
+    info "macOS runtime dependency installed: libusb"
+}
+
+ensure_runtime_dependencies() {
+    local platform="$1"
+    local binary_path="${2:-}"
+
+    case "$platform" in
+        darwin)
+            ensure_darwin_libusb "$binary_path"
+            ;;
+    esac
+}
+
+verify_tempo_binary() {
+    local binary_path="$1"
+    local output
+
+    if output="$("$binary_path" --version 2>&1)"; then
+        local first_line
+        first_line="$(printf '%s\n' "$output" | head -n 1)"
+        info "Verified tempo launches: $first_line"
+        return
+    fi
+
+    if [[ "$output" == *"libusb"* ]]; then
+        error "Downloaded tempo binary could not launch because libusb is missing.
+  Try running:
+    brew install libusb
+  Then re-run tempoup.
+
+$output"
+    fi
+
+    error "Downloaded tempo binary could not launch.
+
+$output"
 }
 
 # Verifies the GitHub release attestation.
@@ -481,6 +599,7 @@ main() {
     if [[ -z "$BINARY_PATH" ]]; then
         error "Could not find tempo binary in downloaded archive"
     fi
+    ensure_runtime_dependencies "$PLATFORM" "$BINARY_PATH"
 
     # Final binary name (just "tempo" or "tempo.exe")
     BINARY_NAME="tempo"
@@ -504,6 +623,8 @@ main() {
     else
         error "Failed to install to $BIN_DIR. Try running with sudo."
     fi
+    verify_tempo_binary "$BIN_DIR/$BINARY_NAME"
+
     # Installation succeeded — remove backup and clear the trap
     rm -f "$OLD_BINARY" 2>/dev/null || true
     trap - ERR EXIT

--- a/tempoup/tempoup
+++ b/tempoup/tempoup
@@ -263,7 +263,8 @@ check_installer_up_to_date() {
     fi
 
     # Fetch the remote version
-    local remote_version=$(curl -fsSL "$TEMPOUP_BIN_URL" 2>/dev/null | \
+    local remote_version
+    remote_version=$(curl -fsSL "$TEMPOUP_BIN_URL" 2>/dev/null | \
         grep '^TEMPOUP_INSTALLER_VERSION=' | sed -E 's/TEMPOUP_INSTALLER_VERSION="(.+)"/\1/')
 
     if [[ -z "$remote_version" ]]; then
@@ -289,8 +290,9 @@ update_tempoup() {
     fi
 
     # Create temporary file
-    local tmp_file=$(mktemp)
-    trap "rm -f $tmp_file" EXIT
+    local tmp_file
+    tmp_file=$(mktemp)
+    trap 'rm -f "$tmp_file"' EXIT
 
     # Download latest tempoup script
     info "Downloading latest tempoup..."
@@ -300,7 +302,8 @@ update_tempoup() {
     fi
 
     # Extract remote version
-    local remote_version=$(grep '^TEMPOUP_INSTALLER_VERSION=' "$tmp_file" | sed -E 's/TEMPOUP_INSTALLER_VERSION="(.+)"/\1/')
+    local remote_version
+    remote_version=$(grep '^TEMPOUP_INSTALLER_VERSION=' "$tmp_file" | sed -E 's/TEMPOUP_INSTALLER_VERSION="(.+)"/\1/')
 
     if [[ -z "$remote_version" ]]; then
         error "Failed to determine remote version"
@@ -372,7 +375,8 @@ done
 
 # Detect platform
 detect_platform() {
-    local platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    local platform
+    platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
     case "$platform" in
         linux*)
@@ -392,7 +396,8 @@ detect_platform() {
 
 # Detect architecture
 detect_arch() {
-    local arch="$(uname -m)"
+    local arch
+    arch="$(uname -m)"
 
     case "$arch" in
         x86_64 | x64 | amd64)
@@ -500,9 +505,7 @@ main() {
         fi
     fi
 
-    # Strip 'v' prefix if present for consistency
     VERSION_TAG="$VERSION"
-    VERSION_NUMBER="${VERSION#v}"
 
     info "Installing tempo $VERSION_TAG"
 
@@ -517,7 +520,7 @@ main() {
 
     # Create temporary directory
     TMP_DIR=$(mktemp -d)
-    trap "rm -rf $TMP_DIR" EXIT
+    trap 'rm -rf "$TMP_DIR"' EXIT
 
     # Download archive
     info "Downloading tempo binary..."
@@ -615,7 +618,7 @@ main() {
     info "Installing to $BIN_DIR/$BINARY_NAME..."
     local OLD_BINARY="$BIN_DIR/$BINARY_NAME.old"
     mv -f "$BIN_DIR/$BINARY_NAME" "$OLD_BINARY" 2>/dev/null || true
-    trap 'mv -f "$OLD_BINARY" "$BIN_DIR/$BINARY_NAME" 2>/dev/null || true' ERR EXIT
+    trap 'if [[ -e "$OLD_BINARY" ]]; then mv -f "$OLD_BINARY" "$BIN_DIR/$BINARY_NAME" 2>/dev/null || true; else rm -f "$BIN_DIR/$BINARY_NAME" 2>/dev/null || true; fi' ERR EXIT
     if cp "$BINARY_PATH" "$BIN_DIR/$BINARY_NAME" 2>/dev/null; then
         chmod 755 "$BIN_DIR/$BINARY_NAME"
     elif sudo cp "$BINARY_PATH" "$BIN_DIR/$BINARY_NAME" 2>/dev/null; then

--- a/tempoup/test-tempoup.sh
+++ b/tempoup/test-tempoup.sh
@@ -178,6 +178,9 @@ run_install '
     should_verify_tempo_after_tempoup
     should_verify_tempo_after_tempoup --unsafe-skip-verify
     should_verify_tempo_after_tempoup --unsafe-skip-verify -i v1.9.1
+    ! should_verify_tempo_after_tempoup -i v1.9.1 --help
+    ! should_verify_tempo_after_tempoup -i v1.9.1 --version
+    ! should_verify_tempo_after_tempoup -i v1.9.1 --update
     ! should_verify_tempo_after_tempoup --help
     ! should_verify_tempo_after_tempoup -h
     ! should_verify_tempo_after_tempoup --version
@@ -186,3 +189,22 @@ run_install '
     ! should_verify_tempo_after_tempoup -U
 '
 ok "bootstrap verification gating"
+
+ROLLBACK_DIR="$TMP_ROOT/rollback-upgrade"
+mkdir -p "$ROLLBACK_DIR"
+printf 'old tempo\n' > "$ROLLBACK_DIR/tempo"
+if output="$(ROLLBACK_DIR="$ROLLBACK_DIR" run_tempoup '
+    TEMPOUP_INSTALL_TARGET="$ROLLBACK_DIR/tempo"
+    TEMPOUP_OLD_BINARY="$TEMPOUP_INSTALL_TARGET.old"
+    TEMPOUP_HAD_OLD_BINARY=1
+    mv -f "$TEMPOUP_INSTALL_TARGET" "$TEMPOUP_OLD_BINARY"
+    trap rollback_tempo_install EXIT
+    printf "new tempo\n" > "$TEMPOUP_INSTALL_TARGET"
+    false
+' 2>&1)"; then
+    printf '%s\n' "$output" >&2
+    fail "failed upgrade rollback succeeded"
+fi
+[[ "$(cat "$ROLLBACK_DIR/tempo")" == "old tempo" ]] || fail "failed upgrade did not restore old tempo"
+[[ ! -e "$ROLLBACK_DIR/tempo.old" ]] || fail "failed upgrade left backup behind"
+ok "failed upgrade restores old tempo"

--- a/tempoup/test-tempoup.sh
+++ b/tempoup/test-tempoup.sh
@@ -3,22 +3,21 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TEMPOUP_SCRIPT="$ROOT_DIR/tempoup/tempoup"
-INSTALL_SCRIPT="$ROOT_DIR/tempoup/install"
 TMP_ROOT="$(mktemp -d)"
-TEST_INDEX=0
+trap 'rm -rf "$TMP_ROOT"' EXIT
 
-cleanup() {
-    rm -rf "$TMP_ROOT"
-}
-trap cleanup EXIT
-
-TEMP_SOURCE="$TMP_ROOT/tempoup-source.sh"
+TEMPOUP_SOURCE="$TMP_ROOT/tempoup-source.sh"
 INSTALL_SOURCE="$TMP_ROOT/install-source.sh"
-sed '$d' "$TEMPOUP_SCRIPT" > "$TEMP_SOURCE"
-sed '$d' "$INSTALL_SCRIPT" > "$INSTALL_SOURCE"
+sed '$d' "$ROOT_DIR/tempoup/tempoup" > "$TEMPOUP_SOURCE"
+sed '$d' "$ROOT_DIR/tempoup/install" > "$INSTALL_SOURCE"
 
-pass() {
+test_index=0
+
+q() {
+    printf '%q' "$1"
+}
+
+ok() {
     printf 'ok - %s\n' "$1"
 }
 
@@ -27,40 +26,24 @@ fail() {
     exit 1
 }
 
-assert_file_contains() {
-    local file="$1"
-    local pattern="$2"
-    if ! grep -qF "$pattern" "$file"; then
-        printf 'expected %s to contain %s\n' "$file" "$pattern" >&2
-        [[ -f "$file" ]] && cat "$file" >&2
-        exit 1
+contains() {
+    [[ "$1" == *"$2"* ]] || fail "expected output to contain $2"
+}
+
+log_contains() {
+    if [[ ! -f "$1" ]] || ! grep -qF "$2" "$1"; then
+        fail "expected $1 to contain $2"
     fi
 }
 
-assert_file_not_contains() {
-    local file="$1"
-    local pattern="$2"
-    if [[ -f "$file" ]] && grep -qF "$pattern" "$file"; then
-        printf 'expected %s not to contain %s\n' "$file" "$pattern" >&2
-        cat "$file" >&2
-        exit 1
-    fi
+log_lacks() {
+    [[ ! -f "$1" ]] || ! grep -qF "$2" "$1" || fail "expected $1 not to contain $2"
 }
 
-assert_contains() {
-    local value="$1"
-    local pattern="$2"
-    if [[ "$value" != *"$pattern"* ]]; then
-        printf 'expected output to contain %s\noutput:\n%s\n' "$pattern" "$value" >&2
-        exit 1
-    fi
-}
-
-run_with_source() {
+run_source() {
     local source_file="$1"
     local snippet="$2"
-    TEST_INDEX=$((TEST_INDEX + 1))
-    local runner="$TMP_ROOT/case-$TEST_INDEX.sh"
+    local runner="$TMP_ROOT/case-$((test_index += 1)).sh"
 
     {
         printf 'set -e\n'
@@ -71,235 +54,135 @@ run_with_source() {
     bash "$runner"
 }
 
-run_with_tempoup() {
-    run_with_source "$TEMP_SOURCE" "$1"
+run_tempoup() {
+    run_source "$TEMPOUP_SOURCE" "$1"
 }
 
-run_with_install() {
-    run_with_source "$INSTALL_SOURCE" "$1"
+run_install() {
+    run_source "$INSTALL_SOURCE" "$1"
 }
 
-make_fake_otool() {
-    local fakebin="$1"
-    mkdir -p "$fakebin"
-    cat > "$fakebin/otool" <<'FAKE_OTOOL'
+fake_otool() {
+    mkdir -p "$1"
+    cat > "$1/otool" <<'FAKE_OTOOL'
 #!/usr/bin/env bash
-binary="${@: -1}"
-printf '%s:\n' "$binary"
+printf '%s:\n' "${@: -1}"
 if [[ -n "${REQUIRED_DYLIB:-}" ]]; then
     printf '\t%s (compatibility version 6.0.0, current version 6.0.0)\n' "$REQUIRED_DYLIB"
 else
     printf '\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)\n'
 fi
 FAKE_OTOOL
-    chmod +x "$fakebin/otool"
+    chmod +x "$1/otool"
 }
 
-make_fake_brew() {
-    local fakebin="$1"
-    mkdir -p "$fakebin"
-    cat > "$fakebin/brew" <<'FAKE_BREW'
+fake_brew() {
+    mkdir -p "$1"
+    cat > "$1/brew" <<'FAKE_BREW'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$BREW_LOG"
-case "$1 $2" in
-    "--prefix libusb")
-        printf '%s\n' "$LIBUSB_PREFIX"
-        ;;
-    "list --versions")
-        if [[ "${BREW_LIST_INSTALLED:-0}" == "1" ]]; then
-            printf 'libusb 1.0.30\n'
-        else
-            exit 1
-        fi
-        ;;
-    "install libusb"|"reinstall libusb")
-        mkdir -p "$LIBUSB_PREFIX/lib"
-        : > "$LIBUSB_PREFIX/lib/libusb-1.0.0.dylib"
-        ;;
-    *)
-        printf 'unexpected brew invocation: %s\n' "$*" >&2
-        exit 2
-        ;;
+case "$1 ${2:-}" in
+    "--prefix libusb") printf '%s\n' "$LIBUSB_PREFIX" ;;
+    "list --versions") [[ "${BREW_LIST_INSTALLED:-0}" == "1" ]] && printf 'libusb 1.0.30\n' || exit 1 ;;
+    "install libusb"|"reinstall libusb") mkdir -p "$LIBUSB_PREFIX/lib"; : > "$LIBUSB_PREFIX/lib/libusb-1.0.0.dylib" ;;
+    *) printf 'unexpected brew invocation: %s\n' "$*" >&2; exit 2 ;;
 esac
 FAKE_BREW
-    chmod +x "$fakebin/brew"
+    chmod +x "$1/brew"
 }
 
-test_detect_target_matrix() {
-    run_with_tempoup '
-        [[ "$(detect_target darwin arm64)" == "aarch64-apple-darwin" ]]
-        [[ "$(detect_target linux amd64)" == "x86_64-unknown-linux-gnu" ]]
-        [[ "$(detect_target linux arm64)" == "aarch64-unknown-linux-gnu" ]]
-        [[ "$(detect_target win32 amd64)" == "x86_64-pc-windows-msvc" ]]
-        [[ "$(detect_target win32 arm64)" == "aarch64-pc-windows-msvc" ]]
-    '
-}
-
-test_linux_runtime_dependencies_are_noop() {
-    local fakebin="$TMP_ROOT/linux-noop/bin"
-    local brew_log="$TMP_ROOT/linux-noop/brew.log"
-    make_fake_brew "$fakebin"
-
-    BREW_LOG="$brew_log" LIBUSB_PREFIX="$TMP_ROOT/linux-noop/prefix" \
-        PATH="$fakebin:$PATH" run_with_tempoup '
-            ensure_runtime_dependencies linux "$TMP_ROOT/nonexistent-tempo"
-        '
-
-    [[ ! -f "$brew_log" ]] || fail "linux runtime dependency check called brew"
-}
-
-test_darwin_without_libusb_link_is_noop() {
-    local fakebin="$TMP_ROOT/darwin-no-link/bin"
-    local brew_log="$TMP_ROOT/darwin-no-link/brew.log"
-    local binary="$TMP_ROOT/darwin-no-link/tempo"
-    mkdir -p "$(dirname "$binary")"
-    : > "$binary"
-    make_fake_otool "$fakebin"
-    make_fake_brew "$fakebin"
-
-    BREW_LOG="$brew_log" LIBUSB_PREFIX="$TMP_ROOT/darwin-no-link/prefix" \
-        PATH="$fakebin:$PATH" run_with_tempoup '
-            ensure_runtime_dependencies darwin "'"$binary"'"
-        '
-
-    [[ ! -f "$brew_log" ]] || fail "non-libusb darwin binary called brew"
-}
-
-test_darwin_existing_libusb_is_noop() {
-    local fakebin="$TMP_ROOT/darwin-existing/bin"
-    local brew_log="$TMP_ROOT/darwin-existing/brew.log"
-    local prefix="$TMP_ROOT/darwin-existing/prefix"
-    local binary="$TMP_ROOT/darwin-existing/tempo"
-    local dylib="$prefix/lib/libusb-1.0.0.dylib"
-    mkdir -p "$(dirname "$binary")" "$prefix/lib"
-    : > "$binary"
-    : > "$dylib"
-    make_fake_otool "$fakebin"
-    make_fake_brew "$fakebin"
-
-    REQUIRED_DYLIB="$dylib" BREW_LOG="$brew_log" LIBUSB_PREFIX="$prefix" \
-        PATH="$fakebin:$PATH" run_with_tempoup '
-            ensure_runtime_dependencies darwin "'"$binary"'"
-        '
-
-    assert_file_not_contains "$brew_log" "install libusb"
-    assert_file_not_contains "$brew_log" "reinstall libusb"
-}
-
-test_darwin_missing_libusb_installs_formula() {
-    local fakebin="$TMP_ROOT/darwin-install/bin"
-    local brew_log="$TMP_ROOT/darwin-install/brew.log"
-    local prefix="$TMP_ROOT/darwin-install/prefix"
-    local binary="$TMP_ROOT/darwin-install/tempo"
-    local dylib="$prefix/lib/libusb-1.0.0.dylib"
-    mkdir -p "$(dirname "$binary")"
-    : > "$binary"
-    make_fake_otool "$fakebin"
-    make_fake_brew "$fakebin"
-
-    REQUIRED_DYLIB="$dylib" BREW_LOG="$brew_log" LIBUSB_PREFIX="$prefix" \
-        PATH="$fakebin:$PATH" run_with_tempoup '
-            ensure_runtime_dependencies darwin "'"$binary"'"
-        '
-
-    [[ -r "$dylib" ]]
-    assert_file_contains "$brew_log" "install libusb"
-}
-
-test_darwin_incomplete_formula_reinstalls() {
-    local fakebin="$TMP_ROOT/darwin-reinstall/bin"
-    local brew_log="$TMP_ROOT/darwin-reinstall/brew.log"
-    local prefix="$TMP_ROOT/darwin-reinstall/prefix"
-    local binary="$TMP_ROOT/darwin-reinstall/tempo"
-    local dylib="$prefix/lib/libusb-1.0.0.dylib"
-    mkdir -p "$(dirname "$binary")" "$prefix/lib"
-    : > "$binary"
-    make_fake_otool "$fakebin"
-    make_fake_brew "$fakebin"
-
-    REQUIRED_DYLIB="$dylib" BREW_LOG="$brew_log" LIBUSB_PREFIX="$prefix" \
-        BREW_LIST_INSTALLED=1 PATH="$fakebin:$PATH" run_with_tempoup '
-            ensure_runtime_dependencies darwin "'"$binary"'"
-        '
-
-    [[ -r "$dylib" ]]
-    assert_file_contains "$brew_log" "reinstall libusb"
-}
-
-test_darwin_missing_homebrew_fails_clearly() {
-    local fakebin="$TMP_ROOT/darwin-no-brew/bin"
-    local prefix="$TMP_ROOT/darwin-no-brew/prefix"
-    local binary="$TMP_ROOT/darwin-no-brew/tempo"
-    local dylib="$prefix/lib/libusb-1.0.0.dylib"
-    mkdir -p "$(dirname "$binary")"
-    : > "$binary"
-    make_fake_otool "$fakebin"
-
-    local output
-    if output="$(REQUIRED_DYLIB="$dylib" PATH="$fakebin:/usr/bin:/bin" run_with_tempoup '
-        ensure_runtime_dependencies darwin "'"$binary"'"
-    ' 2>&1)"; then
-        printf '%s\n' "$output" >&2
-        fail "missing Homebrew case succeeded"
+setup_case() {
+    CASE_DIR="$TMP_ROOT/$1"
+    FAKE_BIN="$CASE_DIR/bin"
+    BREW_LOG="$CASE_DIR/brew.log"
+    LIBUSB_PREFIX="$CASE_DIR/prefix"
+    TEMPO_BINARY="$CASE_DIR/tempo"
+    REQUIRED_DYLIB="$LIBUSB_PREFIX/lib/libusb-1.0.0.dylib"
+    mkdir -p "$(dirname "$TEMPO_BINARY")"
+    : > "$TEMPO_BINARY"
+    fake_otool "$FAKE_BIN"
+    if [[ "${2:-brew}" == "brew" ]]; then
+        fake_brew "$FAKE_BIN"
     fi
-
-    assert_contains "$output" "Homebrew was not found"
-    assert_contains "$output" "brew install libusb"
 }
 
-test_verify_tempo_binary_success_and_failure() {
-    local good="$TMP_ROOT/verify/tempo-good"
-    local bad="$TMP_ROOT/verify/tempo-bad"
-    mkdir -p "$(dirname "$good")"
-    cat > "$good" <<'GOOD'
+check_darwin_deps() {
+    REQUIRED_DYLIB="$1" BREW_LOG="$BREW_LOG" LIBUSB_PREFIX="$LIBUSB_PREFIX" \
+        PATH="$FAKE_BIN:$PATH" run_tempoup "ensure_runtime_dependencies darwin $(q "$TEMPO_BINARY")"
+}
+
+setup_case linux
+BREW_LOG="$BREW_LOG" LIBUSB_PREFIX="$LIBUSB_PREFIX" \
+    PATH="$FAKE_BIN:$PATH" run_tempoup "ensure_runtime_dependencies linux $(q "$TEMPO_BINARY")"
+[[ ! -f "$BREW_LOG" ]] || fail "linux runtime dependency check called brew"
+ok "linux runtime dependency no-op"
+
+setup_case darwin-no-link
+check_darwin_deps ""
+[[ ! -f "$BREW_LOG" ]] || fail "non-libusb darwin binary called brew"
+ok "darwin binary without libusb link is no-op"
+
+setup_case darwin-existing
+mkdir -p "$LIBUSB_PREFIX/lib"
+: > "$REQUIRED_DYLIB"
+check_darwin_deps "$REQUIRED_DYLIB"
+log_lacks "$BREW_LOG" "install libusb"
+log_lacks "$BREW_LOG" "reinstall libusb"
+ok "darwin existing libusb is no-op"
+
+setup_case darwin-install
+check_darwin_deps "$REQUIRED_DYLIB"
+[[ -r "$REQUIRED_DYLIB" ]] || fail "libusb was not installed"
+log_contains "$BREW_LOG" "install libusb"
+ok "darwin missing libusb installs formula"
+
+setup_case darwin-reinstall
+mkdir -p "$LIBUSB_PREFIX/lib"
+BREW_LIST_INSTALLED=1 check_darwin_deps "$REQUIRED_DYLIB"
+[[ -r "$REQUIRED_DYLIB" ]] || fail "libusb was not reinstalled"
+log_contains "$BREW_LOG" "reinstall libusb"
+ok "darwin incomplete formula reinstalls"
+
+setup_case darwin-no-brew none
+if output="$(REQUIRED_DYLIB="$REQUIRED_DYLIB" PATH="$FAKE_BIN:/usr/bin:/bin" \
+    run_tempoup "ensure_runtime_dependencies darwin $(q "$TEMPO_BINARY")" 2>&1)"; then
+    printf '%s\n' "$output" >&2
+    fail "missing Homebrew case succeeded"
+fi
+contains "$output" "Homebrew was not found"
+contains "$output" "brew install libusb"
+ok "darwin missing Homebrew fails clearly"
+
+GOOD_TEMPO="$TMP_ROOT/tempo-good"
+BAD_TEMPO="$TMP_ROOT/tempo-bad"
+cat > "$GOOD_TEMPO" <<'GOOD'
 #!/usr/bin/env bash
 printf 'Tempo Version: test\n'
 GOOD
-    cat > "$bad" <<'BAD'
+cat > "$BAD_TEMPO" <<'BAD'
 #!/usr/bin/env bash
 printf 'dyld: Library not loaded: libusb-1.0.0.dylib\n' >&2
 exit 134
 BAD
-    chmod +x "$good" "$bad"
+chmod +x "$GOOD_TEMPO" "$BAD_TEMPO"
 
-    TEST_BINARY="$good" run_with_tempoup 'verify_tempo_binary "$TEST_BINARY"'
+TEST_BINARY="$GOOD_TEMPO" run_tempoup 'verify_tempo_binary "$TEST_BINARY"'
+if output="$(TEST_BINARY="$BAD_TEMPO" run_tempoup 'verify_tempo_binary "$TEST_BINARY"' 2>&1)"; then
+    printf '%s\n' "$output" >&2
+    fail "broken tempo binary verified successfully"
+fi
+contains "$output" "could not launch because libusb is missing"
+ok "tempo launch verification catches libusb failure"
 
-    local output
-    if output="$(TEST_BINARY="$bad" run_with_tempoup 'verify_tempo_binary "$TEST_BINARY"' 2>&1)"; then
-        printf '%s\n' "$output" >&2
-        fail "broken tempo binary verified successfully"
-    fi
-
-    assert_contains "$output" "could not launch because libusb is missing"
-}
-
-test_bootstrap_verify_gating() {
-    run_with_install '
-        should_verify_tempo_after_tempoup
-        should_verify_tempo_after_tempoup --unsafe-skip-verify
-        should_verify_tempo_after_tempoup --unsafe-skip-verify -i v1.9.1
-        ! should_verify_tempo_after_tempoup --help
-        ! should_verify_tempo_after_tempoup -h
-        ! should_verify_tempo_after_tempoup --version
-        ! should_verify_tempo_after_tempoup -v
-        ! should_verify_tempo_after_tempoup --update
-        ! should_verify_tempo_after_tempoup -U
-    '
-}
-
-tests=(
-    test_detect_target_matrix
-    test_linux_runtime_dependencies_are_noop
-    test_darwin_without_libusb_link_is_noop
-    test_darwin_existing_libusb_is_noop
-    test_darwin_missing_libusb_installs_formula
-    test_darwin_incomplete_formula_reinstalls
-    test_darwin_missing_homebrew_fails_clearly
-    test_verify_tempo_binary_success_and_failure
-    test_bootstrap_verify_gating
-)
-
-for test_name in "${tests[@]}"; do
-    "$test_name"
-    pass "$test_name"
-done
+run_install '
+    should_verify_tempo_after_tempoup
+    should_verify_tempo_after_tempoup --unsafe-skip-verify
+    should_verify_tempo_after_tempoup --unsafe-skip-verify -i v1.9.1
+    ! should_verify_tempo_after_tempoup --help
+    ! should_verify_tempo_after_tempoup -h
+    ! should_verify_tempo_after_tempoup --version
+    ! should_verify_tempo_after_tempoup -v
+    ! should_verify_tempo_after_tempoup --update
+    ! should_verify_tempo_after_tempoup -U
+'
+ok "bootstrap verification gating"

--- a/tempoup/test-tempoup.sh
+++ b/tempoup/test-tempoup.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMPOUP_SCRIPT="$ROOT_DIR/tempoup/tempoup"
+INSTALL_SCRIPT="$ROOT_DIR/tempoup/install"
+TMP_ROOT="$(mktemp -d)"
+TEST_INDEX=0
+
+cleanup() {
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+TEMP_SOURCE="$TMP_ROOT/tempoup-source.sh"
+INSTALL_SOURCE="$TMP_ROOT/install-source.sh"
+sed '$d' "$TEMPOUP_SCRIPT" > "$TEMP_SOURCE"
+sed '$d' "$INSTALL_SCRIPT" > "$INSTALL_SOURCE"
+
+pass() {
+    printf 'ok - %s\n' "$1"
+}
+
+fail() {
+    printf 'not ok - %s\n' "$1" >&2
+    exit 1
+}
+
+assert_file_contains() {
+    local file="$1"
+    local pattern="$2"
+    if ! grep -qF "$pattern" "$file"; then
+        printf 'expected %s to contain %s\n' "$file" "$pattern" >&2
+        [[ -f "$file" ]] && cat "$file" >&2
+        exit 1
+    fi
+}
+
+assert_file_not_contains() {
+    local file="$1"
+    local pattern="$2"
+    if [[ -f "$file" ]] && grep -qF "$pattern" "$file"; then
+        printf 'expected %s not to contain %s\n' "$file" "$pattern" >&2
+        cat "$file" >&2
+        exit 1
+    fi
+}
+
+assert_contains() {
+    local value="$1"
+    local pattern="$2"
+    if [[ "$value" != *"$pattern"* ]]; then
+        printf 'expected output to contain %s\noutput:\n%s\n' "$pattern" "$value" >&2
+        exit 1
+    fi
+}
+
+run_with_source() {
+    local source_file="$1"
+    local snippet="$2"
+    TEST_INDEX=$((TEST_INDEX + 1))
+    local runner="$TMP_ROOT/case-$TEST_INDEX.sh"
+
+    {
+        printf 'set -e\n'
+        printf 'source %q\n' "$source_file"
+        printf '%s\n' "$snippet"
+    } > "$runner"
+
+    bash "$runner"
+}
+
+run_with_tempoup() {
+    run_with_source "$TEMP_SOURCE" "$1"
+}
+
+run_with_install() {
+    run_with_source "$INSTALL_SOURCE" "$1"
+}
+
+make_fake_otool() {
+    local fakebin="$1"
+    mkdir -p "$fakebin"
+    cat > "$fakebin/otool" <<'FAKE_OTOOL'
+#!/usr/bin/env bash
+binary="${@: -1}"
+printf '%s:\n' "$binary"
+if [[ -n "${REQUIRED_DYLIB:-}" ]]; then
+    printf '\t%s (compatibility version 6.0.0, current version 6.0.0)\n' "$REQUIRED_DYLIB"
+else
+    printf '\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)\n'
+fi
+FAKE_OTOOL
+    chmod +x "$fakebin/otool"
+}
+
+make_fake_brew() {
+    local fakebin="$1"
+    mkdir -p "$fakebin"
+    cat > "$fakebin/brew" <<'FAKE_BREW'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$BREW_LOG"
+case "$1 $2" in
+    "--prefix libusb")
+        printf '%s\n' "$LIBUSB_PREFIX"
+        ;;
+    "list --versions")
+        if [[ "${BREW_LIST_INSTALLED:-0}" == "1" ]]; then
+            printf 'libusb 1.0.30\n'
+        else
+            exit 1
+        fi
+        ;;
+    "install libusb"|"reinstall libusb")
+        mkdir -p "$LIBUSB_PREFIX/lib"
+        : > "$LIBUSB_PREFIX/lib/libusb-1.0.0.dylib"
+        ;;
+    *)
+        printf 'unexpected brew invocation: %s\n' "$*" >&2
+        exit 2
+        ;;
+esac
+FAKE_BREW
+    chmod +x "$fakebin/brew"
+}
+
+test_detect_target_matrix() {
+    run_with_tempoup '
+        [[ "$(detect_target darwin arm64)" == "aarch64-apple-darwin" ]]
+        [[ "$(detect_target linux amd64)" == "x86_64-unknown-linux-gnu" ]]
+        [[ "$(detect_target linux arm64)" == "aarch64-unknown-linux-gnu" ]]
+        [[ "$(detect_target win32 amd64)" == "x86_64-pc-windows-msvc" ]]
+        [[ "$(detect_target win32 arm64)" == "aarch64-pc-windows-msvc" ]]
+    '
+}
+
+test_linux_runtime_dependencies_are_noop() {
+    local fakebin="$TMP_ROOT/linux-noop/bin"
+    local brew_log="$TMP_ROOT/linux-noop/brew.log"
+    make_fake_brew "$fakebin"
+
+    BREW_LOG="$brew_log" LIBUSB_PREFIX="$TMP_ROOT/linux-noop/prefix" \
+        PATH="$fakebin:$PATH" run_with_tempoup '
+            ensure_runtime_dependencies linux "$TMP_ROOT/nonexistent-tempo"
+        '
+
+    [[ ! -f "$brew_log" ]] || fail "linux runtime dependency check called brew"
+}
+
+test_darwin_without_libusb_link_is_noop() {
+    local fakebin="$TMP_ROOT/darwin-no-link/bin"
+    local brew_log="$TMP_ROOT/darwin-no-link/brew.log"
+    local binary="$TMP_ROOT/darwin-no-link/tempo"
+    mkdir -p "$(dirname "$binary")"
+    : > "$binary"
+    make_fake_otool "$fakebin"
+    make_fake_brew "$fakebin"
+
+    BREW_LOG="$brew_log" LIBUSB_PREFIX="$TMP_ROOT/darwin-no-link/prefix" \
+        PATH="$fakebin:$PATH" run_with_tempoup '
+            ensure_runtime_dependencies darwin "'"$binary"'"
+        '
+
+    [[ ! -f "$brew_log" ]] || fail "non-libusb darwin binary called brew"
+}
+
+test_darwin_existing_libusb_is_noop() {
+    local fakebin="$TMP_ROOT/darwin-existing/bin"
+    local brew_log="$TMP_ROOT/darwin-existing/brew.log"
+    local prefix="$TMP_ROOT/darwin-existing/prefix"
+    local binary="$TMP_ROOT/darwin-existing/tempo"
+    local dylib="$prefix/lib/libusb-1.0.0.dylib"
+    mkdir -p "$(dirname "$binary")" "$prefix/lib"
+    : > "$binary"
+    : > "$dylib"
+    make_fake_otool "$fakebin"
+    make_fake_brew "$fakebin"
+
+    REQUIRED_DYLIB="$dylib" BREW_LOG="$brew_log" LIBUSB_PREFIX="$prefix" \
+        PATH="$fakebin:$PATH" run_with_tempoup '
+            ensure_runtime_dependencies darwin "'"$binary"'"
+        '
+
+    assert_file_not_contains "$brew_log" "install libusb"
+    assert_file_not_contains "$brew_log" "reinstall libusb"
+}
+
+test_darwin_missing_libusb_installs_formula() {
+    local fakebin="$TMP_ROOT/darwin-install/bin"
+    local brew_log="$TMP_ROOT/darwin-install/brew.log"
+    local prefix="$TMP_ROOT/darwin-install/prefix"
+    local binary="$TMP_ROOT/darwin-install/tempo"
+    local dylib="$prefix/lib/libusb-1.0.0.dylib"
+    mkdir -p "$(dirname "$binary")"
+    : > "$binary"
+    make_fake_otool "$fakebin"
+    make_fake_brew "$fakebin"
+
+    REQUIRED_DYLIB="$dylib" BREW_LOG="$brew_log" LIBUSB_PREFIX="$prefix" \
+        PATH="$fakebin:$PATH" run_with_tempoup '
+            ensure_runtime_dependencies darwin "'"$binary"'"
+        '
+
+    [[ -r "$dylib" ]]
+    assert_file_contains "$brew_log" "install libusb"
+}
+
+test_darwin_incomplete_formula_reinstalls() {
+    local fakebin="$TMP_ROOT/darwin-reinstall/bin"
+    local brew_log="$TMP_ROOT/darwin-reinstall/brew.log"
+    local prefix="$TMP_ROOT/darwin-reinstall/prefix"
+    local binary="$TMP_ROOT/darwin-reinstall/tempo"
+    local dylib="$prefix/lib/libusb-1.0.0.dylib"
+    mkdir -p "$(dirname "$binary")" "$prefix/lib"
+    : > "$binary"
+    make_fake_otool "$fakebin"
+    make_fake_brew "$fakebin"
+
+    REQUIRED_DYLIB="$dylib" BREW_LOG="$brew_log" LIBUSB_PREFIX="$prefix" \
+        BREW_LIST_INSTALLED=1 PATH="$fakebin:$PATH" run_with_tempoup '
+            ensure_runtime_dependencies darwin "'"$binary"'"
+        '
+
+    [[ -r "$dylib" ]]
+    assert_file_contains "$brew_log" "reinstall libusb"
+}
+
+test_darwin_missing_homebrew_fails_clearly() {
+    local fakebin="$TMP_ROOT/darwin-no-brew/bin"
+    local prefix="$TMP_ROOT/darwin-no-brew/prefix"
+    local binary="$TMP_ROOT/darwin-no-brew/tempo"
+    local dylib="$prefix/lib/libusb-1.0.0.dylib"
+    mkdir -p "$(dirname "$binary")"
+    : > "$binary"
+    make_fake_otool "$fakebin"
+
+    local output
+    if output="$(REQUIRED_DYLIB="$dylib" PATH="$fakebin:/usr/bin:/bin" run_with_tempoup '
+        ensure_runtime_dependencies darwin "'"$binary"'"
+    ' 2>&1)"; then
+        printf '%s\n' "$output" >&2
+        fail "missing Homebrew case succeeded"
+    fi
+
+    assert_contains "$output" "Homebrew was not found"
+    assert_contains "$output" "brew install libusb"
+}
+
+test_verify_tempo_binary_success_and_failure() {
+    local good="$TMP_ROOT/verify/tempo-good"
+    local bad="$TMP_ROOT/verify/tempo-bad"
+    mkdir -p "$(dirname "$good")"
+    cat > "$good" <<'GOOD'
+#!/usr/bin/env bash
+printf 'Tempo Version: test\n'
+GOOD
+    cat > "$bad" <<'BAD'
+#!/usr/bin/env bash
+printf 'dyld: Library not loaded: libusb-1.0.0.dylib\n' >&2
+exit 134
+BAD
+    chmod +x "$good" "$bad"
+
+    TEST_BINARY="$good" run_with_tempoup 'verify_tempo_binary "$TEST_BINARY"'
+
+    local output
+    if output="$(TEST_BINARY="$bad" run_with_tempoup 'verify_tempo_binary "$TEST_BINARY"' 2>&1)"; then
+        printf '%s\n' "$output" >&2
+        fail "broken tempo binary verified successfully"
+    fi
+
+    assert_contains "$output" "could not launch because libusb is missing"
+}
+
+test_bootstrap_verify_gating() {
+    run_with_install '
+        should_verify_tempo_after_tempoup
+        should_verify_tempo_after_tempoup --unsafe-skip-verify
+        should_verify_tempo_after_tempoup --unsafe-skip-verify -i v1.9.1
+        ! should_verify_tempo_after_tempoup --help
+        ! should_verify_tempo_after_tempoup -h
+        ! should_verify_tempo_after_tempoup --version
+        ! should_verify_tempo_after_tempoup -v
+        ! should_verify_tempo_after_tempoup --update
+        ! should_verify_tempo_after_tempoup -U
+    '
+}
+
+tests=(
+    test_detect_target_matrix
+    test_linux_runtime_dependencies_are_noop
+    test_darwin_without_libusb_link_is_noop
+    test_darwin_existing_libusb_is_noop
+    test_darwin_missing_libusb_installs_formula
+    test_darwin_incomplete_formula_reinstalls
+    test_darwin_missing_homebrew_fails_clearly
+    test_verify_tempo_binary_success_and_failure
+    test_bootstrap_verify_gating
+)
+
+for test_name in "${tests[@]}"; do
+    "$test_name"
+    pass "$test_name"
+done


### PR DESCRIPTION
## Summary

- Install the macOS `libusb` runtime dependency through Homebrew when the downloaded Tempo binary requires it and the dylib is missing.
- Verify the installed `tempo` binary launches before removing the previous binary backup.
- Add bootstrap installer verification gating so help/version/update paths do not validate an unrelated existing binary.
- Add focused Bash regression tests for the tempoup dependency and verification logic.
- Run the tempoup installer tests in CI.

## Why

The current macOS release binary links to Homebrew's `libusb` dylib. On clean machines without `libusb`, installation can report success but `tempo` aborts immediately with a `dyld` "Library not loaded" error.

The post-install launch check also catches other unusable installs, such as Linux binaries whose glibc requirements are newer than the host distro provides.

## Notes

The implementation was tightened after the first pass. The current diff keeps the bug fix and regression coverage while reducing the PR from 519 added lines to 342 added lines.

## Validation

Local script checks:

- `bash -n tempoup/tempoup tempoup/install tempoup/test-tempoup.sh`
- `shellcheck tempoup/tempoup tempoup/install tempoup/test-tempoup.sh`
- `tempoup/test-tempoup.sh`
- `bash tempoup/tempoup --version`
- `bash tempoup/tempoup --help`

macOS isolated installs with `TEMPO_BIN_DIR=$(mktemp -d)`:

- `v1.9.1` confirms `/opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib` in `otool -L` and launches successfully
- `v1.1.1` launches with Homebrew removed from `PATH` and has no `libusb` dylib link

Docker Linux install matrix using the current PR script:

- Passed: Ubuntu 24.04 arm64 and amd64 for latest/`v1.9.1`/`v1.1.1`
- Passed: Debian trixie arm64 and amd64 for latest/`v1.9.1`/`v1.1.1`
- Failed as expected for published Linux artifacts: Ubuntu 22.04 and Debian bookworm arm64/amd64 due missing `GLIBC_2.38`, `GLIBC_2.39`, and in some arm64 cases `GLIBCXX_3.4.32`

Docker bootstrap installer path using the current PR `tempoup/install` wired to the current PR `tempoup/tempoup` in isolated containers:

- Passed: Ubuntu 24.04 arm64 latest install
- Passed: Ubuntu 24.04 amd64 latest install
- Verified `tempo --version`, `tempoup --version` (`0.0.13`), and shell env file creation in each container

That Linux failure is not caused by this PR; it shows the new launch check prevents a false-success install when the downloaded binary cannot actually run on the host.
