### PR TITLE
ci(bench): use PR base branch for bench-e2e baseline

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -631,7 +631,7 @@ jobs:
           cat /proc/sys/kernel/perf_event_paranoid
           cat /proc/sys/kernel/kptr_restrict
 
-      - name: Resolve PR head branch
+      - name: Resolve PR branches
         id: pr-info
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -640,13 +640,20 @@ jobs:
         with:
           script: |
             if (process.env.BENCH_PR) {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: parseInt(process.env.BENCH_PR, 10),
+              });
               const ref = process.env.BENCH_PR_HEAD_REF || process.env.INPUT_REF_NAME;
               const sha = process.env.BENCH_PR_HEAD_SHA || process.env.INPUT_SHA;
               core.setOutput('head-ref', ref);
               core.setOutput('head-sha', sha);
+              core.setOutput('base-ref', pr.base.ref);
             } else {
               core.setOutput('head-ref', process.env.INPUT_REF_NAME);
               core.setOutput('head-sha', process.env.INPUT_SHA);
+              core.setOutput('base-ref', 'main');
             }
 
       - name: Resolve baseline and feature refs
@@ -660,6 +667,7 @@ jobs:
          INPUT_SHA: ${{ github.sha }}
          INPUT_PR_HEAD_SHA: ${{ steps.pr-info.outputs.head-sha }}
          INPUT_PR_HEAD_REF: ${{ steps.pr-info.outputs.head-ref }}
+         INPUT_PR_BASE_REF: ${{ steps.pr-info.outputs.base-ref }}
         with:
          script: |
            const { execSync } = require('child_process');
@@ -669,6 +677,7 @@ jobs:
            const featureArg = process.env.INPUT_FEATURE;
            const baselineNameArg = process.env.INPUT_BASELINE_NAME;
            const featureNameArg = process.env.INPUT_FEATURE_NAME;
+           const baseRef = process.env.INPUT_PR_BASE_REF || 'main';
 
            let baselineRef, baselineName, featureRef, featureName;
 
@@ -682,11 +691,12 @@ jobs:
              baselineName = baselineNameArg || baselineArg;
            } else {
              try {
-               baselineRef = run('git merge-base HEAD origin/main');
+               run(`git fetch origin "${baseRef}" --quiet`);
+               baselineRef = run(`git merge-base HEAD "origin/${baseRef}"`);
              } catch {
                baselineRef = process.env.INPUT_SHA;
              }
-             baselineName = baselineNameArg || 'main';
+             baselineName = baselineNameArg || baseRef;
            }
 
            if (featureArg) {


### PR DESCRIPTION
## Summary
- Resolve the PR base branch in `bench-e2e` when a PR number is available.
- Use that base branch for the default baseline merge-base instead of hardcoded `origin/main`.

Prompted by: @shekhirin

## Tests
- `git diff --check`
- `node -e "const fs=require('fs'); const s=fs.readFileSync('.github/workflows/bench-e2e.yml','utf8'); if(!s.includes('INPUT_PR_BASE_REF')) process.exit(1); console.log('ok')"`