### PR TITLE
feat(precompiles): `dispatch!` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13430,6 +13430,7 @@ dependencies = [
  "derive_more",
  "eyre",
  "p256",
+ "paste",
  "proptest",
  "rand 0.8.6",
  "revm",

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -25,6 +25,7 @@ alloy = { workspace = true, features = ["sol-types", "consensus"] }
 alloy-evm = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["map-foldhash"] }
 revm.workspace = true
+paste.workspace = true
 
 commonware-cryptography.workspace = true
 commonware-codec.workspace = true

--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -4,8 +4,6 @@ use super::{AccountKeychain, KeyRestrictions, TokenLimit, authorizeKeyCall};
 use crate::{Precompile, charge_input_cost, dispatch, mutate_void, view};
 use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::PrecompileResult;
-#[cfg(test)]
-use tempo_contracts::precompiles::IAccountKeychain::IAccountKeychainCalls;
 use tempo_contracts::precompiles::{AccountKeychainError, IAccountKeychain};
 
 impl Precompile for AccountKeychain {
@@ -111,7 +109,9 @@ mod tests {
         sol_types::{SolCall, SolError},
     };
     use tempo_chainspec::hardfork::TempoHardfork;
-    use tempo_contracts::precompiles::{UnknownFunctionSelector, legacyAuthorizeKeyCall};
+    use tempo_contracts::precompiles::{
+        IAccountKeychain::IAccountKeychainCalls, UnknownFunctionSelector, legacyAuthorizeKeyCall,
+    };
 
     #[test]
     fn test_account_keychain_selector_coverage() -> eyre::Result<()> {

--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -20,35 +20,35 @@ impl Precompile for AccountKeychain {
                 IAccountKeychain::IAccountKeychainCalls {
                     authorizeKey_0(call) => {
                         if self.storage.spec().is_t3() {
-                        return self.storage.error_result(
-                        AccountKeychainError::legacy_authorize_key_selector_changed(
-                        authorizeKeyCall::SELECTOR.into(),
-                        ),
-                        );
+                            return self.storage.error_result(
+                                AccountKeychainError::legacy_authorize_key_selector_changed(
+                                    authorizeKeyCall::SELECTOR.into(),
+                                ),
+                            );
                         }
 
                         let call = authorizeKeyCall {
-                        keyId: call.keyId,
-                        signatureType: call.signatureType,
-                        config: KeyRestrictions {
-                        expiry: call.expiry,
-                        enforceLimits: call.enforceLimits,
-                        limits: call
-                        .limits
-                        .into_iter()
-                        .map(|limit| TokenLimit {
-                        token: limit.token,
-                        amount: limit.amount,
-                        period: 0,
-                        })
-                        .collect(),
-                        allowAnyCalls: true,
-                        allowedCalls: vec![],
-                        },
+                            keyId: call.keyId,
+                            signatureType: call.signatureType,
+                            config: KeyRestrictions {
+                                expiry: call.expiry,
+                                enforceLimits: call.enforceLimits,
+                                limits: call
+                                    .limits
+                                    .into_iter()
+                                    .map(|limit| TokenLimit {
+                                        token: limit.token,
+                                        amount: limit.amount,
+                                        period: 0,
+                                    })
+                                    .collect(),
+                                allowAnyCalls: true,
+                                allowedCalls: vec![],
+                            },
                         };
 
                         mutate_void(call, msg_sender, |sender, c| {
-                        self.authorize_key(sender, c.keyId, c.signatureType, c.config, None)
+                            self.authorize_key(sender, c.keyId, c.signatureType, c.config, None)
                         })
                     },
                     #[schedule(since = T3)]
@@ -57,13 +57,7 @@ impl Precompile for AccountKeychain {
                     }),
                     #[schedule(since = T5)]
                     authorizeKey_2(call) => mutate_void(call, msg_sender, |sender, c| {
-                        self.authorize_key(
-                        sender,
-                        c.keyId,
-                        c.signatureType,
-                        c.config,
-                        Some(c.witness),
-                        )
+                        self.authorize_key(sender, c.keyId, c.signatureType, c.config, Some(c.witness))
                     }),
                     #[schedule(since = T6)]
                     authorizeAdminKey(call) => mutate_void(call, msg_sender, |sender, c| {

--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -2,10 +2,7 @@
 
 use super::{AccountKeychain, KeyRestrictions, TokenLimit, authorizeKeyCall};
 use crate::{Precompile, charge_input_cost, dispatch, mutate_void, view};
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
+use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::PrecompileResult;
 #[cfg(test)]
 use tempo_contracts::precompiles::IAccountKeychain::IAccountKeychainCalls;

--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -1,35 +1,15 @@
 //! ABI dispatch for the [`AccountKeychain`] precompile.
 
 use super::{AccountKeychain, KeyRestrictions, TokenLimit, authorizeKeyCall};
-use crate::{Precompile, SelectorSchedule, charge_input_cost, dispatch_call, mutate_void, view};
+use crate::{Precompile, charge_input_cost, dispatch, mutate_void, view};
 use alloy::{
     primitives::Address,
     sol_types::{SolCall, SolInterface},
 };
 use revm::precompile::PrecompileResult;
-use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_contracts::precompiles::{
-    AccountKeychainError,
-    IAccountKeychain::{self, IAccountKeychainCalls},
-};
-
-const T3_ADDED: &[[u8; 4]] = &[
-    authorizeKeyCall::SELECTOR,
-    IAccountKeychain::setAllowedCallsCall::SELECTOR,
-    IAccountKeychain::removeAllowedCallsCall::SELECTOR,
-    IAccountKeychain::getRemainingLimitWithPeriodCall::SELECTOR,
-    IAccountKeychain::getAllowedCallsCall::SELECTOR,
-];
-const T3_DROPPED: &[[u8; 4]] = &[IAccountKeychain::getRemainingLimitCall::SELECTOR];
-const T5_ADDED: &[[u8; 4]] = &[
-    IAccountKeychain::authorizeKey_2Call::SELECTOR,
-    IAccountKeychain::burnKeyAuthorizationWitnessCall::SELECTOR,
-    IAccountKeychain::isKeyAuthorizationWitnessBurnedCall::SELECTOR,
-];
-const T6_ADDED: &[[u8; 4]] = &[
-    IAccountKeychain::authorizeAdminKeyCall::SELECTOR,
-    IAccountKeychain::isAdminKeyCall::SELECTOR,
-];
+#[cfg(test)]
+use tempo_contracts::precompiles::IAccountKeychain::IAccountKeychainCalls;
+use tempo_contracts::precompiles::{AccountKeychainError, IAccountKeychain};
 
 impl Precompile for AccountKeychain {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -37,114 +17,91 @@ impl Precompile for AccountKeychain {
             return err;
         }
 
-        dispatch_call(
+        dispatch!(
             calldata,
-            &[
-                SelectorSchedule::new(TempoHardfork::T3)
-                    .with_added(T3_ADDED)
-                    .with_dropped(T3_DROPPED),
-                SelectorSchedule::new(TempoHardfork::T5).with_added(T5_ADDED),
-                SelectorSchedule::new(TempoHardfork::T6).with_added(T6_ADDED),
-            ],
-            IAccountKeychainCalls::abi_decode,
             |call| match call {
-                IAccountKeychainCalls::authorizeKey_0(call) => {
-                    if self.storage.spec().is_t3() {
+                IAccountKeychain::IAccountKeychainCalls {
+                    authorizeKey_0(call) => {
+                        if self.storage.spec().is_t3() {
                         return self.storage.error_result(
-                            AccountKeychainError::legacy_authorize_key_selector_changed(
-                                authorizeKeyCall::SELECTOR.into(),
-                            ),
+                        AccountKeychainError::legacy_authorize_key_selector_changed(
+                        authorizeKeyCall::SELECTOR.into(),
+                        ),
                         );
-                    }
+                        }
 
-                    let call = authorizeKeyCall {
+                        let call = authorizeKeyCall {
                         keyId: call.keyId,
                         signatureType: call.signatureType,
                         config: KeyRestrictions {
-                            expiry: call.expiry,
-                            enforceLimits: call.enforceLimits,
-                            limits: call
-                                .limits
-                                .into_iter()
-                                .map(|limit| TokenLimit {
-                                    token: limit.token,
-                                    amount: limit.amount,
-                                    period: 0,
-                                })
-                                .collect(),
-                            allowAnyCalls: true,
-                            allowedCalls: vec![],
+                        expiry: call.expiry,
+                        enforceLimits: call.enforceLimits,
+                        limits: call
+                        .limits
+                        .into_iter()
+                        .map(|limit| TokenLimit {
+                        token: limit.token,
+                        amount: limit.amount,
+                        period: 0,
+                        })
+                        .collect(),
+                        allowAnyCalls: true,
+                        allowedCalls: vec![],
                         },
-                    };
+                        };
 
-                    mutate_void(call, msg_sender, |sender, c| {
+                        mutate_void(call, msg_sender, |sender, c| {
                         self.authorize_key(sender, c.keyId, c.signatureType, c.config, None)
-                    })
-                }
-                IAccountKeychainCalls::authorizeKey_1(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
+                        })
+                    },
+                    #[schedule(since = T3)]
+                    authorizeKey_1(call) => mutate_void(call, msg_sender, |sender, c| {
                         self.authorize_key(sender, c.keyId, c.signatureType, c.config, None)
-                    })
-                }
-                IAccountKeychainCalls::authorizeKey_2(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
+                    }),
+                    #[schedule(since = T5)]
+                    authorizeKey_2(call) => mutate_void(call, msg_sender, |sender, c| {
                         self.authorize_key(
-                            sender,
-                            c.keyId,
-                            c.signatureType,
-                            c.config,
-                            Some(c.witness),
+                        sender,
+                        c.keyId,
+                        c.signatureType,
+                        c.config,
+                        Some(c.witness),
                         )
-                    })
-                }
-                IAccountKeychainCalls::authorizeAdminKey(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
+                    }),
+                    #[schedule(since = T6)]
+                    authorizeAdminKey(call) => mutate_void(call, msg_sender, |sender, c| {
                         self.authorize_admin_key(sender, c.keyId, c.signatureType, Some(c.witness))
-                    })
-                }
-                IAccountKeychainCalls::burnKeyAuthorizationWitness(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
+                    }),
+                    #[schedule(since = T5)]
+                    burnKeyAuthorizationWitness(call) => mutate_void(call, msg_sender, |sender, c| {
                         self.burn_key_authorization_witness(sender, c)
-                    })
-                }
-                IAccountKeychainCalls::revokeKey(call) => {
-                    mutate_void(call, msg_sender, |sender, c| self.revoke_key(sender, c))
-                }
-                IAccountKeychainCalls::updateSpendingLimit(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
+                    }),
+                    revokeKey(call) => mutate_void(call, msg_sender, |sender, c| self.revoke_key(sender, c)),
+                    updateSpendingLimit(call) => mutate_void(call, msg_sender, |sender, c| {
                         self.update_spending_limit(sender, c)
-                    })
-                }
-                IAccountKeychainCalls::setAllowedCalls(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
+                    }),
+                    #[schedule(since = T3)]
+                    setAllowedCalls(call) => mutate_void(call, msg_sender, |sender, c| {
                         self.set_allowed_calls(sender, c)
-                    })
-                }
-                IAccountKeychainCalls::removeAllowedCalls(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
+                    }),
+                    #[schedule(since = T3)]
+                    removeAllowedCalls(call) => mutate_void(call, msg_sender, |sender, c| {
                         self.remove_allowed_calls(sender, c)
-                    })
+                    }),
+                    getKey(call) => view(call, |c| self.get_key(c)),
+                    #[schedule(until = T3)]
+                    getRemainingLimit(call) => view(call, |c| self.get_remaining_limit(c)),
+                    #[schedule(since = T3)]
+                    getRemainingLimitWithPeriod(call) => view(call, |c| self.get_remaining_limit_with_period(c)),
+                    #[schedule(since = T3)]
+                    getAllowedCalls(call) => view(call, |c| self.get_allowed_calls(c)),
+                    #[schedule(since = T5)]
+                    isKeyAuthorizationWitnessBurned(call) => view(call, |c| self.is_key_authorization_witness_burned(c)),
+                    #[schedule(since = T6)]
+                    isAdminKey(call) => view(call, |c| self.is_admin_key(c.account, c.keyId)),
+                    getTransactionKey(call) => view(call, |c| self.get_transaction_key(c, msg_sender))
                 }
-                IAccountKeychainCalls::getKey(call) => view(call, |c| self.get_key(c)),
-                IAccountKeychainCalls::getRemainingLimit(call) => {
-                    view(call, |c| self.get_remaining_limit(c))
-                }
-                IAccountKeychainCalls::getRemainingLimitWithPeriod(call) => {
-                    view(call, |c| self.get_remaining_limit_with_period(c))
-                }
-                IAccountKeychainCalls::getAllowedCalls(call) => {
-                    view(call, |c| self.get_allowed_calls(c))
-                }
-                IAccountKeychainCalls::isKeyAuthorizationWitnessBurned(call) => {
-                    view(call, |c| self.is_key_authorization_witness_burned(c))
-                }
-                IAccountKeychainCalls::isAdminKey(call) => {
-                    view(call, |c| self.is_admin_key(c.account, c.keyId))
-                }
-                IAccountKeychainCalls::getTransactionKey(call) => {
-                    view(call, |c| self.get_transaction_key(c, msg_sender))
-                }
-            },
+            }
         )
     }
 }

--- a/crates/precompiles/src/address_registry/dispatch.rs
+++ b/crates/precompiles/src/address_registry/dispatch.rs
@@ -1,12 +1,9 @@
 use crate::{
     Precompile, address_registry::AddressRegistry, charge_input_cost, dispatch, mutate, view,
 };
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
+use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::IAddressRegistry::{self, IAddressRegistryCalls};
+use tempo_contracts::precompiles::IAddressRegistry;
 use tempo_primitives::{MasterId, TempoAddressExt, UserTag};
 
 impl Precompile for AddressRegistry {
@@ -59,6 +56,8 @@ mod tests {
         test_util::{assert_full_coverage, check_selector_coverage},
     };
     use alloy::sol_types::{SolCall, SolError, SolValue};
+    use tempo_chainspec::hardfork::TempoHardfork;
+    use tempo_contracts::precompiles::IAddressRegistry::IAddressRegistryCalls;
 
     #[test]
     fn test_selector_coverage() -> eyre::Result<()> {
@@ -68,9 +67,9 @@ mod tests {
 
             let unsupported = check_selector_coverage(
                 &mut registry,
-                SELECTORS,
+                IAddressRegistryCalls::SELECTORS,
                 "IAddressRegistry",
-                name_by_selector,
+                IAddressRegistryCalls::name_by_selector,
             );
 
             assert_full_coverage([unsupported]);

--- a/crates/precompiles/src/address_registry/dispatch.rs
+++ b/crates/precompiles/src/address_registry/dispatch.rs
@@ -1,18 +1,13 @@
 use crate::{
-    Precompile, SelectorSchedule, address_registry::AddressRegistry, charge_input_cost,
-    dispatch_call, mutate, view,
+    Precompile, address_registry::AddressRegistry, charge_input_cost, dispatch, mutate, view,
 };
 use alloy::{
     primitives::Address,
     sol_types::{SolCall, SolInterface},
 };
 use revm::precompile::PrecompileResult;
-use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::IAddressRegistry::{self, IAddressRegistryCalls};
 use tempo_primitives::{MasterId, TempoAddressExt, UserTag};
-
-/// Selectors introduced at T5 (TIP-1035).
-const T5_ADDED: &[[u8; 4]] = &[IAddressRegistry::isImplicitlyApprovedCall::SELECTOR];
 
 impl Precompile for AddressRegistry {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -20,40 +15,37 @@ impl Precompile for AddressRegistry {
             return err;
         }
 
-        dispatch_call(
+        dispatch!(
             calldata,
-            &[SelectorSchedule::new(TempoHardfork::T5).with_added(T5_ADDED)],
-            IAddressRegistryCalls::abi_decode,
             |call| match call {
-                // Registration
-                IAddressRegistryCalls::registerVirtualMaster(call) => {
-                    mutate(call, msg_sender, |s, c| self.register_virtual_master(s, c))
+                IAddressRegistry::IAddressRegistryCalls {
+                    // Registration
+                    registerVirtualMaster(call) => mutate(call, msg_sender, |s, c| {
+                        self.register_virtual_master(s, c)
+                    }),
+
+                    // View functions
+                    getMaster(call) => view(call, |c| {
+                        Ok(self.get_master(c.masterId)?.unwrap_or(Address::ZERO))
+                    }),
+                    resolveRecipient(call) => view(call, |c| self.resolve_recipient(c.to)),
+                    resolveVirtualAddress(call) => view(call, |c| {
+                        self.resolve_virtual_address(c.virtualAddr)
+                    }),
+                    isVirtualAddress(call) => view(call, |c| Ok(c.addr.is_virtual())),
+                    decodeVirtualAddress(call) => view(call, |c| {
+                        let (is_virtual, master_id, user_tag) = match c.addr.decode_virtual() {
+                            Some((mid, tag)) => (true, mid, tag),
+                            None => (false, MasterId::ZERO, UserTag::ZERO),
+                        };
+                        Ok((is_virtual, master_id, user_tag).into())
+                    }),
+                    #[schedule(since = T5)]
+                    isImplicitlyApproved(call) => view(call, |c| {
+                        Ok(self.is_implicitly_approved(c.addr))
+                    })
                 }
-                // View functions
-                IAddressRegistryCalls::getMaster(call) => view(call, |c| {
-                    Ok(self.get_master(c.masterId)?.unwrap_or(Address::ZERO))
-                }),
-                IAddressRegistryCalls::resolveRecipient(call) => {
-                    view(call, |c| self.resolve_recipient(c.to))
-                }
-                IAddressRegistryCalls::resolveVirtualAddress(call) => {
-                    view(call, |c| self.resolve_virtual_address(c.virtualAddr))
-                }
-                // Pure functions
-                IAddressRegistryCalls::isVirtualAddress(call) => {
-                    view(call, |c| Ok(c.addr.is_virtual()))
-                }
-                IAddressRegistryCalls::decodeVirtualAddress(call) => view(call, |c| {
-                    let (is_virtual, master_id, user_tag) = match c.addr.decode_virtual() {
-                        Some((mid, tag)) => (true, mid, tag),
-                        None => (false, MasterId::ZERO, UserTag::ZERO),
-                    };
-                    Ok((is_virtual, master_id, user_tag).into())
-                }),
-                IAddressRegistryCalls::isImplicitlyApproved(call) => {
-                    view(call, |c| Ok(self.is_implicitly_approved(c.addr)))
-                }
-            },
+            }
         )
     }
 }
@@ -67,7 +59,6 @@ mod tests {
         test_util::{assert_full_coverage, check_selector_coverage},
     };
     use alloy::sol_types::{SolCall, SolError, SolValue};
-    use tempo_chainspec::hardfork::TempoHardfork;
 
     #[test]
     fn test_selector_coverage() -> eyre::Result<()> {
@@ -77,9 +68,9 @@ mod tests {
 
             let unsupported = check_selector_coverage(
                 &mut registry,
-                IAddressRegistryCalls::SELECTORS,
+                SELECTORS,
                 "IAddressRegistry",
-                IAddressRegistryCalls::name_by_selector,
+                name_by_selector,
             );
 
             assert_full_coverage([unsupported]);

--- a/crates/precompiles/src/address_registry/dispatch.rs
+++ b/crates/precompiles/src/address_registry/dispatch.rs
@@ -20,7 +20,6 @@ impl Precompile for AddressRegistry {
                     registerVirtualMaster(call) => mutate(call, msg_sender, |s, c| {
                         self.register_virtual_master(s, c)
                     }),
-
                     // View functions
                     getMaster(call) => view(call, |c| {
                         Ok(self.get_master(c.masterId)?.unwrap_or(Address::ZERO))
@@ -29,6 +28,7 @@ impl Precompile for AddressRegistry {
                     resolveVirtualAddress(call) => view(call, |c| {
                         self.resolve_virtual_address(c.virtualAddr)
                     }),
+                    // Pure functions
                     isVirtualAddress(call) => view(call, |c| Ok(c.addr.is_virtual())),
                     decodeVirtualAddress(call) => view(call, |c| {
                         let (is_virtual, master_id, user_tag) = match c.addr.decode_virtual() {

--- a/crates/precompiles/src/address_registry/dispatch.rs
+++ b/crates/precompiles/src/address_registry/dispatch.rs
@@ -1,7 +1,7 @@
 use crate::{
     Precompile, address_registry::AddressRegistry, charge_input_cost, dispatch, mutate, view,
 };
-use alloy::{primitives::Address, sol_types::SolCall};
+use alloy::primitives::Address;
 use revm::precompile::PrecompileResult;
 use tempo_contracts::precompiles::IAddressRegistry;
 use tempo_primitives::{MasterId, TempoAddressExt, UserTag};

--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -135,13 +135,7 @@ pub(crate) fn dispatch_call<T>(
     let storage = StorageCtx::default();
 
     if calldata.len() < 4 {
-        if storage.spec().is_t1() {
-            return Ok(storage.revert_output(Bytes::new()));
-        } else {
-            return Ok(storage.halt_output(PrecompileHalt::Other(
-                "Invalid input: missing function selector".into(),
-            )));
-        }
+        return missing_selector_result();
     }
 
     let result = decode(calldata);
@@ -161,74 +155,35 @@ pub(crate) fn dispatch_call<T>(
 }
 
 macro_rules! dispatch {
-    // Public dispatcher syntax: group match arms by ABI interface.
     ($calldata:expr, |$call:ident| match $match_call:ident {
-        $iface_1:ident::$calls_1:ident { $($(#[$($attr_1:tt)*])* $variant_1:ident($binding_1:pat) => $body_1:expr),* $(,)? }
-        $($iface_n:ident::$calls_n:ident { $($(#[$($attr_n:tt)*])* $variant_n:ident($binding_n:pat) => $body_n:expr),* $(,)? })*
+        $($iface:ident::$calls:ident {
+            $(
+                $(#[schedule($($gate:ident = $hf:ident),+ $(,)?)])*
+                $variant:ident($binding:pat) => $body:expr
+            ),* $(,)?
+        })+
     } $(,)?) => {
         paste::paste! {{
-            // Run hardfork gates before decoding, so malformed gated calls are still unknown.
             if let Some(selector) = crate::dispatch::selector_from_calldata($calldata) {
-                $($(crate::dispatch!(@pre_gate $calldata, selector, $iface_1::[<$variant_1 Call>]::SELECTOR; #[$($attr_1)*]);)*)*
-                $($($(crate::dispatch!(@pre_gate $calldata, selector, $iface_n::[<$variant_n Call>]::SELECTOR; #[$($attr_n)*]);)*)*)*
-
-                // Decode with the ABI whose selector set contains the calldata selector.
-                crate::dispatch!(@decode $calldata, selector, $call, $match_call,
-                    $iface_1::$calls_1 { $($variant_1($binding_1) => $body_1),* }
-                    $($iface_n::$calls_n { $($variant_n($binding_n) => $body_n),* })*
-                    else $iface_1::$calls_1
-                )
-            } else {
-                // Let dispatch_call apply the chain-specific missing-selector behavior.
-                crate::dispatch::dispatch_call($calldata, <$iface_1::$calls_1 as alloy::sol_types::SolInterface>::abi_decode, |_| unreachable!())
+                $($($($(
+                    if selector == <$iface::[<$variant Call>] as alloy::sol_types::SolCall>::SELECTOR
+                        && !crate::dispatch::$gate(tempo_chainspec::hardfork::TempoHardfork::$hf)
+                    {
+                        return crate::dispatch::unknown_selector_result($calldata);
+                    }
+                )+)*)*)+
+                $(
+                    if <$iface::$calls as alloy::sol_types::SolInterface>::valid_selector(selector) {
+                        type Calls = $iface::$calls;
+                        return crate::dispatch::dispatch_call($calldata, <Calls as alloy::sol_types::SolInterface>::abi_decode, |$call| match $match_call {
+                            $(Calls::$variant($binding) => $body,)*
+                        });
+                    }
+                )*
+                return crate::dispatch::unknown_selector_result($calldata);
             }
+            crate::dispatch::missing_selector_result()
         }}
-    };
-    // Try one interface; recurse until a matching selector set is found.
-    (@decode $calldata:expr, $selector:expr, $call:ident, $match_call:ident,
-        $iface:ident::$calls:ident { $($variant:ident($binding:pat) => $body:expr),* } $($rest:tt)*
-    ) => {{
-        type Calls = $iface::$calls;
-        if <Calls as alloy::sol_types::SolInterface>::valid_selector($selector) {
-            // Ensure no selector collision with later interfaces.
-            debug_assert!(!crate::dispatch!(@any_valid_selector $selector, $($rest)*));
-            crate::dispatch::dispatch_call($calldata, <Calls as alloy::sol_types::SolInterface>::abi_decode, |$call| match $match_call {
-                $(Calls::$variant($binding) => $body,)*
-            })
-        } else {
-            crate::dispatch!(@decode $calldata, $selector, $call, $match_call, $($rest)*)
-        }
-    }};
-    // Fallback preserves dispatch_call's unknown-selector decoding path.
-    (@decode $calldata:expr, $selector:expr, $call:ident, $match_call:ident, else $iface:ident::$calls:ident) => {{
-        type Calls = $iface::$calls;
-        crate::dispatch::dispatch_call($calldata, <Calls as alloy::sol_types::SolInterface>::abi_decode, |_| unreachable!())
-    }};
-    // Recursively check whether any remaining interface accepts the selector.
-    (@any_valid_selector $selector:expr, else $iface:ident::$calls:ident) => {
-        false
-    };
-    (@any_valid_selector $selector:expr,
-        $iface:ident::$calls:ident { $($variant:ident($binding:pat) => $body:expr),* } $($rest:tt)*
-    ) => {{
-        type Calls = $iface::$calls;
-        <Calls as alloy::sol_types::SolInterface>::valid_selector($selector)
-            || crate::dispatch!(@any_valid_selector $selector, $($rest)*)
-    }};
-    // Schedule gates: since rejects pre-fork, until rejects from that fork onward.
-    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(since = $since:ident, until = $until:ident)]) => {
-        crate::dispatch!(@pre_gate $calldata, $selector, $call_selector; #[schedule(since = $since)]);
-        crate::dispatch!(@pre_gate $calldata, $selector, $call_selector; #[schedule(until = $until)]);
-    };
-    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(since = $hf:ident)]) => {
-        if $selector == $call_selector && crate::storage::StorageCtx.spec() < tempo_chainspec::hardfork::TempoHardfork::$hf {
-            return crate::dispatch::unknown_selector_result($calldata);
-        }
-    };
-    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(until = $hf:ident)]) => {
-        if $selector == $call_selector && crate::storage::StorageCtx.spec() >= tempo_chainspec::hardfork::TempoHardfork::$hf {
-            return crate::dispatch::unknown_selector_result($calldata);
-        }
     };
 }
 
@@ -240,6 +195,28 @@ pub(crate) fn selector_from_calldata(calldata: &[u8]) -> Option<[u8; 4]> {
             .try_into()
             .expect("selector slice has exactly 4 bytes")
     })
+}
+
+pub(crate) fn missing_selector_result() -> PrecompileResult {
+    let storage = StorageCtx::default();
+
+    if storage.spec().is_t1() {
+        Ok(storage.revert_output(Bytes::new()))
+    } else {
+        Ok(storage.halt_output(PrecompileHalt::Other(
+            "Invalid input: missing function selector".into(),
+        )))
+    }
+}
+
+#[inline]
+pub(crate) fn since(hardfork: tempo_chainspec::hardfork::TempoHardfork) -> bool {
+    StorageCtx.spec() >= hardfork
+}
+
+#[inline]
+pub(crate) fn until(hardfork: tempo_chainspec::hardfork::TempoHardfork) -> bool {
+    StorageCtx.spec() < hardfork
 }
 
 pub(crate) fn unknown_selector_result(calldata: &[u8]) -> PrecompileResult {

--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -1,0 +1,237 @@
+//! ABI dispatch helpers for Tempo precompiles.
+
+use crate::{
+    IntoPrecompileResult, Result, error, input_cost, storage::StorageCtx,
+    storage_credits::StorageCredits,
+};
+use alloy::{
+    primitives::{Address, Bytes},
+    sol,
+    sol_types::{SolCall, SolError},
+};
+use revm::precompile::{PrecompileHalt, PrecompileOutput, PrecompileResult};
+
+sol! {
+    error StaticCallNotAllowed();
+}
+
+/// Dispatches a parameterless view call, encoding the return via `T`.
+#[inline]
+pub(crate) fn metadata<T: SolCall>(f: impl FnOnce() -> Result<T::Return>) -> PrecompileResult {
+    f().into_precompile_result(0, 0, |ret| T::abi_encode_returns(&ret).into())
+}
+
+/// Dispatches a read-only call with decoded arguments, encoding the return via `T`.
+#[inline]
+pub(crate) fn view<T: SolCall>(
+    call: T,
+    f: impl FnOnce(T) -> Result<T::Return>,
+) -> PrecompileResult {
+    f(call).into_precompile_result(0, 0, |ret| T::abi_encode_returns(&ret).into())
+}
+
+/// Dispatches a state-mutating call that returns ABI-encoded data.
+///
+/// Rejects static calls with [`StaticCallNotAllowed`].
+#[inline]
+pub(crate) fn mutate<T: SolCall>(
+    call: T,
+    sender: Address,
+    f: impl FnOnce(Address, T) -> Result<T::Return>,
+) -> PrecompileResult {
+    if StorageCtx.is_static() {
+        return Ok(PrecompileOutput::revert(
+            0,
+            StaticCallNotAllowed {}.abi_encode().into(),
+            StorageCtx.reservoir(),
+        ));
+    }
+    f(sender, call).into_precompile_result(0, 0, |ret| T::abi_encode_returns(&ret).into())
+}
+
+/// Dispatches a state-mutating call that returns no data (e.g. `approve`, `transfer`).
+///
+/// Rejects static calls with [`StaticCallNotAllowed`].
+#[inline]
+pub(crate) fn mutate_void<T: SolCall>(
+    call: T,
+    sender: Address,
+    f: impl FnOnce(Address, T) -> Result<()>,
+) -> PrecompileResult {
+    if StorageCtx.is_static() {
+        return Ok(PrecompileOutput::revert(
+            0,
+            StaticCallNotAllowed {}.abi_encode().into(),
+            StorageCtx.reservoir(),
+        ));
+    }
+    f(sender, call).into_precompile_result(0, 0, |()| Bytes::new())
+}
+
+/// Sets TIP-1060 storage creation mode to Preserve for the given storage-credit owner.
+#[inline]
+pub(crate) fn preserve_storage_credits(credit_owner: Address) -> Result<()> {
+    if StorageCtx.spec().is_t7() {
+        StorageCredits::new().set_mode(
+            credit_owner,
+            tempo_contracts::precompiles::IStorageCredits::Mode::Preserve,
+        )?;
+    }
+    Ok(())
+}
+
+/// Deducts the calldata input cost, returning an OOG halt result if insufficient gas.
+#[inline]
+pub(crate) fn charge_input_cost(
+    storage: &mut StorageCtx,
+    calldata: &[u8],
+) -> Option<PrecompileResult> {
+    if storage.deduct_gas(input_cost(calldata.len())).is_err() {
+        return Some(Ok(storage.halt_output(PrecompileHalt::OutOfGas)));
+    }
+    None
+}
+
+/// Fills state gas accounting on a [`PrecompileOutput`] from the storage context.
+///
+/// State gas / reservoir tracking is only set when TIP-1016 (EIP-8037) is enabled.
+/// When disabled, `state_gas_used` must remain 0 to avoid leaking into revm's reservoir
+/// accounting and corrupting `tx_gas_used()` via `handle_reservoir_remaining_gas`.
+///
+/// SSTORE refund propagation is activated unconditionally at T4 so the
+/// `TempoPrecompileProvider` wrapper can apply refunds with `record_refund`. Pre-T4
+/// blocks were executed without refund propagation, so we cannot change their gas
+/// accounting.
+#[inline]
+fn fill_state_gas(output: &mut PrecompileOutput, storage: &StorageCtx) {
+    if storage.spec().is_t4() && output.is_success() {
+        output.gas_refunded = storage.gas_refunded();
+    }
+
+    if storage.amsterdam_eip8037_enabled() {
+        if output.is_success() {
+            // On success: parent takes the child's final reservoir.
+            output.reservoir = storage.reservoir();
+            output.state_gas_used = storage.state_gas_used();
+        } else {
+            // On revert or halt: state changes are undone, so ALL state gas returns
+            // to the parent's reservoir.
+            output.reservoir = storage.state_gas_used() + storage.reservoir();
+            output.state_gas_used = 0;
+        }
+    }
+}
+
+/// Decodes calldata via `decode`, then dispatches to `f`.
+///
+/// Handles missing selectors (revert on T1+, error on earlier forks), unknown selectors
+/// (ABI-encoded `UnknownFunctionSelector`), and malformed ABI data (empty revert).
+#[inline]
+pub(crate) fn dispatch_call<T>(
+    calldata: &[u8],
+    decode: impl FnOnce(&[u8]) -> core::result::Result<T, alloy::sol_types::Error>,
+    f: impl FnOnce(T) -> PrecompileResult,
+) -> PrecompileResult {
+    let storage = StorageCtx::default();
+
+    if calldata.len() < 4 {
+        if storage.spec().is_t1() {
+            return Ok(storage.revert_output(Bytes::new()));
+        } else {
+            return Ok(storage.halt_output(PrecompileHalt::Other(
+                "Invalid input: missing function selector".into(),
+            )));
+        }
+    }
+
+    let result = decode(calldata);
+
+    match result {
+        Ok(call) => f(call).map(|mut res| {
+            // TODO: fix this, each precompile handler should either return output with proper gas values or don't return any gas values at all.
+            res.gas_used = storage.gas_used();
+            fill_state_gas(&mut res, &storage);
+            res
+        }),
+        Err(alloy::sol_types::Error::UnknownSelector { selector, .. }) => storage.error_result(
+            error::TempoPrecompileError::UnknownFunctionSelector(*selector),
+        ),
+        Err(_) => Ok(storage.revert_output(Bytes::new())),
+    }
+}
+
+macro_rules! dispatch {
+    // Public dispatcher syntax: group match arms by ABI interface.
+    ($calldata:expr, |$call:ident| match $match_call:ident {
+        $iface_1:ident::$calls_1:ident { $($(#[$($attr_1:tt)*])* $variant_1:ident($binding_1:pat) => $body_1:expr),* $(,)? }
+        $($iface_n:ident::$calls_n:ident { $($(#[$($attr_n:tt)*])* $variant_n:ident($binding_n:pat) => $body_n:expr),* $(,)? })*
+    } $(,)?) => {
+        paste::paste! {{
+            // Run hardfork gates before decoding, so malformed gated calls are still unknown.
+            if let Some(selector) = crate::dispatch::selector_from_calldata($calldata) {
+                $($(crate::dispatch!(@pre_gate $calldata, selector, $iface_1::[<$variant_1 Call>]::SELECTOR; #[$($attr_1)*]);)*)*
+                $($($(crate::dispatch!(@pre_gate $calldata, selector, $iface_n::[<$variant_n Call>]::SELECTOR; #[$($attr_n)*]);)*)*)*
+
+                // Decode with the ABI whose selector set contains the calldata selector.
+                crate::dispatch!(@decode $calldata, selector, $call, $match_call,
+                    $iface_1::$calls_1 { $($variant_1($binding_1) => $body_1),* }
+                    $($iface_n::$calls_n { $($variant_n($binding_n) => $body_n),* })*
+                    else $iface_1::$calls_1
+                )
+            } else {
+                // Let dispatch_call apply the chain-specific missing-selector behavior.
+                crate::dispatch::dispatch_call($calldata, <$iface_1::$calls_1 as alloy::sol_types::SolInterface>::abi_decode, |_| unreachable!())
+            }
+        }}
+    };
+    // Try one interface; recurse until a matching selector set is found.
+    (@decode $calldata:expr, $selector:expr, $call:ident, $match_call:ident,
+        $iface:ident::$calls:ident { $($variant:ident($binding:pat) => $body:expr),* } $($rest:tt)*
+    ) => {{
+        type Calls = $iface::$calls;
+        if <Calls as alloy::sol_types::SolInterface>::valid_selector($selector) {
+            crate::dispatch::dispatch_call($calldata, <Calls as alloy::sol_types::SolInterface>::abi_decode, |$call| match $match_call {
+                $(Calls::$variant($binding) => $body,)*
+            })
+        } else {
+            crate::dispatch!(@decode $calldata, $selector, $call, $match_call, $($rest)*)
+        }
+    }};
+    // Fallback preserves dispatch_call's unknown-selector decoding path.
+    (@decode $calldata:expr, $selector:expr, $call:ident, $match_call:ident, else $iface:ident::$calls:ident) => {{
+        type Calls = $iface::$calls;
+        crate::dispatch::dispatch_call($calldata, <Calls as alloy::sol_types::SolInterface>::abi_decode, |_| unreachable!())
+    }};
+    // Schedule gates: since rejects pre-fork, until rejects from that fork onward.
+    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(since = $since:ident, until = $until:ident)]) => {
+        crate::dispatch!(@pre_gate $calldata, $selector, $call_selector; #[schedule(since = $since)]);
+        crate::dispatch!(@pre_gate $calldata, $selector, $call_selector; #[schedule(until = $until)]);
+    };
+    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(since = $hf:ident)]) => {
+        if $selector == $call_selector && crate::storage::StorageCtx.spec() < tempo_chainspec::hardfork::TempoHardfork::$hf {
+            return crate::dispatch::unknown_selector_result($calldata);
+        }
+    };
+    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(until = $hf:ident)]) => {
+        if $selector == $call_selector && crate::storage::StorageCtx.spec() >= tempo_chainspec::hardfork::TempoHardfork::$hf {
+            return crate::dispatch::unknown_selector_result($calldata);
+        }
+    };
+}
+
+pub(crate) use dispatch;
+
+pub(crate) fn selector_from_calldata(calldata: &[u8]) -> Option<[u8; 4]> {
+    calldata.get(..4).map(|selector| {
+        selector
+            .try_into()
+            .expect("selector slice has exactly 4 bytes")
+    })
+}
+
+pub(crate) fn unknown_selector_result(calldata: &[u8]) -> PrecompileResult {
+    let selector = selector_from_calldata(calldata).expect("calldata len >= 4 after decode");
+    StorageCtx::default().error_result(error::TempoPrecompileError::UnknownFunctionSelector(
+        selector,
+    ))
+}

--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -164,6 +164,15 @@ macro_rules! dispatch {
         })+
     } $(,)?) => {
         paste::paste! {{
+            #[cfg(debug_assertions)]
+            {
+                let mut selectors = std::collections::BTreeSet::new();
+                $(assert!(
+                    <$iface::$calls as alloy::sol_types::SolInterface>::selectors().all(|s| selectors.insert(s)),
+                    "duplicate precompile selector in dispatch! macro",
+                );)*
+            }
+
             if let Some(selector) = crate::dispatch::selector_from_calldata($calldata) {
                 $($($($(
                     if selector == <$iface::[<$variant Call>] as alloy::sol_types::SolCall>::SELECTOR

--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -190,6 +190,8 @@ macro_rules! dispatch {
     ) => {{
         type Calls = $iface::$calls;
         if <Calls as alloy::sol_types::SolInterface>::valid_selector($selector) {
+            // Ensure no selector collision with later interfaces.
+            debug_assert!(!crate::dispatch!(@any_valid_selector $selector, $($rest)*));
             crate::dispatch::dispatch_call($calldata, <Calls as alloy::sol_types::SolInterface>::abi_decode, |$call| match $match_call {
                 $(Calls::$variant($binding) => $body,)*
             })
@@ -201,6 +203,17 @@ macro_rules! dispatch {
     (@decode $calldata:expr, $selector:expr, $call:ident, $match_call:ident, else $iface:ident::$calls:ident) => {{
         type Calls = $iface::$calls;
         crate::dispatch::dispatch_call($calldata, <Calls as alloy::sol_types::SolInterface>::abi_decode, |_| unreachable!())
+    }};
+    // Recursively check whether any remaining interface accepts the selector.
+    (@any_valid_selector $selector:expr, else $iface:ident::$calls:ident) => {
+        false
+    };
+    (@any_valid_selector $selector:expr,
+        $iface:ident::$calls:ident { $($variant:ident($binding:pat) => $body:expr),* } $($rest:tt)*
+    ) => {{
+        type Calls = $iface::$calls;
+        <Calls as alloy::sol_types::SolInterface>::valid_selector($selector)
+            || crate::dispatch!(@any_valid_selector $selector, $($rest)*)
     }};
     // Schedule gates: since rejects pre-fork, until rejects from that fork onward.
     (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(since = $since:ident, until = $until:ident)]) => {

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -7,6 +7,10 @@ pub use error::{IntoPrecompileResult, Result};
 
 pub mod storage;
 
+mod dispatch;
+pub use dispatch::StaticCallNotAllowed;
+pub(crate) use dispatch::*;
+
 pub(crate) mod ip_validation;
 
 pub mod account_keychain;
@@ -50,16 +54,12 @@ use tempo_primitives::TempoAddressExt;
 
 #[cfg(test)]
 use alloy::sol_types::SolInterface;
-use alloy::{
-    primitives::{Address, Bytes},
-    sol,
-    sol_types::{SolCall, SolError},
-};
+use alloy::{primitives::Address, sol, sol_types::SolError};
 use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
 use revm::{
     context::CfgEnv,
     handler::EthPrecompiles,
-    precompile::{PrecompileHalt, PrecompileId, PrecompileOutput, PrecompileResult},
+    precompile::{PrecompileId, PrecompileOutput, PrecompileResult},
     primitives::hardfork::SpecId,
 };
 
@@ -209,7 +209,6 @@ pub fn extend_tempo_precompiles(
 
 sol! {
     error DelegateCallNotAllowed();
-    error StaticCallNotAllowed();
 }
 
 macro_rules! tempo_precompile {
@@ -357,224 +356,6 @@ impl StorageCredits {
     }
 }
 
-/// Dispatches a parameterless view call, encoding the return via `T`.
-#[inline]
-fn metadata<T: SolCall>(f: impl FnOnce() -> Result<T::Return>) -> PrecompileResult {
-    f().into_precompile_result(0, 0, |ret| T::abi_encode_returns(&ret).into())
-}
-
-/// Dispatches a read-only call with decoded arguments, encoding the return via `T`.
-#[inline]
-fn view<T: SolCall>(call: T, f: impl FnOnce(T) -> Result<T::Return>) -> PrecompileResult {
-    f(call).into_precompile_result(0, 0, |ret| T::abi_encode_returns(&ret).into())
-}
-
-/// Dispatches a state-mutating call that returns ABI-encoded data.
-///
-/// Rejects static calls with [`StaticCallNotAllowed`].
-#[inline]
-fn mutate<T: SolCall>(
-    call: T,
-    sender: Address,
-    f: impl FnOnce(Address, T) -> Result<T::Return>,
-) -> PrecompileResult {
-    if StorageCtx.is_static() {
-        return Ok(PrecompileOutput::revert(
-            0,
-            StaticCallNotAllowed {}.abi_encode().into(),
-            StorageCtx.reservoir(),
-        ));
-    }
-    f(sender, call).into_precompile_result(0, 0, |ret| T::abi_encode_returns(&ret).into())
-}
-
-/// Dispatches a state-mutating call that returns no data (e.g. `approve`, `transfer`).
-///
-/// Rejects static calls with [`StaticCallNotAllowed`].
-#[inline]
-fn mutate_void<T: SolCall>(
-    call: T,
-    sender: Address,
-    f: impl FnOnce(Address, T) -> Result<()>,
-) -> PrecompileResult {
-    if StorageCtx.is_static() {
-        return Ok(PrecompileOutput::revert(
-            0,
-            StaticCallNotAllowed {}.abi_encode().into(),
-            StorageCtx.reservoir(),
-        ));
-    }
-    f(sender, call).into_precompile_result(0, 0, |()| Bytes::new())
-}
-
-/// Sets TIP-1060 storage creation mode to Preserve for the given storage-credit owner.
-#[inline]
-fn preserve_storage_credits(credit_owner: Address) -> Result<()> {
-    if StorageCtx.spec().is_t7() {
-        StorageCredits::new().set_mode(
-            credit_owner,
-            tempo_contracts::precompiles::IStorageCredits::Mode::Preserve,
-        )?;
-    }
-    Ok(())
-}
-
-/// Deducts the calldata input cost, returning an OOG halt result if insufficient gas.
-#[inline]
-pub(crate) fn charge_input_cost(
-    storage: &mut StorageCtx,
-    calldata: &[u8],
-) -> Option<PrecompileResult> {
-    if storage.deduct_gas(input_cost(calldata.len())).is_err() {
-        return Some(Ok(storage.halt_output(PrecompileHalt::OutOfGas)));
-    }
-    None
-}
-
-/// Fills state gas accounting on a [`PrecompileOutput`] from the storage context.
-///
-/// State gas / reservoir tracking is only set when TIP-1016 (EIP-8037) is enabled.
-/// When disabled, `state_gas_used` must remain 0 to avoid leaking into revm's reservoir
-/// accounting and corrupting `tx_gas_used()` via `handle_reservoir_remaining_gas`.
-///
-/// SSTORE refund propagation is activated unconditionally at T4 so the
-/// `TempoPrecompileProvider` wrapper can apply refunds with `record_refund`. Pre-T4
-/// blocks were executed without refund propagation, so we cannot change their gas
-/// accounting.
-#[inline]
-fn fill_state_gas(output: &mut PrecompileOutput, storage: &StorageCtx) {
-    if storage.spec().is_t4() && output.is_success() {
-        output.gas_refunded = storage.gas_refunded();
-    }
-
-    if storage.amsterdam_eip8037_enabled() {
-        if output.is_success() {
-            // On success: parent takes the child's final reservoir.
-            output.reservoir = storage.reservoir();
-            output.state_gas_used = storage.state_gas_used();
-        } else {
-            // On revert or halt: state changes are undone, so ALL state gas returns
-            // to the parent's reservoir.
-            output.reservoir = storage.state_gas_used() + storage.reservoir();
-            output.state_gas_used = 0;
-        }
-    }
-}
-
-/// Decodes calldata via `decode`, then dispatches to `f`.
-///
-/// Handles missing selectors (revert on T1+, error on earlier forks), unknown selectors
-/// (ABI-encoded `UnknownFunctionSelector`), and malformed ABI data (empty revert).
-#[inline]
-pub(crate) fn dispatch_call<T>(
-    calldata: &[u8],
-    decode: impl FnOnce(&[u8]) -> core::result::Result<T, alloy::sol_types::Error>,
-    f: impl FnOnce(T) -> PrecompileResult,
-) -> PrecompileResult {
-    let storage = StorageCtx::default();
-
-    if calldata.len() < 4 {
-        if storage.spec().is_t1() {
-            return Ok(storage.revert_output(Bytes::new()));
-        } else {
-            return Ok(storage.halt_output(PrecompileHalt::Other(
-                "Invalid input: missing function selector".into(),
-            )));
-        }
-    }
-
-    let result = decode(calldata);
-
-    match result {
-        Ok(call) => f(call).map(|mut res| {
-            // TODO: fix this, each precompile handler should either return output with proper gas values or don't return any gas values at all.
-            res.gas_used = storage.gas_used();
-            fill_state_gas(&mut res, &storage);
-            res
-        }),
-        Err(alloy::sol_types::Error::UnknownSelector { selector, .. }) => storage.error_result(
-            error::TempoPrecompileError::UnknownFunctionSelector(*selector),
-        ),
-        Err(_) => Ok(storage.revert_output(Bytes::new())),
-    }
-}
-
-macro_rules! dispatch {
-    // Public dispatcher syntax: group match arms by ABI interface.
-    ($calldata:expr, |$call:ident| match $match_call:ident {
-        $iface_1:ident::$calls_1:ident { $($(#[$($attr_1:tt)*])* $variant_1:ident($binding_1:pat) => $body_1:expr),* $(,)? }
-        $($iface_n:ident::$calls_n:ident { $($(#[$($attr_n:tt)*])* $variant_n:ident($binding_n:pat) => $body_n:expr),* $(,)? })*
-    } $(,)?) => {
-        paste::paste! {{
-            // Run hardfork gates before decoding, so malformed gated calls are still unknown.
-            if let Some(selector) = crate::selector_from_calldata($calldata) {
-                $($(crate::dispatch!(@pre_gate $calldata, selector, $iface_1::[<$variant_1 Call>]::SELECTOR; #[$($attr_1)*]);)*)*
-                $($($(crate::dispatch!(@pre_gate $calldata, selector, $iface_n::[<$variant_n Call>]::SELECTOR; #[$($attr_n)*]);)*)*)*
-
-                // Decode with the ABI whose selector set contains the calldata selector.
-                crate::dispatch!(@decode $calldata, selector, $call, $match_call,
-                    $iface_1::$calls_1 { $($variant_1($binding_1) => $body_1),* }
-                    $($iface_n::$calls_n { $($variant_n($binding_n) => $body_n),* })*
-                    else $iface_1::$calls_1
-                )
-            } else {
-                // Let dispatch_call apply the chain-specific missing-selector behavior.
-                crate::dispatch_call($calldata, <$iface_1::$calls_1 as alloy::sol_types::SolInterface>::abi_decode, |_| unreachable!())
-            }
-        }}
-    };
-    // Try one interface; recurse until a matching selector set is found.
-    (@decode $calldata:expr, $selector:expr, $call:ident, $match_call:ident,
-        $iface:ident::$calls:ident { $($variant:ident($binding:pat) => $body:expr),* } $($rest:tt)*
-    ) => {{
-        type Calls = $iface::$calls;
-        if <Calls as alloy::sol_types::SolInterface>::valid_selector($selector) {
-            crate::dispatch_call($calldata, <Calls as alloy::sol_types::SolInterface>::abi_decode, |$call| match $match_call {
-                $(Calls::$variant($binding) => $body,)*
-            })
-        } else {
-            crate::dispatch!(@decode $calldata, $selector, $call, $match_call, $($rest)*)
-        }
-    }};
-    // Fallback preserves dispatch_call's unknown-selector decoding path.
-    (@decode $calldata:expr, $selector:expr, $call:ident, $match_call:ident, else $iface:ident::$calls:ident) => {{
-        type Calls = $iface::$calls;
-        crate::dispatch_call($calldata, <Calls as alloy::sol_types::SolInterface>::abi_decode, |_| unreachable!())
-    }};
-    // Schedule gates: since rejects pre-fork, until rejects from that fork onward.
-    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(since = $since:ident, until = $until:ident)]) => {
-        crate::dispatch!(@pre_gate $calldata, $selector, $call_selector; #[schedule(since = $since)]);
-        crate::dispatch!(@pre_gate $calldata, $selector, $call_selector; #[schedule(until = $until)]);
-    };
-    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(since = $hf:ident)]) => {
-        if $selector == $call_selector && crate::storage::StorageCtx.spec() < tempo_chainspec::hardfork::TempoHardfork::$hf {
-            return crate::unknown_selector_result($calldata);
-        }
-    };
-    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(until = $hf:ident)]) => {
-        if $selector == $call_selector && crate::storage::StorageCtx.spec() >= tempo_chainspec::hardfork::TempoHardfork::$hf {
-            return crate::unknown_selector_result($calldata);
-        }
-    };
-}
-
-pub(crate) use dispatch;
-
-fn selector_from_calldata(calldata: &[u8]) -> Option<[u8; 4]> {
-    calldata.get(..4).map(|selector| {
-        selector
-            .try_into()
-            .expect("selector slice has exactly 4 bytes")
-    })
-}
-
-fn unknown_selector_result(calldata: &[u8]) -> PrecompileResult {
-    let selector = selector_from_calldata(calldata).expect("calldata len >= 4 after decode");
-    StorageCtx::default().error_result(error::TempoPrecompileError::UnknownFunctionSelector(
-        selector,
-    ))
-}
-
 /// Asserts that `result` is a reverted output whose bytes decode to `expected_error`.
 #[cfg(test)]
 pub fn expect_precompile_revert<E>(result: &PrecompileResult, expected_error: E)
@@ -600,7 +381,10 @@ mod tests {
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         tip20::TIP20Token,
     };
-    use alloy::primitives::{Address, Bytes, U256, bytes};
+    use alloy::{
+        primitives::{Address, Bytes, U256, bytes},
+        sol_types::SolCall,
+    };
     use alloy_evm::{
         EthEvmFactory, EvmEnv, EvmFactory, EvmInternals,
         precompiles::{Precompile as AlloyEvmPrecompile, PrecompileInput},

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -500,60 +500,61 @@ pub(crate) fn dispatch_call<T>(
 }
 
 macro_rules! dispatch {
+    // Public dispatcher syntax: group match arms by ABI interface.
     ($calldata:expr, |$call:ident| match $match_call:ident {
         $iface_1:ident::$calls_1:ident { $($(#[$($attr_1:tt)*])* $variant_1:ident($binding_1:pat) => $body_1:expr),* $(,)? }
         $($iface_n:ident::$calls_n:ident { $($(#[$($attr_n:tt)*])* $variant_n:ident($binding_n:pat) => $body_n:expr),* $(,)? })*
     } $(,)?) => {
         paste::paste! {{
+            // Run hardfork gates before decoding, so malformed gated calls are still unknown.
             if let Some(selector) = crate::selector_from_calldata($calldata) {
                 $($(crate::dispatch!(@pre_gate $calldata, selector, $iface_1::[<$variant_1 Call>]::SELECTOR; #[$($attr_1)*]);)*)*
                 $($($(crate::dispatch!(@pre_gate $calldata, selector, $iface_n::[<$variant_n Call>]::SELECTOR; #[$($attr_n)*]);)*)*)*
 
+                // Decode with the ABI whose selector set contains the calldata selector.
                 crate::dispatch!(@decode $calldata, selector, $call, $match_call,
                     $iface_1::$calls_1 { $($variant_1($binding_1) => $body_1),* }
                     $($iface_n::$calls_n { $($variant_n($binding_n) => $body_n),* })*
                     else $iface_1::$calls_1
                 )
             } else {
+                // Let dispatch_call apply the chain-specific missing-selector behavior.
                 crate::dispatch_call($calldata, <$iface_1::$calls_1 as alloy::sol_types::SolInterface>::abi_decode, |_| unreachable!())
             }
         }}
     };
+    // Try one interface; recurse until a matching selector set is found.
     (@decode $calldata:expr, $selector:expr, $call:ident, $match_call:ident,
-        $iface:ident::$calls:ident { $($variant:ident($binding:pat) => $body:expr),* }
-        $($rest:tt)*
-    ) => {
-        if <$iface::$calls as alloy::sol_types::SolInterface>::valid_selector($selector) {
-            crate::dispatch_call($calldata, <$iface::$calls as alloy::sol_types::SolInterface>::abi_decode, |$call| match $match_call {
-                $($iface::$calls::$variant($binding) => $body,)*
+        $iface:ident::$calls:ident { $($variant:ident($binding:pat) => $body:expr),* } $($rest:tt)*
+    ) => {{
+        type Calls = $iface::$calls;
+        if <Calls as alloy::sol_types::SolInterface>::valid_selector($selector) {
+            crate::dispatch_call($calldata, <Calls as alloy::sol_types::SolInterface>::abi_decode, |$call| match $match_call {
+                $(Calls::$variant($binding) => $body,)*
             })
         } else {
             crate::dispatch!(@decode $calldata, $selector, $call, $match_call, $($rest)*)
         }
-    };
-    (@decode $calldata:expr, $selector:expr, $call:ident, $match_call:ident, else $iface:ident::$calls:ident) => {
-        crate::dispatch_call($calldata, <$iface::$calls as alloy::sol_types::SolInterface>::abi_decode, |_| unreachable!())
-    };
-    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(since = $hf:ident)]) => {
-        if $selector == $call_selector
-            && crate::storage::StorageCtx::default().spec() < tempo_chainspec::hardfork::TempoHardfork::$hf
-        {
-            return crate::unknown_selector_result($calldata);
-        }
-    };
-    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(until = $hf:ident)]) => {
-        if $selector == $call_selector
-            && crate::storage::StorageCtx::default().spec() >= tempo_chainspec::hardfork::TempoHardfork::$hf
-        {
-            return crate::unknown_selector_result($calldata);
-        }
-    };
+    }};
+    // Fallback preserves dispatch_call's unknown-selector decoding path.
+    (@decode $calldata:expr, $selector:expr, $call:ident, $match_call:ident, else $iface:ident::$calls:ident) => {{
+        type Calls = $iface::$calls;
+        crate::dispatch_call($calldata, <Calls as alloy::sol_types::SolInterface>::abi_decode, |_| unreachable!())
+    }};
+    // Schedule gates: since rejects pre-fork, until rejects from that fork onward.
     (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(since = $since:ident, until = $until:ident)]) => {
         crate::dispatch!(@pre_gate $calldata, $selector, $call_selector; #[schedule(since = $since)]);
         crate::dispatch!(@pre_gate $calldata, $selector, $call_selector; #[schedule(until = $until)]);
     };
-    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(until = $until:ident, since = $since:ident)]) => {
-        crate::dispatch!(@pre_gate $calldata, $selector, $call_selector; #[schedule(since = $since, until = $until)]);
+    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(since = $hf:ident)]) => {
+        if $selector == $call_selector && crate::storage::StorageCtx.spec() < tempo_chainspec::hardfork::TempoHardfork::$hf {
+            return crate::unknown_selector_result($calldata);
+        }
+    };
+    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(until = $hf:ident)]) => {
+        if $selector == $call_selector && crate::storage::StorageCtx.spec() >= tempo_chainspec::hardfork::TempoHardfork::$hf {
+            return crate::unknown_selector_result($calldata);
+        }
     };
 }
 

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -461,64 +461,13 @@ fn fill_state_gas(output: &mut PrecompileOutput, storage: &StorageCtx) {
     }
 }
 
-/// A selector schedule at a given hardfork boundary.
+/// Decodes calldata via `decode`, then dispatches to `f`.
 ///
-/// Before the hardfork activates, selectors in `added` are treated as unknown.
-/// After it activates, selectors in `dropped` are treated as unknown.
-#[derive(Clone, Copy, Debug, Default)]
-pub(crate) struct SelectorSchedule<'a> {
-    hardfork: TempoHardfork,
-    added: &'a [[u8; 4]],
-    dropped: &'a [[u8; 4]],
-}
-
-impl<'a> SelectorSchedule<'a> {
-    /// Creates a new schedule anchored at `hardfork` with no selectors registered yet.
-    pub(crate) const fn new(hardfork: TempoHardfork) -> Self {
-        Self {
-            hardfork,
-            added: &[],
-            dropped: &[],
-        }
-    }
-
-    /// Registers selectors that are introduced at this hardfork boundary.
-    ///
-    /// These selectors are treated as unknown BEFORE `hardfork` activates.
-    pub(crate) const fn with_added(mut self, selectors: &'a [[u8; 4]]) -> Self {
-        self.added = selectors;
-        self
-    }
-
-    /// Registers selectors that are removed at this hardfork boundary.
-    ///
-    /// These selectors are treated as unknown ONCE `hardfork` activates.
-    pub(crate) const fn with_dropped(mut self, selectors: &'a [[u8; 4]]) -> Self {
-        self.dropped = selectors;
-        self
-    }
-
-    /// Returns `true` if this schedule gates out `selector` under the `active` hardfork.
-    #[inline]
-    fn rejects(self, selector: [u8; 4], active: TempoHardfork) -> bool {
-        if self.hardfork <= active {
-            self.dropped
-        } else {
-            self.added
-        }
-        .contains(&selector)
-    }
-}
-
-/// Applies hardfork selector schedules, decodes calldata via `decode`, then dispatches to `f`.
-///
-/// Handles missing selectors (revert on T1+, error on earlier forks), hardfork-gated selectors,
-/// unknown selectors (ABI-encoded `UnknownFunctionSelector`), and malformed ABI data (empty
-/// revert).
+/// Handles missing selectors (revert on T1+, error on earlier forks), unknown selectors
+/// (ABI-encoded `UnknownFunctionSelector`), and malformed ABI data (empty revert).
 #[inline]
 pub(crate) fn dispatch_call<T>(
     calldata: &[u8],
-    hardforks: &[SelectorSchedule<'_>],
     decode: impl FnOnce(&[u8]) -> core::result::Result<T, alloy::sol_types::Error>,
     f: impl FnOnce(T) -> PrecompileResult,
 ) -> PrecompileResult {
@@ -532,16 +481,6 @@ pub(crate) fn dispatch_call<T>(
                 "Invalid input: missing function selector".into(),
             )));
         }
-    }
-
-    let selector: [u8; 4] = calldata[..4].try_into().expect("calldata len >= 4");
-    if hardforks
-        .iter()
-        .any(|schedule| schedule.rejects(selector, storage.spec()))
-    {
-        return storage.error_result(error::TempoPrecompileError::UnknownFunctionSelector(
-            selector,
-        ));
     }
 
     let result = decode(calldata);
@@ -558,6 +497,81 @@ pub(crate) fn dispatch_call<T>(
         ),
         Err(_) => Ok(storage.revert_output(Bytes::new())),
     }
+}
+
+macro_rules! dispatch {
+    ($calldata:expr, |$call:ident| match $match_call:ident {
+        $iface_1:ident::$calls_1:ident { $($(#[$($attr_1:tt)*])* $variant_1:ident($binding_1:pat) => $body_1:expr),* $(,)? }
+        $($iface_n:ident::$calls_n:ident { $($(#[$($attr_n:tt)*])* $variant_n:ident($binding_n:pat) => $body_n:expr),* $(,)? })*
+    } $(,)?) => {
+        paste::paste! {{
+            if let Some(selector) = crate::selector_from_calldata($calldata) {
+                $($(crate::dispatch!(@pre_gate $calldata, selector, $iface_1::[<$variant_1 Call>]::SELECTOR; #[$($attr_1)*]);)*)*
+                $($($(crate::dispatch!(@pre_gate $calldata, selector, $iface_n::[<$variant_n Call>]::SELECTOR; #[$($attr_n)*]);)*)*)*
+
+                crate::dispatch!(@decode $calldata, selector, $call, $match_call,
+                    $iface_1::$calls_1 { $($variant_1($binding_1) => $body_1),* }
+                    $($iface_n::$calls_n { $($variant_n($binding_n) => $body_n),* })*
+                    else $iface_1::$calls_1
+                )
+            } else {
+                crate::dispatch_call($calldata, <$iface_1::$calls_1 as alloy::sol_types::SolInterface>::abi_decode, |_| unreachable!())
+            }
+        }}
+    };
+    (@decode $calldata:expr, $selector:expr, $call:ident, $match_call:ident,
+        $iface:ident::$calls:ident { $($variant:ident($binding:pat) => $body:expr),* }
+        $($rest:tt)*
+    ) => {
+        if <$iface::$calls as alloy::sol_types::SolInterface>::valid_selector($selector) {
+            crate::dispatch_call($calldata, <$iface::$calls as alloy::sol_types::SolInterface>::abi_decode, |$call| match $match_call {
+                $($iface::$calls::$variant($binding) => $body,)*
+            })
+        } else {
+            crate::dispatch!(@decode $calldata, $selector, $call, $match_call, $($rest)*)
+        }
+    };
+    (@decode $calldata:expr, $selector:expr, $call:ident, $match_call:ident, else $iface:ident::$calls:ident) => {
+        crate::dispatch_call($calldata, <$iface::$calls as alloy::sol_types::SolInterface>::abi_decode, |_| unreachable!())
+    };
+    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(since = $hf:ident)]) => {
+        if $selector == $call_selector
+            && crate::storage::StorageCtx::default().spec() < tempo_chainspec::hardfork::TempoHardfork::$hf
+        {
+            return crate::unknown_selector_result($calldata);
+        }
+    };
+    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(until = $hf:ident)]) => {
+        if $selector == $call_selector
+            && crate::storage::StorageCtx::default().spec() >= tempo_chainspec::hardfork::TempoHardfork::$hf
+        {
+            return crate::unknown_selector_result($calldata);
+        }
+    };
+    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(since = $since:ident, until = $until:ident)]) => {
+        crate::dispatch!(@pre_gate $calldata, $selector, $call_selector; #[schedule(since = $since)]);
+        crate::dispatch!(@pre_gate $calldata, $selector, $call_selector; #[schedule(until = $until)]);
+    };
+    (@pre_gate $calldata:expr, $selector:expr, $call_selector:expr; #[schedule(until = $until:ident, since = $since:ident)]) => {
+        crate::dispatch!(@pre_gate $calldata, $selector, $call_selector; #[schedule(since = $since, until = $until)]);
+    };
+}
+
+pub(crate) use dispatch;
+
+fn selector_from_calldata(calldata: &[u8]) -> Option<[u8; 4]> {
+    calldata.get(..4).map(|selector| {
+        selector
+            .try_into()
+            .expect("selector slice has exactly 4 bytes")
+    })
+}
+
+fn unknown_selector_result(calldata: &[u8]) -> PrecompileResult {
+    let selector = selector_from_calldata(calldata).expect("calldata len >= 4 after decode");
+    StorageCtx::default().error_result(error::TempoPrecompileError::UnknownFunctionSelector(
+        selector,
+    ))
 }
 
 /// Asserts that `result` is a reverted output whose bytes decode to `expected_error`.
@@ -1090,7 +1104,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dispatch_call_applies_hardfork_selector_gates() -> eyre::Result<()> {
+    fn test_dispatch_macro_applies_hardfork_selector_gates() -> eyre::Result<()> {
         alloy::sol! {
             interface ISelectorGatedTest {
                 function stable() external;
@@ -1099,31 +1113,32 @@ mod tests {
             }
         }
 
-        const SELECTOR_SCHEDULE: &[SelectorSchedule<'static>] = &[
-            SelectorSchedule::new(TempoHardfork::T2)
-                .with_added(&[ISelectorGatedTest::t2AddedCall::SELECTOR]),
-            SelectorSchedule::new(TempoHardfork::T3)
-                .with_dropped(&[ISelectorGatedTest::t3RemovedCall::SELECTOR]),
-        ];
-
         let call_with_spec = |spec: TempoHardfork, calldata: &[u8]| {
             let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
             StorageCtx::enter(&mut storage, || {
-                dispatch_call(
+                dispatch!(
                     calldata,
-                    SELECTOR_SCHEDULE,
-                    ISelectorGatedTest::ISelectorGatedTestCalls::abi_decode,
                     |call| match call {
-                        ISelectorGatedTest::ISelectorGatedTestCalls::stable(_) => {
-                            Ok(PrecompileOutput::new(0, Bytes::from_static(b"stable"), 0))
+                        ISelectorGatedTest::ISelectorGatedTestCalls {
+                        stable(_) => Ok(PrecompileOutput::new(
+                            0,
+                            Bytes::from_static(b"stable"),
+                            0,
+                        )),
+                        #[schedule(since = T2)]
+                        t2Added(_) => Ok(PrecompileOutput::new(
+                            0,
+                            Bytes::from_static(b"added"),
+                            0,
+                        )),
+                        #[schedule(until = T3)]
+                        t3Removed(_) => Ok(PrecompileOutput::new(
+                            0,
+                            Bytes::from_static(b"removed"),
+                            0,
+                        )),
                         }
-                        ISelectorGatedTest::ISelectorGatedTestCalls::t2Added(_) => {
-                            Ok(PrecompileOutput::new(0, Bytes::from_static(b"added"), 0))
-                        }
-                        ISelectorGatedTest::ISelectorGatedTestCalls::t3Removed(_) => {
-                            Ok(PrecompileOutput::new(0, Bytes::from_static(b"removed"), 0))
-                        }
-                    },
+                    }
                 )
             })
         };

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -905,23 +905,11 @@ mod tests {
                     calldata,
                     |call| match call {
                         ISelectorGatedTest::ISelectorGatedTestCalls {
-                        stable(_) => Ok(PrecompileOutput::new(
-                            0,
-                            Bytes::from_static(b"stable"),
-                            0,
-                        )),
-                        #[schedule(since = T2)]
-                        t2Added(_) => Ok(PrecompileOutput::new(
-                            0,
-                            Bytes::from_static(b"added"),
-                            0,
-                        )),
-                        #[schedule(until = T3)]
-                        t3Removed(_) => Ok(PrecompileOutput::new(
-                            0,
-                            Bytes::from_static(b"removed"),
-                            0,
-                        )),
+                            stable(_) => Ok(PrecompileOutput::new(0, Bytes::from_static(b"stable"), 0)),
+                            #[schedule(since = T2)]
+                            t2Added(_) => Ok(PrecompileOutput::new(0, Bytes::from_static(b"added"), 0)),
+                            #[schedule(until = T3)]
+                            t3Removed(_) => Ok(PrecompileOutput::new(0, Bytes::from_static(b"removed"), 0)),
                         }
                     }
                 )

--- a/crates/precompiles/src/nonce/dispatch.rs
+++ b/crates/precompiles/src/nonce/dispatch.rs
@@ -1,10 +1,9 @@
 //! ABI dispatch for the [`NonceManager`] precompile.
 
 use crate::{Precompile, charge_input_cost, dispatch, nonce::NonceManager, view};
-use alloy::{primitives::Address, sol_types::SolInterface};
+use alloy::primitives::Address;
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::INonce::{self, INonceCalls};
-
+use tempo_contracts::precompiles::INonce;
 impl Precompile for NonceManager {
     fn call(&mut self, calldata: &[u8], _msg_sender: Address) -> PrecompileResult {
         if let Some(err) = charge_input_cost(&mut self.storage, calldata) {
@@ -29,8 +28,7 @@ mod tests {
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{assert_full_coverage, check_selector_coverage},
     };
-    use tempo_contracts::precompiles::INonce::{self, INonceCalls};
-
+    use tempo_contracts::precompiles::INonce::INonceCalls;
     #[test]
     fn test_nonce_selector_coverage() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);

--- a/crates/precompiles/src/nonce/dispatch.rs
+++ b/crates/precompiles/src/nonce/dispatch.rs
@@ -10,14 +10,9 @@ impl Precompile for NonceManager {
             return err;
         }
 
-        dispatch!(
-            calldata,
-            |call| match call {
-                INonce::INonceCalls {
-                    getNonce(call) => view(call, |c| self.get_nonce(c)),
-                }
-            }
-        )
+        dispatch!(calldata, |call| match call {
+            INonce::INonceCalls { getNonce(call) => view(call, |c| self.get_nonce(c)) }
+        })
     }
 }
 

--- a/crates/precompiles/src/nonce/dispatch.rs
+++ b/crates/precompiles/src/nonce/dispatch.rs
@@ -1,9 +1,9 @@
 //! ABI dispatch for the [`NonceManager`] precompile.
 
-use crate::{Precompile, charge_input_cost, dispatch_call, nonce::NonceManager, view};
+use crate::{Precompile, charge_input_cost, dispatch, nonce::NonceManager, view};
 use alloy::{primitives::Address, sol_types::SolInterface};
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::INonce::INonceCalls;
+use tempo_contracts::precompiles::INonce::{self, INonceCalls};
 
 impl Precompile for NonceManager {
     fn call(&mut self, calldata: &[u8], _msg_sender: Address) -> PrecompileResult {
@@ -11,9 +11,14 @@ impl Precompile for NonceManager {
             return err;
         }
 
-        dispatch_call(calldata, &[], INonceCalls::abi_decode, |call| match call {
-            INonceCalls::getNonce(call) => view(call, |c| self.get_nonce(c)),
-        })
+        dispatch!(
+            calldata,
+            |call| match call {
+                INonce::INonceCalls {
+                    getNonce(call) => view(call, |c| self.get_nonce(c)),
+                }
+            }
+        )
     }
 }
 
@@ -24,7 +29,7 @@ mod tests {
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{assert_full_coverage, check_selector_coverage},
     };
-    use tempo_contracts::precompiles::INonce::INonceCalls;
+    use tempo_contracts::precompiles::INonce::{self, INonceCalls};
 
     #[test]
     fn test_nonce_selector_coverage() -> eyre::Result<()> {

--- a/crates/precompiles/src/receive_policy_guard/dispatch.rs
+++ b/crates/precompiles/src/receive_policy_guard/dispatch.rs
@@ -1,12 +1,12 @@
 //! ABI dispatch for the [`ReceivePolicyGuard`] precompile.
 
 use crate::{
-    Precompile, charge_input_cost, dispatch_call, mutate_void,
-    receive_policy_guard::ReceivePolicyGuard, view,
+    Precompile, charge_input_cost, dispatch, mutate_void, receive_policy_guard::ReceivePolicyGuard,
+    view,
 };
 use alloy::{primitives::Address, sol_types::SolInterface};
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::IReceivePolicyGuard::IReceivePolicyGuardCalls;
+use tempo_contracts::precompiles::IReceivePolicyGuard::{self, IReceivePolicyGuardCalls};
 
 impl Precompile for ReceivePolicyGuard {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -14,23 +14,17 @@ impl Precompile for ReceivePolicyGuard {
             return err;
         }
 
-        dispatch_call(
+        dispatch!(
             calldata,
-            &[],
-            IReceivePolicyGuardCalls::abi_decode,
             |call| match call {
-                IReceivePolicyGuardCalls::balanceOf(call) => {
-                    view(call, |c| self.balance_of(c.receipt))
-                }
-                IReceivePolicyGuardCalls::claim(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.claim(s, c.to, c.receipt))
-                }
-                IReceivePolicyGuardCalls::burnBlockedReceipt(call) => {
-                    mutate_void(call, msg_sender, |s, c| {
+                IReceivePolicyGuard::IReceivePolicyGuardCalls {
+                    balanceOf(call) => view(call, |c| self.balance_of(c.receipt)),
+                    claim(call) => mutate_void(call, msg_sender, |s, c| self.claim(s, c.to, c.receipt)),
+                    burnBlockedReceipt(call) => mutate_void(call, msg_sender, |s, c| {
                         self.burn_blocked_receipt(s, c.receipt)
                     })
                 }
-            },
+            }
         )
     }
 }

--- a/crates/precompiles/src/receive_policy_guard/dispatch.rs
+++ b/crates/precompiles/src/receive_policy_guard/dispatch.rs
@@ -4,10 +4,9 @@ use crate::{
     Precompile, charge_input_cost, dispatch, mutate_void, receive_policy_guard::ReceivePolicyGuard,
     view,
 };
-use alloy::{primitives::Address, sol_types::SolInterface};
+use alloy::primitives::Address;
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::IReceivePolicyGuard::{self, IReceivePolicyGuardCalls};
-
+use tempo_contracts::precompiles::IReceivePolicyGuard;
 impl Precompile for ReceivePolicyGuard {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
         if let Some(err) = charge_input_cost(&mut self.storage, calldata) {

--- a/crates/precompiles/src/signature_verifier/dispatch.rs
+++ b/crates/precompiles/src/signature_verifier/dispatch.rs
@@ -1,14 +1,8 @@
 use super::SignatureVerifier;
 use crate::{Precompile, charge_input_cost, dispatch, view};
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
+use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::{
-    ISignatureVerifier::{self, ISignatureVerifierCalls as ISVCalls},
-    SignatureVerifierError,
-};
+use tempo_contracts::precompiles::{ISignatureVerifier, SignatureVerifierError};
 use tempo_primitives::MAX_WEBAUTHN_SIGNATURE_LENGTH;
 
 /// Maximum valid calldata size: `verify(address,bytes32,bytes)` with a WebAuthn signature is the
@@ -63,11 +57,15 @@ mod tests {
     };
     use alloy::{
         primitives::B256,
-        sol_types::{SolCall, SolError},
+        sol_types::{SolCall, SolError, SolInterface},
     };
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
-    use tempo_contracts::precompiles::{ISignatureVerifier, UnknownFunctionSelector};
+    use tempo_chainspec::hardfork::TempoHardfork;
+    use tempo_contracts::precompiles::{
+        ISignatureVerifier, ISignatureVerifier::ISignatureVerifierCalls as ISVCalls,
+        UnknownFunctionSelector,
+    };
     use tempo_primitives::transaction::tt_signature::{
         KeychainSignature, PrimitiveSignature, TempoSignature,
     };

--- a/crates/precompiles/src/signature_verifier/dispatch.rs
+++ b/crates/precompiles/src/signature_verifier/dispatch.rs
@@ -1,11 +1,10 @@
 use super::SignatureVerifier;
-use crate::{Precompile, SelectorSchedule, charge_input_cost, dispatch_call, view};
+use crate::{Precompile, charge_input_cost, dispatch, view};
 use alloy::{
     primitives::Address,
     sol_types::{SolCall, SolInterface},
 };
 use revm::precompile::PrecompileResult;
-use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::{
     ISignatureVerifier::{self, ISignatureVerifierCalls as ISVCalls},
     SignatureVerifierError,
@@ -17,11 +16,6 @@ use tempo_primitives::MAX_WEBAUTHN_SIGNATURE_LENGTH;
 /// dynamic portion: selector(4) + args(4×32) + padded_sig_bytes.
 const MAX_CALLDATA_LEN: usize =
     4 + 32 * 4 + (MAX_WEBAUTHN_SIGNATURE_LENGTH + 1).next_multiple_of(32);
-
-const T6_ADDED: &[[u8; 4]] = &[
-    ISignatureVerifier::verifyKeychainCall::SELECTOR,
-    ISignatureVerifier::verifyKeychainAdminCall::SELECTOR,
-];
 
 impl Precompile for SignatureVerifier {
     fn call(&mut self, calldata: &[u8], _msg_sender: Address) -> PrecompileResult {
@@ -35,22 +29,24 @@ impl Precompile for SignatureVerifier {
                 .abi_revert(SignatureVerifierError::invalid_format()));
         }
 
-        dispatch_call(
+        dispatch!(
             calldata,
-            &[SelectorSchedule::new(TempoHardfork::T6).with_added(T6_ADDED)],
-            ISVCalls::abi_decode,
             |call| match call {
-                ISVCalls::recover(call) => view(call, |c| self.recover(c.hash, c.signature)),
-                ISVCalls::verify(call) => view(call, |c| {
-                    self.recover(c.hash, c.signature).map(|sig| sig == c.signer)
-                }),
-                ISVCalls::verifyKeychain(call) => view(call, |c| {
-                    self.verify_keychain(c.account, c.hash, c.signature)
-                }),
-                ISVCalls::verifyKeychainAdmin(call) => view(call, |c| {
-                    self.verify_keychain_admin(c.account, c.hash, c.signature)
-                }),
-            },
+                ISignatureVerifier::ISignatureVerifierCalls {
+                    recover(call) => view(call, |c| self.recover(c.hash, c.signature)),
+                    verify(call) => view(call, |c| {
+                        self.recover(c.hash, c.signature).map(|sig| sig == c.signer)
+                    }),
+                    #[schedule(since = T6)]
+                    verifyKeychain(call) => view(call, |c| {
+                        self.verify_keychain(c.account, c.hash, c.signature)
+                    }),
+                    #[schedule(since = T6)]
+                    verifyKeychainAdmin(call) => view(call, |c| {
+                        self.verify_keychain_admin(c.account, c.hash, c.signature)
+                    }),
+                }
+            }
         )
     }
 }
@@ -71,7 +67,6 @@ mod tests {
     };
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
-    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{ISignatureVerifier, UnknownFunctionSelector};
     use tempo_primitives::transaction::tt_signature::{
         KeychainSignature, PrimitiveSignature, TempoSignature,

--- a/crates/precompiles/src/signature_verifier/dispatch.rs
+++ b/crates/precompiles/src/signature_verifier/dispatch.rs
@@ -1,6 +1,6 @@
 use super::SignatureVerifier;
 use crate::{Precompile, charge_input_cost, dispatch, view};
-use alloy::{primitives::Address, sol_types::SolCall};
+use alloy::primitives::Address;
 use revm::precompile::PrecompileResult;
 use tempo_contracts::precompiles::{ISignatureVerifier, SignatureVerifierError};
 use tempo_primitives::MAX_WEBAUTHN_SIGNATURE_LENGTH;

--- a/crates/precompiles/src/stablecoin_dex/dispatch.rs
+++ b/crates/precompiles/src/stablecoin_dex/dispatch.rs
@@ -5,121 +5,91 @@ use alloy::{
     sol_types::{SolCall, SolInterface},
 };
 use revm::precompile::PrecompileResult;
-use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::IStablecoinDEX::{self, IStablecoinDEXCalls};
 
 use crate::{
-    Precompile, SelectorSchedule, charge_input_cost, dispatch_call, mutate, mutate_void,
-    preserve_storage_credits,
+    Precompile, charge_input_cost, dispatch, mutate, mutate_void, preserve_storage_credits,
     stablecoin_dex::{StablecoinDEX, orderbook::compute_book_key},
     view,
 };
-
-const T7_ADDED: &[[u8; 4]] = &[IStablecoinDEX::storageCreditsCall::SELECTOR];
 
 impl Precompile for StablecoinDEX {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
         if let Some(err) = charge_input_cost(&mut self.storage, calldata) {
             return err;
         }
-
-        dispatch_call(
+        dispatch!(
             calldata,
-            &[SelectorSchedule::new(TempoHardfork::T7).with_added(T7_ADDED)],
-            IStablecoinDEXCalls::abi_decode,
             |call| match call {
-                IStablecoinDEXCalls::place(call) => mutate(call, msg_sender, |s, c| {
-                    preserve_storage_credits(self.address)?;
-                    self.place(s, c.token, c.amount, c.isBid, c.tick)
-                }),
-                IStablecoinDEXCalls::placeFlip(call) => mutate(call, msg_sender, |s, c| {
-                    preserve_storage_credits(self.address)?;
-                    self.place_flip(s, c.token, c.amount, c.isBid, c.tick, c.flipTick, false)
-                }),
-                IStablecoinDEXCalls::balanceOf(call) => {
-                    view(call, |c| self.balance_of(c.user, c.token))
-                }
-                IStablecoinDEXCalls::getOrder(call) => view(call, |c| {
-                    self.get_order(c.orderId).map(|order| order.into())
-                }),
-                IStablecoinDEXCalls::getTickLevel(call) => view(call, |c| {
-                    let level = self.get_price_level(c.base, c.tick, c.isBid)?;
-                    Ok((level.head, level.tail, level.total_liquidity).into())
-                }),
-                IStablecoinDEXCalls::pairKey(call) => {
-                    view(call, |c| Ok(compute_book_key(c.tokenA, c.tokenB)))
-                }
-                IStablecoinDEXCalls::books(call) => {
-                    view(call, |c| self.books(c.pairKey).map(Into::into))
-                }
-                IStablecoinDEXCalls::storageCredits(call) => {
-                    view(call, |c| self.storage_credits(c.user))
-                }
-                IStablecoinDEXCalls::nextOrderId(call) => view(call, |_| self.next_order_id()),
-                IStablecoinDEXCalls::createPair(call) => mutate(call, msg_sender, |_, c| {
-                    preserve_storage_credits(self.address)?;
-                    self.create_pair(c.base)
-                }),
-                IStablecoinDEXCalls::withdraw(call) => mutate_void(call, msg_sender, |s, c| {
-                    preserve_storage_credits(self.address)?;
-                    self.withdraw(s, c.token, c.amount)
-                }),
-                IStablecoinDEXCalls::cancel(call) => mutate_void(call, msg_sender, |s, c| {
-                    preserve_storage_credits(self.address)?;
-                    self.cancel(s, c.orderId)
-                }),
-                IStablecoinDEXCalls::cancelStaleOrder(call) => {
-                    mutate_void(call, msg_sender, |_, c| {
+                IStablecoinDEX::IStablecoinDEXCalls {
+                    place(call) => mutate(call, msg_sender, |s, c| {
+                        preserve_storage_credits(self.address)?;
+                        self.place(s, c.token, c.amount, c.isBid, c.tick)
+                    }),
+                    placeFlip(call) => mutate(call, msg_sender, |s, c| {
+                        preserve_storage_credits(self.address)?;
+                        self.place_flip(s, c.token, c.amount, c.isBid, c.tick, c.flipTick, false)
+                    }),
+                    balanceOf(call) => view(call, |c| self.balance_of(c.user, c.token)),
+                    getOrder(call) => view(call, |c| {
+                        self.get_order(c.orderId).map(|order| order.into())
+                    }),
+                    getTickLevel(call) => view(call, |c| {
+                        let level = self.get_price_level(c.base, c.tick, c.isBid)?;
+                        Ok((level.head, level.tail, level.total_liquidity).into())
+                    }),
+                    pairKey(call) => view(call, |c| Ok(compute_book_key(c.tokenA, c.tokenB))),
+                    books(call) => view(call, |c| self.books(c.pairKey).map(Into::into)),
+                    #[schedule(since = T7)]
+                    storageCredits(call) => view(call, |c| self.storage_credits(c.user)),
+                    nextOrderId(call) => view(call, |_| self.next_order_id()),
+                    createPair(call) => mutate(call, msg_sender, |_, c| {
+                        preserve_storage_credits(self.address)?;
+                        self.create_pair(c.base)
+                    }),
+                    withdraw(call) => mutate_void(call, msg_sender, |s, c| {
+                        preserve_storage_credits(self.address)?;
+                        self.withdraw(s, c.token, c.amount)
+                    }),
+                    cancel(call) => mutate_void(call, msg_sender, |s, c| {
+                        preserve_storage_credits(self.address)?;
+                        self.cancel(s, c.orderId)
+                    }),
+                    cancelStaleOrder(call) => mutate_void(call, msg_sender, |_, c| {
                         preserve_storage_credits(self.address)?;
                         self.cancel_stale_order(c.orderId)
-                    })
-                }
-                IStablecoinDEXCalls::swapExactAmountIn(call) => mutate(call, msg_sender, |s, c| {
-                    preserve_storage_credits(self.address)?;
-                    self.swap_exact_amount_in(s, c.tokenIn, c.tokenOut, c.amountIn, c.minAmountOut)
-                }),
-                IStablecoinDEXCalls::swapExactAmountOut(call) => {
-                    mutate(call, msg_sender, |s, c| {
+                    }),
+                    swapExactAmountIn(call) => mutate(call, msg_sender, |s, c| {
+                        preserve_storage_credits(self.address)?;
+                        self.swap_exact_amount_in(s, c.tokenIn, c.tokenOut, c.amountIn, c.minAmountOut)
+                    }),
+                    swapExactAmountOut(call) => mutate(call, msg_sender, |s, c| {
                         preserve_storage_credits(self.address)?;
                         self.swap_exact_amount_out(
-                            s,
-                            c.tokenIn,
-                            c.tokenOut,
-                            c.amountOut,
-                            c.maxAmountIn,
+                        s,
+                        c.tokenIn,
+                        c.tokenOut,
+                        c.amountOut,
+                        c.maxAmountIn,
                         )
-                    })
+                    }),
+                    quoteSwapExactAmountIn(call) => view(call, |c| {
+                        self.quote_swap_exact_amount_in(c.tokenIn, c.tokenOut, c.amountIn)
+                    }),
+                    quoteSwapExactAmountOut(call) => view(call, |c| {
+                        self.quote_swap_exact_amount_out(c.tokenIn, c.tokenOut, c.amountOut)
+                    }),
+                    MIN_TICK(call) => view(call, |_| Ok(crate::stablecoin_dex::MIN_TICK)),
+                    MAX_TICK(call) => view(call, |_| Ok(crate::stablecoin_dex::MAX_TICK)),
+                    TICK_SPACING(call) => view(call, |_| Ok(crate::stablecoin_dex::TICK_SPACING)),
+                    PRICE_SCALE(call) => view(call, |_| Ok(crate::stablecoin_dex::PRICE_SCALE)),
+                    MIN_ORDER_AMOUNT(call) => view(call, |_| Ok(crate::stablecoin_dex::MIN_ORDER_AMOUNT)),
+                    MIN_PRICE(call) => view(call, |_| Ok(self.min_price())),
+                    MAX_PRICE(call) => view(call, |_| Ok(self.max_price())),
+                    tickToPrice(call) => view(call, |c| self.tick_to_price(c.tick)),
+                    priceToTick(call) => view(call, |c| self.price_to_tick(c.price))
                 }
-                IStablecoinDEXCalls::quoteSwapExactAmountIn(call) => view(call, |c| {
-                    self.quote_swap_exact_amount_in(c.tokenIn, c.tokenOut, c.amountIn)
-                }),
-                IStablecoinDEXCalls::quoteSwapExactAmountOut(call) => view(call, |c| {
-                    self.quote_swap_exact_amount_out(c.tokenIn, c.tokenOut, c.amountOut)
-                }),
-                IStablecoinDEXCalls::MIN_TICK(call) => {
-                    view(call, |_| Ok(crate::stablecoin_dex::MIN_TICK))
-                }
-                IStablecoinDEXCalls::MAX_TICK(call) => {
-                    view(call, |_| Ok(crate::stablecoin_dex::MAX_TICK))
-                }
-                IStablecoinDEXCalls::TICK_SPACING(call) => {
-                    view(call, |_| Ok(crate::stablecoin_dex::TICK_SPACING))
-                }
-                IStablecoinDEXCalls::PRICE_SCALE(call) => {
-                    view(call, |_| Ok(crate::stablecoin_dex::PRICE_SCALE))
-                }
-                IStablecoinDEXCalls::MIN_ORDER_AMOUNT(call) => {
-                    view(call, |_| Ok(crate::stablecoin_dex::MIN_ORDER_AMOUNT))
-                }
-                IStablecoinDEXCalls::MIN_PRICE(call) => view(call, |_| Ok(self.min_price())),
-                IStablecoinDEXCalls::MAX_PRICE(call) => view(call, |_| Ok(self.max_price())),
-                IStablecoinDEXCalls::tickToPrice(call) => {
-                    view(call, |c| self.tick_to_price(c.tick))
-                }
-                IStablecoinDEXCalls::priceToTick(call) => {
-                    view(call, |c| self.price_to_tick(c.price))
-                }
-            },
+            }
         )
     }
 }
@@ -137,7 +107,6 @@ mod tests {
         primitives::{Address, U256},
         sol_types::{SolCall, SolValue},
     };
-    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::IStablecoinDEX::IStablecoinDEXCalls;
 
     /// Setup a basic exchange with tokens and liquidity for swap tests
@@ -494,9 +463,9 @@ mod tests {
 
             let unsupported = check_selector_coverage(
                 &mut exchange,
-                IStablecoinDEXCalls::SELECTORS,
+                SELECTORS,
                 "IStablecoinDEX",
-                IStablecoinDEXCalls::name_by_selector,
+                name_by_selector,
             );
 
             // All selectors should be supported

--- a/crates/precompiles/src/stablecoin_dex/dispatch.rs
+++ b/crates/precompiles/src/stablecoin_dex/dispatch.rs
@@ -1,6 +1,6 @@
 //! ABI dispatch for the [`StablecoinDEX`] precompile.
 
-use alloy::{primitives::Address, sol_types::SolCall};
+use alloy::primitives::Address;
 use revm::precompile::PrecompileResult;
 use tempo_contracts::precompiles::IStablecoinDEX;
 

--- a/crates/precompiles/src/stablecoin_dex/dispatch.rs
+++ b/crates/precompiles/src/stablecoin_dex/dispatch.rs
@@ -1,11 +1,8 @@
 //! ABI dispatch for the [`StablecoinDEX`] precompile.
 
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
+use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::IStablecoinDEX::{self, IStablecoinDEXCalls};
+use tempo_contracts::precompiles::IStablecoinDEX;
 
 use crate::{
     Precompile, charge_input_cost, dispatch, mutate, mutate_void, preserve_storage_credits,
@@ -107,6 +104,7 @@ mod tests {
         primitives::{Address, U256},
         sol_types::{SolCall, SolValue},
     };
+    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::IStablecoinDEX::IStablecoinDEXCalls;
 
     /// Setup a basic exchange with tokens and liquidity for swap tests
@@ -463,9 +461,9 @@ mod tests {
 
             let unsupported = check_selector_coverage(
                 &mut exchange,
-                SELECTORS,
+                IStablecoinDEXCalls::SELECTORS,
                 "IStablecoinDEX",
-                name_by_selector,
+                IStablecoinDEXCalls::name_by_selector,
             );
 
             // All selectors should be supported

--- a/crates/precompiles/src/stablecoin_dex/dispatch.rs
+++ b/crates/precompiles/src/stablecoin_dex/dispatch.rs
@@ -62,13 +62,7 @@ impl Precompile for StablecoinDEX {
                     }),
                     swapExactAmountOut(call) => mutate(call, msg_sender, |s, c| {
                         preserve_storage_credits(self.address)?;
-                        self.swap_exact_amount_out(
-                        s,
-                        c.tokenIn,
-                        c.tokenOut,
-                        c.amountOut,
-                        c.maxAmountIn,
-                        )
+                        self.swap_exact_amount_out(s, c.tokenIn, c.tokenOut, c.amountOut, c.maxAmountIn)
                     }),
                     quoteSwapExactAmountIn(call) => view(call, |c| {
                         self.quote_swap_exact_amount_in(c.tokenIn, c.tokenOut, c.amountIn)

--- a/crates/precompiles/src/stablecoin_dex/dispatch.rs
+++ b/crates/precompiles/src/stablecoin_dex/dispatch.rs
@@ -37,8 +37,6 @@ impl Precompile for StablecoinDEX {
                     }),
                     pairKey(call) => view(call, |c| Ok(compute_book_key(c.tokenA, c.tokenB))),
                     books(call) => view(call, |c| self.books(c.pairKey).map(Into::into)),
-                    #[schedule(since = T7)]
-                    storageCredits(call) => view(call, |c| self.storage_credits(c.user)),
                     nextOrderId(call) => view(call, |_| self.next_order_id()),
                     createPair(call) => mutate(call, msg_sender, |_, c| {
                         preserve_storage_credits(self.address)?;
@@ -78,7 +76,10 @@ impl Precompile for StablecoinDEX {
                     MIN_PRICE(call) => view(call, |_| Ok(self.min_price())),
                     MAX_PRICE(call) => view(call, |_| Ok(self.max_price())),
                     tickToPrice(call) => view(call, |c| self.tick_to_price(c.tick)),
-                    priceToTick(call) => view(call, |c| self.price_to_tick(c.price))
+                    priceToTick(call) => view(call, |c| self.price_to_tick(c.price)),
+
+                    #[schedule(since = T7)]
+                    storageCredits(call) => view(call, |c| self.storage_credits(c.user))
                 }
             }
         )

--- a/crates/precompiles/src/storage_credits/dispatch.rs
+++ b/crates/precompiles/src/storage_credits/dispatch.rs
@@ -3,9 +3,9 @@
 use crate::{
     Precompile, charge_input_cost, dispatch, mutate_void, storage_credits::StorageCredits, view,
 };
-use alloy::{primitives::Address, sol_types::SolInterface};
+use alloy::primitives::Address;
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::IStorageCredits::{self, IStorageCreditsCalls};
+use tempo_contracts::precompiles::IStorageCredits;
 
 impl Precompile for StorageCredits {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -39,8 +39,10 @@ mod tests {
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{assert_full_coverage, check_selector_coverage},
     };
-    use alloy::sol_types::SolCall;
-    use tempo_contracts::precompiles::{IStorageCredits, StorageCreditsError};
+    use alloy::sol_types::{SolCall, SolInterface};
+    use tempo_contracts::precompiles::{
+        IStorageCredits, IStorageCredits::IStorageCreditsCalls, StorageCreditsError,
+    };
 
     #[test]
     fn test_storage_credits_selector_coverage() -> eyre::Result<()> {
@@ -50,9 +52,9 @@ mod tests {
 
             let unsupported = check_selector_coverage(
                 &mut storage_credits_precompile,
-                SELECTORS,
+                IStorageCreditsCalls::SELECTORS,
                 "IStorageCredits",
-                name_by_selector,
+                IStorageCreditsCalls::name_by_selector,
             );
 
             assert_full_coverage([unsupported]);

--- a/crates/precompiles/src/storage_credits/dispatch.rs
+++ b/crates/precompiles/src/storage_credits/dispatch.rs
@@ -1,12 +1,11 @@
 //! ABI dispatch for the storage credits precompile.
 
 use crate::{
-    Precompile, charge_input_cost, dispatch_call, mutate_void, storage_credits::StorageCredits,
-    view,
+    Precompile, charge_input_cost, dispatch, mutate_void, storage_credits::StorageCredits, view,
 };
 use alloy::{primitives::Address, sol_types::SolInterface};
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::IStorageCredits::IStorageCreditsCalls;
+use tempo_contracts::precompiles::IStorageCredits::{self, IStorageCreditsCalls};
 
 impl Precompile for StorageCredits {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -14,27 +13,21 @@ impl Precompile for StorageCredits {
             return err;
         }
 
-        dispatch_call(
+        dispatch!(
             calldata,
-            &[],
-            IStorageCreditsCalls::abi_decode,
             |call| match call {
-                IStorageCreditsCalls::balanceOf(call) => view(call, |c| self.balance_of(c.account)),
-                IStorageCreditsCalls::modeOf(call) => {
-                    view(call, |c| self.mode_of(c.account).map(Into::into))
-                }
-                IStorageCreditsCalls::budgetOf(call) => view(call, |c| self.budget_of(c.account)),
-                IStorageCreditsCalls::setMode(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
+                IStorageCredits::IStorageCreditsCalls {
+                    balanceOf(call) => view(call, |c| self.balance_of(c.account)),
+                    modeOf(call) => view(call, |c| self.mode_of(c.account).map(Into::into)),
+                    budgetOf(call) => view(call, |c| self.budget_of(c.account)),
+                    setMode(call) => mutate_void(call, msg_sender, |sender, c| {
                         self.set_mode(sender, c.newMode)
-                    })
-                }
-                IStorageCreditsCalls::setBudget(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
+                    }),
+                    setBudget(call) => mutate_void(call, msg_sender, |sender, c| {
                         self.set_budget(sender, c.credits)
                     })
                 }
-            },
+            }
         )
     }
 }
@@ -57,9 +50,9 @@ mod tests {
 
             let unsupported = check_selector_coverage(
                 &mut storage_credits_precompile,
-                IStorageCreditsCalls::SELECTORS,
+                SELECTORS,
                 "IStorageCredits",
-                IStorageCreditsCalls::name_by_selector,
+                name_by_selector,
             );
 
             assert_full_coverage([unsupported]);

--- a/crates/precompiles/src/tip20/dispatch.rs
+++ b/crates/precompiles/src/tip20/dispatch.rs
@@ -84,9 +84,7 @@ impl Precompile for TIP20Token {
                     claimRewards(call) => mutate(call, msg_sender, |_, _| self.claim_rewards(msg_sender)),
                     globalRewardPerToken(call) => view(call, |_| self.get_global_reward_per_token()),
                     optedInSupply(call) => view(call, |_| self.get_opted_in_supply()),
-                    userRewardInfo(call) => view(call, |c| {
-                        self.get_user_reward_info(c.account).map(|info| info.into())
-                    }),
+                    userRewardInfo(call) => view(call, |c| self.get_user_reward_info(c.account).map(|info| info.into())),
                     getPendingRewards(call) => view(call, |c| self.get_pending_rewards(c.account)),
 
                     #[schedule(since = T2)]
@@ -125,7 +123,6 @@ mod tests {
         sol_types::{SolCall, SolError, SolInterface, SolValue},
     };
     use tempo_chainspec::hardfork::TempoHardfork;
-
     use tempo_contracts::precompiles::{
         IRolesAuth, RolesAuthError, TIP20Error, UnknownFunctionSelector,
     };

--- a/crates/precompiles/src/tip20/dispatch.rs
+++ b/crates/precompiles/src/tip20/dispatch.rs
@@ -6,10 +6,7 @@ use crate::{
     tip20::{ITIP20, TIP20Token},
     view,
 };
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
+use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::PrecompileResult;
 use tempo_contracts::precompiles::{IRolesAuth, TIP20Error};
 
@@ -42,6 +39,7 @@ impl Precompile for TIP20Token {
                     supplyCap(_) => metadata::<ITIP20::supplyCapCall>(|| self.supply_cap()),
                     transferPolicyId(_) => metadata::<ITIP20::transferPolicyIdCall>(|| self.transfer_policy_id()),
                     paused(_) => metadata::<ITIP20::pausedCall>(|| self.paused()),
+                    #[schedule(since = T5)]
                     logoURI(_) => metadata::<ITIP20::logoURICall>(|| self.logo_uri()),
 
                     // View functions
@@ -126,6 +124,7 @@ mod tests {
         primitives::{Bytes, U256, address},
         sol_types::{SolCall, SolError, SolInterface, SolValue},
     };
+    use tempo_chainspec::hardfork::TempoHardfork;
 
     use tempo_contracts::precompiles::{
         IRolesAuth, RolesAuthError, TIP20Error, UnknownFunctionSelector,

--- a/crates/precompiles/src/tip20/dispatch.rs
+++ b/crates/precompiles/src/tip20/dispatch.rs
@@ -6,7 +6,7 @@ use crate::{
     tip20::{ITIP20, TIP20Token},
     view,
 };
-use alloy::{primitives::Address, sol_types::SolCall};
+use alloy::primitives::Address;
 use revm::precompile::PrecompileResult;
 use tempo_contracts::precompiles::{IRolesAuth, TIP20Error};
 

--- a/crates/precompiles/src/tip20/dispatch.rs
+++ b/crates/precompiles/src/tip20/dispatch.rs
@@ -1,7 +1,7 @@
 //! ABI dispatch for the [`TIP20Token`] precompile.
 
 use crate::{
-    Precompile, SelectorSchedule, charge_input_cost, dispatch_call, metadata, mutate, mutate_void,
+    Precompile, charge_input_cost, dispatch, metadata, mutate, mutate_void,
     storage::ContractStorage,
     tip20::{ITIP20, TIP20Token},
     view,
@@ -11,39 +11,7 @@ use alloy::{
     sol_types::{SolCall, SolInterface},
 };
 use revm::precompile::PrecompileResult;
-use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_contracts::precompiles::{IRolesAuth::IRolesAuthCalls, ITIP20::ITIP20Calls, TIP20Error};
-
-const T2_ADDED: &[[u8; 4]] = &[
-    ITIP20::permitCall::SELECTOR,
-    ITIP20::noncesCall::SELECTOR,
-    ITIP20::DOMAIN_SEPARATORCall::SELECTOR,
-];
-
-/// Selectors added at T5: TIP-1026 Token Logo URI.
-const T5_ADDED: &[[u8; 4]] = &[
-    ITIP20::logoURICall::SELECTOR,
-    ITIP20::setLogoURICall::SELECTOR,
-];
-
-/// Decoded call variant — either a TIP-20 token call or a role-management call.
-enum TIP20Call {
-    TIP20(ITIP20Calls),
-    RolesAuth(IRolesAuthCalls),
-}
-
-impl TIP20Call {
-    fn decode(calldata: &[u8]) -> Result<Self, alloy::sol_types::Error> {
-        // safe to expect as `dispatch_call` pre-validates calldata len
-        let selector: [u8; 4] = calldata[..4].try_into().expect("calldata len >= 4");
-
-        if IRolesAuthCalls::valid_selector(selector) {
-            IRolesAuthCalls::abi_decode(calldata).map(Self::RolesAuth)
-        } else {
-            ITIP20Calls::abi_decode(calldata).map(Self::TIP20)
-        }
-    }
-}
+use tempo_contracts::precompiles::{IRolesAuth, TIP20Error};
 
 impl Precompile for TIP20Token {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -61,177 +29,86 @@ impl Precompile for TIP20Token {
             return self.storage.error_result(TIP20Error::uninitialized());
         }
 
-        dispatch_call(
+        dispatch!(
             calldata,
-            &[
-                SelectorSchedule::new(TempoHardfork::T2).with_added(T2_ADDED),
-                SelectorSchedule::new(TempoHardfork::T5).with_added(T5_ADDED),
-            ],
-            TIP20Call::decode,
             |call| match call {
-                // Metadata functions (no calldata decoding needed)
-                TIP20Call::TIP20(ITIP20Calls::name(_)) => {
-                    metadata::<ITIP20::nameCall>(|| self.name())
-                }
-                TIP20Call::TIP20(ITIP20Calls::symbol(_)) => {
-                    metadata::<ITIP20::symbolCall>(|| self.symbol())
-                }
-                TIP20Call::TIP20(ITIP20Calls::decimals(_)) => {
-                    metadata::<ITIP20::decimalsCall>(|| self.decimals())
-                }
-                TIP20Call::TIP20(ITIP20Calls::currency(_)) => {
-                    metadata::<ITIP20::currencyCall>(|| self.currency())
-                }
-                TIP20Call::TIP20(ITIP20Calls::totalSupply(_)) => {
-                    metadata::<ITIP20::totalSupplyCall>(|| self.total_supply())
-                }
-                TIP20Call::TIP20(ITIP20Calls::supplyCap(_)) => {
-                    metadata::<ITIP20::supplyCapCall>(|| self.supply_cap())
-                }
-                TIP20Call::TIP20(ITIP20Calls::transferPolicyId(_)) => {
-                    metadata::<ITIP20::transferPolicyIdCall>(|| self.transfer_policy_id())
-                }
-                TIP20Call::TIP20(ITIP20Calls::paused(_)) => {
-                    metadata::<ITIP20::pausedCall>(|| self.paused())
-                }
-                TIP20Call::TIP20(ITIP20Calls::logoURI(_)) => {
-                    metadata::<ITIP20::logoURICall>(|| self.logo_uri())
-                }
+                ITIP20::ITIP20Calls {
+                    // Metadata functions (no calldata decoding needed)
+                    name(_) => metadata::<ITIP20::nameCall>(|| self.name()),
+                    symbol(_) => metadata::<ITIP20::symbolCall>(|| self.symbol()),
+                    decimals(_) => metadata::<ITIP20::decimalsCall>(|| self.decimals()),
+                    currency(_) => metadata::<ITIP20::currencyCall>(|| self.currency()),
+                    totalSupply(_) => metadata::<ITIP20::totalSupplyCall>(|| self.total_supply()),
+                    supplyCap(_) => metadata::<ITIP20::supplyCapCall>(|| self.supply_cap()),
+                    transferPolicyId(_) => metadata::<ITIP20::transferPolicyIdCall>(|| self.transfer_policy_id()),
+                    paused(_) => metadata::<ITIP20::pausedCall>(|| self.paused()),
+                    logoURI(_) => metadata::<ITIP20::logoURICall>(|| self.logo_uri()),
 
-                // View functions
-                TIP20Call::TIP20(ITIP20Calls::balanceOf(call)) => {
-                    view(call, |c| self.balance_of(c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::allowance(call)) => view(call, |c| self.allowance(c)),
-                TIP20Call::TIP20(ITIP20Calls::quoteToken(call)) => {
-                    view(call, |_| self.quote_token())
-                }
-                TIP20Call::TIP20(ITIP20Calls::nextQuoteToken(call)) => {
-                    view(call, |_| self.next_quote_token())
-                }
-                TIP20Call::TIP20(ITIP20Calls::PAUSE_ROLE(call)) => {
-                    view(call, |_| Ok(Self::pause_role()))
-                }
-                TIP20Call::TIP20(ITIP20Calls::UNPAUSE_ROLE(call)) => {
-                    view(call, |_| Ok(Self::unpause_role()))
-                }
-                TIP20Call::TIP20(ITIP20Calls::ISSUER_ROLE(call)) => {
-                    view(call, |_| Ok(Self::issuer_role()))
-                }
-                TIP20Call::TIP20(ITIP20Calls::BURN_BLOCKED_ROLE(call)) => {
-                    view(call, |_| Ok(Self::burn_blocked_role()))
-                }
+                    // View functions
+                    balanceOf(call) => view(call, |c| self.balance_of(c)),
+                    allowance(call) => view(call, |c| self.allowance(c)),
+                    quoteToken(call) => view(call, |_| self.quote_token()),
+                    nextQuoteToken(call) => view(call, |_| self.next_quote_token()),
+                    PAUSE_ROLE(call) => view(call, |_| Ok(Self::pause_role())),
+                    UNPAUSE_ROLE(call) => view(call, |_| Ok(Self::unpause_role())),
+                    ISSUER_ROLE(call) => view(call, |_| Ok(Self::issuer_role())),
+                    BURN_BLOCKED_ROLE(call) => view(call, |_| Ok(Self::burn_blocked_role())),
 
-                // State changing functions
-                TIP20Call::TIP20(ITIP20Calls::transferFrom(call)) => {
-                    mutate(call, msg_sender, |s, c| self.transfer_from(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::transfer(call)) => {
-                    mutate(call, msg_sender, |s, c| self.transfer(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::approve(call)) => {
-                    mutate(call, msg_sender, |s, c| self.approve(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::changeTransferPolicyId(call)) => {
-                    mutate_void(call, msg_sender, |s, c| {
+                    // State changing functions
+                    transferFrom(call) => mutate(call, msg_sender, |s, c| self.transfer_from(s, c)),
+                    transfer(call) => mutate(call, msg_sender, |s, c| self.transfer(s, c)),
+                    approve(call) => mutate(call, msg_sender, |s, c| self.approve(s, c)),
+                    changeTransferPolicyId(call) => mutate_void(call, msg_sender, |s, c| {
                         self.change_transfer_policy_id(s, c)
-                    })
-                }
-                TIP20Call::TIP20(ITIP20Calls::setSupplyCap(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.set_supply_cap(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::setLogoURI(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.set_logo_uri(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::pause(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.pause(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::unpause(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.unpause(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::setNextQuoteToken(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.set_next_quote_token(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::completeQuoteTokenUpdate(call)) => {
-                    mutate_void(call, msg_sender, |s, c| {
+                    }),
+                    setSupplyCap(call) => mutate_void(call, msg_sender, |s, c| self.set_supply_cap(s, c)),
+                    #[schedule(since = T5)]
+                    setLogoURI(call) => mutate_void(call, msg_sender, |s, c| self.set_logo_uri(s, c)),
+                    pause(call) => mutate_void(call, msg_sender, |s, c| self.pause(s, c)),
+                    unpause(call) => mutate_void(call, msg_sender, |s, c| self.unpause(s, c)),
+                    setNextQuoteToken(call) => mutate_void(call, msg_sender, |s, c| self.set_next_quote_token(s, c)),
+                    completeQuoteTokenUpdate(call) => mutate_void(call, msg_sender, |s, c| {
                         self.complete_quote_token_update(s, c)
-                    })
-                }
-                TIP20Call::TIP20(ITIP20Calls::mint(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.mint(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::mintWithMemo(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.mint_with_memo(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::burn(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.burn(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::burnWithMemo(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.burn_with_memo(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::burnBlocked(call)) => {
-                    mutate_void(call, msg_sender, |s, c| {
+                    }),
+                    mint(call) => mutate_void(call, msg_sender, |s, c| self.mint(s, c)),
+                    mintWithMemo(call) => mutate_void(call, msg_sender, |s, c| self.mint_with_memo(s, c)),
+                    burn(call) => mutate_void(call, msg_sender, |s, c| self.burn(s, c)),
+                    burnWithMemo(call) => mutate_void(call, msg_sender, |s, c| self.burn_with_memo(s, c)),
+                    burnBlocked(call) => mutate_void(call, msg_sender, |s, c| {
                         self.burn_blocked(s, c.from, c.amount, true)
-                    })
-                }
-                TIP20Call::TIP20(ITIP20Calls::transferWithMemo(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.transfer_with_memo(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::transferFromWithMemo(call)) => {
-                    mutate(call, msg_sender, |sender, c| {
+                    }),
+                    transferWithMemo(call) => mutate_void(call, msg_sender, |s, c| self.transfer_with_memo(s, c)),
+                    transferFromWithMemo(call) => mutate(call, msg_sender, |sender, c| {
                         self.transfer_from_with_memo(sender, c)
-                    })
-                }
-                TIP20Call::TIP20(ITIP20Calls::distributeReward(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.distribute_reward(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::setRewardRecipient(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.set_reward_recipient(s, c))
-                }
-                TIP20Call::TIP20(ITIP20Calls::claimRewards(call)) => {
-                    mutate(call, msg_sender, |_, _| self.claim_rewards(msg_sender))
-                }
-                TIP20Call::TIP20(ITIP20Calls::globalRewardPerToken(call)) => {
-                    view(call, |_| self.get_global_reward_per_token())
-                }
-                TIP20Call::TIP20(ITIP20Calls::optedInSupply(call)) => {
-                    view(call, |_| self.get_opted_in_supply())
-                }
-                TIP20Call::TIP20(ITIP20Calls::userRewardInfo(call)) => view(call, |c| {
-                    self.get_user_reward_info(c.account).map(|info| info.into())
-                }),
-                TIP20Call::TIP20(ITIP20Calls::getPendingRewards(call)) => {
-                    view(call, |c| self.get_pending_rewards(c.account))
+                    }),
+                    distributeReward(call) => mutate_void(call, msg_sender, |s, c| self.distribute_reward(s, c)),
+                    setRewardRecipient(call) => mutate_void(call, msg_sender, |s, c| self.set_reward_recipient(s, c)),
+                    claimRewards(call) => mutate(call, msg_sender, |_, _| self.claim_rewards(msg_sender)),
+                    globalRewardPerToken(call) => view(call, |_| self.get_global_reward_per_token()),
+                    optedInSupply(call) => view(call, |_| self.get_opted_in_supply()),
+                    userRewardInfo(call) => view(call, |c| {
+                        self.get_user_reward_info(c.account).map(|info| info.into())
+                    }),
+                    getPendingRewards(call) => view(call, |c| self.get_pending_rewards(c.account)),
+
+                    #[schedule(since = T2)]
+                    permit(call) => mutate_void(call, msg_sender, |_s, c| self.permit(c)),
+                    #[schedule(since = T2)]
+                    nonces(call) => view(call, |c| self.nonces(c)),
+                    #[schedule(since = T2)]
+                    DOMAIN_SEPARATOR(call) => view(call, |_| self.domain_separator())
                 }
 
-                TIP20Call::TIP20(ITIP20Calls::permit(call)) => {
-                    mutate_void(call, msg_sender, |_s, c| self.permit(c))
+                IRolesAuth::IRolesAuthCalls {
+                    // RolesAuth functions
+                    hasRole(call) => view(call, |c| self.has_role(c)),
+                    getRoleAdmin(call) => view(call, |c| self.get_role_admin(c)),
+                    grantRole(call) => mutate_void(call, msg_sender, |s, c| self.grant_role(s, c)),
+                    revokeRole(call) => mutate_void(call, msg_sender, |s, c| self.revoke_role(s, c)),
+                    renounceRole(call) => mutate_void(call, msg_sender, |s, c| self.renounce_role(s, c)),
+                    setRoleAdmin(call) => mutate_void(call, msg_sender, |s, c| self.set_role_admin(s, c))
                 }
-                TIP20Call::TIP20(ITIP20Calls::nonces(call)) => view(call, |c| self.nonces(c)),
-                TIP20Call::TIP20(ITIP20Calls::DOMAIN_SEPARATOR(call)) => {
-                    view(call, |_| self.domain_separator())
-                }
-
-                // RolesAuth functions
-                TIP20Call::RolesAuth(IRolesAuthCalls::hasRole(call)) => {
-                    view(call, |c| self.has_role(c))
-                }
-                TIP20Call::RolesAuth(IRolesAuthCalls::getRoleAdmin(call)) => {
-                    view(call, |c| self.get_role_admin(c))
-                }
-                TIP20Call::RolesAuth(IRolesAuthCalls::grantRole(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.grant_role(s, c))
-                }
-                TIP20Call::RolesAuth(IRolesAuthCalls::revokeRole(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.revoke_role(s, c))
-                }
-                TIP20Call::RolesAuth(IRolesAuthCalls::renounceRole(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.renounce_role(s, c))
-                }
-                TIP20Call::RolesAuth(IRolesAuthCalls::setRoleAdmin(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.set_role_admin(s, c))
-                }
-            },
+            }
         )
     }
 }
@@ -250,7 +127,6 @@ mod tests {
         sol_types::{SolCall, SolError, SolInterface, SolValue},
     };
 
-    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{
         IRolesAuth, RolesAuthError, TIP20Error, UnknownFunctionSelector,
     };

--- a/crates/precompiles/src/tip20_channel_reserve/dispatch.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/dispatch.rs
@@ -5,15 +5,9 @@ use crate::{
     Precompile, charge_input_cost, dispatch, metadata, mutate, mutate_void,
     preserve_storage_credits, view,
 };
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
+use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::{
-    ITIP20ChannelReserve, ITIP20ChannelReserve::ITIP20ChannelReserveCalls,
-};
-
+use tempo_contracts::precompiles::ITIP20ChannelReserve;
 impl Precompile for TIP20ChannelReserve {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
         if let Some(err) = charge_input_cost(&mut self.storage, calldata) {

--- a/crates/precompiles/src/tip20_channel_reserve/dispatch.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/dispatch.rs
@@ -5,7 +5,7 @@ use crate::{
     Precompile, charge_input_cost, dispatch, metadata, mutate, mutate_void,
     preserve_storage_credits, view,
 };
-use alloy::{primitives::Address, sol_types::SolCall};
+use alloy::primitives::Address;
 use revm::precompile::PrecompileResult;
 use tempo_contracts::precompiles::ITIP20ChannelReserve;
 impl Precompile for TIP20ChannelReserve {

--- a/crates/precompiles/src/tip20_channel_reserve/dispatch.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/dispatch.rs
@@ -2,7 +2,7 @@
 
 use super::{CLOSE_GRACE_PERIOD, TIP20ChannelReserve, VOUCHER_TYPEHASH};
 use crate::{
-    Precompile, SelectorSchedule, charge_input_cost, dispatch_call, metadata, mutate, mutate_void,
+    Precompile, charge_input_cost, dispatch, metadata, mutate, mutate_void,
     preserve_storage_credits, view,
 };
 use alloy::{
@@ -10,86 +10,57 @@ use alloy::{
     sol_types::{SolCall, SolInterface},
 };
 use revm::precompile::PrecompileResult;
-use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::{
     ITIP20ChannelReserve, ITIP20ChannelReserve::ITIP20ChannelReserveCalls,
 };
-
-const T7_ADDED: &[[u8; 4]] = &[ITIP20ChannelReserve::storageCreditsCall::SELECTOR];
 
 impl Precompile for TIP20ChannelReserve {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
         if let Some(err) = charge_input_cost(&mut self.storage, calldata) {
             return err;
         }
-
-        dispatch_call(
+        dispatch!(
             calldata,
-            &[SelectorSchedule::new(TempoHardfork::T7).with_added(T7_ADDED)],
-            ITIP20ChannelReserveCalls::abi_decode,
             |call| match call {
-                ITIP20ChannelReserveCalls::CLOSE_GRACE_PERIOD(_) => {
-                    metadata::<ITIP20ChannelReserve::CLOSE_GRACE_PERIODCall>(|| {
+                ITIP20ChannelReserve::ITIP20ChannelReserveCalls {
+                    CLOSE_GRACE_PERIOD(_) => metadata::<ITIP20ChannelReserve::CLOSE_GRACE_PERIODCall>(|| {
                         Ok(CLOSE_GRACE_PERIOD)
-                    })
-                }
-                ITIP20ChannelReserveCalls::VOUCHER_TYPEHASH(_) => {
-                    metadata::<ITIP20ChannelReserve::VOUCHER_TYPEHASHCall>(|| Ok(*VOUCHER_TYPEHASH))
-                }
-                ITIP20ChannelReserveCalls::open(call) => mutate(call, msg_sender, |sender, c| {
-                    preserve_storage_credits(self.address)?;
-                    self.open(sender, c)
-                }),
-                ITIP20ChannelReserveCalls::settle(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
+                    }),
+                    VOUCHER_TYPEHASH(_) => metadata::<ITIP20ChannelReserve::VOUCHER_TYPEHASHCall>(|| Ok(*VOUCHER_TYPEHASH)),
+                    open(call) => mutate(call, msg_sender, |sender, c| {
+                        preserve_storage_credits(self.address)?;
+                        self.open(sender, c)
+                    }),
+                    settle(call) => mutate_void(call, msg_sender, |sender, c| {
                         preserve_storage_credits(self.address)?;
                         self.settle(sender, c)
-                    })
-                }
-                ITIP20ChannelReserveCalls::topUp(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
+                    }),
+                    topUp(call) => mutate_void(call, msg_sender, |sender, c| {
                         preserve_storage_credits(self.address)?;
                         self.top_up(sender, c)
-                    })
-                }
-                ITIP20ChannelReserveCalls::close(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
+                    }),
+                    close(call) => mutate_void(call, msg_sender, |sender, c| {
                         preserve_storage_credits(self.address)?;
                         self.close(sender, c)
-                    })
-                }
-                ITIP20ChannelReserveCalls::requestClose(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
+                    }),
+                    requestClose(call) => mutate_void(call, msg_sender, |sender, c| {
                         preserve_storage_credits(self.address)?;
                         self.request_close(sender, c)
-                    })
-                }
-                ITIP20ChannelReserveCalls::withdraw(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
+                    }),
+                    withdraw(call) => mutate_void(call, msg_sender, |sender, c| {
                         preserve_storage_credits(self.address)?;
                         self.withdraw(sender, c)
-                    })
+                    }),
+                    getChannel(call) => view(call, |c| self.get_channel(c)),
+                    getChannelState(call) => view(call, |c| self.get_channel_state(c)),
+                    getChannelStatesBatch(call) => view(call, |c| self.get_channel_states_batch(c)),
+                    computeChannelId(call) => view(call, |c| self.compute_channel_id(c)),
+                    getVoucherDigest(call) => view(call, |c| self.get_voucher_digest(c)),
+                    domainSeparator(call) => view(call, |_| self.domain_separator()),
+                    #[schedule(since = T7)]
+                    storageCredits(call) => view(call, |c| self.storage_credits(c.payer))
                 }
-                ITIP20ChannelReserveCalls::getChannel(call) => view(call, |c| self.get_channel(c)),
-                ITIP20ChannelReserveCalls::getChannelState(call) => {
-                    view(call, |c| self.get_channel_state(c))
-                }
-                ITIP20ChannelReserveCalls::getChannelStatesBatch(call) => {
-                    view(call, |c| self.get_channel_states_batch(c))
-                }
-                ITIP20ChannelReserveCalls::computeChannelId(call) => {
-                    view(call, |c| self.compute_channel_id(c))
-                }
-                ITIP20ChannelReserveCalls::getVoucherDigest(call) => {
-                    view(call, |c| self.get_voucher_digest(c))
-                }
-                ITIP20ChannelReserveCalls::domainSeparator(call) => {
-                    view(call, |_| self.domain_separator())
-                }
-                ITIP20ChannelReserveCalls::storageCredits(call) => {
-                    view(call, |c| self.storage_credits(c.payer))
-                }
-            },
+            }
         )
     }
 }

--- a/crates/precompiles/src/tip20_channel_reserve/dispatch.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/dispatch.rs
@@ -13,6 +13,7 @@ impl Precompile for TIP20ChannelReserve {
         if let Some(err) = charge_input_cost(&mut self.storage, calldata) {
             return err;
         }
+
         dispatch!(
             calldata,
             |call| match call {

--- a/crates/precompiles/src/tip20_factory/dispatch.rs
+++ b/crates/precompiles/src/tip20_factory/dispatch.rs
@@ -1,7 +1,7 @@
 //! ABI dispatch for the [`TIP20Factory`] precompile.
 
 use crate::{Precompile, charge_input_cost, dispatch, mutate, tip20_factory::TIP20Factory, view};
-use alloy::{primitives::Address, sol_types::SolCall};
+use alloy::primitives::Address;
 use revm::precompile::PrecompileResult;
 use tempo_contracts::precompiles::ITIP20Factory;
 

--- a/crates/precompiles/src/tip20_factory/dispatch.rs
+++ b/crates/precompiles/src/tip20_factory/dispatch.rs
@@ -4,8 +4,6 @@ use crate::{Precompile, charge_input_cost, dispatch, mutate, tip20_factory::TIP2
 use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::PrecompileResult;
 use tempo_contracts::precompiles::ITIP20Factory;
-#[cfg(test)]
-use tempo_contracts::precompiles::createTokenWithLogoCall;
 
 impl Precompile for TIP20Factory {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -41,7 +39,7 @@ mod tests {
     };
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{
-        ITIP20Factory::ITIP20FactoryCalls, UnknownFunctionSelector,
+        ITIP20Factory::ITIP20FactoryCalls, UnknownFunctionSelector, createTokenWithLogoCall,
     };
 
     #[test]

--- a/crates/precompiles/src/tip20_factory/dispatch.rs
+++ b/crates/precompiles/src/tip20_factory/dispatch.rs
@@ -1,10 +1,7 @@
 //! ABI dispatch for the [`TIP20Factory`] precompile.
 
 use crate::{Precompile, charge_input_cost, dispatch, mutate, tip20_factory::TIP20Factory, view};
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
+use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::PrecompileResult;
 use tempo_contracts::precompiles::ITIP20Factory;
 #[cfg(test)]

--- a/crates/precompiles/src/tip20_factory/dispatch.rs
+++ b/crates/precompiles/src/tip20_factory/dispatch.rs
@@ -1,19 +1,14 @@
 //! ABI dispatch for the [`TIP20Factory`] precompile.
 
-use crate::{
-    Precompile, SelectorSchedule, charge_input_cost, dispatch_call, mutate,
-    tip20_factory::TIP20Factory, view,
-};
+use crate::{Precompile, charge_input_cost, dispatch, mutate, tip20_factory::TIP20Factory, view};
 use alloy::{
     primitives::Address,
     sol_types::{SolCall, SolInterface},
 };
 use revm::precompile::PrecompileResult;
-use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_contracts::precompiles::{ITIP20Factory::ITIP20FactoryCalls, createTokenWithLogoCall};
-
-/// Selectors added at T5: TIP-1026 Token Logo URI factory overload.
-const T5_ADDED: &[[u8; 4]] = &[createTokenWithLogoCall::SELECTOR];
+use tempo_contracts::precompiles::ITIP20Factory;
+#[cfg(test)]
+use tempo_contracts::precompiles::createTokenWithLogoCall;
 
 impl Precompile for TIP20Factory {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -21,20 +16,15 @@ impl Precompile for TIP20Factory {
             return err;
         }
 
-        dispatch_call(
+        dispatch!(
             calldata,
-            &[SelectorSchedule::new(TempoHardfork::T5).with_added(T5_ADDED)],
-            ITIP20FactoryCalls::abi_decode,
             |call| match call {
-                ITIP20FactoryCalls::createToken_0(call) => {
-                    mutate(call, msg_sender, |s, c| self.create_token(s, c))
-                }
-                ITIP20FactoryCalls::createToken_1(call) => {
-                    mutate(call, msg_sender, |s, c| self.create_token_with_logo(s, c))
-                }
-                ITIP20FactoryCalls::isTIP20(call) => view(call, |c| self.is_tip20(c.token)),
-                ITIP20FactoryCalls::getTokenAddress(call) => {
-                    view(call, |c| self.get_token_address(c))
+                ITIP20Factory::ITIP20FactoryCalls {
+                    createToken_0(call) => mutate(call, msg_sender, |s, c| self.create_token(s, c)),
+                    #[schedule(since = T5)]
+                    createToken_1(call) => mutate(call, msg_sender, |s, c| self.create_token_with_logo(s, c)),
+                    isTIP20(call) => view(call, |c| self.is_tip20(c.token)),
+                    getTokenAddress(call) => view(call, |c| self.get_token_address(c)),
                 }
             },
         )

--- a/crates/precompiles/src/tip403_registry/dispatch.rs
+++ b/crates/precompiles/src/tip403_registry/dispatch.rs
@@ -1,7 +1,7 @@
 //! ABI dispatch for the [`TIP403Registry`] precompile.
 
 use crate::{
-    Precompile, SelectorSchedule, charge_input_cost, dispatch_call, mutate, mutate_void,
+    Precompile, charge_input_cost, dispatch, mutate, mutate_void,
     tip403_registry::{AuthRole, TIP403Registry},
     view,
 };
@@ -10,22 +10,7 @@ use alloy::{
     sol_types::{SolCall, SolInterface},
 };
 use revm::precompile::PrecompileResult;
-use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::ITIP403Registry::{self, ITIP403RegistryCalls};
-
-const T2_ADDED: &[[u8; 4]] = &[
-    ITIP403Registry::isAuthorizedSenderCall::SELECTOR,
-    ITIP403Registry::isAuthorizedRecipientCall::SELECTOR,
-    ITIP403Registry::isAuthorizedMintRecipientCall::SELECTOR,
-    ITIP403Registry::compoundPolicyDataCall::SELECTOR,
-    ITIP403Registry::createCompoundPolicyCall::SELECTOR,
-];
-
-const T6_ADDED: &[[u8; 4]] = &[
-    ITIP403Registry::receivePolicyCall::SELECTOR,
-    ITIP403Registry::validateReceivePolicyCall::SELECTOR,
-    ITIP403Registry::setReceivePolicyCall::SELECTOR,
-];
 
 impl Precompile for TIP403Registry {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -33,72 +18,57 @@ impl Precompile for TIP403Registry {
             return err;
         }
 
-        dispatch_call(
+        dispatch!(
             calldata,
-            &[
-                SelectorSchedule::new(TempoHardfork::T2).with_added(T2_ADDED),
-                SelectorSchedule::new(TempoHardfork::T6).with_added(T6_ADDED),
-            ],
-            ITIP403RegistryCalls::abi_decode,
             |call| match call {
-                ITIP403RegistryCalls::policyIdCounter(call) => {
-                    view(call, |_| self.policy_id_counter())
-                }
-                ITIP403RegistryCalls::policyExists(call) => view(call, |c| self.policy_exists(c)),
-                ITIP403RegistryCalls::policyData(call) => view(call, |c| self.policy_data(c)),
-                ITIP403RegistryCalls::isAuthorized(call) => view(call, |c| {
-                    self.is_authorized_as(c.policyId, c.user, AuthRole::Transfer)
-                }),
-                // TIP-1015: T2+ only (gated via T2_ADDED_SELECTORS)
-                ITIP403RegistryCalls::isAuthorizedSender(call) => view(call, |c| {
-                    self.is_authorized_as(c.policyId, c.user, AuthRole::Sender)
-                }),
-                ITIP403RegistryCalls::isAuthorizedRecipient(call) => view(call, |c| {
-                    self.is_authorized_as(c.policyId, c.user, AuthRole::Recipient)
-                }),
-                ITIP403RegistryCalls::isAuthorizedMintRecipient(call) => view(call, |c| {
-                    self.is_authorized_as(c.policyId, c.user, AuthRole::MintRecipient)
-                }),
-                ITIP403RegistryCalls::compoundPolicyData(call) => {
-                    view(call, |c| self.compound_policy_data(c))
-                }
-                ITIP403RegistryCalls::receivePolicy(call) => {
-                    view(call, |c| self.receive_policy(c.account))
-                }
-                ITIP403RegistryCalls::validateReceivePolicy(call) => view(call, |c| {
-                    let blocked_reason = self
+                ITIP403Registry::ITIP403RegistryCalls {
+                    policyIdCounter(call) => view(call, |_| self.policy_id_counter()),
+                    policyExists(call) => view(call, |c| self.policy_exists(c)),
+                    policyData(call) => view(call, |c| self.policy_data(c)),
+                    isAuthorized(call) => view(call, |c| {
+                        self.is_authorized_as(c.policyId, c.user, AuthRole::Transfer)
+                    }),
+                    // TIP-1015: T2+ only (gated via T2_ADDED_SELECTORS)
+                    #[schedule(since = T2)]
+                    isAuthorizedSender(call) => view(call, |c| {
+                        self.is_authorized_as(c.policyId, c.user, AuthRole::Sender)
+                    }),
+                    #[schedule(since = T2)]
+                    isAuthorizedRecipient(call) => view(call, |c| {
+                        self.is_authorized_as(c.policyId, c.user, AuthRole::Recipient)
+                    }),
+                    #[schedule(since = T2)]
+                    isAuthorizedMintRecipient(call) => view(call, |c| {
+                        self.is_authorized_as(c.policyId, c.user, AuthRole::MintRecipient)
+                    }),
+                    #[schedule(since = T2)]
+                    compoundPolicyData(call) => view(call, |c| self.compound_policy_data(c)),
+                    #[schedule(since = T6)]
+                    receivePolicy(call) => view(call, |c| self.receive_policy(c.account)),
+                    #[schedule(since = T6)]
+                    validateReceivePolicy(call) => view(call, |c| {
+                        let blocked_reason = self
                         .validate_receive_policy(c.token, c.sender, c.receiver)?
                         .unwrap_or(ITIP403Registry::BlockedReason::NONE);
-                    Ok(ITIP403Registry::validateReceivePolicyReturn {
+                        Ok(ITIP403Registry::validateReceivePolicyReturn {
                         authorized: blocked_reason == ITIP403Registry::BlockedReason::NONE,
                         blockedReason: blocked_reason,
-                    })
-                }),
-                ITIP403RegistryCalls::setReceivePolicy(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.set_receive_policy(s, c))
-                }
-                ITIP403RegistryCalls::createPolicy(call) => {
-                    mutate(call, msg_sender, |s, c| self.create_policy(s, c))
-                }
-                ITIP403RegistryCalls::createPolicyWithAccounts(call) => {
-                    mutate(call, msg_sender, |s, c| {
+                        })
+                    }),
+                    #[schedule(since = T6)]
+                    setReceivePolicy(call) => mutate_void(call, msg_sender, |s, c| self.set_receive_policy(s, c)),
+                    createPolicy(call) => mutate(call, msg_sender, |s, c| self.create_policy(s, c)),
+                    createPolicyWithAccounts(call) => mutate(call, msg_sender, |s, c| {
                         self.create_policy_with_accounts(s, c)
-                    })
+                    }),
+                    setPolicyAdmin(call) => mutate_void(call, msg_sender, |s, c| self.set_policy_admin(s, c)),
+                    modifyPolicyWhitelist(call) => mutate_void(call, msg_sender, |s, c| self.modify_policy_whitelist(s, c)),
+                    modifyPolicyBlacklist(call) => mutate_void(call, msg_sender, |s, c| self.modify_policy_blacklist(s, c)),
+                    // TIP-1015: T2+ only (gated via T2_ADDED_SELECTORS)
+                    #[schedule(since = T2)]
+                    createCompoundPolicy(call) => mutate(call, msg_sender, |s, c| self.create_compound_policy(s, c))
                 }
-                ITIP403RegistryCalls::setPolicyAdmin(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.set_policy_admin(s, c))
-                }
-                ITIP403RegistryCalls::modifyPolicyWhitelist(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.modify_policy_whitelist(s, c))
-                }
-                ITIP403RegistryCalls::modifyPolicyBlacklist(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.modify_policy_blacklist(s, c))
-                }
-                // TIP-1015: T2+ only (gated via T2_ADDED_SELECTORS)
-                ITIP403RegistryCalls::createCompoundPolicy(call) => {
-                    mutate(call, msg_sender, |s, c| self.create_compound_policy(s, c))
-                }
-            },
+            }
         )
     }
 }
@@ -112,7 +82,6 @@ mod tests {
         tip403_registry::ITIP403Registry,
     };
     use alloy::sol_types::{SolCall, SolError, SolValue};
-    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{
         ITIP403Registry::ITIP403RegistryCalls, UnknownFunctionSelector,
     };
@@ -567,9 +536,9 @@ mod tests {
 
             let unsupported = check_selector_coverage(
                 &mut registry,
-                ITIP403RegistryCalls::SELECTORS,
+                SELECTORS,
                 "ITIP403Registry",
-                ITIP403RegistryCalls::name_by_selector,
+                name_by_selector,
             );
 
             assert_full_coverage([unsupported]);

--- a/crates/precompiles/src/tip403_registry/dispatch.rs
+++ b/crates/precompiles/src/tip403_registry/dispatch.rs
@@ -45,11 +45,11 @@ impl Precompile for TIP403Registry {
                     #[schedule(since = T6)]
                     validateReceivePolicy(call) => view(call, |c| {
                         let blocked_reason = self
-                        .validate_receive_policy(c.token, c.sender, c.receiver)?
-                        .unwrap_or(ITIP403Registry::BlockedReason::NONE);
+                            .validate_receive_policy(c.token, c.sender, c.receiver)?
+                            .unwrap_or(ITIP403Registry::BlockedReason::NONE);
                         Ok(ITIP403Registry::validateReceivePolicyReturn {
-                        authorized: blocked_reason == ITIP403Registry::BlockedReason::NONE,
-                        blockedReason: blocked_reason,
+                            authorized: blocked_reason == ITIP403Registry::BlockedReason::NONE,
+                            blockedReason: blocked_reason,
                         })
                     }),
                     #[schedule(since = T6)]

--- a/crates/precompiles/src/tip403_registry/dispatch.rs
+++ b/crates/precompiles/src/tip403_registry/dispatch.rs
@@ -25,7 +25,6 @@ impl Precompile for TIP403Registry {
                     isAuthorized(call) => view(call, |c| {
                         self.is_authorized_as(c.policyId, c.user, AuthRole::Transfer)
                     }),
-                    // TIP-1015: T2+ only (gated via T2_ADDED_SELECTORS)
                     #[schedule(since = T2)]
                     isAuthorizedSender(call) => view(call, |c| {
                         self.is_authorized_as(c.policyId, c.user, AuthRole::Sender)
@@ -61,7 +60,6 @@ impl Precompile for TIP403Registry {
                     setPolicyAdmin(call) => mutate_void(call, msg_sender, |s, c| self.set_policy_admin(s, c)),
                     modifyPolicyWhitelist(call) => mutate_void(call, msg_sender, |s, c| self.modify_policy_whitelist(s, c)),
                     modifyPolicyBlacklist(call) => mutate_void(call, msg_sender, |s, c| self.modify_policy_blacklist(s, c)),
-                    // TIP-1015: T2+ only (gated via T2_ADDED_SELECTORS)
                     #[schedule(since = T2)]
                     createCompoundPolicy(call) => mutate(call, msg_sender, |s, c| self.create_compound_policy(s, c))
                 }

--- a/crates/precompiles/src/tip403_registry/dispatch.rs
+++ b/crates/precompiles/src/tip403_registry/dispatch.rs
@@ -5,12 +5,9 @@ use crate::{
     tip403_registry::{AuthRole, TIP403Registry},
     view,
 };
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
+use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::ITIP403Registry::{self, ITIP403RegistryCalls};
+use tempo_contracts::precompiles::ITIP403Registry;
 
 impl Precompile for TIP403Registry {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -82,6 +79,7 @@ mod tests {
         tip403_registry::ITIP403Registry,
     };
     use alloy::sol_types::{SolCall, SolError, SolValue};
+    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{
         ITIP403Registry::ITIP403RegistryCalls, UnknownFunctionSelector,
     };
@@ -536,9 +534,9 @@ mod tests {
 
             let unsupported = check_selector_coverage(
                 &mut registry,
-                SELECTORS,
+                ITIP403RegistryCalls::SELECTORS,
                 "ITIP403Registry",
-                name_by_selector,
+                ITIP403RegistryCalls::name_by_selector,
             );
 
             assert_full_coverage([unsupported]);

--- a/crates/precompiles/src/tip403_registry/dispatch.rs
+++ b/crates/precompiles/src/tip403_registry/dispatch.rs
@@ -5,7 +5,7 @@ use crate::{
     tip403_registry::{AuthRole, TIP403Registry},
     view,
 };
-use alloy::{primitives::Address, sol_types::SolCall};
+use alloy::primitives::Address;
 use revm::precompile::PrecompileResult;
 use tempo_contracts::precompiles::ITIP403Registry;
 

--- a/crates/precompiles/src/tip_fee_manager/dispatch.rs
+++ b/crates/precompiles/src/tip_fee_manager/dispatch.rs
@@ -54,20 +54,14 @@ impl Precompile for TipFeeManager {
 
                     // ITIPFeeAMM mutate functions
                     mint(call) => mutate(call, msg_sender, |s, c| {
-                        self.mint(
-                        s,
-                        c.userToken,
-                        c.validatorToken,
-                        c.amountValidatorToken,
-                        c.to,
-                        )
+                        self.mint(s, c.userToken, c.validatorToken, c.amountValidatorToken, c.to)
                     }),
                     burn(call) => mutate(call, msg_sender, |s, c| {
                         let (amount_user_token, amount_validator_token) =
-                        self.burn(s, c.userToken, c.validatorToken, c.liquidity, c.to)?;
+                            self.burn(s, c.userToken, c.validatorToken, c.liquidity, c.to)?;
                         Ok(ITIPFeeAMM::burnReturn {
-                        amountUserToken: amount_user_token,
-                        amountValidatorToken: amount_validator_token,
+                            amountUserToken: amount_user_token,
+                            amountValidatorToken: amount_validator_token,
                         })
                     }),
                     rebalanceSwap(call) => mutate(call, msg_sender, |s, c| {

--- a/crates/precompiles/src/tip_fee_manager/dispatch.rs
+++ b/crates/precompiles/src/tip_fee_manager/dispatch.rs
@@ -1,7 +1,7 @@
 //! ABI dispatch for the [`TipFeeManager`] precompile.
 
 use crate::{
-    Precompile, charge_input_cost, dispatch_call, metadata, mutate, mutate_void,
+    Precompile, charge_input_cost, dispatch, metadata, mutate, mutate_void,
     storage::Handler,
     tip_fee_manager::{
         ITIPFeeAMM, TipFeeManager,
@@ -9,28 +9,11 @@ use crate::{
     },
     view,
 };
-use alloy::{primitives::Address, sol_types::SolInterface};
+use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::{IFeeManager::IFeeManagerCalls, ITIPFeeAMM::ITIPFeeAMMCalls};
-
-/// Unified calldata discriminant for both `IFeeManager` and `ITIPFeeAMM` selectors.
-enum TipFeeManagerCall {
-    FeeManager(IFeeManagerCalls),
-    Amm(ITIPFeeAMMCalls),
-}
-
-impl TipFeeManagerCall {
-    fn decode(calldata: &[u8]) -> Result<Self, alloy::sol_types::Error> {
-        // safe to expect as `dispatch_call` pre-validates calldata len
-        let selector: [u8; 4] = calldata[..4].try_into().expect("calldata len >= 4");
-
-        if IFeeManagerCalls::valid_selector(selector) {
-            IFeeManagerCalls::abi_decode(calldata).map(Self::FeeManager)
-        } else {
-            ITIPFeeAMMCalls::abi_decode(calldata).map(Self::Amm)
-        }
-    }
-}
+use tempo_contracts::precompiles::{
+    IFeeManager, IFeeManager::IFeeManagerCalls, ITIPFeeAMM::ITIPFeeAMMCalls,
+};
 
 impl Precompile for TipFeeManager {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -38,97 +21,63 @@ impl Precompile for TipFeeManager {
             return err;
         }
 
-        dispatch_call(
+        dispatch!(
             calldata,
-            &[],
-            TipFeeManagerCall::decode,
             |call| match call {
-                // IFeeManager view functions
-                TipFeeManagerCall::FeeManager(IFeeManagerCalls::userTokens(call)) => {
-                    view(call, |c| self.user_tokens(c))
-                }
-                TipFeeManagerCall::FeeManager(IFeeManagerCalls::validatorTokens(call)) => {
-                    view(call, |c| self.get_validator_token(c.validator))
-                }
-                TipFeeManagerCall::FeeManager(IFeeManagerCalls::collectedFees(call)) => {
-                    view(call, |c| self.collected_fees[c.validator][c.token].read())
-                }
+                IFeeManager::IFeeManagerCalls {
+                    // IFeeManager view functions
+                    userTokens(call) => view(call, |c| self.user_tokens(c)),
+                    validatorTokens(call) => view(call, |c| self.get_validator_token(c.validator)),
+                    collectedFees(call) => view(call, |c| self.collected_fees[c.validator][c.token].read()),
 
-                // IFeeManager mutate functions
-                TipFeeManagerCall::FeeManager(IFeeManagerCalls::setValidatorToken(call)) => {
-                    mutate_void(call, msg_sender, |s, c| {
+                    // IFeeManager mutate functions
+                    setValidatorToken(call) => mutate_void(call, msg_sender, |s, c| {
                         let beneficiary = self.storage.beneficiary();
                         self.set_validator_token(s, c, beneficiary)
-                    })
-                }
-                TipFeeManagerCall::FeeManager(IFeeManagerCalls::setUserToken(call)) => {
-                    mutate_void(call, msg_sender, |s, c| self.set_user_token(s, c))
-                }
-                TipFeeManagerCall::FeeManager(IFeeManagerCalls::distributeFees(call)) => {
-                    mutate_void(call, msg_sender, |_, c| {
+                    }),
+                    setUserToken(call) => mutate_void(call, msg_sender, |s, c| self.set_user_token(s, c)),
+                    distributeFees(call) => mutate_void(call, msg_sender, |_, c| {
                         self.distribute_fees(c.validator, c.token)
                     })
-                }
 
-                // ITIPFeeAMM metadata functions
-                TipFeeManagerCall::Amm(ITIPFeeAMMCalls::M(_)) => {
-                    metadata::<ITIPFeeAMM::MCall>(|| Ok(M))
                 }
-                TipFeeManagerCall::Amm(ITIPFeeAMMCalls::N(_)) => {
-                    metadata::<ITIPFeeAMM::NCall>(|| Ok(N))
-                }
-                TipFeeManagerCall::Amm(ITIPFeeAMMCalls::SCALE(_)) => {
-                    metadata::<ITIPFeeAMM::SCALECall>(|| Ok(SCALE))
-                }
-                TipFeeManagerCall::Amm(ITIPFeeAMMCalls::MIN_LIQUIDITY(_)) => {
-                    metadata::<ITIPFeeAMM::MIN_LIQUIDITYCall>(|| Ok(MIN_LIQUIDITY))
-                }
+                ITIPFeeAMM::ITIPFeeAMMCalls {
+                    // ITIPFeeAMM metadata functions
+                    M(_) => metadata::<ITIPFeeAMM::MCall>(|| Ok(M)),
+                    N(_) => metadata::<ITIPFeeAMM::NCall>(|| Ok(N)),
+                    SCALE(_) => metadata::<ITIPFeeAMM::SCALECall>(|| Ok(SCALE)),
+                    MIN_LIQUIDITY(_) => metadata::<ITIPFeeAMM::MIN_LIQUIDITYCall>(|| Ok(MIN_LIQUIDITY)),
 
-                // ITIPFeeAMM view functions
-                TipFeeManagerCall::Amm(ITIPFeeAMMCalls::getPoolId(call)) => {
-                    view(call, |c| Ok(self.pool_id(c.userToken, c.validatorToken)))
-                }
-                TipFeeManagerCall::Amm(ITIPFeeAMMCalls::getPool(call)) => {
-                    view(call, |c| Ok(self.get_pool(c)?.into()))
-                }
-                TipFeeManagerCall::Amm(ITIPFeeAMMCalls::pools(call)) => {
-                    view(call, |c| Ok(self.pools[c.poolId].read()?.into()))
-                }
-                TipFeeManagerCall::Amm(ITIPFeeAMMCalls::totalSupply(call)) => {
-                    view(call, |c| self.total_supply[c.poolId].read())
-                }
-                TipFeeManagerCall::Amm(ITIPFeeAMMCalls::liquidityBalances(call)) => {
-                    view(call, |c| self.liquidity_balances[c.poolId][c.user].read())
-                }
+                    // ITIPFeeAMM view functions
+                    getPoolId(call) => view(call, |c| Ok(self.pool_id(c.userToken, c.validatorToken))),
+                    getPool(call) => view(call, |c| Ok(self.get_pool(c)?.into())),
+                    pools(call) => view(call, |c| Ok(self.pools[c.poolId].read()?.into())),
+                    totalSupply(call) => view(call, |c| self.total_supply[c.poolId].read()),
+                    liquidityBalances(call) => view(call, |c| self.liquidity_balances[c.poolId][c.user].read()),
 
-                // ITIPFeeAMM mutate functions
-                TipFeeManagerCall::Amm(ITIPFeeAMMCalls::mint(call)) => {
-                    mutate(call, msg_sender, |s, c| {
+                    // ITIPFeeAMM mutate functions
+                    mint(call) => mutate(call, msg_sender, |s, c| {
                         self.mint(
-                            s,
-                            c.userToken,
-                            c.validatorToken,
-                            c.amountValidatorToken,
-                            c.to,
+                        s,
+                        c.userToken,
+                        c.validatorToken,
+                        c.amountValidatorToken,
+                        c.to,
                         )
-                    })
-                }
-                TipFeeManagerCall::Amm(ITIPFeeAMMCalls::burn(call)) => {
-                    mutate(call, msg_sender, |s, c| {
+                    }),
+                    burn(call) => mutate(call, msg_sender, |s, c| {
                         let (amount_user_token, amount_validator_token) =
-                            self.burn(s, c.userToken, c.validatorToken, c.liquidity, c.to)?;
+                        self.burn(s, c.userToken, c.validatorToken, c.liquidity, c.to)?;
                         Ok(ITIPFeeAMM::burnReturn {
-                            amountUserToken: amount_user_token,
-                            amountValidatorToken: amount_validator_token,
+                        amountUserToken: amount_user_token,
+                        amountValidatorToken: amount_validator_token,
                         })
-                    })
-                }
-                TipFeeManagerCall::Amm(ITIPFeeAMMCalls::rebalanceSwap(call)) => {
-                    mutate(call, msg_sender, |s, c| {
+                    }),
+                    rebalanceSwap(call) => mutate(call, msg_sender, |s, c| {
                         self.rebalance_swap(s, c.userToken, c.validatorToken, c.amountOut, c.to)
                     })
                 }
-            },
+            }
         )
     }
 }

--- a/crates/precompiles/src/tip_fee_manager/dispatch.rs
+++ b/crates/precompiles/src/tip_fee_manager/dispatch.rs
@@ -9,12 +9,9 @@ use crate::{
     },
     view,
 };
-use alloy::{primitives::Address, sol_types::SolCall};
+use alloy::primitives::Address;
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::{
-    IFeeManager, IFeeManager::IFeeManagerCalls, ITIPFeeAMM::ITIPFeeAMMCalls,
-};
-
+use tempo_contracts::precompiles::IFeeManager;
 impl Precompile for TipFeeManager {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
         if let Some(err) = charge_input_cost(&mut self.storage, calldata) {

--- a/crates/precompiles/src/validator_config/dispatch.rs
+++ b/crates/precompiles/src/validator_config/dispatch.rs
@@ -22,8 +22,8 @@ impl Precompile for ValidatorConfig {
                     getValidators(call) => view(call, |_| self.get_validators()),
                     getNextFullDkgCeremony(call) => view(call, |_| self.get_next_full_dkg_ceremony()),
                     validatorsArray(call) => view(call, |c| {
-                        let index =
-                        u64::try_from(c.index).map_err(|_| TempoPrecompileError::array_oob())?;
+                        let index = u64::try_from(c.index)
+                            .map_err(|_| TempoPrecompileError::array_oob())?;
                         self.validators_array(index)
                     }),
                     validators(call) => view(call, |c| self.validators(c.validator)),

--- a/crates/precompiles/src/validator_config/dispatch.rs
+++ b/crates/precompiles/src/validator_config/dispatch.rs
@@ -4,7 +4,7 @@ use super::ValidatorConfig;
 use crate::{
     Precompile, charge_input_cost, dispatch, error::TempoPrecompileError, mutate_void, view,
 };
-use alloy::{primitives::Address, sol_types::SolCall};
+use alloy::primitives::Address;
 use revm::precompile::PrecompileResult;
 use tempo_contracts::precompiles::IValidatorConfig;
 

--- a/crates/precompiles/src/validator_config/dispatch.rs
+++ b/crates/precompiles/src/validator_config/dispatch.rs
@@ -2,72 +2,50 @@
 
 use super::ValidatorConfig;
 use crate::{
-    Precompile, SelectorSchedule, charge_input_cost, dispatch_call, error::TempoPrecompileError,
-    mutate_void, view,
+    Precompile, charge_input_cost, dispatch, error::TempoPrecompileError, mutate_void, view,
 };
 use alloy::{
     primitives::Address,
     sol_types::{SolCall, SolInterface},
 };
 use revm::precompile::PrecompileResult;
-use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::IValidatorConfig::{self, IValidatorConfigCalls};
-
-const T1_ADDED: &[[u8; 4]] = &[IValidatorConfig::changeValidatorStatusByIndexCall::SELECTOR];
 
 impl Precompile for ValidatorConfig {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
         if let Some(err) = charge_input_cost(&mut self.storage, calldata) {
             return err;
         }
-
-        dispatch_call(
+        dispatch!(
             calldata,
-            &[SelectorSchedule::new(TempoHardfork::T1).with_added(T1_ADDED)],
-            IValidatorConfigCalls::abi_decode,
             |call| match call {
-                // View functions
-                IValidatorConfigCalls::owner(call) => view(call, |_| self.owner()),
-                IValidatorConfigCalls::getValidators(call) => view(call, |_| self.get_validators()),
-                IValidatorConfigCalls::getNextFullDkgCeremony(call) => {
-                    view(call, |_| self.get_next_full_dkg_ceremony())
-                }
-                IValidatorConfigCalls::validatorsArray(call) => view(call, |c| {
-                    let index =
+                IValidatorConfig::IValidatorConfigCalls {
+                    // View functions
+                    owner(call) => view(call, |_| self.owner()),
+                    getValidators(call) => view(call, |_| self.get_validators()),
+                    getNextFullDkgCeremony(call) => view(call, |_| self.get_next_full_dkg_ceremony()),
+                    validatorsArray(call) => view(call, |c| {
+                        let index =
                         u64::try_from(c.index).map_err(|_| TempoPrecompileError::array_oob())?;
-                    self.validators_array(index)
-                }),
-                IValidatorConfigCalls::validators(call) => {
-                    view(call, |c| self.validators(c.validator))
-                }
-                IValidatorConfigCalls::validatorCount(call) => {
-                    view(call, |_| self.validator_count())
-                }
+                        self.validators_array(index)
+                    }),
+                    validators(call) => view(call, |c| self.validators(c.validator)),
+                    validatorCount(call) => view(call, |_| self.validator_count()),
 
-                // Mutate functions
-                IValidatorConfigCalls::addValidator(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.add_validator(s, c))
-                }
-                IValidatorConfigCalls::updateValidator(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.update_validator(s, c))
-                }
-                IValidatorConfigCalls::changeValidatorStatus(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.change_validator_status(s, c))
-                }
-                IValidatorConfigCalls::changeValidatorStatusByIndex(call) => {
-                    mutate_void(call, msg_sender, |s, c| {
+                    // Mutate functions
+                    addValidator(call) => mutate_void(call, msg_sender, |s, c| self.add_validator(s, c)),
+                    updateValidator(call) => mutate_void(call, msg_sender, |s, c| self.update_validator(s, c)),
+                    changeValidatorStatus(call) => mutate_void(call, msg_sender, |s, c| self.change_validator_status(s, c)),
+                    #[schedule(since = T1)]
+                    changeValidatorStatusByIndex(call) => mutate_void(call, msg_sender, |s, c| {
                         self.change_validator_status_by_index(s, c)
-                    })
-                }
-                IValidatorConfigCalls::changeOwner(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.change_owner(s, c))
-                }
-                IValidatorConfigCalls::setNextFullDkgCeremony(call) => {
-                    mutate_void(call, msg_sender, |s, c| {
+                    }),
+                    changeOwner(call) => mutate_void(call, msg_sender, |s, c| self.change_owner(s, c)),
+                    setNextFullDkgCeremony(call) => mutate_void(call, msg_sender, |s, c| {
                         self.set_next_full_dkg_ceremony(s, c)
                     })
                 }
-            },
+            }
         )
     }
 }
@@ -85,7 +63,6 @@ mod tests {
         sol_types::{SolCall, SolValue},
     };
 
-    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{
         IValidatorConfig, IValidatorConfig::IValidatorConfigCalls, ValidatorConfigError,
     };
@@ -230,9 +207,9 @@ mod tests {
 
             let unsupported = check_selector_coverage(
                 &mut validator_config,
-                IValidatorConfigCalls::SELECTORS,
+                SELECTORS,
                 "IValidatorConfig",
-                IValidatorConfigCalls::name_by_selector,
+                name_by_selector,
             );
 
             assert_full_coverage([unsupported]);

--- a/crates/precompiles/src/validator_config/dispatch.rs
+++ b/crates/precompiles/src/validator_config/dispatch.rs
@@ -60,9 +60,10 @@ mod tests {
         sol_types::{SolCall, SolValue},
     };
     use tempo_chainspec::hardfork::TempoHardfork;
-    use tempo_contracts::precompiles::IValidatorConfig::IValidatorConfigCalls;
-
-    use tempo_contracts::precompiles::{IValidatorConfig, ValidatorConfigError};
+    use tempo_contracts::precompiles::{
+        IValidatorConfig::{self, IValidatorConfigCalls},
+        ValidatorConfigError,
+    };
 
     #[test]
     fn test_function_selector_dispatch() -> eyre::Result<()> {

--- a/crates/precompiles/src/validator_config/dispatch.rs
+++ b/crates/precompiles/src/validator_config/dispatch.rs
@@ -4,12 +4,9 @@ use super::ValidatorConfig;
 use crate::{
     Precompile, charge_input_cost, dispatch, error::TempoPrecompileError, mutate_void, view,
 };
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
+use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::IValidatorConfig::{self, IValidatorConfigCalls};
+use tempo_contracts::precompiles::IValidatorConfig;
 
 impl Precompile for ValidatorConfig {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -62,10 +59,10 @@ mod tests {
         primitives::{Address, FixedBytes},
         sol_types::{SolCall, SolValue},
     };
+    use tempo_chainspec::hardfork::TempoHardfork;
+    use tempo_contracts::precompiles::IValidatorConfig::IValidatorConfigCalls;
 
-    use tempo_contracts::precompiles::{
-        IValidatorConfig, IValidatorConfig::IValidatorConfigCalls, ValidatorConfigError,
-    };
+    use tempo_contracts::precompiles::{IValidatorConfig, ValidatorConfigError};
 
     #[test]
     fn test_function_selector_dispatch() -> eyre::Result<()> {
@@ -207,9 +204,9 @@ mod tests {
 
             let unsupported = check_selector_coverage(
                 &mut validator_config,
-                SELECTORS,
+                IValidatorConfigCalls::SELECTORS,
                 "IValidatorConfig",
-                name_by_selector,
+                IValidatorConfigCalls::name_by_selector,
             );
 
             assert_full_coverage([unsupported]);

--- a/crates/precompiles/src/validator_config_v2/dispatch.rs
+++ b/crates/precompiles/src/validator_config_v2/dispatch.rs
@@ -2,9 +2,9 @@
 
 use super::*;
 use crate::{Precompile, charge_input_cost, dispatch, mutate, mutate_void, view};
-use alloy::{primitives::Address, sol_types::SolInterface};
+use alloy::primitives::Address;
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::IValidatorConfigV2::{self, IValidatorConfigV2Calls};
+use tempo_contracts::precompiles::IValidatorConfigV2;
 
 impl Precompile for ValidatorConfigV2 {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -253,8 +253,12 @@ mod tests {
         StorageCtx::enter(&mut storage, || {
             let mut vc = ValidatorConfigV2::new();
 
-            let unsupported =
-                check_selector_coverage(&mut vc, SELECTORS, "IValidatorConfigV2", name_by_selector);
+            let unsupported = check_selector_coverage(
+                &mut vc,
+                IValidatorConfigV2Calls::SELECTORS,
+                "IValidatorConfigV2",
+                IValidatorConfigV2Calls::name_by_selector,
+            );
 
             assert_full_coverage([unsupported]);
 

--- a/crates/precompiles/src/validator_config_v2/dispatch.rs
+++ b/crates/precompiles/src/validator_config_v2/dispatch.rs
@@ -1,10 +1,10 @@
 //! ABI dispatch for the [`ValidatorConfigV2`] precompile (T2+).
 
 use super::*;
-use crate::{Precompile, charge_input_cost, dispatch_call, mutate, mutate_void, view};
+use crate::{Precompile, charge_input_cost, dispatch, mutate, mutate_void, view};
 use alloy::{primitives::Address, sol_types::SolInterface};
 use revm::precompile::PrecompileResult;
-use tempo_contracts::precompiles::IValidatorConfigV2::IValidatorConfigV2Calls;
+use tempo_contracts::precompiles::IValidatorConfigV2::{self, IValidatorConfigV2Calls};
 
 impl Precompile for ValidatorConfigV2 {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -17,72 +17,36 @@ impl Precompile for ValidatorConfigV2 {
             return Ok(self.storage.success_output(Default::default()));
         }
 
-        dispatch_call(
+        dispatch!(
             calldata,
-            &[],
-            IValidatorConfigV2Calls::abi_decode,
             |call| match call {
-                IValidatorConfigV2Calls::owner(call) => view(call, |_| self.owner()),
-                IValidatorConfigV2Calls::getActiveValidators(call) => {
-                    view(call, |_| self.get_active_validators())
-                }
-                IValidatorConfigV2Calls::getInitializedAtHeight(call) => {
-                    view(call, |_| self.get_initialized_at_height())
-                }
-                IValidatorConfigV2Calls::validatorCount(call) => {
-                    view(call, |_| self.validator_count())
-                }
-                IValidatorConfigV2Calls::validatorByIndex(call) => {
-                    view(call, |c| self.validator_by_index(c.index))
-                }
-                IValidatorConfigV2Calls::validatorByAddress(call) => {
-                    view(call, |c| self.validator_by_address(c.validatorAddress))
-                }
-                IValidatorConfigV2Calls::validatorByPublicKey(call) => {
-                    view(call, |c| self.validator_by_public_key(c.publicKey))
-                }
-                IValidatorConfigV2Calls::getNextNetworkIdentityRotationEpoch(call) => {
-                    view(call, |_| self.get_next_network_identity_rotation_epoch())
-                }
-                IValidatorConfigV2Calls::isInitialized(call) => {
-                    view(call, |_| self.is_initialized())
-                }
+                IValidatorConfigV2::IValidatorConfigV2Calls {
+                    owner(call) => view(call, |_| self.owner()),
+                    getActiveValidators(call) => view(call, |_| self.get_active_validators()),
+                    getInitializedAtHeight(call) => view(call, |_| self.get_initialized_at_height()),
+                    validatorCount(call) => view(call, |_| self.validator_count()),
+                    validatorByIndex(call) => view(call, |c| self.validator_by_index(c.index)),
+                    validatorByAddress(call) => view(call, |c| self.validator_by_address(c.validatorAddress)),
+                    validatorByPublicKey(call) => view(call, |c| self.validator_by_public_key(c.publicKey)),
+                    getNextNetworkIdentityRotationEpoch(call) => view(call, |_| self.get_next_network_identity_rotation_epoch()),
+                    isInitialized(call) => view(call, |_| self.is_initialized()),
 
-                IValidatorConfigV2Calls::addValidator(call) => {
-                    mutate(call, msg_sender, |s, c| self.add_validator(s, c))
-                }
-                IValidatorConfigV2Calls::deactivateValidator(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.deactivate_validator(s, c))
-                }
-                IValidatorConfigV2Calls::rotateValidator(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.rotate_validator(s, c))
-                }
-                IValidatorConfigV2Calls::setFeeRecipient(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.set_fee_recipient(s, c))
-                }
-                IValidatorConfigV2Calls::setIpAddresses(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.set_ip_addresses(s, c))
-                }
-                IValidatorConfigV2Calls::transferValidatorOwnership(call) => {
-                    mutate_void(call, msg_sender, |s, c| {
+                    addValidator(call) => mutate(call, msg_sender, |s, c| self.add_validator(s, c)),
+                    deactivateValidator(call) => mutate_void(call, msg_sender, |s, c| self.deactivate_validator(s, c)),
+                    rotateValidator(call) => mutate_void(call, msg_sender, |s, c| self.rotate_validator(s, c)),
+                    setFeeRecipient(call) => mutate_void(call, msg_sender, |s, c| self.set_fee_recipient(s, c)),
+                    setIpAddresses(call) => mutate_void(call, msg_sender, |s, c| self.set_ip_addresses(s, c)),
+                    transferValidatorOwnership(call) => mutate_void(call, msg_sender, |s, c| {
                         self.transfer_validator_ownership(s, c)
-                    })
-                }
-                IValidatorConfigV2Calls::transferOwnership(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.transfer_ownership(s, c))
-                }
-                IValidatorConfigV2Calls::setNetworkIdentityRotationEpoch(call) => {
-                    mutate_void(call, msg_sender, |s, c| {
+                    }),
+                    transferOwnership(call) => mutate_void(call, msg_sender, |s, c| self.transfer_ownership(s, c)),
+                    setNetworkIdentityRotationEpoch(call) => mutate_void(call, msg_sender, |s, c| {
                         self.set_network_identity_rotation_epoch(s, c)
-                    })
+                    }),
+                    migrateValidator(call) => mutate_void(call, msg_sender, |s, c| self.migrate_validator(s, c)),
+                    initializeIfMigrated(call) => mutate_void(call, msg_sender, |s, _| self.initialize_if_migrated(s))
                 }
-                IValidatorConfigV2Calls::migrateValidator(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.migrate_validator(s, c))
-                }
-                IValidatorConfigV2Calls::initializeIfMigrated(call) => {
-                    mutate_void(call, msg_sender, |s, _| self.initialize_if_migrated(s))
-                }
-            },
+            }
         )
     }
 }
@@ -289,12 +253,8 @@ mod tests {
         StorageCtx::enter(&mut storage, || {
             let mut vc = ValidatorConfigV2::new();
 
-            let unsupported = check_selector_coverage(
-                &mut vc,
-                IValidatorConfigV2Calls::SELECTORS,
-                "IValidatorConfigV2",
-                IValidatorConfigV2Calls::name_by_selector,
-            );
+            let unsupported =
+                check_selector_coverage(&mut vc, SELECTORS, "IValidatorConfigV2", name_by_selector);
 
             assert_full_coverage([unsupported]);
 


### PR DESCRIPTION
This PR keeps precompile ABI dispatch backwards compatible while replacing the old selector scheduling machinery with a simpler macro-based dispatcher.

Previously, hardfork-aware ABI compatibility was handled with `SelectorSchedule` values plus, in some precompiles, custom compatibility enums to decode across multiple ABI interfaces. For example, TIP20 needed an intermediate enum to represent calls decoded from either `ITIP20Calls` or `IRolesAuthCalls`, plus a custom `decode` implementation that chose which ABI to use based on the selector.

This PR removes that pattern and introduces a shared `dispatch!` macro instead. TIP20 can now express dispatch directly as grouped ABI match arms:

```rust
dispatch!(
    calldata,
    |call| match call {
        ITIP20::ITIP20Calls {
            name(_) => metadata::<ITIP20::nameCall>(|| self.name()),
            balanceOf(call) => view(call, |c| self.balance_of(c)),

            #[schedule(since = T5)]
            logoURI(_) => metadata::<ITIP20::logoURICall>(|| self.logo_uri()),

            #[schedule(since = T2, until = T10)]
            permit(call) => mutate_void(call, msg_sender, |s, c| self.permit(s, c)),
        }

        IRolesAuth::IRolesAuthCalls {
            hasRole(call) => view(call, |c| self.has_role(c)),
            grantRole(call) => mutate_void(call, msg_sender, |s, c| self.grant_role(s, c)),
        }
    }
)
```

The macro expands into dispatch code that:

1. extracts the 4-byte selector from calldata,
2. checks any `#[schedule(...)]` gates before decoding,
3. returns `UnknownFunctionSelector` when a selector is not active for the current hardfork,
4. selects the ABI interface whose selector set contains the calldata selector,
5. decodes with that interface, then runs the matching handler.

Because ABI interface selection happens inside the macro, TIP20 and similar precompiles no longer need hand-written multi-ABI compatibility enums just to support split interfaces. The old selector scheduler types are also removed in favor of local `#[schedule]` annotations, so the hardfork availability of a call is visible directly beside the call implementation.

The result is less duplicated dispatch code, fewer manual selector lists to keep in sync, and the same backwards-compatible behavior for existing precompile ABIs across hardfork boundaries.
