### PR TITLE
define a sync window of 3 epochs by overriding `--minimal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12934,6 +12934,7 @@ dependencies = [
  "reth-node-builder",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-prune-types",
  "reth-rpc-server-types",
  "reth-storage-api",
  "reth-trie",

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -93,6 +93,7 @@ reth-network-peers.workspace = true
 reth-node-builder.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
+reth-prune-types.workspace = true
 reth-rpc-server-types.workspace = true
 secp256k1.workspace = true
 reth-storage-api.workspace = true

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -4,14 +4,18 @@ use jiff::SignedDuration;
 use reth_cli_commands::download::DownloadDefaults;
 use reth_ethereum::node::core::args::{
     DefaultDiscoveryArgs, DefaultEngineValues, DefaultNetworkArgs, DefaultPayloadBuilderValues,
-    DefaultTraceValues, DefaultTxPoolValues,
+    DefaultPruningValues, DefaultTraceValues, DefaultTxPoolValues,
 };
+use reth_prune_types::PruneMode;
 use std::{borrow::Cow, str::FromStr, time::Duration};
 use tempo_chainspec::spec::TEMPO_T7_BASE_FEE_FLOOR;
 use url::Url;
 
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/4217";
 const SNAPSHOT_API_URL: &str = "https://snapshots.tempoxyz.dev/api/snapshots";
+const MAINNET_EPOCH_LENGTH_BLOCKS: u64 = 21_600;
+const MINIMAL_PEER_SYNC_FINALIZED_BLOCKS: u64 = 3 * MAINNET_EPOCH_LENGTH_BLOCKS;
+const MINIMAL_PEER_SYNC_RETENTION_BLOCKS: u64 = MINIMAL_PEER_SYNC_FINALIZED_BLOCKS + 64;
 
 /// CLI arguments for telemetry configuration.
 #[derive(Debug, Clone, clap::Args)]
@@ -211,6 +215,20 @@ fn init_engine_defaults() {
         .expect("failed to initialize engine defaults");
 }
 
+fn init_pruning_defaults() {
+    let mut minimal_prune_modes = DefaultPruningValues::default().minimal_prune_modes;
+    // This defines Tempo's minimum peer sync window: nodes should retain enough
+    // block bodies to serve peers up to three mainnet epochs behind the finalized
+    // tip, plus Reth's normal 64-block safety margin.
+    minimal_prune_modes.bodies_history =
+        Some(PruneMode::Distance(MINIMAL_PEER_SYNC_RETENTION_BLOCKS));
+
+    DefaultPruningValues::default()
+        .with_minimal_prune_modes(minimal_prune_modes)
+        .try_init()
+        .expect("failed to initialize pruning defaults");
+}
+
 fn init_trace_defaults() {
     DefaultTraceValues::default()
         .with_service_name("tempo")
@@ -258,6 +276,7 @@ pub(crate) fn init_defaults() {
     init_payload_builder_defaults();
     init_txpool_defaults();
     init_engine_defaults();
+    init_pruning_defaults();
     init_trace_defaults();
     init_otlp_defaults();
     init_network_defaults();

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -6,15 +6,15 @@ use reth_ethereum::node::core::args::{
     DefaultDiscoveryArgs, DefaultEngineValues, DefaultNetworkArgs, DefaultPayloadBuilderValues,
     DefaultPruningValues, DefaultTraceValues, DefaultTxPoolValues,
 };
-use reth_prune_types::PruneMode;
+use reth_prune_types::{PruneMode, PruneModes};
 use std::{borrow::Cow, str::FromStr, time::Duration};
 use tempo_chainspec::spec::TEMPO_T7_BASE_FEE_FLOOR;
 use url::Url;
 
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/4217";
 const SNAPSHOT_API_URL: &str = "https://snapshots.tempoxyz.dev/api/snapshots";
-const MAINNET_EPOCH_LENGTH_BLOCKS: u64 = 21_600;
-const MINIMAL_PEER_SYNC_FINALIZED_BLOCKS: u64 = 3 * MAINNET_EPOCH_LENGTH_BLOCKS;
+const MAINNET_TESTNET_EPOCH_LENGTH_BLOCKS: u64 = 21_600;
+const MINIMAL_PEER_SYNC_FINALIZED_BLOCKS: u64 = 3 * MAINNET_TESTNET_EPOCH_LENGTH_BLOCKS;
 const MINIMAL_PEER_SYNC_RETENTION_BLOCKS: u64 = MINIMAL_PEER_SYNC_FINALIZED_BLOCKS + 64;
 
 /// CLI arguments for telemetry configuration.
@@ -216,12 +216,16 @@ fn init_engine_defaults() {
 }
 
 fn init_pruning_defaults() {
-    let mut minimal_prune_modes = DefaultPruningValues::default().minimal_prune_modes;
-    // This defines Tempo's minimum peer sync window: nodes should retain enough
-    // block bodies to serve peers up to three mainnet epochs behind the finalized
-    // tip, plus Reth's normal 64-block safety margin.
-    minimal_prune_modes.bodies_history =
-        Some(PruneMode::Distance(MINIMAL_PEER_SYNC_RETENTION_BLOCKS));
+    let minimal_history_retention = Some(PruneMode::Distance(MINIMAL_PEER_SYNC_RETENTION_BLOCKS));
+    // This defines Tempo's minimum history retention window: nodes should retain
+    // enough block and state history for peers and unwinds up to three mainnet
+    // epochs behind the finalized tip, plus Reth's normal 64-block safety margin.
+    let minimal_prune_modes = PruneModes {
+        account_history: minimal_history_retention,
+        storage_history: minimal_history_retention,
+        bodies_history: minimal_history_retention,
+        ..DefaultPruningValues::default().minimal_prune_modes
+    };
 
     DefaultPruningValues::default()
         .with_minimal_prune_modes(minimal_prune_modes)


### PR DESCRIPTION
## Summary
- override Reth's `--minimal` pruning defaults from Tempo startup
- retain 64,864 blocks for block bodies/transactions so peers can sync recent blocks
- define this as Tempo's minimum peer sync window: nodes up to three mainnet epochs behind the finalized tip should be able to sync from peers, with an extra 64-block safety margin
- leave receipts, account history, storage history, sender recovery, and transaction lookup behavior inherited from Reth's minimal preset

## Context
- Tempo mainnet epochs are 21,600 blocks, so Reth's current ~10k block minimal bodies window does not cover even one epoch.
- A network made only of `--minimal` nodes can therefore fail to provide enough block bodies for peers to catch up within the required peer sync window.
- The consensus layer has no concept of archive nodes, so the execution-layer minimal profile needs to retain the bodies needed for peer sync.

## Tests
- `cargo fmt --check --package tempo`
- `cargo check -p tempo`
- `git diff --check`

Prompted by: @SuperFluffy
