### PR TITLE
docs(tip-1070): simplify current committee spec

### DIFF
--- a/tips/tip-1070.md
+++ b/tips/tip-1070.md
@@ -17,8 +17,8 @@ This TIP proposes an EIP-4788-like system call that writes the current committee
 ## Motivation
 
 `ValidatorConfigV2.getActiveValidators()` is a recurring source of confusion because it returns the configured validator registry, not necessarily the committee currently active in consensus.
-Registry changes such as `addValidator`, `rotateValidator`, and `deactivateValidator` immediately affect the return value of `getActiveValidators` returns even if the changes have not yet been propagated to the committee.
-Likewise, the committee is only updated if the relevant DKG round succeeds; if DKG fails, the committee remains that of the previous epoch, thus potentially containing validators that are marked deactivated and which would therefore be excluded from `getActiveValidators`.
+Registry changes such as `addValidator`, `rotateValidator`, and `deactivateValidator` immediately affect the return value of `getActiveValidators()` even if the changes have not yet been propagated to the committee.
+Likewise, the committee is only updated if the relevant DKG round succeeds; if DKG fails, the committee remains that of the previous epoch, thus potentially containing validators that are marked deactivated and which would therefore be excluded from `getActiveValidators()`.
 
 Callers that need the current effective committee must therefore inspect consensus data or reconstruct it from epoch-boundary block data.
 This TIP gives contracts a stable execution-layer query for that value while keeping it separate from `ValidatorConfigV2`: that registry remains the input to future DKG player selection, while the new committee state records the DKG result consensus actually selected for the current epoch.
@@ -36,7 +36,7 @@ This TIP gives contracts a stable execution-layer query for that value while kee
 
 - **Consensus proposer**: can propose the last block of an epoch and its extra data, but cannot choose whether the committee update runs. The VM executes the required system call during block processing, and invalid committee updates are consensus-invalid.
 - **ValidatorConfigV2 owner**: can change configured validator state, but cannot directly change the effective committee except through the normal DKG process.
-- **Contract callers and offchain tools**: untrusted readers. They rely on this query as a canonical view of effective committee membership and should not  infer committee state from `getActiveValidators()`.
+- **Contract callers and offchain tools**: untrusted readers. They rely on this query as a canonical view of effective committee membership and should not infer committee state from `getActiveValidators()`.
 - **Failed or incomplete DKG rounds**: in scope. The interface must expose the fallback committee selected by consensus, not the intended player set from registry state.
 
 ---
@@ -71,7 +71,7 @@ function getCommitteeMembers()
 ```
 
 `getCommitteeMembers()` MUST return the committee used by consensus for the epoch containing the block at which the call is evaluated.
-The returned `epoch` MUST be computed from the block number at which the call is evaluated and the chain's epoch schedule. It MUST NOT be stored in the committee contract's state.
+The returned `epoch` MUST be computed from the block number at which the call is evaluated and the chain's epoch schedule.
 
 The returned `publicKeys` MUST be ordered exactly as the `players` vector in the DKG outcome selected for that epoch. If consensus falls back to a previous DKG outcome, the returned `publicKeys` MUST match the fallback outcome.
 
@@ -87,7 +87,7 @@ Implementations MUST NOT persist the epoch alongside the committee members. The 
 
 ## System Call Execution
 
-The VM MUST execute the committee update as a system call while processing the last block of epoch `E`. The system call MUST read the DKG outcome for epoch `E+1` from that block's extra data and persist the effective committee for epoch `E+1` to execution-layer state.
+The VM MUST execute the committee update as a system call while processing the last block of epoch `E`.
 
 The system call MUST run from a post-execution hook after all user transactions in the last block of epoch `E` have executed. It is not a user transaction and MUST NOT appear in the transaction list. Transactions in the last block of epoch `E` MUST continue to observe the committee for epoch `E`; the persisted committee for epoch `E+1` MUST only become visible to EVM execution in the first block of epoch `E+1`.
 
@@ -103,26 +103,24 @@ The system call MUST call `CURRENT_COMMITTEE_ADDRESS` from the system address wi
 function setCommitteeMembers(bytes32[] calldata publicKeys) external;
 ```
 
-The `publicKeys` argument MUST be `selected_dkg_outcome(E).players`, converted to `bytes32[]` without reordering. The system call MUST NOT pass an epoch argument.
+The system call MUST NOT pass an epoch argument.
 
-The persisted committee MUST be the effective DKG outcome selected by consensus:
+The system call MUST read the DKG outcome from the boundary block's extra data and persist:
 
 ```text
 committee(E+1) = selected_dkg_outcome(E).players
 ```
 
-The system call MUST overwrite the stored `bytes32[] publicKeys` array with the new committee members. Implementations MUST NOT append a new committee record per epoch or otherwise grow state as epochs advance. A block for the last slot of epoch `E` is invalid if processing it does not perform the system call with the committee implied by that block's extra data.
+The system call MUST overwrite the stored `bytes32[] publicKeys` array with `selected_dkg_outcome(E).players`, converted to `bytes32[]` without reordering. Implementations MUST NOT append a new committee record per epoch or otherwise grow state as epochs advance. A block for the last slot of epoch `E` is invalid if processing it does not perform the system call with the committee implied by that block's extra data.
 
 ## Activation
 
 At activation, implementations MUST deploy the committee contract at `CURRENT_COMMITTEE_ADDRESS`. Activation MUST NOT initialize the committee state from the latest DKG outcome.
 
-The first committee state write MUST happen through the boundary system call at the end of the epoch in which activation occurs. Before that first boundary system call completes, `getCommitteeMembers()` MUST NOT return `getActiveValidators()` or any inferred fallback committee.
-
-After the first boundary system call, every epoch boundary MUST update the persisted current committee state for the next epoch.
+Before the first boundary system call completes, `getCommitteeMembers()` MUST NOT return `getActiveValidators()` or any inferred fallback committee.
 
 # Invariants
 
-- The boundary system call MUST write exactly the `players` recorded in the DKG outcome encoded in the last block's extra data as the committee members for the next epoch.
+- The boundary system call MUST write exactly the `players` recorded in the boundary block's DKG outcome as the committee members for the next epoch.
 - `getCommitteeMembers()` MUST return those same `players` as the effective committee members for the epoch in which the call is evaluated.
 - Validators MUST verify that the last block of an epoch contains the required DKG outcome in its extra data and that block processing writes exactly the committee implied by that DKG outcome.


### PR DESCRIPTION
Simplifies TIP-1070 wording without changing the intended semantics.

Changes:
- Removes duplicated epoch-storage wording from the interface section.
- Consolidates repeated boundary-system-call and committee persistence language.
- Trims activation wording that repeats the system-call requirements.
- Fixes minor `getActiveValidators()` formatting and spacing issues.

Prompted by: @klkvr