### PR TITLE
fix(follow): relax upstream URL resolution, enforce websocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13042,6 +13042,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-client",
  "alloy-rpc-types-engine",
  "axum",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13093,6 +13093,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber 0.3.23",
+ "url",
 ]
 
 [[package]]

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -28,6 +28,7 @@ tempo-telemetry-util.workspace = true
 
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
+alloy-rpc-client = { workspace = true, features = ["ws-base"] }
 alloy-rpc-types-engine.workspace = true
 alloy-rlp.workspace = true
 

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -75,6 +75,7 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "sync", "net", "rt", "time"] }
 tokio-stream = { workspace = true, features = ["sync"] }
 tracing.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 tempo-precompiles = { workspace = true, features = ["test-utils"] }

--- a/crates/consensus/src/follow/upstream/actor.rs
+++ b/crates/consensus/src/follow/upstream/actor.rs
@@ -20,6 +20,7 @@ use tokio::{
     sync::{mpsc, oneshot},
 };
 use tracing::{debug, debug_span, instrument, warn, warn_span};
+use url::Url;
 
 use crate::utils::OptionFuture;
 
@@ -38,7 +39,7 @@ pub(crate) struct Actor<TContext> {
     pub(super) context: ContextCell<TContext>,
     pub(super) connection: Option<Arc<WsClient>>,
     pub(super) mailbox: mpsc::UnboundedReceiver<super::ingress::Message>,
-    pub(super) url: &'static str,
+    pub(super) url: &'static Url,
     pub(super) pending_connect: OptionFuture<BoxFuture<'static, (u64, eyre::Result<WsClient>)>>,
     pub(super) pending_stream:
         OptionFuture<BoxFuture<'static, Result<Subscription<Event>, client::Error>>>,
@@ -78,7 +79,7 @@ where
                                 %reason,
                                 attempts,
                                 reconnect_in = %display_duration(reconnect_in),
-                                url = self.url,
+                                url = %self.url,
                                 "connecting to upstream node failed, attempting again",
                             ));
                             self.pending_connect.replace({
@@ -128,7 +129,7 @@ where
                         }
                         None => {
                             warn_span!("event_subscription").in_scope(|| warn!(
-                                url = self.url,
+                                url = %self.url,
                                 "event stream terminated",
                             ));
                             self.event_stream = inactive_event_stream();
@@ -165,7 +166,7 @@ where
         if client.is_connected() {
             self.pending_stream.replace(subscribe(client));
         } else {
-            warn!(url = self.url, "upstream client disconnected, reconnecting");
+            warn!(url = %self.url, "upstream client disconnected, reconnecting");
             self.connection.take();
             self.pending_connect.replace(connect(self.url, 1));
         }
@@ -198,12 +199,12 @@ where
     }
 }
 
-fn connect(url: &'static str, attempts: u64) -> BoxFuture<'static, (u64, eyre::Result<WsClient>)> {
+fn connect(url: &'static Url, attempts: u64) -> BoxFuture<'static, (u64, eyre::Result<WsClient>)> {
     async move {
         (
             attempts,
             WsClientBuilder::default()
-                .build(&url)
+                .build(url)
                 .await
                 .map_err(Report::new),
         )

--- a/crates/consensus/src/follow/upstream/mod.rs
+++ b/crates/consensus/src/follow/upstream/mod.rs
@@ -3,11 +3,10 @@
 //! Maintains a regular connection to an upstream node over websocker
 //! or `in_process::Actor` as an in-process actor working off of channels.
 
-use std::net::SocketAddr;
-
+use alloy_rpc_client::BuiltInConnectionString;
 use commonware_consensus::Reporter;
 use commonware_runtime::{Clock, ContextCell, Metrics, Spawner};
-use eyre::{WrapErr as _, ensure};
+use eyre::WrapErr as _;
 use tempo_node::rpc::consensus::Event;
 use tokio::sync::mpsc;
 use url::Url;
@@ -79,16 +78,9 @@ pub(crate) struct Config {
 }
 
 fn parse_upstream_url(url: &str) -> eyre::Result<Url> {
-    let url: Url = if url.starts_with("localhost:") || url.parse::<SocketAddr>().is_ok() {
-        format!("ws://{url}").parse()?
-    } else {
-        url.parse()?
+    let BuiltInConnectionString::Ws(url, _) = BuiltInConnectionString::try_as_ws(url)? else {
+        unreachable!("try_as_ws always returns a websocket connection string on success")
     };
-    ensure!(
-        matches!(url.scheme(), "ws" | "wss"),
-        "URL scheme must be ws or wss, was `{}`",
-        url.scheme()
-    );
     Ok(url)
 }
 

--- a/crates/consensus/src/follow/upstream/mod.rs
+++ b/crates/consensus/src/follow/upstream/mod.rs
@@ -3,10 +3,13 @@
 //! Maintains a regular connection to an upstream node over websocker
 //! or `in_process::Actor` as an in-process actor working off of channels.
 
+use std::net::SocketAddr;
+
 use commonware_consensus::Reporter;
 use commonware_runtime::{Clock, ContextCell, Metrics, Spawner};
 use tempo_node::rpc::consensus::Event;
 use tokio::sync::mpsc;
+use url::Url;
 
 use crate::utils::OptionFuture;
 
@@ -43,11 +46,13 @@ where
 pub(crate) fn init<TContext>(
     context: TContext,
     config: Config,
-) -> (Actor<TContext>, ingress::Mailbox) {
+) -> eyre::Result<(Actor<TContext>, ingress::Mailbox)> {
     let (tx, rx) = mpsc::unbounded_channel();
     let mailbox = ingress::Mailbox::new(tx);
 
-    let url = Box::leak(Box::<str>::from(config.upstream_url));
+    let url = Box::leak(Box::<str>::from(
+        parse_upstream_url(&config.upstream_url)?.to_string(),
+    ));
     let actor = Actor {
         context: ContextCell::new(context),
         connection: None,
@@ -59,10 +64,51 @@ pub(crate) fn init<TContext>(
         waiters: Vec::new(),
     };
 
-    (actor, mailbox)
+    Ok((actor, mailbox))
 }
 
 pub(crate) struct Config {
     /// The URL to connect to.
     pub(crate) upstream_url: String,
+}
+
+fn parse_upstream_url(url: &str) -> eyre::Result<Url> {
+    if url.starts_with("localhost:") || url.parse::<SocketAddr>().is_ok() {
+        Ok(format!("ws://{url}").parse()?)
+    } else {
+        Ok(url.parse()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_upstream_url_preserves_explicit_url() {
+        assert_eq!(
+            parse_upstream_url("wss://upstream.example:8546")
+                .unwrap()
+                .to_string(),
+            "wss://upstream.example:8546/"
+        );
+    }
+
+    #[test]
+    fn parse_upstream_url_prefixes_localhost_and_socketaddr() {
+        assert_eq!(
+            parse_upstream_url("localhost:8546").unwrap().to_string(),
+            "ws://localhost:8546/"
+        );
+        assert_eq!(
+            parse_upstream_url("127.0.0.1:8546").unwrap().to_string(),
+            "ws://127.0.0.1:8546/"
+        );
+    }
+
+    #[test]
+    fn parse_upstream_url_rejects_non_url_values() {
+        assert!(parse_upstream_url("not a url").is_err());
+        assert!(parse_upstream_url("localhost").is_err());
+    }
 }

--- a/crates/consensus/src/follow/upstream/mod.rs
+++ b/crates/consensus/src/follow/upstream/mod.rs
@@ -7,6 +7,7 @@ use std::net::SocketAddr;
 
 use commonware_consensus::Reporter;
 use commonware_runtime::{Clock, ContextCell, Metrics, Spawner};
+use eyre::{WrapErr as _, ensure};
 use tempo_node::rpc::consensus::Event;
 use tokio::sync::mpsc;
 use url::Url;
@@ -50,8 +51,13 @@ pub(crate) fn init<TContext>(
     let (tx, rx) = mpsc::unbounded_channel();
     let mailbox = ingress::Mailbox::new(tx);
 
-    let url = Box::leak(Box::<str>::from(
-        parse_upstream_url(&config.upstream_url)?.to_string(),
+    let url = Box::leak(Box::from(
+        parse_upstream_url(&config.upstream_url).wrap_err_with(|| {
+            format!(
+                "failed parsing upstream location as websocket URL: `{}`",
+                config.upstream_url
+            )
+        })?,
     ));
     let actor = Actor {
         context: ContextCell::new(context),
@@ -73,11 +79,17 @@ pub(crate) struct Config {
 }
 
 fn parse_upstream_url(url: &str) -> eyre::Result<Url> {
-    if url.starts_with("localhost:") || url.parse::<SocketAddr>().is_ok() {
-        Ok(format!("ws://{url}").parse()?)
+    let url: Url = if url.starts_with("localhost:") || url.parse::<SocketAddr>().is_ok() {
+        format!("ws://{url}").parse()?
     } else {
-        Ok(url.parse()?)
-    }
+        url.parse()?
+    };
+    ensure!(
+        matches!(url.scheme(), "ws" | "wss"),
+        "URL scheme must be ws or wss, was `{}`",
+        url.scheme()
+    );
+    Ok(url)
 }
 
 #[cfg(test)]
@@ -104,6 +116,11 @@ mod tests {
             parse_upstream_url("127.0.0.1:8546").unwrap().to_string(),
             "ws://127.0.0.1:8546/"
         );
+    }
+
+    #[test]
+    fn parse_upstream_url_rejects_non_ws_schemes() {
+        assert!(parse_upstream_url("http://upstream.example:8546").is_err());
     }
 
     #[test]

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -196,7 +196,7 @@ pub async fn run_follow_stack(
         context.with_label("upstream"),
         crate::follow::upstream::Config { upstream_url },
     )
-    .wrap_err("failed to initialize upstream follow actor")?;
+    .wrap_err("failed to initialize client to upstream node")?;
 
     let config = follow::Config {
         execution_node,

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -195,7 +195,8 @@ pub async fn run_follow_stack(
     let (upstream, upstream_mailbox) = crate::follow::upstream::init(
         context.with_label("upstream"),
         crate::follow::upstream::Config { upstream_url },
-    );
+    )
+    .wrap_err("failed to initialize upstream follow actor")?;
 
     let config = follow::Config {
         execution_node,


### PR DESCRIPTION
## Summary

Relaxes parsing of the `--follow <url>` argument: `<ip>:<addr>` pairs are now permitted (similar to upstream reth). Also enforces that URLs have schemes `ws://` or `wss://` at startup to provide better diagnostics.

Prompted by: @SuperFluffy

