### PR TITLE
feat(payload): thread skip-state-root into tempo builder

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -730,6 +730,7 @@ where
                 is_dev: ctx.is_dev(),
                 state_provider_metrics: self.state_provider_metrics,
                 enable_prewarming: self.enable_prewarming,
+                skip_state_root: ctx.config().tree_config().skip_state_root(),
                 build_time_multiplier: self.build_time_multiplier,
             },
         ))

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -112,8 +112,6 @@ pub struct TempoPayloadBuilder<Provider> {
     highest_invalid_subblock: Arc<AtomicU64>,
     /// Whether to include block access lists in built execution payloads.
     enable_bal: bool,
-    /// Whether payload builds should skip state-root computation.
-    skip_state_root: bool,
     /// Learned estimate of total replayable build work divided by work at tx cutoff.
     ///
     /// This lets the builder reserve time for non-interruptible
@@ -181,7 +179,6 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             cache_metrics: CachedStateMetrics::zeroed(CachedStateMetricsSource::Builder),
             highest_invalid_subblock: Default::default(),
             enable_bal: cfg!(feature = "bal"),
-            skip_state_root: config.skip_state_root,
             build_time_multiplier: Arc::new(AtomicU64::new(scaled_build_time_multiplier(
                 config.build_time_multiplier,
             ))),
@@ -941,45 +938,46 @@ where
             finish_provider.hashed_post_state(&db.bundle_state)
         };
 
-        let (state_root_outcome, sparse_trie_state_root_wait_elapsed) = if self.skip_state_root {
-            debug!(
-                target: "payload_builder",
-                id = %payload_id,
-                state_root = ?parent_header.state_root(),
-                "skipping payload state-root computation"
-            );
-            None
-        } else if let Some(mut handle) = trie_handle {
-            let state_root_wait_start = Instant::now();
-            let _span = debug_span!(target: "payload_builder", "await_state_root").entered();
-            match handle.state_root() {
-                Ok(outcome) => {
-                    let elapsed = state_root_wait_start.elapsed();
-                    self.metrics
-                        .sparse_trie_state_root_wait_duration_seconds
-                        .record(elapsed);
-                    debug!(
-                        target: "payload_builder",
-                        id = %payload_id,
-                        state_root = ?outcome.state_root,
-                        "received state root from sparse trie"
-                    );
-                    Some((outcome, elapsed))
+        let (state_root_outcome, sparse_trie_state_root_wait_elapsed) =
+            if self.config.skip_state_root {
+                debug!(
+                    target: "payload_builder",
+                    id = %payload_id,
+                    state_root = ?parent_header.state_root(),
+                    "skipping payload state-root computation"
+                );
+                None
+            } else if let Some(mut handle) = trie_handle {
+                let state_root_wait_start = Instant::now();
+                let _span = debug_span!(target: "payload_builder", "await_state_root").entered();
+                match handle.state_root() {
+                    Ok(outcome) => {
+                        let elapsed = state_root_wait_start.elapsed();
+                        self.metrics
+                            .sparse_trie_state_root_wait_duration_seconds
+                            .record(elapsed);
+                        debug!(
+                            target: "payload_builder",
+                            id = %payload_id,
+                            state_root = ?outcome.state_root,
+                            "received state root from sparse trie"
+                        );
+                        Some((outcome, elapsed))
+                    }
+                    Err(err) => {
+                        warn!(
+                            target: "payload_builder",
+                            id = %payload_id,
+                            %err,
+                            "sparse trie failed, falling back to sync state root"
+                        );
+                        None
+                    }
                 }
-                Err(err) => {
-                    warn!(
-                        target: "payload_builder",
-                        id = %payload_id,
-                        %err,
-                        "sparse trie failed, falling back to sync state root"
-                    );
-                    None
-                }
+            } else {
+                None
             }
-        } else {
-            None
-        }
-        .unzip();
+            .unzip();
 
         let (block_access_list, block_access_list_hash) = if let Some(bal_rx) = bal_rx {
             let (bal, bal_hash) = bal_rx.blocking_recv().map_err(PayloadBuilderError::other)?;
@@ -988,7 +986,7 @@ where
             (None, None)
         };
 
-        let (state_root, trie_updates) = if self.skip_state_root {
+        let (state_root, trie_updates) = if self.config.skip_state_root {
             (parent_header.state_root(), Arc::new(Default::default()))
         } else if let Some(outcome) = state_root_outcome {
             (outcome.state_root, outcome.trie_updates)

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -144,19 +144,6 @@ pub struct TempoPayloadBuilderConfig {
     pub build_time_multiplier: f64,
 }
 
-impl Default for TempoPayloadBuilderConfig {
-    fn default() -> Self {
-        Self {
-            desired_gas_limit: None,
-            is_dev: false,
-            state_provider_metrics: false,
-            enable_prewarming: true,
-            skip_state_root: false,
-            build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
-        }
-    }
-}
-
 impl TempoPayloadBuilderConfig {
     /// Returns the gas limit for the next block based on the parent gas limit and an optional
     /// target from payload attributes.

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -117,6 +117,8 @@ pub struct TempoPayloadBuilder<Provider> {
     enable_prewarming: bool,
     /// Whether to include block access lists in built execution payloads.
     enable_bal: bool,
+    /// Whether payload builds should skip state-root computation.
+    skip_state_root: bool,
     /// Learned estimate of total replayable build work divided by work at tx cutoff.
     ///
     /// This lets the builder reserve time for non-interruptible
@@ -133,6 +135,8 @@ pub struct TempoPayloadBuilderConfig {
     pub state_provider_metrics: bool,
     /// Whether to enable prewarming of best transactions.
     pub enable_prewarming: bool,
+    /// Whether payload builds should skip state-root computation.
+    pub skip_state_root: bool,
     /// Initial estimate of total replayable build work divided by work at tx cutoff.
     ///
     /// `1.0` means no finish-work headroom beyond observed work so far. Values
@@ -147,6 +151,7 @@ impl Default for TempoPayloadBuilderConfig {
             is_dev: false,
             state_provider_metrics: false,
             enable_prewarming: true,
+            skip_state_root: false,
             build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
         }
     }
@@ -172,6 +177,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             state_provider_metrics: config.state_provider_metrics,
             enable_prewarming: config.enable_prewarming,
             enable_bal: cfg!(feature = "bal"),
+            skip_state_root: config.skip_state_root,
             build_time_multiplier: Arc::new(AtomicU64::new(scaled_build_time_multiplier(
                 config.build_time_multiplier,
             ))),
@@ -929,38 +935,45 @@ where
             finish_provider.hashed_post_state(&db.bundle_state)
         };
 
-        let (state_root_outcome, sparse_trie_state_root_wait_elapsed) =
-            if let Some(mut handle) = trie_handle {
-                let state_root_wait_start = Instant::now();
-                let _span = debug_span!(target: "payload_builder", "await_state_root").entered();
-                match handle.state_root() {
-                    Ok(outcome) => {
-                        let elapsed = state_root_wait_start.elapsed();
-                        self.metrics
-                            .sparse_trie_state_root_wait_duration_seconds
-                            .record(elapsed);
-                        debug!(
-                            target: "payload_builder",
-                            id = %payload_id,
-                            state_root = ?outcome.state_root,
-                            "received state root from sparse trie"
-                        );
-                        Some((outcome, elapsed))
-                    }
-                    Err(err) => {
-                        warn!(
-                            target: "payload_builder",
-                            id = %payload_id,
-                            %err,
-                            "sparse trie failed, falling back to sync state root"
-                        );
-                        None
-                    }
+        let (state_root_outcome, sparse_trie_state_root_wait_elapsed) = if self.skip_state_root {
+            debug!(
+                target: "payload_builder",
+                id = %payload_id,
+                state_root = ?parent_header.state_root(),
+                "skipping payload state-root computation"
+            );
+            None
+        } else if let Some(mut handle) = trie_handle {
+            let state_root_wait_start = Instant::now();
+            let _span = debug_span!(target: "payload_builder", "await_state_root").entered();
+            match handle.state_root() {
+                Ok(outcome) => {
+                    let elapsed = state_root_wait_start.elapsed();
+                    self.metrics
+                        .sparse_trie_state_root_wait_duration_seconds
+                        .record(elapsed);
+                    debug!(
+                        target: "payload_builder",
+                        id = %payload_id,
+                        state_root = ?outcome.state_root,
+                        "received state root from sparse trie"
+                    );
+                    Some((outcome, elapsed))
                 }
-            } else {
-                None
+                Err(err) => {
+                    warn!(
+                        target: "payload_builder",
+                        id = %payload_id,
+                        %err,
+                        "sparse trie failed, falling back to sync state root"
+                    );
+                    None
+                }
             }
-            .unzip();
+        } else {
+            None
+        }
+        .unzip();
 
         let (block_access_list, block_access_list_hash) = if let Some(bal_rx) = bal_rx {
             let (bal, bal_hash) = bal_rx.blocking_recv().map_err(PayloadBuilderError::other)?;
@@ -969,7 +982,9 @@ where
             (None, None)
         };
 
-        let (state_root, trie_updates) = if let Some(outcome) = state_root_outcome {
+        let (state_root, trie_updates) = if self.skip_state_root {
+            (parent_header.state_root(), Arc::new(Default::default()))
+        } else if let Some(outcome) = state_root_outcome {
             (outcome.state_root, outcome.trie_updates)
         } else {
             let (state_root, trie_updates) = finish_provider


### PR DESCRIPTION
## Summary
- plumb `TreeConfig::skip_state_root()` into `TempoPayloadBuilderConfig`
- skip Tempo payload state-root and trie update computation when the benchmarking flag is enabled
- reuse the parent state root for the built block in skip mode

Upstream reference: https://github.com/paradigmxyz/reth/pull/25635

Prompted by: @klkvr

## Testing
- `cargo fmt --check`
- `cargo check -p tempo-node -p tempo-payload-builder`