### PR TITLE
feat(builder): gas limit from CLI arguments and chain defaults

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -9,12 +9,13 @@ use crate::{
     },
 };
 use alloy_primitives::B256;
+use reth_chainspec::EthChainSpec;
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes,
     PayloadAttributesBuilder, PayloadTypes,
 };
 use reth_node_builder::{
-    BuilderContext, DebugNode, Node, NodeAdapter,
+    BuilderContext, DebugNode, Node, NodeAdapter, PayloadBuilderConfig,
     components::{
         BasicPayloadServiceBuilder, ComponentsBuilder, ConsensusBuilder, ExecutorBuilder,
         PayloadBuilderBuilder, PoolBuilder, spawn_maintenance_tasks,
@@ -721,12 +722,17 @@ where
         pool: TempoTransactionPool<Node::Provider>,
         evm_config: TempoEvmConfig,
     ) -> eyre::Result<Self::PayloadBuilder> {
+        let conf = ctx.payload_builder_config();
+        let chain = ctx.chain_spec().chain();
+        let gas_limit = conf.gas_limit_for(chain);
+
         Ok(TempoPayloadBuilder::new(
             pool,
             ctx.provider().clone(),
             ctx.task_executor().clone(),
             evm_config,
             TempoPayloadBuilderConfig {
+                desired_gas_limit: gas_limit,
                 is_dev: ctx.is_dev(),
                 state_provider_metrics: self.state_provider_metrics,
                 enable_prewarming: self.enable_prewarming,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -727,7 +727,7 @@ where
     ) -> eyre::Result<Self::PayloadBuilder> {
         let conf = ctx.payload_builder_config();
         let chain = ctx.chain_spec().chain();
-        let gas_limit = conf.gas_limit().or_else(|| match chain.kind() {
+        let desired_gas_limit = conf.gas_limit().or_else(|| match chain.kind() {
             ChainKind::Named(NamedChain::Tempo | NamedChain::TempoModerato) => {
                 Some(BLOCK_GAS_LIMIT_500M)
             }
@@ -740,7 +740,7 @@ where
             ctx.task_executor().clone(),
             evm_config,
             TempoPayloadBuilderConfig {
-                desired_gas_limit: gas_limit,
+                desired_gas_limit,
                 is_dev: ctx.is_dev(),
                 state_provider_metrics: self.state_provider_metrics,
                 enable_prewarming: self.enable_prewarming,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -9,7 +9,8 @@ use crate::{
     },
 };
 use alloy_primitives::B256;
-use reth_chainspec::EthChainSpec;
+use eyre::bail;
+use reth_chainspec::{ChainKind, EthChainSpec, NamedChain};
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes,
     PayloadAttributesBuilder, PayloadTypes,
@@ -58,6 +59,8 @@ use tempo_transaction_pool::{
         TempoTransactionValidator,
     },
 };
+
+pub const BLOCK_GAS_LIMIT_500M: u64 = 500_000_000;
 
 /// Tempo node CLI arguments.
 #[derive(Debug, Clone, Copy, PartialEq, clap::Args)]
@@ -724,7 +727,16 @@ where
     ) -> eyre::Result<Self::PayloadBuilder> {
         let conf = ctx.payload_builder_config();
         let chain = ctx.chain_spec().chain();
-        let gas_limit = conf.gas_limit_for(chain);
+        let gas_limit = if let Some(limit) = conf.gas_limit() {
+            limit
+        } else {
+            match chain.kind() {
+                ChainKind::Named(NamedChain::Tempo | NamedChain::TempoModerato) => {
+                    BLOCK_GAS_LIMIT_500M
+                }
+                _ => bail!("unsupported chain kind: {:?}", chain.kind()),
+            }
+        };
 
         Ok(TempoPayloadBuilder::new(
             pool,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -732,9 +732,12 @@ where
             limit
         } else {
             match chain.kind() {
-                ChainKind::Named(NamedChain::Tempo | NamedChain::TempoModerato) => {
-                    BLOCK_GAS_LIMIT_500M
-                }
+                ChainKind::Named(
+                    NamedChain::Tempo
+                    | NamedChain::TempoModerato
+                    | NamedChain::TempoDevnet
+                    | NamedChain::Dev,
+                ) => BLOCK_GAS_LIMIT_500M,
                 _ => bail!("unsupported chain kind: {:?}", chain.kind()),
             }
         };

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -9,7 +9,6 @@ use crate::{
     },
 };
 use alloy_primitives::B256;
-use eyre::bail;
 use reth_chainspec::{ChainKind, EthChainSpec, NamedChain};
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes,
@@ -728,19 +727,12 @@ where
     ) -> eyre::Result<Self::PayloadBuilder> {
         let conf = ctx.payload_builder_config();
         let chain = ctx.chain_spec().chain();
-        let gas_limit = if let Some(limit) = conf.gas_limit() {
-            limit
-        } else {
-            match chain.kind() {
-                ChainKind::Named(
-                    NamedChain::Tempo
-                    | NamedChain::TempoModerato
-                    | NamedChain::TempoDevnet
-                    | NamedChain::Dev,
-                ) => BLOCK_GAS_LIMIT_500M,
-                _ => bail!("unsupported chain kind: {:?}", chain.kind()),
+        let gas_limit = conf.gas_limit().or_else(|| match chain.kind() {
+            ChainKind::Named(NamedChain::Tempo | NamedChain::TempoModerato) => {
+                Some(BLOCK_GAS_LIMIT_500M)
             }
-        };
+            _ => None,
+        });
 
         Ok(TempoPayloadBuilder::new(
             pool,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -60,6 +60,7 @@ use tempo_transaction_pool::{
     },
 };
 
+/// 500M gas limit
 pub const BLOCK_GAS_LIMIT_500M: u64 = 500_000_000;
 
 /// Tempo node CLI arguments.

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 use alloy_consensus::{BlockHeader as _, Signed, Transaction as _, TxLegacy, TxReceipt};
 use alloy_eip7928::bal::Bal;
-use alloy_eips::eip2718::Encodable2718;
+use alloy_eips::{eip1559::calculate_block_gas_limit, eip2718::Encodable2718};
 use alloy_primitives::{Address, B256, Bloom, Bytes, U256, keccak256};
 use alloy_rlp::{Decodable, Encodable};
 use reth_basic_payload_builder::{
@@ -117,6 +117,8 @@ pub struct TempoPayloadBuilder<Provider> {
     enable_prewarming: bool,
     /// Whether to include block access lists in built execution payloads.
     enable_bal: bool,
+    /// Desired gas limit.
+    desired_gas_limit: u64,
     /// Learned estimate of total replayable build work divided by work at tx cutoff.
     ///
     /// This lets the builder reserve time for non-interruptible
@@ -127,6 +129,8 @@ pub struct TempoPayloadBuilder<Provider> {
 /// Runtime settings for the Tempo payload builder.
 #[derive(Debug, Clone, Copy)]
 pub struct TempoPayloadBuilderConfig {
+    /// Desired gas limit.
+    pub desired_gas_limit: u64,
     /// Whether the node is configured in `--dev` miner mode.
     pub is_dev: bool,
     /// Whether to enable state provider metrics.
@@ -144,11 +148,27 @@ pub struct TempoPayloadBuilderConfig {
 impl Default for TempoPayloadBuilderConfig {
     fn default() -> Self {
         Self {
+            desired_gas_limit: alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M,
             is_dev: false,
             state_provider_metrics: false,
             enable_prewarming: true,
             build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
         }
+    }
+}
+
+impl TempoPayloadBuilderConfig {
+    /// Returns the gas limit for the next block based on the parent gas limit and an optional
+    /// target from payload attributes.
+    pub fn gas_limit_with_target(
+        &self,
+        parent_gas_limit: u64,
+        target_gas_limit: Option<u64>,
+    ) -> u64 {
+        calculate_block_gas_limit(
+            parent_gas_limit,
+            target_gas_limit.unwrap_or(self.desired_gas_limit),
+        )
     }
 }
 
@@ -172,6 +192,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             state_provider_metrics: config.state_provider_metrics,
             enable_prewarming: config.enable_prewarming,
             enable_bal: cfg!(feature = "bal"),
+            desired_gas_limit: config.desired_gas_limit,
             build_time_multiplier: Arc::new(AtomicU64::new(scaled_build_time_multiplier(
                 config.build_time_multiplier,
             ))),
@@ -384,7 +405,11 @@ where
             .chain_spec()
             .is_osaka_active_at_timestamp(attributes.timestamp);
 
-        let block_gas_limit: u64 = parent_header.gas_limit();
+        let block_gas_limit = TempoPayloadBuilderConfig {
+            desired_gas_limit: self.desired_gas_limit,
+            ..Default::default()
+        }
+        .gas_limit_with_target(parent_header.gas_limit(), attributes.target_gas_limit);
         let shared_gas_limit =
             chain_spec.shared_gas_limit_at(attributes.timestamp, block_gas_limit);
         // Non-shared gas limit is the maximum gas available for proposer's pool transactions.

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -123,7 +123,9 @@ pub struct TempoPayloadBuilder<Provider> {
 #[derive(Debug, Clone, Copy)]
 pub struct TempoPayloadBuilderConfig {
     /// Desired gas limit.
-    pub desired_gas_limit: u64,
+    ///
+    /// If not set, the parent gas limit is used.
+    pub desired_gas_limit: Option<u64>,
     /// Whether the node is configured in `--dev` miner mode.
     pub is_dev: bool,
     /// Whether to enable state provider metrics.
@@ -141,6 +143,8 @@ pub struct TempoPayloadBuilderConfig {
 impl TempoPayloadBuilderConfig {
     /// Returns the gas limit for the next block based on the parent gas limit and an optional
     /// target from payload attributes.
+    ///
+    /// If [`TempoPayloadBuilderConfig::desired_gas_limit`] is [`None`], the parent gas limit is used.
     pub fn gas_limit_with_target(
         &self,
         parent_gas_limit: u64,
@@ -148,7 +152,9 @@ impl TempoPayloadBuilderConfig {
     ) -> u64 {
         calculate_block_gas_limit(
             parent_gas_limit,
-            target_gas_limit.unwrap_or(self.desired_gas_limit),
+            target_gas_limit
+                .or(self.desired_gas_limit)
+                .unwrap_or(parent_gas_limit),
         )
     }
 }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -96,6 +96,7 @@ pub struct TempoPayloadBuilder<Provider> {
     pool: TempoTransactionPool<Provider>,
     provider: Provider,
     executor: TaskExecutor,
+    config: TempoPayloadBuilderConfig,
     evm_config: TempoEvmConfig,
     metrics: TempoPayloadBuilderMetrics,
     cache_metrics: CachedStateMetrics,
@@ -109,16 +110,8 @@ pub struct TempoPayloadBuilder<Provider> {
     /// last height at which we've seen an invalid subblock, and not including any subblocks
     /// at this height for any payloads.
     highest_invalid_subblock: Arc<AtomicU64>,
-    /// Whether the node is configured in `--dev` miner mode.
-    is_dev: bool,
-    /// Whether to enable state provider metrics.
-    state_provider_metrics: bool,
-    /// Whether to enable prewarming of best transactions.
-    enable_prewarming: bool,
     /// Whether to include block access lists in built execution payloads.
     enable_bal: bool,
-    /// Desired gas limit.
-    desired_gas_limit: u64,
     /// Learned estimate of total replayable build work divided by work at tx cutoff.
     ///
     /// This lets the builder reserve time for non-interruptible
@@ -143,18 +136,6 @@ pub struct TempoPayloadBuilderConfig {
     /// above `1.0` stop transaction execution earlier to leave room for
     /// `builder_finish`, which validators also repeat.
     pub build_time_multiplier: f64,
-}
-
-impl Default for TempoPayloadBuilderConfig {
-    fn default() -> Self {
-        Self {
-            desired_gas_limit: alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M,
-            is_dev: false,
-            state_provider_metrics: false,
-            enable_prewarming: true,
-            build_time_multiplier: DEFAULT_BUILD_TIME_MULTIPLIER,
-        }
-    }
 }
 
 impl TempoPayloadBuilderConfig {
@@ -184,15 +165,12 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             pool,
             provider,
             executor,
+            config,
             evm_config,
             metrics: TempoPayloadBuilderMetrics::default(),
             cache_metrics: CachedStateMetrics::zeroed(CachedStateMetricsSource::Builder),
             highest_invalid_subblock: Default::default(),
-            is_dev: config.is_dev,
-            state_provider_metrics: config.state_provider_metrics,
-            enable_prewarming: config.enable_prewarming,
             enable_bal: cfg!(feature = "bal"),
-            desired_gas_limit: config.desired_gas_limit,
             build_time_multiplier: Arc::new(AtomicU64::new(scaled_build_time_multiplier(
                 config.build_time_multiplier,
             ))),
@@ -354,7 +332,7 @@ where
             // When trie handle is provided, we build the payload once so the shared trie can be reused.
             trie_handle.is_some()
             // `--dev` mode does not use the shared-trie builder flow.
-            && !self.is_dev;
+            && !self.config.is_dev;
 
         macro_rules! check_cancel {
             () => {
@@ -383,7 +361,7 @@ where
                 Some(self.cache_metrics.clone()),
             ));
         }
-        if self.state_provider_metrics {
+        if self.config.state_provider_metrics {
             state_provider = Box::new(InstrumentedStateProvider::new(state_provider, "builder"));
         }
 
@@ -405,11 +383,9 @@ where
             .chain_spec()
             .is_osaka_active_at_timestamp(attributes.timestamp);
 
-        let block_gas_limit = TempoPayloadBuilderConfig {
-            desired_gas_limit: self.desired_gas_limit,
-            ..Default::default()
-        }
-        .gas_limit_with_target(parent_header.gas_limit(), attributes.target_gas_limit);
+        let block_gas_limit = self
+            .config
+            .gas_limit_with_target(parent_header.gas_limit(), attributes.target_gas_limit);
         let shared_gas_limit =
             chain_spec.shared_gas_limit_at(attributes.timestamp, block_gas_limit);
         // Non-shared gas limit is the maximum gas available for proposer's pool transactions.
@@ -573,7 +549,7 @@ where
         ));
         // Wrap best transactions into state-aware wrapper to skip transactions that
         // get invalidated by already-executed ones.
-        let mut best_txs = StateAwareBestTransactions::new(if self.enable_prewarming {
+        let mut best_txs = StateAwareBestTransactions::new(if self.config.enable_prewarming {
             Box::new(BestTransactionsPrewarming::new(
                 self.executor.clone(),
                 self.provider.clone(),


### PR DESCRIPTION
Set the payload builder gas limit from CLI arguments and chain defaults.

Gas limit resolution:
1. `--builder.gaslimit` CLI argument
1. Mainnet/testnet hardcoded gas limit (500M for both right now)
1. Parent block gas limit (useful for devnets and custom chains, like in benchmarking)

Gas limit for the next block is resolved using [`calculate_block_gas_limit`](https://docs.rs/alloy-eips/latest/alloy_eips/eip1559/fn.calculate_block_gas_limit.html) that gradually raises it to the target.