### PR TITLE
chore: fix coverage bloat scope

### DIFF
--- a/tempo.nu
+++ b/tempo.nu
@@ -3342,7 +3342,6 @@ tempo-precompiles = { path = '($tempo_root)/crates/precompiles' }
                         --max-concurrent-requests 100
                         --build-profile "coverage"
                         --benchmark-mode "coverage"
-                        --bloat-mib $bloat
                         --bloat-token-count ($TIP20_TOKEN_IDS | length))
                     if not $bench_result.ok {
                         print "Bench finished (or interrupted)."


### PR DESCRIPTION
## Summary
- remove `--bloat-mib $bloat` from the coverage txgen path where `$bloat` is not in scope
- keep bloat metadata forwarding in the actual `bench` paths from #6282

## Test
- `nu --ide-check 0 tempo.nu`

Prompted by: @shekhirin