### PR TITLE
ci(bench): disable txgen txpool drain wait

### DIFF
--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -1,7 +1,6 @@
 const TXGEN_HELPER_ACCOUNT_MNEMONIC = "test test test test test test test test test test test junk"
 const TXGEN_HELPER_DEFAULT_SEED = 99
 const TXGEN_HELPER_SCRAPE_INTERVAL_MS = 200
-const TXGEN_HELPER_DRAIN_TIMEOUT_SECS = 300
 const TXGEN_HELPER_FUND_DRAIN_TIMEOUT_SECS = 120
 const TXGEN_HELPER_PRESETS_DIR = "contrib/bench/txgen/presets"
 const TXGEN_HELPER_EXISTING_RECIPIENTS_PRESETS = ["tip20_existing_recipients" "tip20_2d_nonces" "tip20_protocol_nonces"]
@@ -312,7 +311,6 @@ def txgen-run-preset-pipeline [
         "--retries" 0
         ...$metrics_url_args
         "--scrape-interval-ms" $TXGEN_HELPER_SCRAPE_INTERVAL_MS
-        "--drain-timeout" $TXGEN_HELPER_DRAIN_TIMEOUT_SECS
     ]
         | append (if $victoriametrics_url != "" and $benchmark_start > 0 { ["--metrics-align" $"($benchmark_start)"] } else { [] })
     let report_args = ["--report" $"json:($report_path)"]


### PR DESCRIPTION
## Summary
- remove the shared txgen helper `--drain-timeout` argument from `bench send`
- applies to all txgen benches using `txgen-run-preset-pipeline`

## Validation
- `nu --commands 'source contrib/bench/txgen/helpers.nu'`
- `git diff --check`

Prompted by: @shekhirin