### PR TITLE
Add bench general gas limit override

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -116,6 +116,11 @@ on:
         type: string
         required: true
         default: "5000000000"
+      general-gas-limit:
+        description: General non-payment gas limit override.
+        type: string
+        required: false
+        default: ""
       force-bloat:
         description: Force regeneration of local benchmark state.
         type: boolean
@@ -258,6 +263,10 @@ on:
         type: string
         required: false
         default: "5000000000"
+      general-gas-limit:
+        type: string
+        required: false
+        default: ""
       run-type:
         type: string
         required: false
@@ -384,6 +393,7 @@ jobs:
       BENCH_BASELINE_ARGS: ${{ inputs.baseline-args }}
       BENCH_FEATURE_ARGS: ${{ inputs.feature-args }}
       BENCH_GAS_LIMIT: ${{ inputs.gas-limit || '5000000000' }}
+      BENCH_GENERAL_GAS_LIMIT: ${{ inputs.general-gas-limit }}
       BENCH_RUN_TYPE: ${{ inputs.run-type || 'dispatch' }}
       BENCH_FORCE_BLOAT: ${{ inputs.force-bloat || 'false' }}
       BENCH_NO_CACHE: ${{ inputs.no-cache || 'false' }}
@@ -554,12 +564,14 @@ jobs:
             const noCache = process.env.BENCH_NO_CACHE === 'true';
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const gasLimit = process.env.BENCH_GAS_LIMIT;
+            const generalGasLimit = process.env.BENCH_GENERAL_GAS_LIMIT || '';
+            const generalGasLimitNote = generalGasLimit ? `, general-gas-limit: \`${generalGasLimit}\`` : '';
             const runPairs = process.env.BENCH_RUN_PAIRS || '2';
             const runSide = process.env.BENCH_RUN_SIDE || 'comparison';
             const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
             const featureFlagsNote = `${baselineFeatureFlags ? `, baseline-features: \`${baselineFeatureFlags}\`` : ''}${featureFeatureFlags ? `, feature-features: \`${featureFeatureFlags}\`` : ''}`;
             const runSideNote = runSide !== 'comparison' ? `, run-side: \`${runSide}\`` : '';
-            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, token-count: \`${tokenCount}\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`${runSideNote}, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${noCacheNote}`);
+            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, token-count: \`${tokenCount}\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`${generalGasLimitNote}, run-pairs: \`${runPairs}\`${runSideNote}, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${noCacheNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -788,12 +800,14 @@ jobs:
             const noCache = process.env.BENCH_NO_CACHE === 'true';
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const gasLimit = process.env.BENCH_GAS_LIMIT;
+            const generalGasLimit = process.env.BENCH_GENERAL_GAS_LIMIT || '';
+            const generalGasLimitNote = generalGasLimit ? `, general-gas-limit: \`${generalGasLimit}\`` : '';
             const runPairs = process.env.BENCH_RUN_PAIRS || '2';
             const runSide = process.env.BENCH_RUN_SIDE || 'comparison';
             const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
             const featureFlagsNote = `${baselineFeatureFlags ? `, baseline-features: \`${baselineFeatureFlags}\`` : ''}${featureFeatureFlags ? `, feature-features: \`${featureFeatureFlags}\`` : ''}`;
             const runSideNote = runSide !== 'comparison' ? `, run-side: \`${runSide}\`` : '';
-            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, token-count: \`${tokenCount}\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`${runSideNote}, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${noCacheNote}`;
+            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, token-count: \`${tokenCount}\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`${generalGasLimitNote}, run-pairs: \`${runPairs}\`${runSideNote}, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${noCacheNote}`;
             core.exportVariable('BENCH_CONFIG', config);
 
             const { data: comment } = await github.rest.issues.createComment({
@@ -867,6 +881,7 @@ jobs:
           [ "$BENCH_NO_CACHE" = "true" ] && cmd+=(--no-cache)
           [ "$BENCH_SAMPLY" = "true" ] && cmd+=(--samply)
           [ "$BENCH_TRACY" != "off" ] && cmd+=(--tracy "$BENCH_TRACY" --tracy-seconds "$BENCH_TRACY_SECONDS" --tracy-offset "$BENCH_TRACY_OFFSET")
+          [ -n "$BENCH_GENERAL_GAS_LIMIT" ] && cmd+=(--general-gas-limit "$BENCH_GENERAL_GAS_LIMIT")
           [ -n "$BENCH_BASELINE_HARDFORK" ] && cmd+=(--baseline-hardfork="$BENCH_BASELINE_HARDFORK")
           [ -n "$BENCH_FEATURE_HARDFORK" ] && cmd+=(--feature-hardfork="$BENCH_FEATURE_HARDFORK")
           [ -n "$BENCH_BASELINE_FEATURES" ] && cmd+=(--baseline-features="$BENCH_BASELINE_FEATURES")
@@ -936,6 +951,7 @@ jobs:
             no-cache="$BENCH_NO_CACHE"
             force-bloat="$BENCH_FORCE_BLOAT"
           )
+          [ -n "$BENCH_GENERAL_GAS_LIMIT" ] && derek_cmd+=(general-gas-limit="$BENCH_GENERAL_GAS_LIMIT")
           [ -n "$BENCH_TXGEN_REF" ] && derek_cmd+=(txgen-ref="$BENCH_TXGEN_REF")
           [ "$BENCH_SAMPLY" = "true" ] && derek_cmd+=(samply)
           [ "$BENCH_TRACY" != "off" ] && derek_cmd+=(tracy="$BENCH_TRACY" tracy-seconds="$BENCH_TRACY_SECONDS" tracy-offset="$BENCH_TRACY_OFFSET")

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -54,6 +54,7 @@ jobs:
       baseline-args: ${{ steps.args.outputs.baseline-args }}
       feature-args: ${{ steps.args.outputs.feature-args }}
       gas-limit: ${{ steps.args.outputs.gas-limit }}
+      general-gas-limit: ${{ steps.args.outputs.general-gas-limit }}
       run-type: ${{ steps.args.outputs.run-type }}
       force-bloat: ${{ steps.args.outputs.force-bloat }}
       no-cache: ${{ steps.args.outputs.no-cache }}
@@ -122,7 +123,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
-            let pr, actor, mode, preset, duration, bloat, tokenCount, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, baselineFeatures, featureFeatures, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, valscope, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, metrics, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs, runSide;
+            let pr, actor, mode, preset, duration, bloat, tokenCount, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, baselineFeatures, featureFeatures, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, valscope, baselineArgs, featureArgs, gasLimit, generalGasLimit, runType, forceBloat, noCache, noSlack, metrics, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs, runSide;
             let explicitWarmup = false;
             let explicitDuration = false;
             let explicitRunPairs = false;
@@ -132,13 +133,13 @@ jobs:
             actor = context.payload.comment.user.login;
 
             const body = context.payload.comment.body.trim();
-            const intArgs = new Set(['duration', 'bloat', 'token-count', 'tps', 'accounts', 'max-concurrent-requests', 'gas-limit', 'tracy-seconds', 'tracy-offset', 'blocks', 'warmup', 'run-pairs']);
+            const intArgs = new Set(['duration', 'bloat', 'token-count', 'tps', 'accounts', 'max-concurrent-requests', 'gas-limit', 'general-gas-limit', 'tracy-seconds', 'tracy-offset', 'blocks', 'warmup', 'run-pairs']);
             const refArgs = new Set(['baseline', 'feature', 'txgen-ref']);
             const stringArgs = new Set(['mode', 'preset', 'baseline-args', 'feature-args', 'baseline-features', 'feature-features', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain', 'baseline-hardfork', 'feature-hardfork', 'run-side']);
             const boolArgs = new Set(['samply', 'tracy', 'force-bloat', 'no-cache', 'no-slack', 'otlp', 'valscope', 'metrics']);
             const bloatValues = new Set(['1', '10', '100']);
             const hardforkValues = new Set(['T0', 'T1', 'T1A', 'T1B', 'T1C', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8']);
-            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', 'token-count': '4', tps: '50000', accounts: '1000', 'max-concurrent-requests': '500', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'baseline-features': '', 'feature-features': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '10', 'tracy-offset': '', otlp: 'true', valscope: 'false', metrics: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '5000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2', 'run-side': 'comparison' };
+            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', 'token-count': '4', tps: '50000', accounts: '1000', 'max-concurrent-requests': '500', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'baseline-features': '', 'feature-features': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '10', 'tracy-offset': '', otlp: 'true', valscope: 'false', metrics: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '5000000000', 'general-gas-limit': '', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2', 'run-side': 'comparison' };
             const unknown = [];
             const invalid = [];
             const defaultWarmup = (blockCount) => String(Math.floor(Number(blockCount) / 4));
@@ -178,7 +179,7 @@ jobs:
                 } else {
                   defaults[key] = value;
                 }
-              } else if (key === 'gas-limit') {
+              } else if (key === 'gas-limit' || key === 'general-gas-limit') {
                 const parsedGasLimit = parseGasLimit(value);
                 if (parsedGasLimit === null) {
                   invalid.push(`\`${key}=${value}\` (must be a positive integer, optionally using M/G/T suffix)`);
@@ -221,7 +222,7 @@ jobs:
             if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
             if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
             if (errors.length) {
-              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [run-side=comparison|feature] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6|T7|T8] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6|T7|T8] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [tracy] [otlp] [metrics[=true|false]] [valscope] [force-bloat] [no-cache] [no-slack] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
+              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [run-side=comparison|feature] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [general-gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6|T7|T8] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6|T7|T8] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [tracy] [otlp] [metrics[=true|false]] [valscope] [force-bloat] [no-cache] [no-slack] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -256,6 +257,7 @@ jobs:
             baselineArgs = defaults['baseline-args'];
             featureArgs = defaults['feature-args'];
             gasLimit = defaults['gas-limit'];
+            generalGasLimit = defaults['general-gas-limit'];
             runType = 'manual';
             forceBloat = defaults['force-bloat'];
             noCache = defaults['no-cache'];
@@ -280,7 +282,7 @@ jobs:
               tracyOffset = String(Math.floor(Number(duration) / 2));
             }
 
-            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [run-side=comparison|feature] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6|T7|T8] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6|T7|T8] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [tracy] [otlp] [metrics[=true|false]] [valscope] [force-bloat] [no-cache] [no-slack] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
+            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [run-side=comparison|feature] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [general-gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6|T7|T8] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6|T7|T8] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [tracy] [otlp] [metrics[=true|false]] [valscope] [force-bloat] [no-cache] [no-slack] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 
             // Validate chain value
             if (!['mainnet', 'testnet'].includes(chain)) {
@@ -454,6 +456,7 @@ jobs:
             core.setOutput('baseline-args', baselineArgs || '');
             core.setOutput('feature-args', featureArgs || '');
             core.setOutput('gas-limit', gasLimit);
+            core.setOutput('general-gas-limit', generalGasLimit || '');
             core.setOutput('run-type', runType);
             core.setOutput('force-bloat', forceBloat);
             core.setOutput('no-cache', noCache);
@@ -498,6 +501,7 @@ jobs:
           ACK_BASELINE_ARGS: ${{ steps.args.outputs.baseline-args }}
           ACK_FEATURE_ARGS: ${{ steps.args.outputs.feature-args }}
           ACK_GAS_LIMIT: ${{ steps.args.outputs.gas-limit }}
+          ACK_GENERAL_GAS_LIMIT: ${{ steps.args.outputs.general-gas-limit }}
           ACK_RUN_PAIRS: ${{ steps.args.outputs.run-pairs }}
           ACK_RUN_SIDE: ${{ steps.args.outputs.run-side }}
           ACK_NO_CACHE: ${{ steps.args.outputs.no-cache }}
@@ -546,6 +550,8 @@ jobs:
             const fNa = process.env.ACK_FEATURE_ARGS || '';
             const naNote = (bNa || fNa) ? `${bNa ? `, baseline-args: \`${bNa}\`` : ''}${fNa ? `, feature-args: \`${fNa}\`` : ''}` : '';
             const gasLimit = process.env.ACK_GAS_LIMIT;
+            const generalGasLimit = process.env.ACK_GENERAL_GAS_LIMIT || '';
+            const generalGasLimitNote = generalGasLimit ? `, general-gas-limit: \`${generalGasLimit}\`` : '';
             const runPairs = process.env.ACK_RUN_PAIRS || '2';
             const runSide = process.env.ACK_RUN_SIDE || 'comparison';
             const noCache = process.env.ACK_NO_CACHE === 'true';
@@ -553,7 +559,7 @@ jobs:
             const hardforkNote = (baselineHardfork || featureHardfork) ? `, baseline-hardfork: \`${baselineHardfork}\`, feature-hardfork: \`${featureHardfork}\`` : '';
             const featureFlagsNote = `${baselineFeatureFlags ? `, baseline-features: \`${baselineFeatureFlags}\`` : ''}${featureFeatureFlags ? `, feature-features: \`${featureFeatureFlags}\`` : ''}`;
             const runSideNote = runSide !== 'comparison' ? `, run-side: \`${runSide}\`` : '';
-            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, token-count: \`${tokenCount}\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, run-pairs: \`${runPairs}\`${runSideNote}, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${naNote}${noCacheNote}`;
+            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, token-count: \`${tokenCount}\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`${generalGasLimitNote}, run-pairs: \`${runPairs}\`${runSideNote}, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${hardforkNote}${featureFlagsNote}${samplyNote}${tracyNote}${otlpNote}${valscopeNote}${naNote}${noCacheNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -596,6 +602,7 @@ jobs:
       baseline-args: ${{ needs.tempo-bench-ack.outputs.baseline-args }}
       feature-args: ${{ needs.tempo-bench-ack.outputs.feature-args }}
       gas-limit: ${{ needs.tempo-bench-ack.outputs.gas-limit }}
+      general-gas-limit: ${{ needs.tempo-bench-ack.outputs.general-gas-limit }}
       run-pairs: ${{ needs.tempo-bench-ack.outputs.run-pairs }}
       run-side: ${{ needs.tempo-bench-ack.outputs.run-side }}
       run-type: ${{ needs.tempo-bench-ack.outputs.run-type }}

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -376,10 +376,31 @@ def e2e-snapshot-state-gas-limit [datadir: string] {
     ""
 }
 
+def e2e-snapshot-state-general-gas-limit [datadir: string] {
+    let marker = (read-bench-marker $datadir)
+    if $marker != null {
+        let marker_general_gas_limit = ($marker | get -o general_gas_limit | default "")
+        if $marker_general_gas_limit != "" {
+            return (normalize-gas-limit $marker_general_gas_limit)
+        }
+    }
+
+    let genesis_path = $"($datadir)/($BENCH_META_SUBDIR)/genesis.json"
+    if ($genesis_path | path exists) {
+        let genesis_general_gas_limit = (open $genesis_path | get -o config.generalGasLimit | default "")
+        if $genesis_general_gas_limit != "" {
+            return (normalize-gas-limit $genesis_general_gas_limit)
+        }
+    }
+
+    ""
+}
+
 def e2e-update-snapshot-genesis-marker [
     datadir: string,
     hardfork: string,
     gas_limit: string,
+    general_gas_limit: string,
 ] {
     let marker_path = $"($datadir)/($BENCH_META_SUBDIR)/marker.json"
     mut marker = (open $marker_path)
@@ -390,6 +411,11 @@ def e2e-update-snapshot-genesis-marker [
     if $gas_limit != "" {
         $marker = ($marker | upsert gas_limit (normalize-gas-limit $gas_limit))
     }
+    if $general_gas_limit != "" {
+        $marker = ($marker | upsert general_gas_limit (normalize-gas-limit $general_gas_limit))
+    } else {
+        $marker = ($marker | reject -o general_gas_limit)
+    }
     $marker | to json | save -f $marker_path
 }
 
@@ -398,6 +424,7 @@ def e2e-synthesize-genesis [
     target_genesis: string,
     hardfork: string,
     gas_limit: string,
+    general_gas_limit: string,
 ] {
     let source = (open $source_genesis)
     mut config = ($source | get config)
@@ -408,6 +435,13 @@ def e2e-synthesize-genesis [
             $config = ($config | upsert $field.name $field.value)
         }
         $patch_labels = ($patch_labels | append $"hardfork=($fork)")
+    }
+    if $general_gas_limit != "" {
+        let normalized_general_gas_limit = (normalize-gas-limit $general_gas_limit)
+        $config = ($config | upsert generalGasLimit ($normalized_general_gas_limit | into int))
+        $patch_labels = ($patch_labels | append $"general_gas_limit=($normalized_general_gas_limit)")
+    } else {
+        $config = ($config | reject -o generalGasLimit)
     }
     mut genesis = ($source | upsert config $config)
     if $gas_limit != "" {
@@ -432,14 +466,18 @@ def e2e-regenesis [
     datadir: string,
     hardfork: string,
     gas_limit: string,
+    general_gas_limit: string,
 ] {
     let target_hardfork = if $hardfork != "" { normalize-hardfork $hardfork } else { latest-tempo-hardfork }
     let target_gas_limit = if $gas_limit != "" { normalize-gas-limit $gas_limit } else { "" }
+    let target_general_gas_limit = if $general_gas_limit != "" { normalize-gas-limit $general_gas_limit } else { "" }
     let current_hardfork = (e2e-snapshot-state-hardfork $datadir)
     let current_gas_limit = (e2e-snapshot-state-gas-limit $datadir)
+    let current_general_gas_limit = (e2e-snapshot-state-general-gas-limit $datadir)
     let hardfork_matches = $current_hardfork == $target_hardfork
     let gas_limit_matches = $target_gas_limit == "" or $current_gas_limit == $target_gas_limit
-    if $hardfork_matches and $gas_limit_matches {
+    let general_gas_limit_matches = $current_general_gas_limit == $target_general_gas_limit
+    if $hardfork_matches and $gas_limit_matches and $general_gas_limit_matches {
         mut matches = []
         if $target_hardfork != "" {
             $matches = ($matches | append $"state_hardfork=($target_hardfork)")
@@ -447,12 +485,15 @@ def e2e-regenesis [
         if $target_gas_limit != "" {
             $matches = ($matches | append $"gas_limit=($target_gas_limit)")
         }
+        if $target_general_gas_limit != "" {
+            $matches = ($matches | append $"general_gas_limit=($target_general_gas_limit)")
+        }
         print $"Skipping tempo regenesis for ($datadir); marker already matches (($matches | str join ', '))"
         return
     }
 
     let target_genesis = $"($datadir)/($BENCH_META_SUBDIR)/regenesis-target.json"
-    e2e-synthesize-genesis $genesis $target_genesis $target_hardfork $target_gas_limit
+    e2e-synthesize-genesis $genesis $target_genesis $target_hardfork $target_gas_limit $target_general_gas_limit
 
     mut changes = []
     if not $hardfork_matches {
@@ -460,6 +501,9 @@ def e2e-regenesis [
     }
     if not $gas_limit_matches {
         $changes = ($changes | append $"gas_limit=($current_gas_limit) -> ($target_gas_limit)")
+    }
+    if not $general_gas_limit_matches {
+        $changes = ($changes | append $"general_gas_limit=($current_general_gas_limit) -> ($target_general_gas_limit)")
     }
     print $"Running tempo regenesis for ($datadir): ($changes | str join ', ') with ($target_genesis)..."
     let result = (run-external $tempo_bin "regenesis" "--chain" $target_genesis "--datadir" $datadir | complete)
@@ -469,8 +513,8 @@ def e2e-regenesis [
         print $"Error: tempo regenesis failed for ($datadir) with exit code ($result.exit_code)"
         exit $result.exit_code
     }
-    e2e-synthesize-genesis $"($datadir)/($BENCH_META_SUBDIR)/genesis.json" $"($datadir)/($BENCH_META_SUBDIR)/genesis.json" $target_hardfork $target_gas_limit
-    e2e-update-snapshot-genesis-marker $datadir $target_hardfork $target_gas_limit
+    e2e-synthesize-genesis $"($datadir)/($BENCH_META_SUBDIR)/genesis.json" $"($datadir)/($BENCH_META_SUBDIR)/genesis.json" $target_hardfork $target_gas_limit $target_general_gas_limit
+    e2e-update-snapshot-genesis-marker $datadir $target_hardfork $target_gas_limit $target_general_gas_limit
     rm $target_genesis
 }
 
@@ -937,9 +981,9 @@ def run-local-e2e-phase [run: record, ctx: record] {
             exit 1
         }
     }
-    if $hardfork != "" or $ctx.gas_limit != "" {
-        e2e-regenesis $ctx.regenesis_tempo $genesis $ctx.a.datadir $hardfork $ctx.gas_limit
-        e2e-regenesis $ctx.regenesis_tempo $genesis $ctx.b.datadir $hardfork $ctx.gas_limit
+    if $hardfork != "" or $ctx.gas_limit != "" or $ctx.general_gas_limit != "" {
+        e2e-regenesis $ctx.regenesis_tempo $genesis $ctx.a.datadir $hardfork $ctx.gas_limit $ctx.general_gas_limit
+        e2e-regenesis $ctx.regenesis_tempo $genesis $ctx.b.datadir $hardfork $ctx.gas_limit $ctx.general_gas_limit
     }
     for role_info in [
         { role: "a", node_dir: $ctx.a.node_dir }
@@ -1272,6 +1316,7 @@ def "main e2e" [
     --bloat: int = $E2E_DEFAULT_BLOAT                   # State bloat snapshot size in GiB: 0, 1, 10, or 100
     --token-count: int = 4                         # Number of TIP20 tokens to use in txgen presets
     --gas-limit: string = $E2E_GAS_LIMIT                # Builder gas limit
+    --general-gas-limit: string = ""                    # General (non-payment) gas limit override
     --force-bloat                                      # Regenerate and promote both local e2e snapshots
     --init-only                                         # Refresh snapshots and exit without running benchmark phases
     --profile: string = $DEFAULT_PROFILE                # Cargo build profile
@@ -1389,6 +1434,7 @@ def "main e2e" [
     }
     let reference_epoch = (($run_started_at | into int) / 1_000_000_000 | into int)
     let gas_limit_args = if $gas_limit != "" { ["--gas-limit" $gas_limit] } else { [] }
+    let general_gas_limit_args = if $general_gas_limit != "" { ["--general-gas-limit" $general_gas_limit] } else { [] }
     let tracing_otlp = (derive-tracing-otlp $tracing_otlp)
     if $tracing_otlp != "" {
         $env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = $tracing_otlp
@@ -1430,7 +1476,7 @@ def "main e2e" [
         let tempo_bin = if $profile == "dev" { "./target/debug/tempo" } else { $"./target/($profile)/tempo" }
         let genesis_accounts = ([$accounts 3] | math max) + 1
         print $"Generating local e2e localnet config for validators: ($E2E_VALIDATORS)"
-        cargo run -p tempo-xtask --profile $profile -- generate-localnet -o $init_dir --accounts $genesis_accounts --validators $E2E_VALIDATORS --seed $E2E_SEED --force ...$gas_limit_args ...$snapshot_hardfork_args
+        cargo run -p tempo-xtask --profile $profile -- generate-localnet -o $init_dir --accounts $genesis_accounts --validators $E2E_VALIDATORS --seed $E2E_SEED --force ...$gas_limit_args ...$general_gas_limit_args ...$snapshot_hardfork_args
 
         let trusted_peers = (trusted-peers-from-localnet $init_dir)
         if $trusted_peers == "" {
@@ -1451,6 +1497,7 @@ def "main e2e" [
             validators: $E2E_VALIDATORS
             seed: $E2E_SEED
             gas_limit: $gas_limit
+            general_gas_limit: $general_gas_limit
             dkg_in_genesis: true
             topology: "single-runner"
             state_hardfork: $snapshot_state_hardfork
@@ -1476,8 +1523,8 @@ def "main e2e" [
     if $hardfork_mode {
         if ($hardfork_genesis_dir | path exists) { rm -rf $hardfork_genesis_dir }
         mkdir $hardfork_genesis_dir
-        e2e-synthesize-genesis $genesis_path $baseline_genesis_path $baseline_hardfork_name $gas_limit
-        e2e-synthesize-genesis $genesis_path $feature_genesis_path $feature_hardfork_name $gas_limit
+        e2e-synthesize-genesis $genesis_path $baseline_genesis_path $baseline_hardfork_name $gas_limit $general_gas_limit
+        e2e-synthesize-genesis $genesis_path $feature_genesis_path $feature_hardfork_name $gas_limit $general_gas_limit
     }
     let trusted_peers = if ($a_trusted_peers_path | path exists) {
         open $a_trusted_peers_path | str trim
@@ -1499,7 +1546,7 @@ def "main e2e" [
     mkdir $BENCH_WORKTREES_DIR
     let baseline_wt = $"($BENCH_WORKTREES_DIR)/e2e-local-baseline"
     let feature_wt = $"($BENCH_WORKTREES_DIR)/e2e-local-feature"
-    let regenesis_needed = $hardfork_mode or $gas_limit != ""
+    let regenesis_needed = $hardfork_mode or $gas_limit != "" or $general_gas_limit != ""
     let needs_baseline = $run_side == "comparison"
     let worktrees = if $needs_baseline { [$baseline_wt $feature_wt] } else { [$feature_wt] }
     for wt in $worktrees {
@@ -1606,6 +1653,7 @@ def "main e2e" [
         tune: $tune
         loud: $loud
         gas_limit: $gas_limit
+        general_gas_limit: $general_gas_limit
         baseline_local_reth_args: $baseline_arg_filter.supported
         feature_local_reth_args: $feature_arg_filter.supported
         regenesis_tempo: $regenesis_tempo

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -39,7 +39,7 @@ use alloy_hardforks::hardfork;
 ///   - `tempo_fork_activation()` (required — the only method implementors provide)
 ///   - `tempo_hardfork_at()` — walks `VARIANTS` in reverse to find the latest active fork
 ///   - `is_<fork>_active_at_timestamp()` — per-fork convenience helpers
-///   - `general_gas_limit_at()` — gas limit lookup by timestamp
+///   - `shared_gas_limit_at()` — shared gas limit lookup by timestamp
 /// * Generates a `#[cfg(test)] mod tests` with activation, naming, trait, and serde tests
 ///
 /// `Genesis` (first variant) is treated as the baseline and does not get `is_*()` methods.
@@ -79,11 +79,6 @@ macro_rules! tempo_hardfork {
             /// Retrieves activation condition for a Tempo-specific hardfork.
             fn tempo_fork_activation(&self, fork: TempoHardfork) -> reth_chainspec::ForkCondition;
 
-            /// Optional chainspec override for the general (non-payment) gas limit.
-            fn general_gas_limit_override(&self) -> Option<u64> {
-                None
-            }
-
             /// Retrieves the Tempo hardfork active at a given timestamp.
             fn tempo_hardfork_at(&self, timestamp: u64) -> TempoHardfork {
                 for &fork in TempoHardfork::VARIANTS.iter().rev() {
@@ -102,19 +97,6 @@ macro_rules! tempo_hardfork {
                             .active_at_timestamp(timestamp)
                     }
                 )*
-            }
-
-            /// Returns the general (non-payment) gas limit for the given timestamp and block.
-            /// - T1+: fixed at 30M gas
-            /// - Pre-T1: calculated as (gas_limit - shared_gas_limit) / 2
-            fn general_gas_limit_at(&self, timestamp: u64, gas_limit: u64, shared_gas_limit: u64) -> u64 {
-                if let Some(general_gas_limit) = self.general_gas_limit_override() {
-                    return general_gas_limit;
-                }
-
-                self.tempo_hardfork_at(timestamp)
-                    .general_gas_limit()
-                    .unwrap_or_else(|| (gas_limit - shared_gas_limit) / 2)
             }
 
             /// Returns the shared gas limit for the given timestamp and block.

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -79,6 +79,11 @@ macro_rules! tempo_hardfork {
             /// Retrieves activation condition for a Tempo-specific hardfork.
             fn tempo_fork_activation(&self, fork: TempoHardfork) -> reth_chainspec::ForkCondition;
 
+            /// Optional chainspec override for the general (non-payment) gas limit.
+            fn general_gas_limit_override(&self) -> Option<u64> {
+                None
+            }
+
             /// Retrieves the Tempo hardfork active at a given timestamp.
             fn tempo_hardfork_at(&self, timestamp: u64) -> TempoHardfork {
                 for &fork in TempoHardfork::VARIANTS.iter().rev() {
@@ -103,6 +108,10 @@ macro_rules! tempo_hardfork {
             /// - T1+: fixed at 30M gas
             /// - Pre-T1: calculated as (gas_limit - shared_gas_limit) / 2
             fn general_gas_limit_at(&self, timestamp: u64, gas_limit: u64, shared_gas_limit: u64) -> u64 {
+                if let Some(general_gas_limit) = self.general_gas_limit_override() {
+                    return general_gas_limit;
+                }
+
                 self.tempo_hardfork_at(timestamp)
                     .general_gas_limit()
                     .unwrap_or_else(|| (gas_limit - shared_gas_limit) / 2)

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -214,12 +214,10 @@ impl TempoChainSpec {
         gas_limit: u64,
         shared_gas_limit: u64,
     ) -> u64 {
-        self.info.general_gas_limit()
-        .or_else(|| {
-            self.tempo_hardfork_at(timestamp)
-                .general_gas_limit()
-        })
-        .unwrap_or_else(|| (gas_limit - shared_gas_limit) / 2)
+        self.info
+            .general_gas_limit()
+            .or_else(|| self.tempo_hardfork_at(timestamp).general_gas_limit())
+            .unwrap_or_else(|| (gas_limit - shared_gas_limit) / 2)
     }
 
     /// Converts the given [`Genesis`] into a [`TempoChainSpec`].

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -214,11 +214,12 @@ impl TempoChainSpec {
         gas_limit: u64,
         shared_gas_limit: u64,
     ) -> u64 {
-        self.info.general_gas_limit().unwrap_or_else(|| {
+        self.info.general_gas_limit()
+        .or_else(|| {
             self.tempo_hardfork_at(timestamp)
                 .general_gas_limit()
-                .unwrap_or_else(|| (gas_limit - shared_gas_limit) / 2)
         })
+        .unwrap_or_else(|| (gas_limit - shared_gas_limit) / 2)
     }
 
     /// Converts the given [`Genesis`] into a [`TempoChainSpec`].

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -34,6 +34,9 @@ pub struct TempoGenesisInfo {
     /// The epoch length used by consensus.
     #[serde(skip_serializing_if = "Option::is_none")]
     epoch_length: Option<u64>,
+    /// Optional override for the general (non-payment) gas limit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    general_gas_limit: Option<u64>,
     /// Activation timestamp for T0 hardfork.
     #[serde(skip_serializing_if = "Option::is_none")]
     t0_time: Option<u64>,
@@ -84,6 +87,10 @@ impl TempoGenesisInfo {
 
     pub fn epoch_length(&self) -> Option<u64> {
         self.epoch_length
+    }
+
+    pub fn general_gas_limit(&self) -> Option<u64> {
+        self.general_gas_limit
     }
 
     /// Returns the activation timestamp for a given hardfork, or `None` if not scheduled.
@@ -396,6 +403,10 @@ impl TempoHardforks for TempoChainSpec {
     fn tempo_fork_activation(&self, fork: TempoHardfork) -> ForkCondition {
         self.fork(fork)
     }
+
+    fn general_gas_limit_override(&self) -> Option<u64> {
+        self.info.general_gas_limit()
+    }
 }
 
 #[cfg(test)]
@@ -563,6 +574,24 @@ mod tests {
         assert_eq!(chainspec.tempo_hardfork_at(0), latest);
         assert_eq!(chainspec.tempo_hardfork_at(1000), latest);
         assert_eq!(chainspec.tempo_hardfork_at(u64::MAX), latest);
+    }
+
+    #[test]
+    fn test_from_genesis_with_general_gas_limit_override() {
+        let genesis: alloy_genesis::Genesis = serde_json::from_value(serde_json::json!({
+            "config": {
+                "chainId": 1234,
+                "t1Time": 0,
+                "generalGasLimit": 123456789
+            },
+            "alloc": {}
+        }))
+        .unwrap();
+
+        let chainspec = super::TempoChainSpec::from_genesis(genesis);
+
+        assert_eq!(chainspec.info.general_gas_limit(), Some(123456789));
+        assert_eq!(chainspec.general_gas_limit_at(0, 500_000_000, 0), 123456789);
     }
 
     fn header(timestamp: u64, base_fee: u64, gas_used: u64) -> super::TempoHeader {

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -204,6 +204,23 @@ impl TempoChainSpec {
         self.default_follow_url
     }
 
+    /// Returns the general (non-payment) gas limit for the given timestamp and block.
+    /// - Genesis override: fixed at the configured value
+    /// - T1+: fixed at 30M gas
+    /// - Pre-T1: calculated as (gas_limit - shared_gas_limit) / 2
+    pub fn general_gas_limit_at(
+        &self,
+        timestamp: u64,
+        gas_limit: u64,
+        shared_gas_limit: u64,
+    ) -> u64 {
+        self.info.general_gas_limit().unwrap_or_else(|| {
+            self.tempo_hardfork_at(timestamp)
+                .general_gas_limit()
+                .unwrap_or_else(|| (gas_limit - shared_gas_limit) / 2)
+        })
+    }
+
     /// Converts the given [`Genesis`] into a [`TempoChainSpec`].
     pub fn from_genesis(genesis: Genesis) -> Self {
         // Extract Tempo genesis info from extra_fields
@@ -403,10 +420,6 @@ impl TempoHardforks for TempoChainSpec {
     fn tempo_fork_activation(&self, fork: TempoHardfork) -> ForkCondition {
         self.fork(fork)
     }
-
-    fn general_gas_limit_override(&self) -> Option<u64> {
-        self.info.general_gas_limit()
-    }
 }
 
 #[cfg(test)]
@@ -577,7 +590,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_genesis_with_general_gas_limit_override() {
+    fn test_general_gas_limit_at_uses_genesis_override() {
         let genesis: alloy_genesis::Genesis = serde_json::from_value(serde_json::json!({
             "config": {
                 "chainId": 1234,

--- a/tempo.nu
+++ b/tempo.nu
@@ -2363,6 +2363,7 @@ def "main bench" [
     --baseline-hardfork: string = ""                # Latest active hardfork for baseline (e.g. T1, T1C, T2)
     --feature-hardfork: string = ""                 # Latest active hardfork for feature (e.g. T1, T1C, T2)
     --gas-limit: string = ""                        # Block gas limit for genesis (raw number, e.g. 1000000000)
+    --general-gas-limit: string = ""                # General (non-payment) gas limit override for genesis
 ] {
     validate-mode $mode
 
@@ -2376,6 +2377,7 @@ def "main bench" [
     let txgen = (txgen-resolve-binaries)
 
     let gas_limit_args = if $gas_limit != "" { ["--gas-limit" $gas_limit] } else { [] }
+    let general_gas_limit_args = if $general_gas_limit != "" { ["--general-gas-limit" $general_gas_limit] } else { [] }
     let txgen_genesis_args = ["--mnemonic" (txgen-account-mnemonic)]
 
     # Auto-derive tracing OTLP URL: prefer GRAFANA_TEMPO, fall back to TEMPO_TELEMETRY_URL
@@ -2586,6 +2588,7 @@ def "main bench" [
                 and ($marker | get -o baseline_hardfork | default "") == ($baseline_hardfork | str upcase)
                 and ($marker | get -o feature_hardfork | default "") == ($feature_hardfork | str upcase)
                 and ($marker | get -o gas_limit | default "") == $gas_limit
+                and ($marker | get -o general_gas_limit | default "") == $general_gas_limit
                 and ($marker | get -o txgen_mnemonic | default "") == (txgen-account-mnemonic)
                 and ($"($baseline_datadir)/db" | path exists)
                 and ($"($feature_datadir)/db" | path exists)
@@ -2604,11 +2607,11 @@ def "main bench" [
                 if ($baseline_genesis_dir | path exists) { rm -rf $baseline_genesis_dir }
                 mkdir $baseline_genesis_dir
                 if $baseline == "local" {
-                    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $baseline_genesis_dir -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$baseline_genesis_args ...$gas_limit_args
+                    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $baseline_genesis_dir -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$baseline_genesis_args ...$gas_limit_args ...$general_gas_limit_args
                 } else {
                     do {
                         cd $baseline_wt
-                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $baseline_genesis_dir -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$baseline_genesis_args ...$gas_limit_args
+                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $baseline_genesis_dir -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$baseline_genesis_args ...$gas_limit_args ...$general_gas_limit_args
                     }
                 }
                 cp $"($baseline_genesis_dir)/genesis.json" $baseline_genesis_path
@@ -2619,13 +2622,13 @@ def "main bench" [
                 if ($feature_genesis_dir | path exists) { rm -rf $feature_genesis_dir }
                 mkdir $feature_genesis_dir
                 if $feature == "local" {
-                    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $feature_genesis_dir -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$feature_genesis_args ...$gas_limit_args
+                    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $feature_genesis_dir -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$feature_genesis_args ...$gas_limit_args ...$general_gas_limit_args
                 } else {
                     # Use feature worktree for feature genesis so it picks up any
                     # new hardfork-related genesis changes from the feature branch
                     do {
                         cd $feature_wt
-                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $feature_genesis_dir -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$feature_genesis_args ...$gas_limit_args
+                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $feature_genesis_dir -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$feature_genesis_args ...$gas_limit_args ...$general_gas_limit_args
                     }
                 }
                 cp $"($feature_genesis_dir)/genesis.json" $feature_genesis_path
@@ -2662,6 +2665,7 @@ def "main bench" [
                     baseline_hardfork: ($baseline_hardfork | str upcase)
                     feature_hardfork: ($feature_hardfork | str upcase)
                     gas_limit: $gas_limit
+                    general_gas_limit: $general_gas_limit
                     txgen_mnemonic: (txgen-account-mnemonic)
                 } [[$baseline_genesis_path "genesis-baseline.json"] [$feature_genesis_path "genesis-feature.json"]] $bloat $bloat_file
 
@@ -2680,6 +2684,7 @@ def "main bench" [
                 and ($marker.bloat_mib | into int) == $bloat
                 and ($marker.accounts | into int) == $genesis_accounts
                 and ($marker | get -o gas_limit | default "") == $gas_limit
+                and ($marker | get -o general_gas_limit | default "") == $general_gas_limit
                 and ($marker | get -o txgen_mnemonic | default "") == (txgen-account-mnemonic)
                 and ($"($datadir)/db" | path exists)
                 and ($"($meta_dir)/genesis.json" | path exists)
@@ -2695,11 +2700,11 @@ def "main bench" [
                     if not ($abs_localnet | path exists) { mkdir $abs_localnet }
                     print $"Generating genesis with ($genesis_accounts) accounts from baseline..."
                     if $baseline == "local" {
-                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$gas_limit_args
+                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$gas_limit_args ...$general_gas_limit_args
                     } else {
                         do {
                             cd $baseline_wt
-                            cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$gas_limit_args
+                            cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$gas_limit_args ...$general_gas_limit_args
                         }
                     }
                 }
@@ -2725,6 +2730,7 @@ def "main bench" [
                     accounts: $genesis_accounts,
                     bench_datadir: $datadir,
                     gas_limit: $gas_limit,
+                    general_gas_limit: $general_gas_limit,
                     txgen_mnemonic: (txgen-account-mnemonic)
                 } [[$genesis_path_std "genesis.json"]] $bloat $bloat_file
 

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -89,6 +89,10 @@ pub(crate) struct GenesisArgs {
     #[arg(long, default_value_t = 500_000_000)]
     gas_limit: u64,
 
+    /// Override the general (non-payment) gas limit
+    #[arg(long)]
+    general_gas_limit: Option<u64>,
+
     /// The hard-coded length of an epoch in blocks.
     #[arg(long, default_value_t = 302_400)]
     epoch_length: u64,
@@ -569,6 +573,11 @@ impl GenesisArgs {
         chain_config
             .extra_fields
             .insert_value("epochLength".to_string(), self.epoch_length)?;
+        if let Some(general_gas_limit) = self.general_gas_limit {
+            chain_config
+                .extra_fields
+                .insert_value("generalGasLimit".to_string(), general_gas_limit)?;
+        }
         chain_config
             .extra_fields
             .insert_value("t0Time".to_string(), self.t0_time)?;


### PR DESCRIPTION
## Summary
- add optional `generalGasLimit` genesis metadata and use it in chainspec gas limit lookup
- expose `--general-gas-limit` on `tempo.nu bench` and `tempo-xtask generate-genesis`
- include the override in bench snapshot cache invalidation

Prompted by: @klkvr

## Tests
- `cargo test -p tempo-chainspec test_from_genesis_with_general_gas_limit_override`
- `cargo check -p tempo-xtask`
- `cargo run -q -p tempo-xtask -- generate-genesis --output "$tmpdir" -a 2 --no-dkg-in-genesis --general-gas-limit 123456789` + verified `.config.generalGasLimit == 123456789`
- `nu -c 'source tempo.nu; help main bench | ignore'`