### PR TITLE
ci(bench): add TIP-20 protocol nonce txgen preset

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -37,6 +37,7 @@ on:
         options:
           - tip20
           - tip20_2d_nonces
+          - tip20_protocol_nonces
           - tip20_random_recipients
           - tip20_existing_recipients
           - mpp

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -4,7 +4,7 @@ const TXGEN_HELPER_SCRAPE_INTERVAL_MS = 200
 const TXGEN_HELPER_DRAIN_TIMEOUT_SECS = 300
 const TXGEN_HELPER_FUND_DRAIN_TIMEOUT_SECS = 120
 const TXGEN_HELPER_PRESETS_DIR = "contrib/bench/txgen/presets"
-const TXGEN_HELPER_EXISTING_RECIPIENTS_PRESETS = ["tip20_existing_recipients" "tip20_2d_nonces"]
+const TXGEN_HELPER_EXISTING_RECIPIENTS_PRESETS = ["tip20_existing_recipients" "tip20_2d_nonces" "tip20_protocol_nonces"]
 const TXGEN_HELPER_EXISTING_RECIPIENTS_START = 10000
 
 def txgen-tip20-token-address [token_id: int] {

--- a/contrib/bench/txgen/presets/tip20_protocol_nonces.yml
+++ b/contrib/bench/txgen/presets/tip20_protocol_nonces.yml
@@ -1,0 +1,107 @@
+chain_id: 1337
+
+gas:
+  max_fee_per_gas: 100000000000
+  max_priority_fee_per_gas: 100000000000
+
+accounts:
+  users:
+    mnemonic: "test test test test test test test test test test test junk"
+    range:
+      - 0
+      - ${TXGEN_ACCOUNTS}
+
+address_pools:
+  existing_recipients:
+    fast:
+      seed: "test test test test test test test test test test test junk"
+      range:
+        - ${TXGEN_EXISTING_RECIPIENTS_START}
+        - ${TXGEN_EXISTING_RECIPIENTS_END}
+
+artifacts:
+  ERC20: ../erc20.abi.json
+  FeeAMM: ../fee-amm.abi.json
+
+setup:
+  steps:
+    - id: mint_alpha_pathusd_liquidity
+      tx:
+        type: tempo
+        from:
+          pool: users
+          select: { index: 0 }
+        gas_limit: 1000000
+        max_fee_per_gas: 100000000000
+        max_priority_fee_per_gas: 100000000000
+        call:
+          to: "0xfeec000000000000000000000000000000000000"
+          abi: FeeAMM
+          function: mint
+          args:
+            - "0x20c0000000000000000000000000000000000001"
+            - "0x20c0000000000000000000000000000000000000"
+            - 10000000000
+            - "0xfeec000000000000000000000000000000000000"
+    - id: mint_beta_pathusd_liquidity
+      tx:
+        type: tempo
+        from:
+          pool: users
+          select: { index: 0 }
+        gas_limit: 1000000
+        max_fee_per_gas: 100000000000
+        max_priority_fee_per_gas: 100000000000
+        call:
+          to: "0xfeec000000000000000000000000000000000000"
+          abi: FeeAMM
+          function: mint
+          args:
+            - "0x20c0000000000000000000000000000000000002"
+            - "0x20c0000000000000000000000000000000000000"
+            - 10000000000
+            - "0xfeec000000000000000000000000000000000000"
+    - id: mint_theta_pathusd_liquidity
+      tx:
+        type: tempo
+        from:
+          pool: users
+          select: { index: 0 }
+        gas_limit: 1000000
+        max_fee_per_gas: 100000000000
+        max_priority_fee_per_gas: 100000000000
+        call:
+          to: "0xfeec000000000000000000000000000000000000"
+          abi: FeeAMM
+          function: mint
+          args:
+            - "0x20c0000000000000000000000000000000000003"
+            - "0x20c0000000000000000000000000000000000000"
+            - 10000000000
+            - "0xfeec000000000000000000000000000000000000"
+
+templates:
+  tip20_transfer:
+    type: tempo
+    from:
+      pool: users
+      select: random
+    gas_limit: 350000
+    max_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 100000000000
+    fee_token:
+      choice: ${TXGEN_TIP20_TOKENS}
+    call:
+      to:
+        choice: ${TXGEN_TIP20_TOKENS}
+      abi: ERC20
+      function: transfer
+      args:
+        - address_pool:
+            pool: existing_recipients
+            select: random
+        - 1
+
+mix:
+  - template: tip20_transfer
+    weight: 100


### PR DESCRIPTION
## Summary
- add `tip20_protocol_nonces.yml`, matching `tip20_2d_nonces.yml` except it uses normal protocol nonces
- register the preset for existing-recipient environment configuration

## Verification
- `uv run python - <<'PY' ...` parsed the new preset and confirmed no `nonce_key` / `expiring_nonce` fields
- `nu -c 'source contrib/bench/txgen/helpers.nu; txgen-available-presets | to json -r'` includes `tip20_protocol_nonces`

Prompted by: @shekhirin