### PR TITLE
ci: clear derek comments by author

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -129,18 +129,7 @@ jobs:
               content: 'eyes',
             });
 
-            const markers = [
-              '🚀 Benchmark queued!',
-              '🚀 Benchmark started!',
-              '🚀 Replay benchmark started!',
-              '✅ Benchmark complete',
-              '✅ Replay benchmark complete',
-              '❌ Benchmark failed.',
-              '❌ Replay benchmark failed.',
-              '⚠️ Benchmark cancelled.',
-              '⚠️ Replay benchmark cancelled.',
-              '❌ **Invalid bench command**',
-            ];
+            const derekCommentAuthors = new Set(['decofe']);
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -151,7 +140,7 @@ jobs:
             let deleted = 0;
             for (const comment of comments) {
               if (comment.id === triggerCommentId) continue;
-              if (!markers.some(marker => comment.body.includes(marker))) continue;
+              if (!derekCommentAuthors.has(comment.user.login)) continue;
 
               await github.rest.issues.deleteComment({
                 owner: context.repo.owner,


### PR DESCRIPTION
Changes `derek clear` to delete all PR comments authored by Derek/decofe instead of matching comment text.

The previous matcher missed result comments with status-specific prefixes; deleting by author matches the requested behavior and avoids touching user comments or other bot comments.

Validation:
- `uv run --with pyyaml python ...` parsed `.github/workflows/bench.yml`
- Node fixture check confirmed only `decofe` comments match
- `git diff --check`

Prompted by: @shekhirin