### PR TITLE
TIP-1060: add benchmark note

### DIFF
--- a/tips/tip-1060.md
+++ b/tips/tip-1060.md
@@ -88,6 +88,21 @@ The table below enumerates every `(original, present, new)` transition class, th
 
 A `nonzero -> 0` transition mints one credit irrespective of `O` and of mode (**credit +1**). A `0 -> nonzero` transition is a creation: `STORAGE_CREDIT_VALUE` is handled per mode (see [Storage Credit Consumption](#storage-credit-consumption-present--0-to-new--0)) — either consuming one credit (**credit −1**) or charging `STORAGE_CREDIT_VALUE` — while `SSTORE_SET_COST` is charged only on a clean creation (`original == present == 0`). Every other transition neither mints nor consumes a credit.
 
+### Benchmark note
+
+To validate that `SSTORE_SET_COST = 5,000` properly prices the state-write/root work of credited storage creation, the residual was checked with a DB-backed Reth/Tempo provider benchmark that exercises hashed storage/trie state, `state_root_with_updates`, provider hashed-post-state checks, and DB/trie commit smoke checks. The benchmark uses 5k slot updates in one transaction as an upper-bound case: this is slightly above the theoretical maximum number of credited clean creations that can fit under the production transaction gas cap once the 5k residual per slot and fixed transaction overhead are included. Each row compares `0 -> X` creations against comparable `X -> Y` updates, averaging three runs per scenario.
+
+> [!NOTE]
+> Benchmark host: Apple M4 Max, 36 GiB memory, macOS Tahoe 26.5.1.
+
+| Pre-existing account non-zero slots | `X -> Y` storage updates : removals | `0 -> X` storage updates : removals | `X -> Y` ns/slot | `0 -> X` ns/slot | Relative `0 -> X` cost |
+|------------------------------------:|----------------------------------:|----------------------------------:|-----------------:|-----------------:|-----------------------:|
+| 0 | 397 : 397 | 397 : 0 | 476.092 | 369.912 | 0.777x |
+| 10k | 1,317 : 1,317 | 1,318 : 651 | 1,184.140 | 1,073.815 | 0.907x |
+| 100k | 3,780 : 3,780 | 3,781 : 3,401 | 3,908.699 | 3,817.203 | 0.977x |
+
+Trie diagnostics show that both cases update the same or nearly the same number of storage trie nodes; `X -> Y` updates remove more old trie nodes, while `0 -> X` inserts remove fewer. The results support the 5k residual as the execution price for the state-write/root path, while the remaining `STORAGE_CREDIT_VALUE` prices long-term storage growth.
+
 ## State
 
 ### Persistent state


### PR DESCRIPTION
## Summary
- add a succinct benchmark note for the 5k SSTORE residual
- summarize the DB-backed state-root benchmark setup and observed 0->X vs X->Y ratios

## Tests
- not run; documentation-only change

Prompted by: @0xrusowsky