### PR TITLE
chore: assert dispatch selector disjointness

### DIFF
--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -164,6 +164,15 @@ macro_rules! dispatch {
         })+
     } $(,)?) => {
         paste::paste! {{
+            #[cfg(debug_assertions)]
+            {
+                let mut selectors = std::collections::BTreeSet::new();
+                $(assert!(
+                    <$iface::$calls as alloy::sol_types::SolInterface>::selectors().all(|s| selectors.insert(s)),
+                    "duplicate precompile selector in dispatch! macro",
+                );)*
+            }
+
             if let Some(selector) = crate::dispatch::selector_from_calldata($calldata) {
                 $($($($(
                     if selector == <$iface::[<$variant Call>] as alloy::sol_types::SolCall>::SELECTOR


### PR DESCRIPTION
## Summary
- move selector collision protection into the shared `dispatch!` macro
- add a debug-only assertion that every generated interface selector inserted by a `dispatch!` invocation is unique before precedence-sensitive dispatch runs
- remove the TIP20-only manual check so all macro consumers get the same collision guarantee

## Tests
- `cargo fmt --check`
- `cargo test -p tempo-precompiles tip20_test_selector_coverage`

Prompted by: @0xrusowsky