### PR TITLE
Remove fixed nonce from 2D txgen preset

### DIFF
--- a/contrib/bench/txgen/presets/tip20_2d_nonces.yml
+++ b/contrib/bench/txgen/presets/tip20_2d_nonces.yml
@@ -93,7 +93,6 @@ templates:
       choice: ${TXGEN_TIP20_TOKENS}
     nonce_key:
       uniform: [1, 18446744073709551615]
-    nonce: 0
     call:
       to:
         choice: ${TXGEN_TIP20_TOKENS}


### PR DESCRIPTION
## Summary
- Remove the hard-coded `nonce: 0` from the `tip20_2d_nonces` txgen benchmark preset.

## Validation
- `uv run --with pyyaml python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('contrib/bench/txgen/presets/tip20_2d_nonces.yml').read_text()); print('YAML OK')"`\n\nPrompted by: @shekhirin