### PR TITLE
ci(bench): display Tracy bench config as enabled

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -541,7 +541,7 @@ jobs:
             const samply = process.env.BENCH_SAMPLY === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
             const tracy = process.env.BENCH_TRACY;
-            const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
+            const tracyNote = tracy !== 'off' ? ', tracy: `enabled`' : '';
             const otlp = process.env.BENCH_OTLP === 'true';
             const otlpNote = otlp ? ', otlp: `enabled`' : ', otlp: `disabled`';
             const valscope = process.env.BENCH_VALSCOPE === 'true';
@@ -773,7 +773,7 @@ jobs:
             const samply = process.env.BENCH_SAMPLY === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
             const tracy = process.env.BENCH_TRACY;
-            const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
+            const tracyNote = tracy !== 'off' ? ', tracy: `enabled`' : '';
             const otlp = process.env.BENCH_OTLP === 'true';
             const otlpNote = otlp ? ', otlp: `enabled`' : ', otlp: `disabled`';
             const valscope = process.env.BENCH_VALSCOPE === 'true';

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -511,7 +511,7 @@ jobs:
             const samply = process.env.ACK_SAMPLY === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
             const tracy = process.env.ACK_TRACY;
-            const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
+            const tracyNote = tracy !== 'off' ? ', tracy: `enabled`' : '';
             const otlp = process.env.ACK_OTLP === 'true';
             const otlpNote = otlp ? ', otlp: `enabled`' : ', otlp: `disabled`';
             const valscope = process.env.ACK_VALSCOPE === 'true';


### PR DESCRIPTION
## Summary
- Display Tracy profiling in bench PR comments as `tracy: enabled` instead of `tracy: tracy`
- Keep the internal Tracy mode value unchanged

Prompted by: @shekhirin