### PR TITLE
fix(consensus): set default listen addr to 0.0.0.0:8000

### DIFF
--- a/crates/consensus/src/args.rs
+++ b/crates/consensus/src/args.rs
@@ -67,7 +67,7 @@ pub struct Args {
 
     /// The socket address that will be bound to listen for consensus communication from
     /// other nodes.
-    #[arg(long = "consensus.listen-address", default_value = "127.0.0.1:8000")]
+    #[arg(long = "consensus.listen-address", default_value = "0.0.0.0:8000")]
     pub listen_address: SocketAddr,
 
     /// The socket address that will be bound to export consensus specific


### PR DESCRIPTION
Summary:
- Change the default `--consensus.listen-address` from `127.0.0.1:8000` to `0.0.0.0:8000`.

Explainer:
- The old default binds consensus P2P to localhost, which is a footgun for validators running outside k8s or without an explicit override: they can initiate outbound connections but do not accept inbound connections on the registered consensus port. Recent testnet connectivity debugging showed this configuration can leave validators unable to receive enough inbound consensus traffic, and consensus inbound connections are already authenticated, so the default should listen on all interfaces while operators can still override it when needed.

Tests:
- `cargo check -p tempo-consensus`

Prompted by: @kuyziss