### PR TITLE
Fix TIP20 bloat funding for feeAMM benches

### DIFF
--- a/tempo.nu
+++ b/tempo.nu
@@ -18,6 +18,7 @@ const LOCALNET_SIGNING_KEY_SECRET = "tempo-localnet-signing-key-secret"
 
 # TIP20 token IDs created by localnet genesis (pathUSD, AlphaUSD, BetaUSD, ThetaUSD)
 const TIP20_TOKEN_IDS = [0, 1, 2, 3]
+const TIP20_BLOAT_ACCOUNT_BALANCE = 1000000000000
 
 # ============================================================================
 # Helper functions
@@ -141,7 +142,13 @@ def generate-bloat-file [bloat_size: int, profile: string, skip_build: bool] {
     }
     print $"Generating state bloat \(($bloat_size) MiB\)..."
     let token_args = ($TIP20_TOKEN_IDS | each { |id| ["--token" $"($id)"] } | flatten)
-    run-tempo-xtask $profile $skip_build ["generate-state-bloat" "--size" $"($bloat_size)" "--out" $bloat_file ...$token_args]
+    run-tempo-xtask $profile $skip_build [
+        "generate-state-bloat"
+        "--size" $"($bloat_size)"
+        "--out" $bloat_file
+        "--balance" $"($TIP20_BLOAT_ACCOUNT_BALANCE)"
+        ...$token_args
+    ]
 }
 
 # Load the bloat file into a single node's database


### PR DESCRIPTION
## Summary
- fund TIP20 state-bloat accounts at the same amount as the local faucet
- keeps feeAMM liquidity setup working when `tempo.nu bench --bloat ...` skips faucet funding

Prompted by: @shekhirin

## Testing
- `nu --ide-check 0 tempo.nu`
- `cargo test -p tempo-xtask generate_state_bloat`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo install --git https://github.com/tempoxyz/txgen --locked txgen-tempo bench-cli`
- `nu tempo.nu bench --preset tip20_2d_nonces --bloat 10 --duration 10 --no-infra` (passed locally: 63,059 sent, 63,059 success, 0 failed)

## Notes
- The exact command without `--no-infra` still fails in this sandbox before the bench starts because local `docker` does not support `docker compose -f`; `--no-infra` skips only the Grafana/Prometheus stack and exercised localnet, bloat loading, feeAMM setup, txgen generation, and transaction submission.
