### PR TITLE
ci(bench): set explicit nonce for TIP-20 2D txgen preset

### DIFF
--- a/contrib/bench/txgen/presets/tip20_2d_nonces.yml
+++ b/contrib/bench/txgen/presets/tip20_2d_nonces.yml
@@ -93,6 +93,7 @@ templates:
       choice: ${TXGEN_TIP20_TOKENS}
     nonce_key:
       uniform: [1, 18446744073709551615]
+    nonce: 0
     call:
       to:
         choice: ${TXGEN_TIP20_TOKENS}


### PR DESCRIPTION
## Summary
- set `nonce: 0` in `tip20_2d_nonces.yml`
- keeps random 2D nonce keys but avoids txgen nonce tracking/fetching for the preset

Depends on: https://github.com/tempoxyz/txgen/pull/139

Prompted by: @shekhirin

## Testing
- rg -n "nonce: 0|nonce_key" contrib/bench/txgen/presets/tip20_2d_nonces.yml