### PR TITLE
docs(tip-1070): remove no-code system call clause

### DIFF
--- a/tips/tip-1070.md
+++ b/tips/tip-1070.md
@@ -95,8 +95,7 @@ This system call follows the same execution convention as EIP-4788-style system 
 
 - the call MUST execute to completion;
 - the call MUST NOT count against the block gas limit;
-- the call MUST NOT transfer value or apply EIP-1559 burn semantics;
-- if no code exists at `CURRENT_COMMITTEE_ADDRESS`, the call MUST fail silently.
+- the call MUST NOT transfer value or apply EIP-1559 burn semantics.
 
 The system call MUST call `CURRENT_COMMITTEE_ADDRESS` from the system address with calldata equivalent to:
 


### PR DESCRIPTION
Removes the no-code silent-failure clause from TIP-1070 because the committee precompile is deployed at activation and the clause is not relevant to this TIP.

Prompted by: @klkvr