### PR TITLE
docs(tip-1077): use chunked replay probes

### DIFF
--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -79,7 +79,8 @@ PRE_TIP_1077_MAX_EXPIRY_SECS  = 30
 EXPIRING_NONCE_MAX_EXPIRY_SECS = 300
 EXPIRING_NONCE_BUCKET_COUNT    = 301
 EXPIRING_NONCE_BUCKET_CAPACITY = 131_072
-EXPIRING_NONCE_MAX_PROBES      = 32
+EXPIRING_NONCE_POSITION_BITS   = 17
+EXPIRING_NONCE_MAX_PROBES      = 5
 
 EXPIRING_NONCE_CELL_COUNT      = 39_452_672
 EXPIRING_NONCE_CELL_BASE_SLOT  = 0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa2400000
@@ -94,6 +95,8 @@ old ring entries.
 
 `EXPIRING_NONCE_BUCKET_COUNT` MUST be greater than `EXPIRING_NONCE_MAX_EXPIRY_SECS`.
 `EXPIRING_NONCE_BUCKET_CAPACITY` MUST be a power of two.
+`EXPIRING_NONCE_POSITION_BITS` MUST equal `log2(EXPIRING_NONCE_BUCKET_CAPACITY)`.
+`EXPIRING_NONCE_POSITION_BITS * EXPIRING_NONCE_MAX_PROBES` MUST be less than or equal to 256.
 `EXPIRING_NONCE_CELL_COUNT` MUST equal
 `EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY`.
 
@@ -164,31 +167,27 @@ T = block.timestamp
 `H` MUST be the canonical protocol-computed replay hash, `keccak256(encode_for_signing || sender)`.
 It is not user-provided input.
 
+Bit ranges in this section are zero-indexed, half-open ranges from the most significant bit of
+`H`. For example, `H[0..17]` means the first 17 bits of `H`.
+
 The transaction first chooses its time bucket:
 
 ```text
 bucket = V % EXPIRING_NONCE_BUCKET_COUNT
 ```
 
-It then chooses a deterministic probe path inside that bucket:
+It then chooses a deterministic probe path inside that bucket. For probe `i`:
 
 ```text
-home = uint32_be(H[0..4]) % EXPIRING_NONCE_BUCKET_CAPACITY
-step = (uint32_be(H[4..8]) | 1) % EXPIRING_NONCE_BUCKET_CAPACITY
-```
-
-For probe `i`:
-
-```text
-position_i = (home + i * step) % EXPIRING_NONCE_BUCKET_CAPACITY
+position_i = uint17(H[i * EXPIRING_NONCE_POSITION_BITS
+                    .. (i + 1) * EXPIRING_NONCE_POSITION_BITS])
 cell_id_i  = bucket * EXPIRING_NONCE_BUCKET_CAPACITY + position_i
 slot_i     = EXPIRING_NONCE_CELL_BASE_SLOT + cell_id_i
 ```
 
-`step` is forced odd so that, with power-of-two bucket capacity, the probe path can cycle through
-the bucket instead of being trapped in a smaller divisor-sized subset.
-Since `EXPIRING_NONCE_BUCKET_CAPACITY` is a power of two, implementations MAY use bit masks instead
-of modulo operations for `home`, `step`, and `position_i`.
+With the chosen constants, the five probe positions are `H[0..17]`, `H[17..34]`, `H[34..51]`,
+`H[51..68]`, and `H[68..85]`. Since `EXPIRING_NONCE_BUCKET_CAPACITY` is `2^17`, each 17-bit chunk
+selects one cell in the bucket without modulo bias or rejection sampling.
 
 ## Replay Algorithm
 
@@ -205,7 +204,7 @@ T < V <= T + EXPIRING_NONCE_MAX_EXPIRY_SECS
 Then the Nonce precompile executes:
 
 ```text
-fingerprint = H[8..32]
+fingerprint = low_192_bits(H)
 
 for i in 0..EXPIRING_NONCE_MAX_PROBES:
     cell_id = cell_id_i
@@ -263,7 +262,7 @@ Examples:
 | ---: | ---: |
 | 1 | 5,000 |
 | 2 | 7,100 |
-| 32 | 70,100 |
+| 5 | 13,400 |
 
 This charge intentionally does not apply TIP-1000 permanent new-slot pricing to first-touch replay
 cells. Expiring nonce cells are bounded temporary protocol state, not user-created permanent state.
@@ -279,7 +278,7 @@ bookkeeping.
 No expiring nonce insertion or later overwrite mints or consumes TIP-1060 storage credits.
 
 The time-wheel lookup performs no Keccak beyond the canonical replay hash `H`. If `H` has already
-been computed by transaction validation or pool deduplication, deriving `bucket`, `home`, `step`,
+been computed by transaction validation or pool deduplication, deriving `bucket`, `position_i`,
 `fingerprint`, `cell_id`, and `slot` requires only slicing and arithmetic:
 
 ```text
@@ -328,8 +327,8 @@ The wheel has two independent dimensions:
 - `EXPIRING_NONCE_BUCKET_COUNT` separates expiry seconds. It only needs to be greater than the
   maximum expiry window, so 301 buckets covers a 300 second window.
 - `EXPIRING_NONCE_BUCKET_CAPACITY` controls collision probability within one exact
-  `valid_before` second. This value must be a power of two so the odd probe step can cover every
-  cell in the bucket.
+  `valid_before` second. This value must be a power of two so each fixed-width position chunk selects
+  one cell without modulo bias.
 
 Rounding the time-bucket count from 301 to 512 would not reduce same-second collisions: each exact
 `valid_before` second would still use one bucket with 131,072 cells. It would only reserve 211
@@ -344,22 +343,27 @@ The table below models random hash placement inside one bucket.
 slot+value bytes = 301 buckets * cells_per_bucket * 64
 ```
 
-| Cells per bucket | Load at 20k TPS | First-cell collisions per 20k txs | Avg probes per tx | Max slot+value bloat |
-| ---: | ---: | ---: | ---: | ---: |
-| 16,777,216 | 0.12% | ~12 | 1.0006 | 301.00 GiB |
-| 1,048,576 | 1.91% | ~190 | 1.0097 | 18.81 GiB |
-| 524,288 | 3.81% | ~377 | 1.0196 | 9.41 GiB |
-| 262,144 | 7.63% | ~744 | 1.0402 | 4.70 GiB |
-| 131,072 | 15.26% | ~1,451 | 1.0851 | 2.35 GiB |
-| 65,536 | 30.52% | ~2,764 | 1.1931 | 1.18 GiB |
-| 32,768 | 61.04% | ~5,030 | 1.5442 | 602.00 MiB |
-| 25,000 | 80.00% | ~6,233 | 2.0118 | 459.29 MiB |
-| 20,000 | 100.00% | ~7,358 | unstable | 367.43 MiB |
-| 16,384 | 122.07% | ~8,450 | overloaded | 301.00 MiB |
+| Cells per bucket | Load at 20k TPS | First-probe misses per 20k txs | Avg reads per attempted tx | Probe-exhausted txs per 20k | Max slot+value bloat |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 16,777,216 | 0.12% | ~12 | 1.0006 | ~0 | 301.00 GiB |
+| 1,048,576 | 1.91% | ~191 | 1.0097 | ~0 | 18.81 GiB |
+| 524,288 | 3.81% | ~381 | 1.0196 | ~0 | 9.41 GiB |
+| 262,144 | 7.63% | ~763 | 1.0402 | ~0.009 | 4.70 GiB |
+| 131,072 | 15.26% | ~1,526 | 1.0850 | ~0.28 | 2.35 GiB |
+| 65,536 | 30.52% | ~3,052 | 1.1925 | ~8.8 | 1.18 GiB |
+| 32,768 | 61.04% | ~6,103 | 1.5139 | ~282 | 602.00 MiB |
+| 25,000 | 80.00% | ~8,000 | 1.8232 | ~1,092 | 459.29 MiB |
+| 20,000 | 100.00% | ~10,000 | 2.2832 | ~3,333 | 367.43 MiB |
+| 16,384 | 122.07% | overloaded | overloaded | overloaded | 301.00 MiB |
 
 This TIP chooses 301 time buckets and 131,072 cells per bucket. The bucket count is the minimum
 that preserves the cheap expiry proof for a 300 second window, and the cell count keeps the
-per-`valid_before` load at 15.26% with an average accepted path of about 1.085 probes at 20k TPS.
+per-`valid_before` load at 15.26% with about 1.085 replay-cell reads per attempted transaction at
+20k TPS.
+
+The five-probe cap bounds worst-case replay work to 5 cold reads and keeps the maximum replay
+bookkeeping charge at 13,400 gas. Under the uniform 20k TPS sizing model, the expected random
+probe-exhaustion rate is about 0.28 transactions per 20,000 same-second attempts.
 
 Smaller tables reduce the maximum footprint but increase average reads and tail risk. In
 particular, 65,536 cells per bucket would halve the footprint to 1.18 GiB but double load to
@@ -396,8 +400,8 @@ the unique `expiringNonceSeen[H]` slot to notice when a pooled transaction was i
 TIP-1077 there is no unique per-transaction slot: each transaction has a probe path through shared
 replay cells, and another transaction may write a different fingerprint into one of those cells. If
 the pool keeps inclusion tracking from state updates, it should watch the probe-path cells and
-remove a transaction only when the written word is that transaction's exact `V || H[8..32]` value,
-not merely because a watched cell became non-zero.
+remove a transaction only when the written word is that transaction's exact
+`V || low_192_bits(H)` value, not merely because a watched cell became non-zero.
 
 To preserve replay protection across the hardfork boundary, implementations MUST perform a
 temporary dual replay check:
@@ -506,7 +510,7 @@ expiringNonceCells[cell_id] = valid_before || fingerprint
 This keeps the storage layout familiar, but every probed cell requires computing
 `keccak256(cell_id || mapping_slot)` before the `SLOAD`. At the chosen capacity, the expected
 accepted transaction reads about 1.085 cells, so mapping layout would add about 1.085 Keccak
-computations per accepted transaction on average and up to 32 in the worst probe path. The direct
+computations per accepted transaction on average and up to 5 in the worst probe path. The direct
 slot range preserves the same bounded table and probe behavior while making each probe slot
 derivable with integer addition.
 

--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -167,9 +167,6 @@ T = block.timestamp
 `H` MUST be the canonical protocol-computed replay hash, `keccak256(encode_for_signing || sender)`.
 It is not user-provided input.
 
-Bit ranges in this section are zero-indexed, half-open ranges from the most significant bit of
-`H`. For example, `H[0..17]` means the first 17 bits of `H`.
-
 The transaction first chooses its time bucket:
 
 ```text
@@ -204,7 +201,7 @@ T < V <= T + EXPIRING_NONCE_MAX_EXPIRY_SECS
 Then the Nonce precompile executes:
 
 ```text
-fingerprint = low_192_bits(H)
+fingerprint = H[8..32]
 
 for i in 0..EXPIRING_NONCE_MAX_PROBES:
     cell_id = cell_id_i
@@ -327,8 +324,7 @@ The wheel has two independent dimensions:
 - `EXPIRING_NONCE_BUCKET_COUNT` separates expiry seconds. It only needs to be greater than the
   maximum expiry window, so 301 buckets covers a 300 second window.
 - `EXPIRING_NONCE_BUCKET_CAPACITY` controls collision probability within one exact
-  `valid_before` second. This value must be a power of two so each fixed-width position chunk selects
-  one cell without modulo bias.
+  `valid_before` second.
 
 Rounding the time-bucket count from 301 to 512 would not reduce same-second collisions: each exact
 `valid_before` second would still use one bucket with 131,072 cells. It would only reserve 211
@@ -360,10 +356,6 @@ This TIP chooses 301 time buckets and 131,072 cells per bucket. The bucket count
 that preserves the cheap expiry proof for a 300 second window, and the cell count keeps the
 per-`valid_before` load at 15.26% with about 1.085 replay-cell reads per attempted transaction at
 20k TPS.
-
-The five-probe cap bounds worst-case replay work to 5 cold reads and keeps the maximum replay
-bookkeeping charge at 13,400 gas. Under the uniform 20k TPS sizing model, the expected random
-probe-exhaustion rate is about 0.28 transactions per 20,000 same-second attempts.
 
 Smaller tables reduce the maximum footprint but increase average reads and tail risk. In
 particular, 65,536 cells per bucket would halve the footprint to 1.18 GiB but double load to
@@ -400,8 +392,8 @@ the unique `expiringNonceSeen[H]` slot to notice when a pooled transaction was i
 TIP-1077 there is no unique per-transaction slot: each transaction has a probe path through shared
 replay cells, and another transaction may write a different fingerprint into one of those cells. If
 the pool keeps inclusion tracking from state updates, it should watch the probe-path cells and
-remove a transaction only when the written word is that transaction's exact
-`V || low_192_bits(H)` value, not merely because a watched cell became non-zero.
+remove a transaction only when the written word is that transaction's exact `V || H[8..32]` value,
+not merely because a watched cell became non-zero.
 
 To preserve replay protection across the hardfork boundary, implementations MUST perform a
 temporary dual replay check:


### PR DESCRIPTION
Changes TIP-1077 to derive five probe positions from contiguous 17-bit chunks of the sender-scoped replay hash.

Caps expiring nonce replay probing at five cells and updates the gas examples, random-load table, and related prose.