### PR TITLE
refactor(payload): remove redundant prewarm tx clone

### DIFF
--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -113,7 +113,7 @@ impl BestTransactionsPrewarming {
                 let prewarm = ctx.prewarm.clone();
                 let commands_tx = ctx.commands_tx.clone();
                 scope.spawn(move |_| {
-                    Self::prewarm_transaction(prewarm, tx.clone(), expiring_nonce_offset);
+                    Self::prewarm_transaction(prewarm, tx, expiring_nonce_offset);
                     let _ = commands_tx.send(BestTransactionsCommand::Advance);
                 });
             };


### PR DESCRIPTION
Removes the redundant `Arc` clone when scheduling transaction prewarming. The builder queue still receives its cloned handle, while the scoped prewarm task consumes the original transaction handle.