### PR TITLE
chore(deps): patch reth deps to PR 25590

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8656,7 +8656,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8716,7 +8716,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8736,7 +8736,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8749,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8832,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8895,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8911,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8938,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8963,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8992,7 +8992,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9048,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9171,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9393,7 +9393,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9411,7 +9411,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9450,7 +9450,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9511,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9552,7 +9552,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "clap",
  "eyre",
@@ -9575,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9591,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9607,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9650,7 +9650,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9664,7 +9664,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9674,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9699,7 +9699,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9737,7 +9737,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9807,7 +9807,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "serde",
  "serde_json",
@@ -9831,7 +9831,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "bytes",
  "futures",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9896,7 +9896,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "bindgen",
  "cc",
@@ -9905,7 +9905,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "futures",
  "metrics",
@@ -9918,7 +9918,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9927,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9941,7 +9941,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9999,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10024,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10063,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10077,7 +10077,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10094,7 +10094,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10118,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10186,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10241,7 +10241,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10288,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10312,7 +10312,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10336,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "bytes",
  "eyre",
@@ -10365,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10377,7 +10377,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10401,7 +10401,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10413,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10528,7 +10528,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10556,7 +10556,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10587,7 +10587,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10665,7 +10665,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10695,7 +10695,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10758,7 +10758,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10789,7 +10789,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10887,7 +10887,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10901,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10932,7 +10932,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10983,7 +10983,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11011,7 +11011,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11045,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11060,7 +11060,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11086,7 +11086,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11104,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11125,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11151,7 +11151,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "clap",
  "eyre",
@@ -11171,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11190,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11235,7 +11235,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11261,7 +11261,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11289,7 +11289,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11308,7 +11308,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11337,7 +11337,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fuse-unbounded-tx-channels#42033039c0aa70ae48adff9bfcfba87dde81f630"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/use-unbounded-tx-channels", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
References https://github.com/paradigmxyz/reth/pull/25590

Patches the workspace Reth git dependencies to `paradigmxyz/reth#25590`'s head branch, `mattsse/use-unbounded-tx-channels`, and refreshes `Cargo.lock` to `42033039c0aa70ae48adff9bfcfba87dde81f630`.

This lets Tempo test the unbounded tx iterator channel changes before the Reth PR lands.