### PR TITLE
docs: update TIP rollout statuses

### DIFF
--- a/tips/tip-1026.md
+++ b/tips/tip-1026.md
@@ -3,7 +3,7 @@ id: TIP-1026
 title: Token Logo URI
 description: Adds a logoURI string field to TIP-20 tokens for on-chain token icon metadata.
 authors: Dan Robinson
-status: Approved
+status: Mainnet
 related: TIP-20
 protocolVersion: T5
 ---

--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -3,7 +3,7 @@ id: TIP-1028
 title: Address-Level Receive Policies
 description: Extends TIP-403 with address-level receive policies, token filters, and receipt-based recovery for blocked TIP-20 transfers and mints.
 authors: Mallesh Pai, 0xrusowsky, 0xKitsune
-status: Approved
+status: Testnet
 related: TIP-403, TIP-1015, TIP-20, TIP-1016, TIP-1022
 protocolVersion: T6
 ---

--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -3,7 +3,7 @@ id: TIP-1028
 title: Address-Level Receive Policies
 description: Extends TIP-403 with address-level receive policies, token filters, and receipt-based recovery for blocked TIP-20 transfers and mints.
 authors: Mallesh Pai, 0xrusowsky, 0xKitsune
-status: Testnet
+status: Mainnet
 related: TIP-403, TIP-1015, TIP-20, TIP-1016, TIP-1022
 protocolVersion: T6
 ---

--- a/tips/tip-1030.md
+++ b/tips/tip-1030.md
@@ -3,7 +3,7 @@ id: TIP-1030
 title: Allow same-tick flip orders
 description: Relaxes the placeFlip validation to allow flipTick to equal tick, enabling flip orders that flip to the same price.
 authors: Dan Robinson
-status: Draft
+status: Mainnet
 related: TIP-1002
 protocolVersion: T5
 supersedes: TIP-1002

--- a/tips/tip-1031.md
+++ b/tips/tip-1031.md
@@ -3,7 +3,7 @@ id: TIP-1031
 title: Embed consensus context in the block Header
 description: Embed consensus context into the block header
 authors: Hamdi, Janis
-status: Approved
+status: Mainnet
 related: N/A
 protocolVersion: T4
 ---

--- a/tips/tip-1033.md
+++ b/tips/tip-1033.md
@@ -3,7 +3,7 @@ id: TIP-1033
 title: Two-Hop FeeAMM Routing
 description: Adds a two-hop fallback path through the FeeAMM when there is insufficient liquidity in the direct userToken→validatorToken pool.
 authors: Daniel Robinson
-status: Approved
+status: Mainnet
 related: TIP-1000, FeeAMM, FeeManager
 protocolVersion: T5
 ---

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -3,7 +3,7 @@ id: TIP-1034
 title: TIP-20 Channel Reserve Precompile
 description: Enshrines TIP-20 channel reserve as a Tempo precompile with payment-lane admission and native reserve transfer semantics.
 authors: Tanishk Goyal, Brendan Ryan
-status: Devnet
+status: Mainnet
 related: TIP-20, TIP-1000, TIP-1009, TIP-1020, Tempo Session, Tempo Charge
 protocolVersion: T5
 ---

--- a/tips/tip-1035.md
+++ b/tips/tip-1035.md
@@ -3,7 +3,7 @@ id: TIP-1035
 title: Implicit Approval List
 description: Defines an in-protocol list of precompiles that may call system_transfer_from to pull TIP-20 tokens without requiring a prior approve() call.
 authors: Dan Robinson
-status: Draft
+status: Mainnet
 related: TIP-20, TIP-1022
 protocolVersion: T5
 ---

--- a/tips/tip-1045.md
+++ b/tips/tip-1045.md
@@ -3,7 +3,7 @@ id: TIP-1045
 title: Payment Transaction Classification
 description: Defines consensus rules for classifying transactions as payment lane eligible using an allow-list of call targets/selectors and bounded auxiliary payloads.
 authors: @0xrusowsky, Arsenii Kulikov @klkvr, Dan Robinson @danrobinson, Tanishk Goyal @legion2002
-status: Approved
+status: Mainnet
 related: TIP-1010, TIP-1000, Payment Lane Specification, TIP-20, TIP-1034
 protocolVersion: T5
 ---

--- a/tips/tip-1046.md
+++ b/tips/tip-1046.md
@@ -3,7 +3,7 @@ id: TIP-1046
 title: T4 Hardfork Meta TIP
 description: Meta TIP collecting all bug fixes and security hardening changes gated behind the T4 hardfork.
 authors: Federico Gimenez (@fgimenez), Derek Cofausper (@decofe), Tanishk Goyal (@legion2002), Marc Martinez (@0xrusowsky), Arsenii Kulikov (@klkvr)
-status: Approved
+status: Mainnet
 related: TIP-1011, TIP-1016, TIP-1031, TIP-1038
 protocolVersion: T4
 ---

--- a/tips/tip-1049.md
+++ b/tips/tip-1049.md
@@ -3,7 +3,7 @@ id: TIP-1049
 title: Admin Access Keys
 description: Extend access keys with an admin flag that grants key-management capabilities
 authors: Jake Moxey (@jxom), Georgios Konstantopoulos (@gakonst), Tanishk Goyal (@tanishkgoyal)
-status: Approved
+status: Testnet
 related: TIP-1011, TIP-1020
 protocolVersion: T6
 ---

--- a/tips/tip-1049.md
+++ b/tips/tip-1049.md
@@ -3,7 +3,7 @@ id: TIP-1049
 title: Admin Access Keys
 description: Extend access keys with an admin flag that grants key-management capabilities
 authors: Jake Moxey (@jxom), Georgios Konstantopoulos (@gakonst), Tanishk Goyal (@tanishkgoyal)
-status: Testnet
+status: Mainnet
 related: TIP-1011, TIP-1020
 protocolVersion: T6
 ---

--- a/tips/tip-1053.md
+++ b/tips/tip-1053.md
@@ -3,7 +3,7 @@ id: TIP-1053
 title: Witnesses in Key Authorizations
 description: Add an optional 32-byte witness to key authorizations so a single signature can both authorize an access key and bind to an arbitrary application context, with manual witness burning for revocation.
 authors: Jake Moxey (@jxom)
-status: Approved
+status: Mainnet
 related: TIP-1011, TIP-1020
 protocolVersion: T5
 ---

--- a/tips/tip-1056.md
+++ b/tips/tip-1056.md
@@ -3,7 +3,7 @@ id: TIP-1056
 title: Keep the same order ID when flip orders flip
 description: Reuses the same order ID when a flip order flips and emits OrderFlipped instead of creating a new order ID and emitting OrderPlaced.
 authors: Dan Robinson
-status: Draft
+status: Mainnet
 related: TIP-1030, TIP-1044
 protocolVersion: T5
 ---

--- a/tips/tip-1057.md
+++ b/tips/tip-1057.md
@@ -3,7 +3,7 @@ id: TIP-1057
 title: T5 Hardfork Meta TIP
 description: Meta TIP collecting bug fixes, security hardening, and infrastructure changes gated behind the T5 hardfork.
 authors: Marc Martinez (@0xrusowsky)
-status: Draft
+status: Mainnet
 related: TIP-1026, TIP-1030, TIP-1033, TIP-1034, TIP-1035, TIP-1045, TIP-1053, TIP-1056
 protocolVersion: T5
 ---

--- a/tips/tip-1064.md
+++ b/tips/tip-1064.md
@@ -3,7 +3,7 @@ id: TIP-1064
 title: StablecoinDEX Order Storage Credits
 description: Adds per-order reusable storage accounting to the StablecoinDEX, using TIP-1060 precompile storage gas tokens to charge storage creation costs to the user who expands order-attributable DEX state.
 authors: Dankrad Feist
-status: Draft
+status: Mainnet
 related: TIP-1000, TIP-1058, TIP-1060
 protocolVersion: T5
 ---

--- a/tips/tip-1064.md
+++ b/tips/tip-1064.md
@@ -3,9 +3,9 @@ id: TIP-1064
 title: StablecoinDEX Order Storage Credits
 description: Adds per-order reusable storage accounting to the StablecoinDEX, using TIP-1060 precompile storage gas tokens to charge storage creation costs to the user who expands order-attributable DEX state.
 authors: Dankrad Feist
-status: Mainnet
+status: Scheduled
 related: TIP-1000, TIP-1058, TIP-1060
-protocolVersion: T5
+protocolVersion: T7
 ---
 
 # TIP-1064: StablecoinDEX Order Storage Credits


### PR DESCRIPTION
## Summary
- mark T4/T5 TIPs from the stale-status audit as Mainnet
- mark T6 TIPs from the stale-status audit as Testnet

Prompted by: @shekhirin