### PR TITLE
docs: add T6 and T7 meta TIPs

### DIFF
--- a/tips/tip-1076.md
+++ b/tips/tip-1076.md
@@ -1,0 +1,53 @@
+---
+id: TIP-1076
+title: T6 Hardfork Meta TIP
+description: Meta TIP collecting bug fixes, security hardening, and infrastructure changes gated behind the T6 hardfork.
+authors: Tempo Contributors
+status: Mainnet
+related: TIP-1028, TIP-1049
+protocolVersion: T6
+---
+
+# TIP-1076: T6 Hardfork Meta TIP
+
+## Abstract
+
+This meta TIP collects bug fixes, security hardening, and infrastructure changes that activate at T6. Each item is small in isolation, but together they define the complete in-scope T6 hardfork support bundle. Feature changes already specified by standalone TIPs (TIP-1028 and TIP-1049) are intentionally excluded from this meta TIP.
+
+## Motivation
+
+T6 introduced address-level receive policies and admin access keys. Internal review uncovered hardfork-gated correctness issues around protected receive-policy addresses and TIP-20 user-state validation, while rollout required explicit hardfork wiring and test activation. Because these changes alter state-function behavior or chain configuration at activation boundaries, they are grouped here as one coordinated rollout under T6.
+
+---
+
+# Changes
+
+## 1. Add T6 hardfork wiring
+
+**PR**: [#3801](https://github.com/tempoxyz/tempo/pull/3801) · **Author**: @0xKitsune
+
+T6 is added as a chain hardfork so protocol code can gate T6 behavior on a concrete activation point. This provides the fork identifier used by T6 features and follow-up fixes.
+
+## 2. Gate receive-policy escrow protection behind T6
+
+**PR**: [#3901](https://github.com/tempoxyz/tempo/pull/3901)
+
+The blocked-transfer recovery path protects the receive-policy guard escrow address from invalid burn behavior. T6+ gates this protection at the hardfork boundary so pre-T6 behavior remains unchanged while post-T6 receive-policy receipts cannot be burned through the wrong path.
+
+## 3. Enable T6 invariant coverage
+
+**PR**: [#4404](https://github.com/tempoxyz/tempo/pull/4404)
+
+Invariant tests are extended to run against the T6 hardfork configuration. This keeps the receive-policy and admin-key execution paths covered under the same fork conditions that production nodes use.
+
+## 4. Reject precompiles as receive-policy recovery addresses
+
+**PR**: [#5476](https://github.com/tempoxyz/tempo/pull/5476) · **Author**: @0xKitsune
+
+`set_receive_policy` must reject recovery addresses that are system precompiles. Precompiles cannot initiate ordinary user calls, so allowing them as recovery authorities could strand blocked TIP-20 receipts. T6+ rejects those recovery addresses during policy configuration.
+
+## 5. Add T6 rollout timestamps
+
+**PR**: [#5584](https://github.com/tempoxyz/tempo/pull/5584) · **Author**: @jenpaff
+
+The chain specification is updated with T6 activation timestamps. This completes the network rollout configuration for the T6 hardfork.

--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -1,0 +1,59 @@
+---
+id: TIP-1077
+title: T7 Hardfork Meta TIP
+description: Meta TIP collecting bug fixes, security hardening, and infrastructure changes gated behind the T7 hardfork.
+authors: Tempo Contributors
+status: Draft
+related: TIP-1060, TIP-1064, TIP-1067, TIP-1075
+protocolVersion: T7
+---
+
+# TIP-1077: T7 Hardfork Meta TIP
+
+## Abstract
+
+This meta TIP collects bug fixes, security hardening, and infrastructure changes that activate at T7. Each item is small in isolation, but together they define the complete in-scope T7 hardfork support bundle. Feature changes already specified by standalone TIPs (TIP-1060, TIP-1064, TIP-1067, and TIP-1075) are intentionally excluded from this meta TIP.
+
+## Motivation
+
+T7 introduces storage credits, StablecoinDEX storage-credit accounting, dynamic base fee behavior, and the first phase of TIP-20 reward deprecation. Follow-up implementation work uncovered storage-credit edge cases and rollout infrastructure requirements that need hardfork gating. Because these changes alter state-function behavior or chain configuration at activation boundaries, they are grouped here as one coordinated rollout under T7.
+
+---
+
+# Changes
+
+## 1. Add T7 hardfork scaffold
+
+**PR**: [#5266](https://github.com/tempoxyz/tempo/pull/5266)
+
+T7 is added as a chain hardfork so protocol code can gate T7 behavior on a concrete activation point. This provides the fork identifier used by T7 features and follow-up fixes.
+
+## 2. Avoid recreating exhausted periodic spending-limit state
+
+**PR**: [#6233](https://github.com/tempoxyz/tempo/pull/6233) · **Author**: @klkvr
+
+Periodic AccountKeychain spending limits must not clear and recreate the `remaining` field when a period allowance reaches zero. T7+ represents exhausted remaining allowance with a nonzero sentinel so later accounting cannot mint an unbacked storage credit from stale keychain-owned state.
+
+## 3. Exclude non-creditable storage slots from TIP-1060 accounting
+
+**PR**: [#6206](https://github.com/tempoxyz/tempo/pull/6206) · **Author**: @0xrusowsky
+
+Storage-credit minting must only apply to user-owned storage that is eligible under TIP-1060. T7+ excludes protocol metadata and other non-creditable slots from storage-credit accounting so system-owned writes cannot create credits users did not earn.
+
+## 4. Disable credit minting for fee distribution
+
+**PR**: [#6237](https://github.com/tempoxyz/tempo/pull/6237)
+
+Fee-distribution writes are protocol/system writes, not user-metered storage lifecycle events. T7+ prevents fee-distribution cleanup from minting storage credits.
+
+## 5. Harden periodic-limit sentinel handling
+
+**PRs**: [#6291](https://github.com/tempoxyz/tempo/pull/6291), [#6310](https://github.com/tempoxyz/tempo/pull/6310) · **Authors**: @0xrusowsky, @0xalpharush
+
+The T7 periodic-limit sentinel must decode as zero remaining allowance on all read paths while remaining distinguishable from a real configured allowance. T7+ updates keychain reads and storage-credit handling so exhausted limits remain observable as zero to callers without clearing the underlying storage slot.
+
+## 6. Allow T7 benchmark hardfork selection
+
+**PRs**: [#6194](https://github.com/tempoxyz/tempo/pull/6194), [#6261](https://github.com/tempoxyz/tempo/pull/6261)
+
+Gas-estimate expectations and benchmark tooling are updated so T7 can be selected explicitly in performance runs. This lets T7 behavior be measured under the same hardfork configuration used by the protocol implementation.


### PR DESCRIPTION
## Summary
- add TIP-1076 as the T6 hardfork meta TIP
- add TIP-1077 as the T7 hardfork meta TIP
- link the standalone T6/T7 TIPs and collect hardfork-gated follow-up fixes

## Tests
- git diff --check

Prompted by: @0xalpharush