### PR TITLE
Merge main into PR 6237

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: master
+          ref: centaur/update-tempo-pr-6206-1782139029
           path: foundry
           persist-credentials: false
 
@@ -261,7 +261,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: master
+          ref: centaur/update-tempo-pr-6206-1782139029
           path: foundry
           persist-credentials: false
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6671,9 +6671,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -17,7 +17,7 @@ use reth_revm::{
 };
 use std::ops::{Deref, DerefMut};
 use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_precompiles::storage::{StorageAction, StorageActions};
+use tempo_precompiles::storage::StorageAction;
 use tempo_revm::{
     TempoHaltReason, TempoInvalidTransaction, TempoTxEnv, ValidationContext, evm::TempoContext,
     handler::TempoEvmHandler,
@@ -65,8 +65,6 @@ impl EvmFactory for TempoEvmFactory {
 #[expect(missing_debug_implementations)]
 pub struct TempoEvm<DB: Database, I = NoOpInspector> {
     inner: tempo_revm::TempoEvm<DB, I>,
-    /// Recorded storage actions.
-    actions: StorageActions,
     inspect: bool,
 }
 
@@ -82,10 +80,8 @@ impl<DB: Database> TempoEvm<DB> {
             .with_cfg(input.cfg_env)
             .with_tx(Default::default());
 
-        let actions = StorageActions::disabled();
         Self {
-            inner: tempo_revm::TempoEvm::new_with_actions(ctx, NoOpInspector {}, actions.clone()),
-            actions,
+            inner: tempo_revm::TempoEvm::new(ctx, NoOpInspector {}),
             inspect: false,
         }
     }
@@ -135,7 +131,6 @@ impl<DB: Database, I> TempoEvm<DB, I> {
     pub fn with_inspector<OINSP>(self, inspector: OINSP) -> TempoEvm<DB, OINSP> {
         TempoEvm {
             inner: self.inner.with_inspector(inspector),
-            actions: self.actions,
             inspect: true,
         }
     }
@@ -154,18 +149,18 @@ impl<DB: Database, I> TempoEvm<DB, I> {
 
     /// Enables recording of storage actions.
     pub fn with_actions(self) -> Self {
-        self.actions.enable();
+        self.inner.actions().enable();
         self
     }
 
     /// Replaces the recorded storage actions with an empty buffer, returning the previous actions.
     pub fn take_actions(&mut self) -> Option<Vec<StorageAction>> {
-        self.actions.take()
+        self.inner.actions().take()
     }
 
     /// Replaces the recorded storage actions with the given ones, returning the previous actions.
     pub fn replace_actions(&mut self, actions: Vec<StorageAction>) -> Option<Vec<StorageAction>> {
-        self.actions.replace(actions)
+        self.inner.actions().replace(actions)
     }
 }
 
@@ -310,7 +305,7 @@ mod tests {
     use tempo_precompiles::{
         PATH_USD_ADDRESS, STORAGE_CREDITS_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
         TIP403_REGISTRY_ADDRESS,
-        storage::{StorageAction, StorageCtx, StorageKey},
+        storage::{StorageAction, StorageActions, StorageCtx, StorageKey},
         storage_credits::StorageCredits,
         test_util::TIP20Setup,
         tip_fee_manager::slots as fee_manager_slots,

--- a/crates/node/tests/it/storage_credits.rs
+++ b/crates/node/tests/it/storage_credits.rs
@@ -23,6 +23,7 @@ use tempo_precompiles::{ACCOUNT_KEYCHAIN_ADDRESS, STORAGE_CREDITS_ADDRESS};
 use tempo_primitives::{
     TempoTransaction, TempoTxEnvelope,
     transaction::{
+        calc_gas_balance_spending,
         tempo_transaction::Call,
         tt_signature::{KeychainSignature, PrimitiveSignature, TempoSignature},
     },
@@ -158,8 +159,241 @@ async fn test_tip1060_keychain_fee_refund_does_not_retain_storage_credit() -> ey
     Ok(())
 }
 
-/// A normal TIP-20 precompile storage clear should mint a TIP-1060 credit for the token, and a
-/// later storage creation by the same token should redeem that account-local credit in Refund mode.
+/// Successful access-key fee refunds must cancel a TIP-1060 credit minted by a same-tx user spend
+/// if post-tx reimbursement recreates the keychain spending-limit slot.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tip1060_successful_keychain_spend_fee_refund_cancels_restored_limit_credit()
+-> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let root = MnemonicBuilder::from_phrase(TEST_MNEMONIC).build()?;
+    let root_addr = root.address();
+    let provider = ProviderBuilder::new()
+        .wallet(root.clone())
+        .connect_http(setup.http_url);
+    let access_key = PrivateKeySigner::random();
+
+    let gas_limit = 500_000u64;
+    let gas_price = 1_000_000_000_000u128;
+    let max_fee = calc_gas_balance_spending(gas_limit, gas_price);
+    let transfer_amount = U256::from(1_234u64);
+    let spending_limit = max_fee + transfer_amount;
+    let recipient = Address::repeat_byte(0xcc);
+
+    let authorize = authorizeKeyCall {
+        keyId: access_key.address(),
+        signatureType: SignatureType::Secp256k1,
+        config: KeyRestrictions {
+            expiry: u64::MAX,
+            enforceLimits: true,
+            limits: vec![TokenLimit {
+                token: DEFAULT_FEE_TOKEN,
+                amount: spending_limit,
+                period: 0,
+            }],
+            allowAnyCalls: true,
+            allowedCalls: vec![],
+        },
+    };
+    let authorize_hash = provider
+        .send_transaction(
+            TransactionRequest::default()
+                .to(ACCOUNT_KEYCHAIN_ADDRESS)
+                .input(authorize.abi_encode().into())
+                .gas_limit(2_000_000),
+        )
+        .await?
+        .watch()
+        .await?;
+    let authorize_receipt = provider
+        .raw_request::<_, TempoTransactionReceipt>(
+            "eth_getTransactionReceipt".into(),
+            (authorize_hash,),
+        )
+        .await?;
+    assert!(authorize_receipt.status());
+
+    let keychain = IAccountKeychainInstance::new(ACCOUNT_KEYCHAIN_ADDRESS, &provider);
+    let credits = IStorageCredits::new(STORAGE_CREDITS_ADDRESS, &provider);
+
+    let remaining_before = keychain
+        .getRemainingLimitWithPeriod(root_addr, access_key.address(), DEFAULT_FEE_TOKEN)
+        .call()
+        .await?
+        .remaining;
+    let credit_before = credits.balanceOf(ACCOUNT_KEYCHAIN_ADDRESS).call().await?;
+    assert_eq!(remaining_before, spending_limit);
+
+    let tx = TempoTransaction {
+        chain_id: provider.get_chain_id().await?,
+        nonce: provider.get_transaction_count(root_addr).await?,
+        max_priority_fee_per_gas: gas_price,
+        max_fee_per_gas: gas_price,
+        gas_limit,
+        calls: vec![Call {
+            to: DEFAULT_FEE_TOKEN.into(),
+            value: U256::ZERO,
+            input: ITIP20::transferCall {
+                to: recipient,
+                amount: transfer_amount,
+            }
+            .abi_encode()
+            .into(),
+        }],
+        fee_token: Some(DEFAULT_FEE_TOKEN),
+        ..Default::default()
+    };
+
+    let keychain_hash = KeychainSignature::signing_hash(tx.signature_hash(), root_addr);
+    let access_signature = access_key.sign_hash_sync(&keychain_hash)?;
+    let envelope: TempoTxEnvelope = tx
+        .into_signed(TempoSignature::Keychain(KeychainSignature::new(
+            root_addr,
+            PrimitiveSignature::Secp256k1(access_signature),
+        )))
+        .into();
+
+    let tx_hash = provider
+        .send_raw_transaction(&envelope.encoded_2718())
+        .await?
+        .watch()
+        .await?;
+    let receipt = provider
+        .raw_request::<_, TempoTransactionReceipt>("eth_getTransactionReceipt".into(), (tx_hash,))
+        .await?;
+    assert!(receipt.status());
+
+    let remaining_after = keychain
+        .getRemainingLimitWithPeriod(root_addr, access_key.address(), DEFAULT_FEE_TOKEN)
+        .call()
+        .await?
+        .remaining;
+    let credit_after = credits.balanceOf(ACCOUNT_KEYCHAIN_ADDRESS).call().await?;
+    let fee_token = ITIP20::new(DEFAULT_FEE_TOKEN, &provider);
+
+    assert!(remaining_after > U256::ZERO);
+    assert_eq!(
+        credit_after, credit_before,
+        "post-tx fee refund recreates the keychain limit slot, so the same-tx clear credit must be canceled"
+    );
+    assert_eq!(
+        fee_token.balanceOf(recipient).call().await?,
+        transfer_amount
+    );
+
+    Ok(())
+}
+
+/// Successful fee-token refunds must cancel a TIP-1060 credit minted by a same-tx user spend if
+/// post-tx reimbursement recreates the fee payer's TIP-20 balance slot.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tip1060_successful_fee_token_spend_fee_refund_cancels_restored_balance_credit()
+-> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let root = MnemonicBuilder::from_phrase(TEST_MNEMONIC).build()?;
+    let root_provider = ProviderBuilder::new()
+        .wallet(root.clone())
+        .connect_http(setup.http_url.clone());
+
+    let fee_payer = PrivateKeySigner::random();
+    let fee_payer_addr = fee_payer.address();
+    let fee_payer_provider = ProviderBuilder::new()
+        .wallet(fee_payer.clone())
+        .connect_http(setup.http_url);
+
+    let gas_limit = 500_000u64;
+    let gas_price = 1_000_000_000_000u128;
+    let max_fee = calc_gas_balance_spending(gas_limit, gas_price);
+    let transfer_amount = U256::from(1_234u64);
+    let initial_fee_payer_balance = max_fee + transfer_amount;
+    let recipient = Address::repeat_byte(0xdd);
+
+    let fee_token = ITIP20::new(DEFAULT_FEE_TOKEN, root_provider.clone());
+    let recipient_seed_receipt = fee_token
+        .transfer(recipient, U256::ONE)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(recipient_seed_receipt.status());
+    let fee_payer_seed_receipt = fee_token
+        .transfer(fee_payer_addr, initial_fee_payer_balance)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(fee_payer_seed_receipt.status());
+    assert_eq!(
+        fee_token.balanceOf(fee_payer_addr).call().await?,
+        initial_fee_payer_balance
+    );
+
+    let credits = IStorageCredits::new(STORAGE_CREDITS_ADDRESS, &root_provider);
+    let credit_before = credits.balanceOf(DEFAULT_FEE_TOKEN).call().await?;
+
+    let tx = TempoTransaction {
+        chain_id: fee_payer_provider.get_chain_id().await?,
+        nonce: fee_payer_provider
+            .get_transaction_count(fee_payer_addr)
+            .await?,
+        max_priority_fee_per_gas: gas_price,
+        max_fee_per_gas: gas_price,
+        gas_limit,
+        calls: vec![Call {
+            to: DEFAULT_FEE_TOKEN.into(),
+            value: U256::ZERO,
+            input: ITIP20::transferCall {
+                to: recipient,
+                amount: transfer_amount,
+            }
+            .abi_encode()
+            .into(),
+        }],
+        fee_token: Some(DEFAULT_FEE_TOKEN),
+        ..Default::default()
+    };
+    let sig = fee_payer.sign_hash_sync(&tx.signature_hash())?;
+    let envelope: TempoTxEnvelope = tx
+        .into_signed(TempoSignature::Primitive(PrimitiveSignature::Secp256k1(
+            sig,
+        )))
+        .into();
+
+    let tx_hash = fee_payer_provider
+        .send_raw_transaction(&envelope.encoded_2718())
+        .await?
+        .watch()
+        .await?;
+    let receipt = root_provider
+        .raw_request::<_, TempoTransactionReceipt>("eth_getTransactionReceipt".into(), (tx_hash,))
+        .await?;
+    assert!(receipt.status());
+    assert_eq!(receipt.fee_token, Some(DEFAULT_FEE_TOKEN));
+
+    let spent_fee = calc_gas_balance_spending(receipt.gas_used, receipt.effective_gas_price());
+    let expected_refund = max_fee - spent_fee;
+    assert!(expected_refund > U256::ZERO);
+
+    assert_eq!(
+        fee_token.balanceOf(fee_payer_addr).call().await?,
+        expected_refund
+    );
+    assert_eq!(
+        fee_token.balanceOf(recipient).call().await?,
+        transfer_amount + U256::ONE
+    );
+    assert_eq!(
+        credits.balanceOf(DEFAULT_FEE_TOKEN).call().await?,
+        credit_before,
+        "post-tx fee refund recreates the payer balance slot, so the same-tx clear credit must be canceled"
+    );
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tip1060_tip20_clear_mints_and_later_creation_redeems_credit() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -39,6 +39,9 @@ const TIP20_TRANSFER_SELECTOR: [u8; 4] = ITIP20::transferCall::SELECTOR;
 const TIP20_APPROVE_SELECTOR: [u8; 4] = ITIP20::approveCall::SELECTOR;
 const TIP20_TRANSFER_WITH_MEMO_SELECTOR: [u8; 4] = ITIP20::transferWithMemoCall::SELECTOR;
 
+/// Alias for zero remaining periodic spend, used to avoid clearing the storage slot.
+const ZERO_PERIODIC_REMAINING_SENTINEL: U256 = U256::MAX;
+
 #[inline]
 pub fn is_constrained_tip20_selector(selector: [u8; 4]) -> bool {
     matches!(
@@ -1331,12 +1334,18 @@ impl AccountKeychain {
         let mut remaining = limit_state.remaining;
         let is_periodic = limit_state.period != 0;
 
-        if is_periodic && current_timestamp >= limit_state.period_end {
-            let next_end = limit_state.compute_next_period_end(current_timestamp);
+        if is_periodic {
+            if self.storage.spec().is_t7() && remaining == ZERO_PERIODIC_REMAINING_SENTINEL {
+                remaining = U256::ZERO;
+            }
 
-            remaining = U256::from(limit_state.max);
-            limit_state.remaining = remaining;
-            limit_state.period_end = next_end;
+            if current_timestamp >= limit_state.period_end {
+                let next_end = limit_state.compute_next_period_end(current_timestamp);
+
+                remaining = U256::from(limit_state.max);
+                limit_state.remaining = remaining;
+                limit_state.period_end = next_end;
+            }
         }
 
         if amount > remaining {
@@ -1346,7 +1355,11 @@ impl AccountKeychain {
         // Update remaining limit
         let new_remaining = remaining - amount;
         if is_periodic {
-            limit_state.remaining = new_remaining;
+            if self.storage.spec().is_t7() && new_remaining.is_zero() {
+                limit_state.remaining = ZERO_PERIODIC_REMAINING_SENTINEL;
+            } else {
+                limit_state.remaining = new_remaining;
+            }
             self.spending_limits[limit_key][token].write(limit_state)?;
         } else {
             self.spending_limits[limit_key][token]
@@ -4535,6 +4548,63 @@ mod tests {
                 token,
             })?;
             assert_eq!(remaining, U256::from(90));
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t7_periodic_exact_depletion_stores_sentinel_but_emits_zero() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T7);
+        storage.set_timestamp(U256::from(1_000u64));
+
+        let account = Address::random();
+        let key_id = Address::random();
+        let token = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+
+            authorize_key(
+                &mut keychain,
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: true,
+                        limits: vec![TokenLimit {
+                            token,
+                            amount: U256::from(100),
+                            period: 60,
+                        }],
+                        allowAnyCalls: true,
+                        allowedCalls: vec![],
+                    },
+                },
+            )?;
+            keychain.clear_emitted_events();
+
+            keychain.verify_and_update_spending(account, key_id, token, U256::from(100))?;
+
+            let limit_key = AccountKeychain::spending_limit_key(account, key_id);
+            assert_eq!(
+                keychain.spending_limits[limit_key][token]
+                    .remaining
+                    .read()?,
+                ZERO_PERIODIC_REMAINING_SENTINEL
+            );
+            keychain.assert_emitted_events(vec![AccountKeychainEvent::access_key_spend(
+                account,
+                key_id,
+                token,
+                U256::from(100),
+                U256::ZERO,
+            )]);
+
             Ok(())
         })
     }

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -35,7 +35,7 @@ use crate::{
     signature_verifier::SignatureVerifier,
     stablecoin_dex::StablecoinDEX,
     storage::{StorageCtx, actions::StorageActions},
-    storage_credits::StorageCredits,
+    storage_credits::{NonCreditableSlots, StorageCredits},
     tip_fee_manager::TipFeeManager,
     tip20::TIP20Token,
     tip20_channel_reserve::TIP20ChannelReserve,
@@ -44,6 +44,7 @@ use crate::{
     validator_config::ValidatorConfig,
     validator_config_v2::ValidatorConfigV2,
 };
+use std::{cell::RefCell, rc::Rc};
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_primitives::TempoAddressExt;
 
@@ -132,22 +133,36 @@ pub trait Precompile {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult;
 }
 
+/// Shared execution environment captured by Tempo precompile wrappers.
+#[derive(Clone)]
+pub struct PrecompileEnv {
+    cfg: CfgEnv<TempoHardfork>,
+    actions: StorageActions,
+    non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
+}
+
+impl PrecompileEnv {
+    pub fn new(
+        cfg: &CfgEnv<TempoHardfork>,
+        actions: StorageActions,
+        non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
+    ) -> Self {
+        Self {
+            cfg: cfg.clone(),
+            actions,
+            non_creditable_slots,
+        }
+    }
+}
+
 /// Returns the full Tempo precompiles for the given config.
 ///
 /// Pre-T1C hardforks use Prague precompiles, T1C+ uses Osaka precompiles.
 /// Tempo-specific precompiles are also registered via [`extend_tempo_precompiles`].
-#[cfg(test)]
-pub fn tempo_precompiles(cfg: &CfgEnv<TempoHardfork>) -> PrecompilesMap {
-    tempo_precompiles_with_actions(cfg, StorageActions::disabled())
-}
-
-/// Returns the full Tempo precompiles for the given config and storage actions.
-///
-/// Pre-T1C hardforks use Prague precompiles, T1C+ uses Osaka precompiles.
-/// Tempo-specific precompiles are also registered via [`extend_tempo_precompiles`].
-pub fn tempo_precompiles_with_actions(
+pub fn tempo_precompiles(
     cfg: &CfgEnv<TempoHardfork>,
     actions: StorageActions,
+    non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
 ) -> PrecompilesMap {
     let spec = if cfg.spec.is_t1c() {
         cfg.spec.into()
@@ -155,7 +170,7 @@ pub fn tempo_precompiles_with_actions(
         SpecId::PRAGUE
     };
     let mut precompiles = PrecompilesMap::from_static(EthPrecompiles::new(spec).precompiles);
-    extend_tempo_precompiles(&mut precompiles, cfg, actions);
+    extend_tempo_precompiles(&mut precompiles, cfg, actions, non_creditable_slots);
     precompiles
 }
 
@@ -168,45 +183,39 @@ pub fn extend_tempo_precompiles(
     precompiles: &mut PrecompilesMap,
     cfg: &CfgEnv<TempoHardfork>,
     actions: StorageActions,
+    non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
 ) {
-    let cfg = cfg.clone();
+    let env = PrecompileEnv::new(cfg, actions, non_creditable_slots);
 
     precompiles.set_precompile_lookup(move |address: &Address| {
         if address.is_tip20() {
-            Some(TIP20Token::create_precompile(
-                *address,
-                &cfg,
-                actions.clone(),
-            ))
+            Some(TIP20Token::create_precompile(*address, &env))
         } else if *address == TIP20_FACTORY_ADDRESS {
-            Some(TIP20Factory::create_precompile(&cfg, actions.clone()))
-        } else if *address == TIP20_CHANNEL_RESERVE_ADDRESS && cfg.spec.is_t5() {
-            Some(TIP20ChannelReserve::create_precompile(
-                &cfg,
-                actions.clone(),
-            ))
-        } else if *address == ADDRESS_REGISTRY_ADDRESS && cfg.spec.is_t3() {
-            Some(AddressRegistry::create_precompile(&cfg, actions.clone()))
+            Some(TIP20Factory::create_precompile(&env))
+        } else if *address == TIP20_CHANNEL_RESERVE_ADDRESS && env.cfg.spec.is_t5() {
+            Some(TIP20ChannelReserve::create_precompile(&env))
+        } else if *address == ADDRESS_REGISTRY_ADDRESS && env.cfg.spec.is_t3() {
+            Some(AddressRegistry::create_precompile(&env))
         } else if *address == TIP403_REGISTRY_ADDRESS {
-            Some(TIP403Registry::create_precompile(&cfg, actions.clone()))
+            Some(TIP403Registry::create_precompile(&env))
         } else if *address == TIP_FEE_MANAGER_ADDRESS {
-            Some(TipFeeManager::create_precompile(&cfg, actions.clone()))
+            Some(TipFeeManager::create_precompile(&env))
         } else if *address == STABLECOIN_DEX_ADDRESS {
-            Some(StablecoinDEX::create_precompile(&cfg, actions.clone()))
+            Some(StablecoinDEX::create_precompile(&env))
         } else if *address == NONCE_PRECOMPILE_ADDRESS {
-            Some(NonceManager::create_precompile(&cfg, actions.clone()))
+            Some(NonceManager::create_precompile(&env))
         } else if *address == VALIDATOR_CONFIG_ADDRESS {
-            Some(ValidatorConfig::create_precompile(&cfg, actions.clone()))
+            Some(ValidatorConfig::create_precompile(&env))
         } else if *address == ACCOUNT_KEYCHAIN_ADDRESS {
-            Some(AccountKeychain::create_precompile(&cfg, actions.clone()))
+            Some(AccountKeychain::create_precompile(&env))
         } else if *address == VALIDATOR_CONFIG_V2_ADDRESS {
-            Some(ValidatorConfigV2::create_precompile(&cfg, actions.clone()))
-        } else if *address == SIGNATURE_VERIFIER_ADDRESS && cfg.spec.is_t3() {
-            Some(SignatureVerifier::create_precompile(&cfg, actions.clone()))
-        } else if *address == RECEIVE_POLICY_GUARD_ADDRESS && cfg.spec.is_t6() {
-            Some(ReceivePolicyGuard::create_precompile(&cfg, actions.clone()))
-        } else if *address == STORAGE_CREDITS_ADDRESS && cfg.spec.is_t7() {
-            Some(StorageCredits::create_precompile(&cfg, actions.clone()))
+            Some(ValidatorConfigV2::create_precompile(&env))
+        } else if *address == SIGNATURE_VERIFIER_ADDRESS && env.cfg.spec.is_t3() {
+            Some(SignatureVerifier::create_precompile(&env))
+        } else if *address == RECEIVE_POLICY_GUARD_ADDRESS && env.cfg.spec.is_t6() {
+            Some(ReceivePolicyGuard::create_precompile(&env))
+        } else if *address == STORAGE_CREDITS_ADDRESS && env.cfg.spec.is_t7() {
+            Some(StorageCredits::create_precompile(&env))
         } else {
             None
         }
@@ -223,13 +232,20 @@ macro_rules! tempo_precompile {
         #[cfg(not(test))]
         compile_error!("tempo_precompile! without actions is only available in tests");
         #[cfg(test)]
-        tempo_precompile!($id, $cfg, StorageActions::disabled(), |$input| $impl)
+        let env = PrecompileEnv::new(
+            $cfg,
+            StorageActions::disabled(),
+            Rc::new(RefCell::new(NonCreditableSlots::empty())),
+        );
+        tempo_precompile!($id, env: &env, |$input| $impl)
     }};
-    ($id:expr, $cfg:expr, $actions:expr, |$input:ident| $impl:expr) => {{
-        let spec = $cfg.spec;
-        let amsterdam_eip8037_enabled = $cfg.enable_amsterdam_eip8037;
-        let gas_params = $cfg.gas_params.clone();
-        let actions = $actions.clone();
+    ($id:expr, env: $env:expr, |$input:ident| $impl:expr) => {{
+        let env = $env.clone();
+        let spec = env.cfg.spec;
+        let amsterdam_eip8037_enabled = env.cfg.enable_amsterdam_eip8037;
+        let gas_params = env.cfg.gas_params.clone();
+        let actions = env.actions.clone();
+        let non_creditable_slots = env.non_creditable_slots.clone();
         DynPrecompile::new_stateful(PrecompileId::Custom($id.into()), move |$input| {
             if !$input.is_direct_call() {
                 return Ok(PrecompileOutput::revert(
@@ -247,7 +263,8 @@ macro_rules! tempo_precompile {
                 $input.is_static,
                 gas_params.clone(),
             )
-            .with_actions(actions.clone());
+            .with_actions(actions.clone())
+            .with_non_creditable_slots(non_creditable_slots.clone());
             crate::storage::StorageCtx::enter(&mut storage, || {
                 $impl.call($input.data, $input.caller)
             })
@@ -257,52 +274,36 @@ macro_rules! tempo_precompile {
 
 impl TipFeeManager {
     /// Creates the EVM precompile for this type.
-    pub fn create_precompile(
-        cfg: &CfgEnv<TempoHardfork>,
-        actions: StorageActions,
-    ) -> DynPrecompile {
-        tempo_precompile!("TipFeeManager", cfg, actions, |input| { Self::new() })
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("TipFeeManager", env: env, |input| { Self::new() })
     }
 }
 
 impl AddressRegistry {
     /// Creates the EVM precompile for this type.
-    pub fn create_precompile(
-        cfg: &CfgEnv<TempoHardfork>,
-        actions: StorageActions,
-    ) -> DynPrecompile {
-        tempo_precompile!("AddressRegistry", cfg, actions, |input| { Self::new() })
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("AddressRegistry", env: env, |input| { Self::new() })
     }
 }
 
 impl TIP403Registry {
     /// Creates the EVM precompile for this type.
-    pub fn create_precompile(
-        cfg: &CfgEnv<TempoHardfork>,
-        actions: StorageActions,
-    ) -> DynPrecompile {
-        tempo_precompile!("TIP403Registry", cfg, actions, |input| { Self::new() })
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("TIP403Registry", env: env, |input| { Self::new() })
     }
 }
 
 impl TIP20Factory {
     /// Creates the EVM precompile for this type.
-    pub fn create_precompile(
-        cfg: &CfgEnv<TempoHardfork>,
-        actions: StorageActions,
-    ) -> DynPrecompile {
-        tempo_precompile!("TIP20Factory", cfg, actions, |input| { Self::new() })
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("TIP20Factory", env: env, |input| { Self::new() })
     }
 }
 
 impl TIP20Token {
     /// Creates the EVM precompile for this type.
-    pub fn create_precompile(
-        address: Address,
-        cfg: &CfgEnv<TempoHardfork>,
-        actions: StorageActions,
-    ) -> DynPrecompile {
-        tempo_precompile!("TIP20Token", cfg, actions, |input| {
+    pub fn create_precompile(address: Address, env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("TIP20Token", env: env, |input| {
             Self::from_address(address).expect("TIP20 prefix already verified")
         })
     }
@@ -310,93 +311,64 @@ impl TIP20Token {
 
 impl StablecoinDEX {
     /// Creates the EVM precompile for this type.
-    pub fn create_precompile(
-        cfg: &CfgEnv<TempoHardfork>,
-        actions: StorageActions,
-    ) -> DynPrecompile {
-        tempo_precompile!("StablecoinDEX", cfg, actions, |input| { Self::new() })
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("StablecoinDEX", env: env, |input| { Self::new() })
     }
 }
 
 impl NonceManager {
     /// Creates the EVM precompile for this type.
-    pub fn create_precompile(
-        cfg: &CfgEnv<TempoHardfork>,
-        actions: StorageActions,
-    ) -> DynPrecompile {
-        tempo_precompile!("NonceManager", cfg, actions, |input| { Self::new() })
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("NonceManager", env: env, |input| { Self::new() })
     }
 }
 
 impl AccountKeychain {
     /// Creates the EVM precompile for this type.
-    pub fn create_precompile(
-        cfg: &CfgEnv<TempoHardfork>,
-        actions: StorageActions,
-    ) -> DynPrecompile {
-        tempo_precompile!("AccountKeychain", cfg, actions, |input| { Self::new() })
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("AccountKeychain", env: env, |input| { Self::new() })
     }
 }
 
 impl ValidatorConfig {
     /// Creates the EVM precompile for this type.
-    pub fn create_precompile(
-        cfg: &CfgEnv<TempoHardfork>,
-        actions: StorageActions,
-    ) -> DynPrecompile {
-        tempo_precompile!("ValidatorConfig", cfg, actions, |input| { Self::new() })
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("ValidatorConfig", env: env, |input| { Self::new() })
     }
 }
 
 impl ValidatorConfigV2 {
     /// Creates the EVM precompile for this type.
-    pub fn create_precompile(
-        cfg: &CfgEnv<TempoHardfork>,
-        actions: StorageActions,
-    ) -> DynPrecompile {
-        tempo_precompile!("ValidatorConfigV2", cfg, actions, |input| { Self::new() })
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("ValidatorConfigV2", env: env, |input| { Self::new() })
     }
 }
 
 impl SignatureVerifier {
     /// Creates the EVM precompile for this type.
-    pub fn create_precompile(
-        cfg: &CfgEnv<TempoHardfork>,
-        actions: StorageActions,
-    ) -> DynPrecompile {
-        tempo_precompile!("SignatureVerifier", cfg, actions, |input| { Self::new() })
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("SignatureVerifier", env: env, |input| { Self::new() })
     }
 }
 
 impl TIP20ChannelReserve {
     /// Creates the EVM precompile for this type.
-    pub fn create_precompile(
-        cfg: &CfgEnv<TempoHardfork>,
-        actions: StorageActions,
-    ) -> DynPrecompile {
-        tempo_precompile!("TIP20ChannelReserve", cfg, actions, |input| { Self::new() })
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("TIP20ChannelReserve", env: env, |input| { Self::new() })
     }
 }
 
 impl ReceivePolicyGuard {
     /// Creates the EVM precompile for this type.
-    pub fn create_precompile(
-        cfg: &CfgEnv<TempoHardfork>,
-        actions: StorageActions,
-    ) -> DynPrecompile {
-        tempo_precompile!("ReceivePolicyGuard", cfg, actions, |input| { Self::new() })
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("ReceivePolicyGuard", env: env, |input| { Self::new() })
     }
 }
 
 impl StorageCredits {
     /// Creates the EVM precompile for this type.
-    pub fn create_precompile(
-        cfg: &CfgEnv<TempoHardfork>,
-        actions: StorageActions,
-    ) -> DynPrecompile {
-        tempo_precompile!("TIP1060StorageCredits", cfg, actions, |input| {
-            Self::new()
-        })
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("TIP1060StorageCredits", env: env, |input| { Self::new() })
     }
 }
 
@@ -627,6 +599,14 @@ mod tests {
         state::{AccountInfo, Bytecode},
     };
     use tempo_contracts::precompiles::{ITIP20, UnknownFunctionSelector};
+
+    fn test_tempo_precompiles(cfg_env: &CfgEnv<TempoHardfork>) -> PrecompilesMap {
+        tempo_precompiles(
+            cfg_env,
+            StorageActions::disabled(),
+            Rc::new(RefCell::new(NonCreditableSlots::empty())),
+        )
+    }
 
     #[test]
     fn test_precompile_delegatecall() {
@@ -1216,7 +1196,7 @@ mod tests {
     fn test_extend_tempo_precompiles_registers_precompiles() {
         let mut cfg = CfgEnv::<TempoHardfork>::default();
         cfg.set_spec_and_mainnet_gas_params(TempoHardfork::T3);
-        let precompiles = tempo_precompiles(&cfg);
+        let precompiles = test_tempo_precompiles(&cfg);
 
         // TIP20Factory should be registered
         let factory_precompile = precompiles.get(&TIP20_FACTORY_ADDRESS);
@@ -1307,7 +1287,7 @@ mod tests {
     #[test]
     fn test_signature_verifier_not_registered_pre_t3() {
         let cfg = CfgEnv::<TempoHardfork>::default();
-        let precompiles = tempo_precompiles(&cfg);
+        let precompiles = test_tempo_precompiles(&cfg);
 
         assert!(
             precompiles.get(&SIGNATURE_VERIFIER_ADDRESS).is_none(),
@@ -1319,7 +1299,7 @@ mod tests {
     fn test_channel_reserve_registered_at_t5_only() {
         let pre_t5 = CfgEnv::<TempoHardfork>::default();
         assert!(
-            tempo_precompiles(&pre_t5)
+            test_tempo_precompiles(&pre_t5)
                 .get(&TIP20_CHANNEL_RESERVE_ADDRESS)
                 .is_none(),
             "TIP20 channel reserve should NOT be registered before T5"
@@ -1328,7 +1308,7 @@ mod tests {
         let mut t5 = CfgEnv::<TempoHardfork>::default();
         t5.set_spec_and_mainnet_gas_params(TempoHardfork::T5);
         assert!(
-            tempo_precompiles(&t5)
+            test_tempo_precompiles(&t5)
                 .get(&TIP20_CHANNEL_RESERVE_ADDRESS)
                 .is_some(),
             "TIP20 channel reserve should be registered at T5"
@@ -1362,7 +1342,7 @@ mod tests {
 
             let mut cfg = CfgEnv::<TempoHardfork>::default();
             cfg.set_spec_and_mainnet_gas_params(spec);
-            tempo_precompiles(&cfg).get(&p256_addr).is_some()
+            test_tempo_precompiles(&cfg).get(&p256_addr).is_some()
         };
 
         // Pre-T1C hardforks should use Prague precompiles (no P256VERIFY)

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::TempoPrecompileError,
     storage::{PrecompileStorageProvider, StorageActions, actions::StorageAction},
-    storage_credits::sstore_storage_credits,
+    storage_credits::{NonCreditableSlots, sstore_storage_credits},
 };
 use alloy::primitives::{Address, Log, LogData, U256};
 use alloy_evm::EvmInternals;
@@ -11,6 +11,7 @@ use revm::{
     interpreter::{SStoreResult, StateLoad, gas::GasTracker},
     state::{AccountInfo, Bytecode},
 };
+use std::{cell::RefCell, rc::Rc};
 use tempo_chainspec::hardfork::TempoHardfork;
 
 /// Production [`PrecompileStorageProvider`] backed by the live EVM journal.
@@ -25,6 +26,7 @@ pub struct EvmPrecompileStorageProvider<'a> {
     gas_params: GasParams,
     tip1060_storage_credits_enabled: bool,
     tip1060_storage_credit_minting_enabled: bool,
+    non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
     /// Debug-only LIFO checkpoint validator. See [`Self::assert_lifo`].
     #[cfg(debug_assertions)]
     checkpoint_stack: Vec<(usize, usize)>,
@@ -52,6 +54,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
             gas_params,
             tip1060_storage_credits_enabled: spec.is_t7(),
             tip1060_storage_credit_minting_enabled: true,
+            non_creditable_slots: Rc::new(RefCell::new(NonCreditableSlots::empty())),
             #[cfg(debug_assertions)]
             checkpoint_stack: Vec::new(),
             actions: StorageActions::disabled(),
@@ -92,6 +95,12 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
     /// Sets the storage actions for this provider.
     pub fn with_actions(mut self, actions: StorageActions) -> Self {
         self.actions = actions;
+        self
+    }
+
+    /// Sets the transaction-local non-creditable clear-slot context for this provider.
+    pub fn with_non_creditable_slots(mut self, slots: Rc<RefCell<NonCreditableSlots>>) -> Self {
+        self.non_creditable_slots = slots;
         self
     }
 
@@ -204,7 +213,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
         // TIP-1060 (T7+): run the storage credits policy so precompile-driven storage
         // writes honor the same accounting as the opcode-level SSTORE hook.
         if self.tip1060_storage_credits_enabled {
-            sstore_storage_credits(self, address, &result)?
+            sstore_storage_credits(self, address, Some(key), &result)?
         }
 
         // dynamic gas
@@ -271,6 +280,13 @@ impl crate::storage_credits::StorageCreditsBackend for EvmPrecompileStorageProvi
     #[inline]
     fn tstore(&mut self, address: Address, key: U256, value: U256) {
         self.internals.tstore(address, key, value);
+    }
+
+    #[inline]
+    fn is_non_creditable_slot(&mut self, owner: Address, key: U256) -> bool {
+        self.non_creditable_slots
+            .borrow()
+            .is_non_creditable_slot(owner, key)
     }
 
     #[inline]

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -1,12 +1,18 @@
 use alloy::primitives::{Address, LogData, U256};
 use revm::{
     context::journaled_state::JournalCheckpoint,
+    context_interface::cfg::GasParams,
+    interpreter::{SStoreResult, StateLoad, gas::GasTracker},
     state::{AccountInfo, Bytecode},
 };
 use std::collections::HashMap;
 use tempo_chainspec::hardfork::TempoHardfork;
 
-use crate::{error::TempoPrecompileError, storage::PrecompileStorageProvider};
+use crate::{
+    error::TempoPrecompileError,
+    storage::PrecompileStorageProvider,
+    storage_credits::{NonCreditableSlots, StorageCreditsBackend, sstore_storage_credits},
+};
 
 /// In-memory [`PrecompileStorageProvider`] for unit tests.
 ///
@@ -23,8 +29,11 @@ pub struct HashMapStorageProvider {
     spec: TempoHardfork,
     amsterdam_eip8037_enabled: bool,
     is_static: bool,
+    gas_params: GasParams,
+    gas_tracker: GasTracker,
     counter_sload: u64,
     counter_sstore: u64,
+    non_creditable_slots: NonCreditableSlots,
     snapshots: Vec<Snapshot>,
 
     /// Emitted events keyed by contract address.
@@ -36,6 +45,7 @@ pub struct HashMapStorageProvider {
 /// PERF: naive cloning strategy due to its limited usage.
 struct Snapshot {
     internals: HashMap<(Address, U256), U256>,
+    transient: HashMap<(Address, U256), U256>,
     events: HashMap<Address, Vec<LogData>>,
 }
 
@@ -67,20 +77,25 @@ impl HashMapStorageProvider {
             spec,
             amsterdam_eip8037_enabled: false,
             is_static: false,
+            gas_params: GasParams::new_spec(spec.into()),
+            gas_tracker: GasTracker::new(u64::MAX, u64::MAX, 0),
             counter_sload: 0,
             counter_sstore: 0,
+            non_creditable_slots: NonCreditableSlots::empty(),
         }
     }
 
     /// Returns self with the hardfork spec overridden (builder pattern).
     pub fn with_spec(mut self, spec: TempoHardfork) -> Self {
         self.spec = spec;
+        self.gas_params = GasParams::new_spec(self.spec.into());
         self
     }
 
     /// Returns self with `amsterdam_eip8037_enabled` overridden (builder pattern).
     pub fn with_amsterdam_eip8037_enabled(mut self, enabled: bool) -> Self {
         self.amsterdam_eip8037_enabled = enabled;
+        self.gas_params = GasParams::new_spec(self.spec.into());
         self
     }
 }
@@ -126,7 +141,25 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         value: U256,
     ) -> Result<(), TempoPrecompileError> {
         self.counter_sstore += 1;
+        let present = self
+            .internals
+            .get(&(address, key))
+            .copied()
+            .unwrap_or(U256::ZERO);
         self.internals.insert((address, key), value);
+
+        if self.spec.is_t7() {
+            let state_load = StateLoad::new(
+                SStoreResult {
+                    original_value: present,
+                    present_value: present,
+                    new_value: value,
+                },
+                false,
+            );
+            sstore_storage_credits(self, address, Some(key), &state_load)?;
+        }
+
         Ok(())
     }
 
@@ -210,6 +243,7 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         let idx = self.snapshots.len();
         self.snapshots.push(Snapshot {
             internals: self.internals.clone(),
+            transient: self.transient.clone(),
             events: self.events.clone(),
         });
         JournalCheckpoint {
@@ -236,6 +270,7 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         );
         if let Some(snapshot) = self.snapshots.drain(checkpoint.journal_i..).next() {
             self.internals = snapshot.internals;
+            self.transient = snapshot.transient;
             self.events = snapshot.events;
         }
     }
@@ -245,8 +280,77 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     }
 }
 
+impl StorageCreditsBackend for HashMapStorageProvider {
+    type Error = TempoPrecompileError;
+
+    fn gas_params(&self) -> &GasParams {
+        &self.gas_params
+    }
+
+    fn gas_tracker(&mut self) -> &mut GasTracker {
+        &mut self.gas_tracker
+    }
+
+    fn sload(
+        &mut self,
+        address: Address,
+        key: U256,
+        _skip_cold_load: bool,
+    ) -> Result<StateLoad<U256>, Self::Error> {
+        Ok(StateLoad::new(
+            self.internals
+                .get(&(address, key))
+                .copied()
+                .unwrap_or(U256::ZERO),
+            false,
+        ))
+    }
+
+    fn sstore(
+        &mut self,
+        address: Address,
+        key: U256,
+        value: U256,
+        _skip_cold_load: bool,
+    ) -> Result<StateLoad<SStoreResult>, Self::Error> {
+        let present_value = self
+            .internals
+            .get(&(address, key))
+            .copied()
+            .unwrap_or(U256::ZERO);
+        self.internals.insert((address, key), value);
+        Ok(StateLoad::new(
+            SStoreResult {
+                original_value: present_value,
+                present_value,
+                new_value: value,
+            },
+            false,
+        ))
+    }
+
+    fn tload(&mut self, address: Address, key: U256) -> U256 {
+        self.transient
+            .get(&(address, key))
+            .copied()
+            .unwrap_or(U256::ZERO)
+    }
+
+    fn tstore(&mut self, address: Address, key: U256, value: U256) {
+        self.transient.insert((address, key), value);
+    }
+
+    fn is_non_creditable_slot(&mut self, owner: Address, key: U256) -> bool {
+        self.non_creditable_slots.is_non_creditable_slot(owner, key)
+    }
+}
+
 #[cfg(any(test, feature = "test-utils"))]
 impl HashMapStorageProvider {
+    pub fn set_non_creditable_slots(&mut self, slots: NonCreditableSlots) {
+        self.non_creditable_slots = slots;
+    }
+
     pub fn fail_next_sload_at(&mut self, address: Address, slot: U256) {
         self.fail_on_sload = Some((address, slot));
     }
@@ -286,6 +390,7 @@ impl HashMapStorageProvider {
     /// Overrides the active hardfork spec.
     pub fn set_spec(&mut self, spec: TempoHardfork) {
         self.spec = spec;
+        self.gas_params = GasParams::new_spec(self.spec.into());
     }
 
     /// Clears all transient storage (simulates a new block).

--- a/crates/precompiles/src/storage_credits/accounting.rs
+++ b/crates/precompiles/src/storage_credits/accounting.rs
@@ -76,6 +76,11 @@ pub trait StorageCreditsBackend {
     /// TSTORE `address[key] = value`.
     fn tstore(&mut self, address: Address, key: U256, value: U256);
 
+    /// Returns true when `owner[key]` is a tx-local slot whose clear must not mint a credit.
+    fn is_non_creditable_slot(&mut self, _owner: Address, _key: U256) -> bool {
+        false
+    }
+
     /// Returns whether x→0 storage clears should mint a persistent storage credit.
     #[inline]
     fn tip1060_storage_credit_minting_enabled(&self) -> bool {
@@ -95,10 +100,12 @@ fn store_credit_state<B: StorageCreditsBackend>(
 
 /// Applies TIP-1060 storage credits after a single SSTORE has been journaled.
 ///
-/// Returns whether to skip normal dynamic/state gas and/or refund accounting.
+/// When provided, `key` lets the hook skip minting a credit for the single transaction-local slot
+/// whose clear must not mint a credit for the storage-owning account.
 pub fn sstore_storage_credits<B: StorageCreditsBackend>(
     backend: &mut B,
     owner: Address,
+    key: Option<U256>,
     caller_state_load: &StateLoad<SStoreResult>,
 ) -> Result<(), B::Error> {
     let values = &caller_state_load.data;
@@ -133,7 +140,14 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
 
     let mut was_changed = false;
     if values.is_new_zero() {
-        // x→0: storage deletion always mints a new credit.
+        // x→0: storage deletion doesn't mint on protocol fee/keychain bookkeeping slots.
+        if let Some(key) = key
+            && backend.is_non_creditable_slot(owner, key)
+        {
+            return Ok(());
+        }
+
+        // x→0: storage deletion mints a new credit on regular slots.
         if backend.tip1060_storage_credit_minting_enabled() {
             credit = credit.saturating_add(1);
             was_changed = true;
@@ -191,4 +205,103 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CreditMode, StorageCredits};
+    use crate::{
+        PATH_USD_ADDRESS, STORAGE_CREDITS_ADDRESS,
+        error::TempoPrecompileError,
+        storage::{PrecompileStorageProvider, StorageCtx, hashmap::HashMapStorageProvider},
+        storage_credits::NonCreditableSlots,
+        tip20::TIP20Token,
+    };
+    use alloy::primitives::{Address, U256};
+    use tempo_chainspec::hardfork::TempoHardfork;
+
+    #[test]
+    fn non_creditable_slot_is_not_persistent_or_direct_spendable_credit() -> eyre::Result<()> {
+        let owner = PATH_USD_ADDRESS;
+        let fee_payer = Address::repeat_byte(0x22);
+        let no_credit_slot = TIP20Token::from_address_unchecked(owner).balances[fee_payer].slot();
+        let fresh_slot = U256::from(0x33);
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        storage.sstore(owner, no_credit_slot, U256::ONE)?;
+        storage.set_spec(TempoHardfork::T7);
+
+        let mut non_creditable_slots = NonCreditableSlots::empty();
+        non_creditable_slots.initialize(fee_payer, owner, None);
+        storage.set_non_creditable_slots(non_creditable_slots);
+        storage.sstore(owner, no_credit_slot, U256::ZERO)?;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut credits = StorageCredits::new();
+            assert_eq!(credits.balance_of(owner)?, 0);
+
+            let mut state = credits.credit_state_of(owner)?;
+            state.mode = CreditMode::Direct;
+            state.budget = u64::MAX;
+            credits.write_credit_state_of(owner, state)
+        })?;
+
+        storage.sstore(owner, fresh_slot, U256::ONE)?;
+
+        StorageCtx::enter(&mut storage, || {
+            let credits = StorageCredits::new();
+            assert_eq!(credits.balance_of(owner)?, 0);
+            assert_eq!(credits.credit_state_of(owner)?.budget, u64::MAX);
+            Ok::<_, TempoPrecompileError>(())
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn non_creditable_slot_recreation_is_accounted_as_normal_creation() -> eyre::Result<()> {
+        let owner = PATH_USD_ADDRESS;
+        let fee_payer = Address::repeat_byte(0x55);
+        let no_credit_slot = TIP20Token::from_address_unchecked(owner).balances[fee_payer].slot();
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        storage.sstore(owner, no_credit_slot, U256::ONE)?;
+        storage.sstore(
+            STORAGE_CREDITS_ADDRESS,
+            StorageCredits::slot(owner),
+            U256::ONE,
+        )?;
+        storage.set_spec(TempoHardfork::T7);
+
+        let mut non_creditable_slots = NonCreditableSlots::empty();
+        non_creditable_slots.initialize(fee_payer, owner, None);
+        storage.set_non_creditable_slots(non_creditable_slots);
+        storage.sstore(owner, no_credit_slot, U256::ZERO)?;
+        storage.sstore(owner, no_credit_slot, U256::ONE)?;
+
+        StorageCtx::enter(&mut storage, || {
+            let credits = StorageCredits::new();
+            let state = credits.credit_state_of(owner)?;
+            assert_eq!(credits.balance_of(owner)?, 1);
+            assert_eq!(state.pending_refunds, 1);
+            Ok::<_, TempoPrecompileError>(())
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn unregistered_zero_key_clear_mints_persistent_credit() -> eyre::Result<()> {
+        let owner = Address::repeat_byte(0x66);
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        storage.sstore(owner, U256::ZERO, U256::ONE)?;
+        storage.set_spec(TempoHardfork::T7);
+
+        storage.sstore(owner, U256::ZERO, U256::ZERO)?;
+
+        StorageCtx::enter(&mut storage, || {
+            assert_eq!(StorageCredits::new().balance_of(owner)?, 1);
+            Ok::<_, TempoPrecompileError>(())
+        })?;
+
+        Ok(())
+    }
 }

--- a/crates/precompiles/src/storage_credits/mod.rs
+++ b/crates/precompiles/src/storage_credits/mod.rs
@@ -6,11 +6,14 @@ pub mod dispatch;
 pub use accounting::{StorageCreditsBackend, StorageCreditsErr, sstore_storage_credits};
 
 use crate::{
-    STORAGE_CREDITS_ADDRESS,
+    ACCOUNT_KEYCHAIN_ADDRESS, STORAGE_CREDITS_ADDRESS,
+    account_keychain::AccountKeychain,
     error::{Result, TempoPrecompileError},
     storage::{Handler, LayoutCtx, StorableType},
+    tip20::TIP20Token,
 };
 use alloy::primitives::{Address, U256};
+use std::cell::OnceCell;
 use tempo_contracts::precompiles::{IStorageCredits::Mode, StorageCreditsError};
 use tempo_precompiles_macros::{Storable, contract};
 
@@ -43,7 +46,7 @@ impl TryFrom<U256> for TransientState {
         Ok(Self {
             budget: limbs[0],
             mode: (limbs[1] as u8).try_into()?,
-            pending_refunds: limbs[3],
+            pending_refunds: limbs[2],
         })
     }
 }
@@ -51,7 +54,89 @@ impl TryFrom<U256> for TransientState {
 impl From<TransientState> for U256 {
     #[inline]
     fn from(value: TransientState) -> Self {
-        Self::from_limbs([value.budget, value.mode as u64, 0, value.pending_refunds])
+        Self::from_limbs([value.budget, value.mode as u64, value.pending_refunds, 0])
+    }
+}
+
+/// Container for slots which are not eligible for storage credits mints.
+///
+/// There are 2 storage slots that are special in terms of TIP-1060 accounting:
+///   1. Balance of the current transaction's fee payer
+///   2. Spending limit of the current transaction's keychain key
+///
+/// Those two slots might get recreated during `collectFeePostTx` call inside of
+/// which we don't do gas accounting or burn storage credits, and thus allowing to
+/// mint credits for those slots during transaction execution might result in those
+/// credits being unbacked.
+#[derive(Debug, Default)]
+pub struct NonCreditableSlots {
+    fee_payer: Address,
+    fee_token: Address,
+    keychain_fee_key: Option<Address>,
+    fee_balance_slot: OnceCell<U256>,
+    keychain_limit_slot: OnceCell<U256>,
+}
+
+impl NonCreditableSlots {
+    #[inline]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn initialize(
+        &mut self,
+        fee_payer: Address,
+        fee_token: Address,
+        keychain_fee_key: Option<Address>,
+    ) {
+        self.fee_payer = fee_payer;
+        self.fee_token = fee_token;
+        self.keychain_fee_key = keychain_fee_key;
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        *self = Self::empty();
+    }
+
+    #[inline]
+    pub(crate) fn is_non_creditable_slot(&self, owner: Address, slot: U256) -> bool {
+        if self.fee_token.is_zero() {
+            return false;
+        }
+
+        if owner == self.fee_token && self.fee_balance_slot() == slot {
+            return true;
+        }
+
+        if owner == ACCOUNT_KEYCHAIN_ADDRESS
+            && self
+                .keychain_limit_slot()
+                .is_some_and(|limit_slot| limit_slot == slot)
+        {
+            return true;
+        }
+
+        false
+    }
+
+    #[inline]
+    fn fee_balance_slot(&self) -> U256 {
+        *self.fee_balance_slot.get_or_init(|| {
+            TIP20Token::from_address_unchecked(self.fee_token).balances[self.fee_payer].slot()
+        })
+    }
+
+    #[inline]
+    fn keychain_limit_slot(&self) -> Option<U256> {
+        let key_id = self.keychain_fee_key?;
+        Some(*self.keychain_limit_slot.get_or_init(|| {
+            let keychain = AccountKeychain::new();
+            let limit_key = AccountKeychain::spending_limit_key(self.fee_payer, key_id);
+            keychain.spending_limits[limit_key][self.fee_token]
+                .remaining
+                .slot()
+        }))
     }
 }
 
@@ -77,7 +162,7 @@ impl StorageCredits {
     }
 
     pub fn balance_of(&self, account: Address) -> Result<u64> {
-        u64::handle(Self::slot(account), LayoutCtx::FULL, self.address).read()
+        self.handler::<u64>(account).read()
     }
 
     pub fn mode_of(&self, account: Address) -> Result<CreditMode> {
@@ -115,21 +200,26 @@ impl StorageCredits {
         self.write_credit_state_of(msg_sender, state)
     }
 
+    /// Returns the storage credit balance/state key for `account`.
     #[inline]
     pub fn slot(account: Address) -> U256 {
         U256::from_be_bytes(account.into_word().0)
     }
 
+    /// Returns a full-slot handler for the account's storage-credit balance/state.
+    #[inline]
+    fn handler<T: StorableType>(&self, account: Address) -> T::Handler {
+        T::handle(Self::slot(account), LayoutCtx::FULL, self.address)
+    }
+
     #[inline]
     fn credit_state_of(&self, account: Address) -> Result<TransientState> {
-        U256::handle(Self::slot(account), LayoutCtx::FULL, self.address)
-            .t_read()?
-            .try_into()
+        self.handler::<U256>(account).t_read()?.try_into()
     }
 
     #[inline]
     fn write_credit_state_of(&mut self, account: Address, state: TransientState) -> Result<()> {
-        U256::handle(Self::slot(account), LayoutCtx::FULL, self.address).t_write(state.into())
+        self.handler::<U256>(account).t_write(state.into())
     }
 }
 
@@ -219,5 +309,54 @@ mod tests {
 
             Ok(())
         })
+    }
+
+    #[test]
+    fn non_creditable_slots_match_fee_bookkeeping_slots() {
+        let fee_token = crate::PATH_USD_ADDRESS;
+        let fee_payer = Address::repeat_byte(0x13);
+        let mut slots = NonCreditableSlots::empty();
+        slots.initialize(fee_payer, fee_token, None);
+
+        let fee_balance_slot =
+            TIP20Token::from_address_unchecked(fee_token).balances[fee_payer].slot();
+        assert!(slots.is_non_creditable_slot(fee_token, fee_balance_slot));
+        assert!(!slots.is_non_creditable_slot(fee_token, fee_balance_slot + U256::ONE));
+    }
+
+    #[test]
+    fn non_creditable_slots_match_keychain_limit_slot() {
+        let fee_payer = Address::repeat_byte(0x16);
+        let key_id = Address::repeat_byte(0x17);
+        let fee_token = crate::PATH_USD_ADDRESS;
+        let mut slots = NonCreditableSlots::empty();
+        slots.initialize(fee_payer, fee_token, Some(key_id));
+
+        let keychain = AccountKeychain::new();
+        let limit_key = AccountKeychain::spending_limit_key(fee_payer, key_id);
+        let remaining_slot = keychain.spending_limits[limit_key][fee_token]
+            .remaining
+            .slot();
+        assert!(slots.is_non_creditable_slot(ACCOUNT_KEYCHAIN_ADDRESS, remaining_slot));
+        assert!(
+            !slots.is_non_creditable_slot(ACCOUNT_KEYCHAIN_ADDRESS, remaining_slot + U256::ONE)
+        );
+    }
+
+    #[test]
+    fn non_creditable_slots_clear_resets_bookkeeping_slots() {
+        let fee_payer = Address::repeat_byte(0x20);
+        let key_id = Address::repeat_byte(0x21);
+        let fee_token = crate::PATH_USD_ADDRESS;
+        let mut slots = NonCreditableSlots::empty();
+        slots.initialize(fee_payer, fee_token, Some(key_id));
+
+        let fee_balance_slot =
+            TIP20Token::from_address_unchecked(fee_token).balances[fee_payer].slot();
+        assert!(slots.is_non_creditable_slot(fee_token, fee_balance_slot));
+
+        slots.clear();
+
+        assert!(!slots.is_non_creditable_slot(fee_token, fee_balance_slot));
     }
 }

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -148,7 +148,7 @@ impl TipFeeManager {
     /// Transfers `max_amount` of `user_token` to the fee manager via [`TIP20Token`] and, if the
     /// validator prefers a different token, verifies sufficient pool liquidity.
     /// Reserves liquidity on T1C+, with a two-hop fallback through `userToken.quoteToken()` on T5+.
-    /// Returns the user's fee token.
+    /// Returns the user's fee token and the validator fee token.
     ///
     /// # Errors
     /// - `InvalidToken` — `user_token` does not have a valid TIP-20 prefix

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -10,8 +10,9 @@ use revm::{
     inspector::InspectorEvmTr,
     interpreter::{InitialAndFloorGas, interpreter::EthInterpreter},
 };
+use std::{cell::RefCell, rc::Rc};
 use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_precompiles::storage::StorageActions;
+use tempo_precompiles::{storage::StorageActions, storage_credits::NonCreditableSlots};
 
 /// The Tempo EVM context type.
 pub type TempoContext<DB> = Context<TempoBlockEnv, TempoTxEnv, CfgEnv<TempoHardfork>, DB>;
@@ -54,18 +55,20 @@ pub struct TempoEvm<DB: Database, I> {
     pub skip_liquidity_check: bool,
     /// Recorded storage actions.
     pub(crate) actions: StorageActions,
+    /// Transaction-local protocol slots whose clears must not mint storage credits.
+    pub(crate) non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
 }
 
 impl<DB: Database, I> TempoEvm<DB, I> {
     /// Create a new Tempo EVM.
     pub fn new(ctx: TempoContext<DB>, inspector: I) -> Self {
-        Self::new_with_actions(ctx, inspector, StorageActions::disabled())
-    }
-
-    /// Create a new Tempo EVM with a buffer for recording storage actions.
-    pub fn new_with_actions(ctx: TempoContext<DB>, inspector: I, actions: StorageActions) -> Self {
-        let precompiles =
-            tempo_precompiles::tempo_precompiles_with_actions(&ctx.cfg, actions.clone());
+        let non_creditable_slots = Rc::new(RefCell::new(NonCreditableSlots::empty()));
+        let actions = StorageActions::disabled();
+        let precompiles = tempo_precompiles::tempo_precompiles(
+            &ctx.cfg,
+            actions.clone(),
+            non_creditable_slots.clone(),
+        );
 
         Self::new_inner(
             Evm {
@@ -76,6 +79,7 @@ impl<DB: Database, I> TempoEvm<DB, I> {
                 frame_stack: FrameStack::new(),
             },
             actions,
+            non_creditable_slots,
         )
     }
 
@@ -91,6 +95,7 @@ impl<DB: Database, I> TempoEvm<DB, I> {
             EthFrame<EthInterpreter>,
         >,
         actions: StorageActions,
+        non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
     ) -> Self {
         Self {
             inner,
@@ -101,6 +106,7 @@ impl<DB: Database, I> TempoEvm<DB, I> {
             skip_valid_after_check: false,
             skip_liquidity_check: false,
             actions,
+            non_creditable_slots,
         }
     }
 
@@ -124,14 +130,17 @@ impl<DB: Database, I> TempoEvm<DB, I> {
 impl<DB: Database, I> TempoEvm<DB, I> {
     /// Consumed self and returns a new Evm type with given Inspector.
     pub fn with_inspector<OINSP>(self, inspector: OINSP) -> TempoEvm<DB, OINSP> {
-        let Self { inner, actions, .. } = self;
-        TempoEvm::new_inner(inner.with_inspector(inspector), actions)
-    }
-
-    /// Consumes self and returns a new Evm type with given Precompiles.
-    pub fn with_precompiles(self, precompiles: PrecompilesMap) -> Self {
-        let Self { inner, actions, .. } = self;
-        Self::new_inner(inner.with_precompiles(precompiles), actions)
+        let Self {
+            inner,
+            actions,
+            non_creditable_slots,
+            ..
+        } = self;
+        TempoEvm::new_inner(
+            inner.with_inspector(inspector),
+            actions,
+            non_creditable_slots,
+        )
     }
 
     /// Consumes self and returns the inner Inspector.
@@ -139,11 +148,17 @@ impl<DB: Database, I> TempoEvm<DB, I> {
         self.inner.into_inspector()
     }
 
+    /// Returns a reference to the recorded storage actions.
+    pub fn actions(&self) -> &StorageActions {
+        &self.actions
+    }
+
     /// Clears all intermediate state from the EVM.
     pub fn clear(&mut self) {
         self.collected_fee = U256::ZERO;
         self.fee_token = None;
         self.key_expiry = None;
+        self.non_creditable_slots.borrow_mut().clear();
     }
 }
 

--- a/crates/revm/src/gas_credits.rs
+++ b/crates/revm/src/gas_credits.rs
@@ -41,7 +41,6 @@ pub fn apply_refund<DB: Database, I>(
     let journal = &mut evm.inner.ctx.journaled_state;
 
     // Take the tx-local storage-credit slots so we can settle them while mutating the journal.
-    // This is safe cause refunds are applied in post-execution.
     let Some(slots) = journal.transient_storage.remove(&STORAGE_CREDITS_ADDRESS) else {
         return Ok(());
     };
@@ -154,6 +153,7 @@ pub(crate) fn sstore<DB: Database>(
                     gas_tracker: interpreter.gas.tracker_mut(),
                 },
                 owner,
+                None,
                 values,
             )?;
         }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1219,6 +1219,8 @@ where
         // already exists. Same-tx auth+use is the exception: that key is registered only after fees
         // are collected, so fee-limit validation uses the inline authorization payload instead.
         let mut loaded_tx_access_key = None;
+        // Access key whose fee-token spending limit was debited during fee collection, if any.
+        let mut keychain_fee_key = None;
         let mut same_tx_key_authorization_use = false;
         if let Some(tempo_tx_env) = tx.tempo_tx_env.as_ref()
             && let Some(keychain_sig) = tempo_tx_env.signature.as_keychain()
@@ -1273,6 +1275,8 @@ where
                             FeePaymentError::Other("SpendingLimitExceeded".to_string()).into()
                         );
                     }
+
+                    keychain_fee_key = Some(key_auth.key_id);
                 }
             } else {
                 // Existing-key path:
@@ -1328,6 +1332,7 @@ where
                 )?;
 
                 evm.key_expiry = Some(loaded_key.key.expiry);
+                keychain_fee_key = loaded_key.key.enforce_limits.then_some(loaded_key.key_id);
                 loaded_tx_access_key = Some(loaded_key);
             }
         }
@@ -1424,6 +1429,19 @@ where
 
                     _ => FeePaymentError::Other(err.to_string()).into(),
                 });
+            }
+
+            if cfg.spec.is_t7() {
+                let keychain_fee_key = if fee_payer == tx.caller {
+                    keychain_fee_key
+                } else {
+                    None
+                };
+                evm.non_creditable_slots.borrow_mut().initialize(
+                    fee_payer,
+                    fee_token,
+                    keychain_fee_key,
+                );
             }
 
             journal.checkpoint_commit();
@@ -1720,6 +1738,7 @@ where
         // Reset per-tx fee state.
         evm.collected_fee = U256::ZERO;
         evm.validator_fee = U256::ZERO;
+        evm.non_creditable_slots.borrow_mut().clear();
 
         // Validate the fee payer signature
         let fee_payer = evm.ctx.tx.fee_payer()?;


### PR DESCRIPTION
## Summary
- Merge latest `main` into #6237.
- Resolve the storage credits integration-test conflict by preserving the PR coverage and the two new main-branch refund regressions.

## Verification
- `cargo fmt` completed with existing rustfmt warnings about unstable `imports_granularity`.
- `cargo test -p tempo-node --test it storage_credits -- --nocapture` built successfully and passed 4/7 filtered tests before the remaining 3 stalled for several minutes; the run was terminated.

Prompted by: @0xrusowsky