### PR TITLE
chore: fix bench bloat metadata forwarding

### DIFF
--- a/tempo.nu
+++ b/tempo.nu
@@ -740,6 +740,7 @@ def run-bench-single [
             --git-ref $git_ref
             --build-profile $build_profile
             --benchmark-mode $benchmark_mode
+            --bloat-mib $bloat
             --bloat-token-count ($TIP20_TOKEN_IDS | length)
             --skip-funding=($bloat > 0))
         if not $result.ok {
@@ -2926,6 +2927,7 @@ def "main bench" [
             --git-ref $current_sha
             --build-profile $profile
             --benchmark-mode $mode
+            --bloat-mib $bloat
             --bloat-token-count ($TIP20_TOKEN_IDS | length)
             --skip-funding=($bloat > 0))
         $result
@@ -3340,6 +3342,7 @@ tempo-precompiles = { path = '($tempo_root)/crates/precompiles' }
                         --max-concurrent-requests 100
                         --build-profile "coverage"
                         --benchmark-mode "coverage"
+                        --bloat-mib $bloat
                         --bloat-token-count ($TIP20_TOKEN_IDS | length))
                     if not $bench_result.ok {
                         print "Bench finished (or interrupted)."


### PR DESCRIPTION
## Summary
- forward `--bloat-mib` from `tempo.nu` txgen benchmark invocations
- keep existing-recipient presets from seeing `bloat_mib=0` when `--bloat` is set

## Test
- `nu --ide-check 0 tempo.nu`

Prompted by: @shekhirin