### PR TITLE
deps: update reth from main (2026-06-25)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8656,7 +8656,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8716,7 +8716,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8736,7 +8736,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8749,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8832,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8895,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8911,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8938,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8963,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8992,7 +8992,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9048,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9171,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9393,7 +9393,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9411,7 +9411,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9450,7 +9450,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9511,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9552,7 +9552,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "clap",
  "eyre",
@@ -9575,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9591,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9607,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9650,7 +9650,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9664,7 +9664,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9674,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9699,7 +9699,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9737,7 +9737,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9807,7 +9807,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "serde",
  "serde_json",
@@ -9831,7 +9831,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "bytes",
  "futures",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9896,7 +9896,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "bindgen",
  "cc",
@@ -9905,7 +9905,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "futures",
  "metrics",
@@ -9918,7 +9918,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9927,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9941,7 +9941,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9999,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10024,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10063,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10077,7 +10077,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10094,7 +10094,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10118,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10186,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10241,7 +10241,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10288,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10312,7 +10312,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10336,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "bytes",
  "eyre",
@@ -10365,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10377,7 +10377,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10401,7 +10401,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10413,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10528,7 +10528,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10556,7 +10556,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10587,7 +10587,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10665,7 +10665,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10695,7 +10695,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10758,7 +10758,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10789,7 +10789,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10887,7 +10887,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10901,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10932,7 +10932,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10983,7 +10983,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11011,7 +11011,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11045,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11060,7 +11060,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11086,7 +11086,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11104,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11125,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11151,7 +11151,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "clap",
  "eyre",
@@ -11171,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11190,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11235,7 +11235,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11261,7 +11261,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11289,7 +11289,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11298,7 +11298,6 @@ dependencies = [
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
- "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
@@ -11309,7 +11308,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11338,7 +11337,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
+source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8656,7 +8656,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8716,7 +8716,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8736,7 +8736,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8749,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8832,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8895,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8911,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8938,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8963,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8992,7 +8992,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9048,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9171,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9393,7 +9393,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9411,7 +9411,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9450,7 +9450,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9511,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9552,7 +9552,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "clap",
  "eyre",
@@ -9575,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9591,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9607,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9650,7 +9650,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9664,7 +9664,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9674,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9699,7 +9699,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9737,7 +9737,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9807,7 +9807,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "serde",
  "serde_json",
@@ -9831,7 +9831,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "bytes",
  "futures",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9896,7 +9896,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "bindgen",
  "cc",
@@ -9905,7 +9905,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "futures",
  "metrics",
@@ -9918,7 +9918,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9927,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9941,7 +9941,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9999,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10024,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10063,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10077,7 +10077,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10094,7 +10094,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10118,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10186,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10241,7 +10241,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10288,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10312,7 +10312,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10336,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "bytes",
  "eyre",
@@ -10365,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10377,7 +10377,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10401,7 +10401,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10413,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10528,7 +10528,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10556,7 +10556,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10587,7 +10587,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10665,7 +10665,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10695,7 +10695,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10758,7 +10758,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10789,7 +10789,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10887,7 +10887,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10901,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10932,7 +10932,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10983,7 +10983,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11011,7 +11011,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11045,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11060,7 +11060,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11086,7 +11086,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11104,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11125,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11151,7 +11151,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "clap",
  "eyre",
@@ -11171,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11190,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11235,7 +11235,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11261,7 +11261,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11289,7 +11289,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11309,7 +11309,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11338,7 +11338,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c0a9431#c0a94311147bef9407a42104ceaa7d88bf07a605"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17201e6cbb4efbb1e510b0746839cd743a5cec3fcfb4673ea2342bd657341c93"
+checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8656,7 +8656,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8716,7 +8716,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8736,7 +8736,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8749,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8832,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8895,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8911,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8938,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8963,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8992,7 +8992,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9048,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9171,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9393,7 +9393,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9411,7 +9411,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9450,7 +9450,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9511,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9552,7 +9552,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "clap",
  "eyre",
@@ -9575,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9591,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9607,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9650,7 +9650,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9664,7 +9664,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9674,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9699,7 +9699,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9737,7 +9737,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9807,7 +9807,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "serde",
  "serde_json",
@@ -9831,7 +9831,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "bytes",
  "futures",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9896,7 +9896,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "bindgen",
  "cc",
@@ -9905,7 +9905,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "futures",
  "metrics",
@@ -9918,7 +9918,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9927,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9941,7 +9941,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9999,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10024,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10063,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10077,7 +10077,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10094,7 +10094,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10118,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10186,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10241,7 +10241,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10288,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10312,7 +10312,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10336,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "bytes",
  "eyre",
@@ -10365,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10377,7 +10377,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10401,7 +10401,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10413,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10528,7 +10528,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10556,7 +10556,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10587,7 +10587,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10665,7 +10665,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10695,7 +10695,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10758,7 +10758,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10789,7 +10789,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10887,7 +10887,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10901,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10932,7 +10932,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10983,7 +10983,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11011,7 +11011,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11045,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11060,7 +11060,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11086,7 +11086,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11104,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11125,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11151,7 +11151,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "clap",
  "eyre",
@@ -11171,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11190,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11235,7 +11235,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11261,7 +11261,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11289,7 +11289,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11309,7 +11309,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11338,7 +11338,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c462ac#1c462acf431347cf545ee0d717ee9255cd1efade"
+source = "git+https://github.com/paradigmxyz/reth?rev=a898520#a8985209db9c73ab1b9278775de3ef7e50c483ca"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a898520", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a898520", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "a898520", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a898520", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,7 +214,7 @@ revm = { version = "41.0.0", features = ["optional_fee_charge"], default-feature
 alloy = { version = "2.1.0", default-features = false }
 alloy-consensus = { version = "2.1.0", default-features = false }
 alloy-contract = { version = "2.1.0", default-features = false }
-alloy-eip7928 = { version = "0.4.3", default-features = false }
+alloy-eip7928 = { version = "0.4.5", default-features = false }
 alloy-eips = { version = "2.1.0", default-features = false }
 alloy-evm = { version = "0.37.1", default-features = false }
 revm-inspectors = "0.41.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a898520", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a898520", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "a898520", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "a898520" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a898520", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "c0a9431", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "1c462ac", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`c0a9431...5d027e5`](https://github.com/paradigmxyz/reth/compare/c0a9431...5d027e5)

🔗 Amp thread: https://ampcode.com/threads/T-019eff21-ceb7-761a-a72c-5105bf975315
**Engine**
- Inline received BAL gas validation [#25662](https://github.com/paradigmxyz/reth/pull/25662)

**RPC**
- Support `sendRawTransactionSync` timeout argument [#25682](https://github.com/paradigmxyz/reth/pull/25682)

**Trie**
- Compute trie changesets on demand and prune subtries in lexicographic order [#25646](https://github.com/paradigmxyz/reth/pull/25646), [#25454](https://github.com/paradigmxyz/reth/pull/25454)

**Perf**
- Expose arc blocks from chain iterators [#25647](https://github.com/paradigmxyz/reth/pull/25647)

**Snap**
- Add version-aware snap message helpers and remove unused snap/1 scaffolding [#25657](https://github.com/paradigmxyz/reth/pull/25657), [#25610](https://github.com/paradigmxyz/reth/pull/25610)

**Tasks**
- Add worker queue metrics [#25649](https://github.com/paradigmxyz/reth/pull/25649)

**CLI**
- Allow overriding `TraceArgs` defaults [#25736](https://github.com/paradigmxyz/reth/pull/25736)

**Deps**
- Bump `alloy-eip7928` to 0.4.5 [#25688](https://github.com/paradigmxyz/reth/pull/25688)

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019eff21-f124-7158-b9ca-8559269da12e
- Bumped Reth git dependencies from rev `c0a9431` to `5d027e5` across all `reth-*` packages
- Upgraded `alloy-eip7928` from `0.4.3` to `0.4.5`

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/28176116696)
