### PR TITLE
feat: recover blocked channel-reserve payouts

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1055,6 +1055,22 @@ impl TIP20Token {
         amount: U256,
         memo: B256,
     ) -> Result<Option<Recipient>> {
+        // Normal transfers attribute the inbound to the debited account itself.
+        self.validate_transfer_as(spender, from, from, to, amount, memo)
+    }
+
+    /// Like [`Self::validate_transfer`], but attributes a blocked inbound to `originator` while
+    /// debiting `from`. They differ only for TIP-1034 channel-reserve payouts (see
+    /// [`Self::validate_inbound_or_block_from`]).
+    fn validate_transfer_as(
+        &mut self,
+        spender: Option<Address>,
+        from: Address,
+        originator: Address,
+        to: Address,
+        amount: U256,
+        memo: B256,
+    ) -> Result<Option<Recipient>> {
         let to = Recipient::resolve(to)?;
         self.check_not_paused()?;
         to.validate()?;
@@ -1066,11 +1082,38 @@ impl TIP20Token {
             self.check_and_update_spending_limit(from, amount)?;
         }
 
-        if self.validate_inbound_or_block(from, &to, amount, None, memo)? {
+        if self.validate_inbound_or_block_from(from, originator, &to, amount, None, memo)? {
             return Ok(None);
         }
 
         Ok(Some(to))
+    }
+
+    /// Transfers `call.amount` out of the TIP-1034 channel `reserve` to settle or refund a channel,
+    /// attributing the payment to the channel `payer`.
+    ///
+    /// Identical to a reserve-sent [`Self::transfer`] except that, if the recipient's receive
+    /// policy blocks the funds, the held receipt records the payer as originator. For an
+    /// originator-sentinel (`address(0)`) recovery policy this lets the payer recover the funds;
+    /// the reserve precompile could never satisfy `ReceivePolicyGuard.claim()`.
+    pub(crate) fn transfer_from_channel_reserve(
+        &mut self,
+        reserve: Address,
+        payer: Address,
+        call: ITIP20::transferCall,
+    ) -> Result<bool> {
+        let Some(to) =
+            self.validate_transfer_as(None, reserve, payer, call.to, call.amount, B256::ZERO)?
+        else {
+            return Ok(true);
+        };
+
+        self._transfer(reserve, &to, call.amount)?;
+        if let Some(hop) = to.build_virtual_transfer_event(call.amount) {
+            self.emit_event(hop)?;
+        }
+
+        Ok(true)
     }
 
     /// Resolves `to`, checks the issuer role, and ensures TIP-403 mint-recipient authorization.
@@ -1213,6 +1256,32 @@ impl TIP20Token {
         mint_total_supply: Option<U256>,
         memo: B256,
     ) -> Result<bool> {
+        // Normal transfers/mints debit the originator itself.
+        self.validate_inbound_or_block_from(
+            originator,
+            originator,
+            to,
+            amount,
+            mint_total_supply,
+            memo,
+        )
+    }
+
+    /// Like [`Self::validate_inbound_or_block`], but debits `debit` while attributing the inbound
+    /// to `originator` for the receive-policy check and the stored claim receipt.
+    ///
+    /// These differ only for TIP-1034 channel-reserve payouts: the funds are custodied by the
+    /// reserve precompile (`debit`), but the economic sender is the channel payer (`originator`),
+    /// so a blocked payout is recoverable by the payer instead of the unsignable reserve address.
+    pub(crate) fn validate_inbound_or_block_from(
+        &mut self,
+        debit: Address,
+        originator: Address,
+        to: &Recipient,
+        amount: U256,
+        mint_total_supply: Option<U256>,
+        memo: B256,
+    ) -> Result<bool> {
         if !self.storage.spec().is_t6() {
             return Ok(false);
         }
@@ -1233,7 +1302,7 @@ impl TIP20Token {
             self.emit_event(TIP20Event::mint(guard.target, amount))?;
             InboundKind::MINT
         } else {
-            self._transfer(originator, &guard, amount)?;
+            self._transfer(debit, &guard, amount)?;
             InboundKind::TRANSFER
         };
         ReceivePolicyGuard::new()

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -192,6 +192,28 @@ impl TIP20ChannelReserve {
         Ok(channel_id)
     }
 
+    /// Pays `amount` of `token` from the reserve to `to` on behalf of channel `payer`.
+    ///
+    /// From T8, a payout blocked by the recipient's receive policy is attributed to the payer, so
+    /// an originator-sentinel (`address(0)`) recovery policy lets the payer recover it via
+    /// `ReceivePolicyGuard.claim()`. Before T8 it is a plain reserve transfer, which if blocked is
+    /// recorded against the reserve and cannot be recovered.
+    fn pay_from_reserve(
+        &self,
+        token: &mut TIP20Token,
+        payer: Address,
+        to: Address,
+        amount: U256,
+    ) -> Result<()> {
+        let call = ITIP20::transferCall { to, amount };
+        if self.storage.spec().is_t8() {
+            token.transfer_from_channel_reserve(self.address, payer, call)?;
+        } else {
+            token.transfer(self.address, call)?;
+        }
+        Ok(())
+    }
+
     /// Settles an increasing cumulative voucher, paying only the unsettled delta to the payee.
     ///
     /// The payee can call directly. If an operator was set when the channel was opened, that
@@ -231,12 +253,11 @@ impl TIP20ChannelReserve {
         state.settled = cumulative;
         self.channel_states[channel_id].write(state)?;
 
-        token.transfer(
-            self.address,
-            ITIP20::transferCall {
-                to: call.descriptor.payee,
-                amount: U256::from(delta),
-            },
+        self.pay_from_reserve(
+            &mut token,
+            call.descriptor.payer,
+            call.descriptor.payee,
+            U256::from(delta),
         )?;
 
         self.emit_event(TIP20ChannelReserveEvent::Settled(
@@ -402,21 +423,19 @@ impl TIP20ChannelReserve {
         let mut token = TIP20Token::from_address(call.descriptor.token)?;
         if !delta.is_zero() {
             token.ensure_authorized_as(call.descriptor.payer, AuthRole::Sender)?;
-            token.transfer(
-                self.address,
-                ITIP20::transferCall {
-                    to: call.descriptor.payee,
-                    amount: U256::from(delta),
-                },
+            self.pay_from_reserve(
+                &mut token,
+                call.descriptor.payer,
+                call.descriptor.payee,
+                U256::from(delta),
             )?;
         }
         if !refund.is_zero() {
-            token.transfer(
-                self.address,
-                ITIP20::transferCall {
-                    to: call.descriptor.payer,
-                    amount: U256::from(refund),
-                },
+            self.pay_from_reserve(
+                &mut token,
+                call.descriptor.payer,
+                call.descriptor.payer,
+                U256::from(refund),
             )?;
         }
 
@@ -460,12 +479,12 @@ impl TIP20ChannelReserve {
 
         self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
         if !refund.is_zero() {
-            TIP20Token::from_address(call.descriptor.token)?.transfer(
-                self.address,
-                ITIP20::transferCall {
-                    to: call.descriptor.payer,
-                    amount: U256::from(refund),
-                },
+            let mut token = TIP20Token::from_address(call.descriptor.token)?;
+            self.pay_from_reserve(
+                &mut token,
+                call.descriptor.payer,
+                call.descriptor.payer,
+                U256::from(refund),
             )?;
         }
         self.emit_event(TIP20ChannelReserveEvent::ChannelClosed(
@@ -770,22 +789,28 @@ mod tests {
     use crate::{
         Precompile,
         address_registry::AddressRegistry,
+        receive_policy_guard::{RECOVERY_ORIGINATOR, ReceivePolicyGuard},
         storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{
             TIP20Setup, VIRTUAL_MASTER, assert_full_coverage, check_selector_coverage,
             register_virtual_master,
         },
-        tip403_registry::{ITIP403Registry, TIP403Registry},
+        tip403_registry::{
+            ALLOW_ALL_POLICY_ID, ITIP403Registry, REJECT_ALL_POLICY_ID, TIP403Registry,
+        },
     };
     use alloy::{
         primitives::{Bytes, Signature},
-        sol_types::SolCall,
+        sol_types::{SolCall, SolValue},
     };
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{
-        ITIP20ChannelReserve::ITIP20ChannelReserveCalls, TIP20Error,
+        IReceivePolicyGuard::{ClaimReceiptV1, InboundKind},
+        ITIP20ChannelReserve::ITIP20ChannelReserveCalls,
+        ITIP403Registry::BlockedReason,
+        ReceivePolicyGuardError, TIP20Error,
     };
 
     fn descriptor(
@@ -1288,6 +1313,139 @@ mod tests {
 
             Ok(())
         })
+    }
+
+    /// A settle payout blocked by the payee's receive policy must be recoverable by the channel
+    /// payer. From T8 the held receipt records the payer as originator, so the payer (authorized
+    /// via the `address(0)` originator sentinel) can claim it; before T8 it was recorded against
+    /// the reserve precompile, which can never satisfy `ReceivePolicyGuard.claim()`.
+    #[test]
+    fn test_blocked_settle_payout_recoverable_by_payer_from_t8() -> eyre::Result<()> {
+        const BLOCKED_AT: u64 = 1_728_000;
+
+        for is_t8 in [false, true] {
+            let spec = if is_t8 {
+                TempoHardfork::T8
+            } else {
+                TempoHardfork::T7
+            };
+            let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
+            storage.set_timestamp(U256::from(BLOCKED_AT));
+            let payer_signer = PrivateKeySigner::random();
+            let payer = payer_signer.address();
+            let payee = Address::random();
+            let salt = B256::random();
+
+            StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
+                let token = TIP20Setup::path_usd(payer)
+                    .with_issuer(payer)
+                    .with_mint(payer, U256::from(1_000u128))
+                    .apply()?;
+
+                let mut reserve = TIP20ChannelReserve::new();
+                reserve.initialize()?;
+                let expiring_nonce_hash = seed_expiring_nonce_hash(&mut reserve)?;
+
+                let channel_id = reserve.open(
+                    payer,
+                    open_call(
+                        payee,
+                        Address::ZERO,
+                        token.address(),
+                        300,
+                        salt,
+                        Address::ZERO,
+                    ),
+                )?;
+
+                // Payee rejects every inbound sender and authorizes the originator (address(0)) to
+                // recover blocked funds.
+                TIP403Registry::new().set_receive_policy(
+                    payee,
+                    ITIP403Registry::setReceivePolicyCall {
+                        senderPolicyId: REJECT_ALL_POLICY_ID,
+                        tokenFilterId: ALLOW_ALL_POLICY_ID,
+                        recoveryAuthority: RECOVERY_ORIGINATOR,
+                    },
+                )?;
+
+                let digest =
+                    reserve.get_voucher_digest(ITIP20ChannelReserve::getVoucherDigestCall {
+                        channelId: channel_id,
+                        cumulativeAmount: U96::from(120),
+                    })?;
+                let signature =
+                    Bytes::copy_from_slice(&payer_signer.sign_hash_sync(&digest)?.as_bytes());
+                let channel_descriptor = descriptor(
+                    payer,
+                    payee,
+                    Address::ZERO,
+                    token.address(),
+                    salt,
+                    Address::ZERO,
+                    expiring_nonce_hash,
+                );
+                reserve.settle(
+                    payee,
+                    ITIP20ChannelReserve::settleCall {
+                        descriptor: channel_descriptor,
+                        cumulativeAmount: U96::from(120),
+                        signature,
+                    },
+                )?;
+
+                // The blocked delta is held by the guard, debited from the reserve either way.
+                let delta = U256::from(120u64);
+                let token = TIP20Token::from_address(token.address())?;
+                assert_eq!(
+                    token.balance_of(ITIP20::balanceOfCall {
+                        account: TIP20_CHANNEL_RESERVE_ADDRESS,
+                    })?,
+                    U256::from(180u64),
+                );
+
+                // Originator is the payer from T8, the reserve before it.
+                let originator = if is_t8 {
+                    payer
+                } else {
+                    TIP20_CHANNEL_RESERVE_ADDRESS
+                };
+                let receipt = ClaimReceiptV1::new(
+                    token.address(),
+                    RECOVERY_ORIGINATOR,
+                    originator,
+                    payee,
+                    BLOCKED_AT,
+                    1,
+                    BlockedReason::RECEIVE_POLICY as u8,
+                    InboundKind::TRANSFER,
+                    B256::ZERO,
+                );
+                let mut guard = ReceivePolicyGuard::new();
+                assert_eq!(guard.balance_of(receipt.abi_encode().into())?, delta);
+
+                if is_t8 {
+                    // The payer is the recorded originator and can recover the funds.
+                    guard.claim(payer, payer, receipt.abi_encode().into())?;
+                    assert_eq!(
+                        token.balance_of(ITIP20::balanceOfCall { account: payer })?,
+                        U256::from(820u64),
+                    );
+                } else {
+                    // The reserve is the recorded originator, so the payer cannot recover.
+                    assert_eq!(
+                        guard
+                            .claim(payer, payer, receipt.abi_encode().into())
+                            .unwrap_err(),
+                        ReceivePolicyGuardError::unauthorized_claimer().into(),
+                    );
+                }
+
+                Ok(())
+            })?;
+        }
+
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Blocked TIP-1034 reserve payouts record the reserve precompile as originator, so the channel payer can never `claim()` them back. From T8, attribute blocked reserve payouts to the payer so they're recoverable. Pre-T8 unchanged. 

Part of OSS-450