### PR TITLE
docs(tip-1084): define vault-backed TIP-20 passthrough tokens

### DIFF
--- a/tips/tip-1084.md
+++ b/tips/tip-1084.md
@@ -1,0 +1,628 @@
+---
+id: TIP-1084
+title: Vault-Backed TIP-20 Passthrough Tokens
+description: Add TIP-20 vault share tokens that forward deposit and withdrawal flows to vault contracts.
+authors: Dan Robinson (@danrobinson), Tanishk Goyal (@legion2002)
+status: In Review
+related: TIP-20, TIP-403, TIP-1028, TIP-1035, TIP-1045
+protocolVersion: TBD
+---
+
+# TIP-1084: Vault-Backed TIP-20 Passthrough Tokens
+
+## Abstract
+
+This TIP extends TIP-20 with vault-backed share tokens. A vault-backed TIP-20 is a normal transferable TIP-20 token for balances, payments, Fee AMM routing, policies, permits, memos, and indexing, but it also exposes deposit, withdrawal, preview, and reward-claim passthrough functions.
+
+The protocol-enshrined part is deliberately narrow: TIP-20 creates and registers the share token, binds it to one immutable vault logic contract, disables direct issuer mint/burn paths, and forwards vault user flows to that contract. The vault contract, not the TIP-20 precompile, owns custody, deposit and withdrawal logic, asset accounting, strategy integration, fee logic, reward logic, and manager execution.
+
+The first contract implementations should be two deployable vault contracts:
+
+- `SingleStrategyVault`: routes deposits into one configured yield source.
+- `MultiStrategyVault`: exposes a third-party-manager-compatible `manage` function so an external manager stack can rebalance vault-owned liquidity.
+
+## Motivation
+
+Tempo needs yield-bearing tokens that are liquid and composable wherever TIP-20 tokens work. Users should see a vault share as a normal TIP-20 balance that can move through wallets, payment flows, the Fee AMM, access-key flows, and indexers, while still entering and exiting through vault deposit and withdrawal methods.
+
+The vault logic itself should not be enshrined in the protocol. Deposit routing, multi-asset accounting, fixed-yield economics, reward campaigns, strategy adapters, and external-manager-compatible execution should live in contracts that Tempo can own, audit, upgrade through normal contract migration, and iterate on without hardforking every vault design change.
+
+This is the intended split from the product doc:
+
+- Enshrine a TIP-20 passthrough share token, similar in spirit to TIP-1080's wrapper direction.
+- Build two vault smart contracts behind that share token: single-strategy and multi-strategy.
+- Keep curation and reward campaign operations outside the protocol, while making the multi-strategy contract compatible with external manager execution.
+
+ERC-4626 is not a good binding standard for this product because it assumes one asset-denominated vault entry point. ERC-7575 is closer to a multi-asset vault model, but does not have enough adoption to bind Tempo's native product surface. This TIP can support adapters later, but the canonical surface is TIP-20 passthrough plus Tempo-owned vault contracts.
+
+## Assumptions
+
+- The vault share token and the vault logic contract are different addresses.
+- The user-facing asset is the TIP-20 share token address, not the vault logic contract address.
+- Users and wallets SHOULD call deposit and withdrawal functions on the TIP-20 share token. The share token forwards those calls to the linked vault contract.
+- The linked vault contract holds funds directly or routes them into strategies. TIP-20 does not hold strategy state.
+- The linked vault contract is immutable for a given vault-backed TIP-20.
+- The linked vault contract is trusted to compute share amounts, release withdrawal assets, enforce vault-level deposit and withdrawal policies, account for fees and rewards, and preserve solvency.
+- The TIP-20 share token remains fungible. Yield distribution mode is configured at the vault-contract level, not chosen per withdrawal.
+- Direct TIP-20 issuer mint and direct burn entrypoints are disabled for vault-backed TIP-20 tokens. Shares are minted and burned only through passthrough deposit and withdrawal flows.
+- TIP-20 share transfers continue to use ordinary TIP-20 transfer policies and TIP-1028 receive-policy behavior.
+- Vault-level KYC, allowlists, rate limits, asset caps, and withdrawal policies are implemented by the linked vault contracts, typically by calling TIP-403 policy primitives.
+- TIP-1035 approve-less pulls MAY be used by the TIP-20 passthrough when the deposited asset is a TIP-20 token and the passthrough is on the Implicit Approval List. Untrusted vault contracts MUST NOT receive generic `system_transfer_from` authority.
+
+## Threat Model
+
+- **TIP-20 vault share token:** trusted protocol component for balances, transfers, approvals, permits, memos, share policy checks, factory registration, passthrough entrypoints, and restricted share mint/burn execution.
+- **Vault logic contract:** trusted contract that owns custody and accounting. A malicious or buggy vault contract can lose assets, compute unfair share amounts, block withdrawals, or misallocate rewards.
+- **Vault owner:** trusted to configure supported assets, policy IDs, rate providers, fee configuration, distribution mode, reward roots, strategy adapters, manager address, and emergency controls in the vault contract.
+- **Vault manager:** trusted only to rebalance vault-owned liquidity in `MultiStrategyVault`. The manager MUST NOT get owner powers over deposits, withdrawals, fees, policies, reward roots, or share issuance.
+- **Single strategy adapter:** trusted by `SingleStrategyVault` to integrate with the configured yield source and report/redeem value correctly.
+- **Rate providers:** trusted by vault contracts to normalize multi-asset deposits and withdrawals into the vault accounting asset.
+- **External curation systems:** may operate behind the `manager` address. They are outside the protocol trust model and do not own the TIP-20 share token.
+- **Users and approved spenders:** may deposit, transfer shares, redeem, withdraw, and claim rewards subject to balances, allowances, policies, vault limits, and slippage bounds.
+
+---
+
+# Specification
+
+## Enshrined Versus Contract Scope
+
+This TIP enshrines only the TIP-20 share and passthrough layer:
+
+- creation of a TIP-20 token bound to one vault logic contract;
+- ordinary TIP-20 share balances and transfers;
+- ordinary TIP-20 transfer policy and receive-policy behavior for shares;
+- deposit, withdrawal, preview, and reward-claim passthrough selectors on the TIP-20 token;
+- restricted share mint and burn as part of successful passthrough flows;
+- optional TIP-1035 asset pulls for TIP-20 deposit assets;
+- optional TIP-1045 payment-lane eligibility for bounded passthrough selectors.
+
+The linked vault contracts own:
+
+- custody of deposited assets;
+- multi-asset deposit and withdrawal support;
+- vault-level KYC and withdrawal policies;
+- asset caps, rate limits, and withdrawal buffers;
+- rate providers and NAV accounting;
+- pro-rata, fixed-yield, and Merkle proof based reward logic;
+- management and performance fees;
+- single-strategy routing;
+- multi-strategy manager execution through a generic `manage` interface.
+
+The protocol MUST NOT enshrine strategy-specific logic, third-party manager verification, partner campaign logic, RWA adapters, or fixed-yield economics beyond the common passthrough interface.
+
+## Factory Interface
+
+The TIP-20 factory is extended with a vault-backed token creation path.
+
+```solidity
+interface ITIP20VaultFactory {
+    /// @notice Emitted after a vault-backed TIP-20 share token is created.
+    /// @dev The ordinary TIP-20 TokenCreated event MUST be emitted first.
+    event VaultTokenCreated(
+        address indexed token,
+        address indexed vault,
+        uint64 indexed transferPolicyId,
+        string name,
+        string symbol,
+        string currency,
+        address quoteToken,
+        address admin,
+        bytes32 salt
+    );
+
+    /// @notice Creates a TIP-20 share token bound to an external vault logic contract.
+    /// @param name TIP-20 share token name.
+    /// @param symbol TIP-20 share token symbol.
+    /// @param currency ISO or issuer-defined currency string.
+    /// @param quoteToken Quote token used by existing TIP-20 quote-token rules.
+    /// @param admin Initial TIP-20 admin.
+    /// @param transferPolicyId Initial TIP-403 transfer policy for share transfers and share mints.
+    /// @param vault External vault logic contract that owns custody and accounting.
+    /// @param salt Deterministic address salt.
+    /// @return token Created vault-backed TIP-20 share token.
+    function createVaultToken(
+        string calldata name,
+        string calldata symbol,
+        string calldata currency,
+        address quoteToken,
+        address admin,
+        uint64 transferPolicyId,
+        address vault,
+        bytes32 salt
+    ) external returns (address token);
+
+    /// @notice Creates a vault-backed TIP-20 share token and sets logoURI atomically.
+    function createVaultToken(
+        string calldata name,
+        string calldata symbol,
+        string calldata currency,
+        address quoteToken,
+        address admin,
+        uint64 transferPolicyId,
+        address vault,
+        bytes32 salt,
+        string calldata logoURI
+    ) external returns (address token);
+
+    /// @notice Returns true if token is a vault-backed TIP-20 created by this factory.
+    function isVaultToken(address token) external view returns (bool);
+
+    /// @notice Predicts the address for a vault-backed TIP-20 deployment.
+    function getVaultTokenAddress(address sender, bytes32 salt) external pure returns (address token);
+}
+```
+
+`createVaultToken` MUST:
+
+1. Validate `vault != address(0)`.
+2. Validate `admin != address(0)`.
+3. Validate `quoteToken` using ordinary TIP-20 factory rules.
+4. Validate `transferPolicyId` using ordinary TIP-403 policy existence rules.
+5. Validate `logoURI` using TIP-1026 rules when the overload is used.
+6. Deploy a TIP-20 share token with immutable `vault`.
+7. Register the created token as an ordinary TIP-20 token and as a vault-backed TIP-20 token.
+8. Call `ITIP20VaultLogic(vault).bindVaultToken(token)` during creation. The call MUST succeed or the entire creation MUST revert.
+9. Emit ordinary TIP-20 `TokenCreated`, then emit `VaultTokenCreated`.
+
+`bindVaultToken` gives the vault contract a one-time binding point without requiring the vault contract to know the final TIP-20 address before factory deployment. Vault contracts MAY also be deployed with the predicted token address and reject `bindVaultToken` unless it matches that prediction.
+
+## TIP-20 Vault Token Interface
+
+A vault-backed TIP-20 MUST support ordinary TIP-20 behavior, plus:
+
+```solidity
+interface ITIP20VaultToken {
+    struct RewardClaim {
+        bytes32 programId;
+        address account;
+        address rewardAsset;
+        uint256 cumulativeAmount;
+        bytes32[] proof;
+    }
+
+    /// @notice Linked vault logic contract.
+    function vault() external view returns (address);
+
+    /// @notice Returns the maximum asset amount receiver can deposit through this token now.
+    function maxDeposit(address asset, address receiver) external view returns (uint256 assets);
+
+    /// @notice Returns the maximum shares receiver can mint through this token now.
+    function maxDepositForShares(address asset, address receiver) external view returns (uint256 shares);
+
+    /// @notice Returns the maximum asset amount owner can withdraw through this token now.
+    function maxWithdraw(address asset, address owner) external view returns (uint256 assets);
+
+    /// @notice Returns the maximum shares owner can redeem through this token now.
+    function maxRedeem(address asset, address owner) external view returns (uint256 shares);
+
+    /// @notice Preview shares minted by depositing an exact asset amount.
+    function previewDeposit(address asset, uint256 assets, address receiver)
+        external
+        view
+        returns (uint256 shares);
+
+    /// @notice Preview assets needed to mint an exact share amount.
+    function previewDepositForShares(address asset, uint256 shares, address receiver)
+        external
+        view
+        returns (uint256 assets);
+
+    /// @notice Preview shares burned to withdraw an exact asset amount.
+    function previewWithdraw(address asset, uint256 assets, address owner)
+        external
+        view
+        returns (uint256 shares);
+
+    /// @notice Preview assets returned by redeeming an exact share amount.
+    function previewRedeem(address asset, uint256 shares, address owner)
+        external
+        view
+        returns (uint256 assets);
+
+    /// @notice Deposit an exact amount of one asset and mint shares to receiver.
+    function deposit(address asset, uint256 assets, address receiver, uint256 minShares)
+        external
+        returns (uint256 shares);
+
+    /// @notice Deposit an exact amount with a memo and mint shares to receiver.
+    function depositWithMemo(address asset, uint256 assets, address receiver, uint256 minShares, bytes32 memo)
+        external
+        returns (uint256 shares);
+
+    /// @notice Deposit up to maxAssets to mint an exact share amount.
+    function depositForShares(address asset, uint256 shares, uint256 maxAssets, address receiver)
+        external
+        returns (uint256 assets);
+
+    /// @notice Burn up to maxShares to withdraw an exact asset amount.
+    function withdraw(address asset, uint256 assets, uint256 maxShares, address receiver, address owner)
+        external
+        returns (uint256 shares);
+
+    /// @notice Burn up to maxShares to withdraw an exact asset amount with a memo.
+    function withdrawWithMemo(
+        address asset,
+        uint256 assets,
+        uint256 maxShares,
+        address receiver,
+        address owner,
+        bytes32 memo
+    ) external returns (uint256 shares);
+
+    /// @notice Burn an exact share amount and receive at least minAssets.
+    function redeem(address asset, uint256 shares, uint256 minAssets, address receiver, address owner)
+        external
+        returns (uint256 assets);
+
+    /// @notice Pass reward claims to the linked vault contract.
+    function claimRewards(RewardClaim[] calldata claims, address receiver)
+        external
+        returns (uint256[] memory amounts);
+}
+```
+
+The preview and max functions MUST be passthrough reads to the linked vault contract. TIP-20 MUST NOT compute NAV, supported assets, rates, withdrawal buffers, fees, or reward eligibility itself.
+
+## Vault Logic Contract Interface
+
+The linked vault contract MUST implement the callback and view surface below. This is a contract interface, not a precompile.
+
+```solidity
+interface ITIP20VaultLogic {
+    enum VaultType {
+        SINGLE_STRATEGY,
+        MULTI_STRATEGY
+    }
+
+    enum DistributionMode {
+        PRO_RATA,
+        FIXED_YIELD,
+        MERKLE_REWARDS
+    }
+
+    struct RewardClaim {
+        bytes32 programId;
+        address account;
+        address rewardAsset;
+        uint256 cumulativeAmount;
+        bytes32[] proof;
+    }
+
+    /// @notice One-time binding from the TIP-20 factory.
+    function bindVaultToken(address token) external;
+
+    /// @notice Bound TIP-20 share token.
+    function vaultToken() external view returns (address);
+
+    /// @notice Returns the vault contract type.
+    function vaultType() external view returns (VaultType);
+
+    /// @notice Returns the current vault distribution mode.
+    function distributionMode() external view returns (DistributionMode);
+
+    /// @notice Returns the accounting asset used by the vault contract.
+    function baseAsset() external view returns (address);
+
+    /// @notice Returns whether the token should pull this asset before onDeposit.
+    function usesPassthroughAssetPull(address asset) external view returns (bool);
+
+    /// @notice Returns the maximum asset amount receiver can deposit now.
+    function maxDeposit(address caller, address asset, address receiver) external view returns (uint256 assets);
+
+    /// @notice Returns the maximum shares receiver can mint now.
+    function maxDepositForShares(address caller, address asset, address receiver) external view returns (uint256 shares);
+
+    /// @notice Returns the maximum asset amount owner can withdraw now.
+    function maxWithdraw(address caller, address asset, address owner) external view returns (uint256 assets);
+
+    /// @notice Returns the maximum shares owner can redeem now.
+    function maxRedeem(address caller, address asset, address owner) external view returns (uint256 shares);
+
+    function previewDeposit(address caller, address asset, uint256 assets, address receiver)
+        external
+        view
+        returns (uint256 shares);
+
+    function previewDepositForShares(address caller, address asset, uint256 shares, address receiver)
+        external
+        view
+        returns (uint256 assets);
+
+    function previewWithdraw(address caller, address asset, uint256 assets, address owner)
+        external
+        view
+        returns (uint256 shares);
+
+    function previewRedeem(address caller, address asset, uint256 shares, address owner)
+        external
+        view
+        returns (uint256 assets);
+
+    /// @notice Called by the TIP-20 share token after any configured passthrough asset pull.
+    function onDeposit(
+        address caller,
+        address asset,
+        uint256 assets,
+        address receiver,
+        uint256 minShares,
+        bytes32 memo
+    ) external returns (uint256 shares);
+
+    /// @notice Called by the TIP-20 share token to process exact-share mint deposits.
+    function onDepositForShares(
+        address caller,
+        address asset,
+        uint256 shares,
+        uint256 maxAssets,
+        address receiver
+    ) external returns (uint256 assets);
+
+    /// @notice Called by the TIP-20 share token before burning shares for an exact-asset withdrawal.
+    function onWithdraw(
+        address caller,
+        address asset,
+        uint256 assets,
+        uint256 maxShares,
+        address receiver,
+        address owner,
+        bytes32 memo
+    ) external returns (uint256 shares);
+
+    /// @notice Called by the TIP-20 share token before burning exact shares for redemption.
+    function onRedeem(
+        address caller,
+        address asset,
+        uint256 shares,
+        uint256 minAssets,
+        address receiver,
+        address owner
+    ) external returns (uint256 assets);
+
+    /// @notice Called by the TIP-20 share token for arbitrary reward claims.
+    function onClaimRewards(address caller, RewardClaim[] calldata claims, address receiver)
+        external
+        returns (uint256[] memory amounts);
+}
+```
+
+All `on*` functions MUST reject unless `msg.sender == vaultToken()`. Direct user entry into the vault contract MAY exist for admin, manager, and strategy functions, but direct user deposit and withdrawal methods MUST either be absent or enforce the same accounting and policy semantics as the TIP-20 passthrough.
+
+## Deposit Flow
+
+`deposit(asset, assets, receiver, minShares)` on the TIP-20 share token MUST:
+
+1. Reject `assets == 0` and `receiver == address(0)`.
+2. Reject if the share token is paused.
+3. Check that minting shares to `receiver` is allowed under the share token's TIP-403 transfer policy and TIP-1028 receive policy.
+4. If `vault.usesPassthroughAssetPull(asset) == true`, transfer `assets` from `msg.sender` to `vault()` before calling `onDeposit`.
+   - If `asset` is a TIP-20 token and this passthrough is on the TIP-1035 Implicit Approval List, the transfer MAY use `system_transfer_from(msg.sender, vault(), assets)`.
+   - Otherwise the transfer MUST use ordinary allowance or another explicit user authorization.
+5. Call `vault.onDeposit(msg.sender, asset, assets, receiver, minShares, memo)`.
+6. Mint exactly the returned `shares` to `receiver`.
+7. Emit ordinary TIP-20 share mint events and a vault passthrough deposit event.
+
+If any step reverts, the entire call MUST revert, including any asset transfer performed through the passthrough. The vault contract computes supported assets, share price, fees, deposit policies, strategy routing, and final share amount.
+
+`depositForShares(asset, shares, maxAssets, receiver)` MUST:
+
+1. Reject `shares == 0` and `receiver == address(0)`.
+2. Reject if the share token is paused.
+3. Check that minting shares to `receiver` is allowed under the share token's TIP-403 transfer policy and TIP-1028 receive policy.
+4. Call `vault.previewDepositForShares(msg.sender, asset, shares, receiver)` to compute the required asset amount.
+5. Revert if the required asset amount is greater than `maxAssets`.
+6. If `vault.usesPassthroughAssetPull(asset) == true`, transfer the required asset amount from `msg.sender` to `vault()` before calling `onDepositForShares`.
+7. Call `vault.onDepositForShares(msg.sender, asset, shares, maxAssets, receiver)`.
+8. Require the returned asset amount to equal the amount pulled by the passthrough when a passthrough pull was used.
+9. Mint exactly `shares` to `receiver`.
+
+The vault contract remains responsible for validating that the preview remains executable at finalization time. If pricing, caps, policy, or strategy state changes between preview and `onDepositForShares`, the vault contract MUST revert rather than finalize against stale assumptions.
+
+## Withdrawal Flow
+
+`withdraw(asset, assets, maxShares, receiver, owner)` on the TIP-20 share token MUST:
+
+1. Reject `assets == 0` and `receiver == address(0)`.
+2. Reject if the share token is paused.
+3. Check `owner` has enough shares.
+4. Spend share allowance if `msg.sender != owner`.
+5. Call `vault.onWithdraw(msg.sender, asset, assets, maxShares, receiver, owner, memo)`.
+6. Burn exactly the returned `shares` from `owner`.
+7. Emit ordinary TIP-20 share burn events and a vault passthrough withdrawal event.
+
+The vault contract transfers the withdrawal asset to `receiver` during `onWithdraw`. If the subsequent share burn fails, the full EVM frame MUST revert, including the vault's asset transfer.
+
+For `withdraw`, `memo` is `bytes32(0)`. `withdrawWithMemo` passes the user-supplied memo.
+
+`redeem(asset, shares, minAssets, receiver, owner)` follows the same model, but burns an exact share amount after the vault contract returns the output asset amount.
+
+The TIP-20 token MUST use a reentrancy guard around passthrough calls. While a passthrough operation is active, the token MUST reject reentrant deposit, withdrawal, reward-claim, mint, burn, or transfer operations on the same vault-backed TIP-20.
+
+## TIP-20 Share Behavior
+
+A vault-backed TIP-20 MUST support ordinary TIP-20 metadata, balances, transfers, approvals, permits, memos, pause state, logo URI, `quoteToken`, `currency`, transfer-policy, and receive-policy behavior.
+
+The following ordinary TIP-20 functions MUST revert on a vault-backed TIP-20 because they bypass vault accounting:
+
+- `mint(address,uint256)`
+- `mintWithMemo(address,uint256,bytes32)`
+- `burn(uint256)`
+- `burnWithMemo(uint256,bytes32)`
+- `burnBlocked(address,uint256)`
+- `distributeReward(uint256)`
+- `claimRewards()` from the ordinary TIP-20 reward surface, if present
+
+Vault-specific rewards are accessed through the passthrough `claimRewards(RewardClaim[],address)`, which forwards to `vault.onClaimRewards`.
+
+## SingleStrategyVault Contract
+
+`SingleStrategyVault` is a deployable contract implementation of `ITIP20VaultLogic`.
+
+It is intended for products where all deposits route into one configured yield source, such as a single lending venue or RWA strategy.
+
+`SingleStrategyVault` MUST:
+
+- bind to exactly one vault-backed TIP-20 share token;
+- hold or route all deposited assets through one immutable strategy adapter configured at deployment;
+- implement multi-asset deposit and withdrawal previews;
+- enforce vault-level deposit and withdrawal policy IDs;
+- support pro-rata and fixed-yield distribution modes;
+- optionally support native cumulative Merkle rewards;
+- support management and performance fee configuration;
+- reject any `manage` interface;
+- have no manager role.
+
+The strategy adapter SHOULD expose:
+
+```solidity
+interface ISingleStrategyAdapter {
+    function supportsDepositAsset(address asset) external view returns (bool);
+    function supportsWithdrawalAsset(address asset) external view returns (bool);
+    function totalBaseAssets() external view returns (uint256 baseAssets);
+    function previewDeposit(address asset, uint256 assets) external view returns (uint256 baseAssets);
+    function previewRedeem(address asset, uint256 baseAssets) external view returns (uint256 assets);
+    function deposit(address asset, uint256 assets) external returns (uint256 baseAssets);
+    function redeem(address asset, uint256 baseAssets, address receiver) external returns (uint256 assets);
+}
+```
+
+The deposit function changes in this contract relative to the multi-strategy contract: every successful deposit is routed into the single configured strategy during the deposit transaction, before shares are minted by the TIP-20 passthrough.
+
+## MultiStrategyVault Contract
+
+`MultiStrategyVault` is a deployable contract implementation of `ITIP20VaultLogic`.
+
+It is intended for products where a manager rebalances vault-owned liquidity across multiple venues.
+
+`MultiStrategyVault` MUST:
+
+- bind to exactly one vault-backed TIP-20 share token;
+- own custody and accounting for supported assets;
+- implement multi-asset deposit and withdrawal previews;
+- enforce vault-level deposit and withdrawal policy IDs;
+- support pro-rata, fixed-yield, and cumulative Merkle reward modes;
+- support management and performance fee configuration;
+- expose a manager role;
+- expose third-party-manager-compatible `manage` functions.
+
+The manager interface is:
+
+```solidity
+function manage(address target, bytes calldata data, uint256 value)
+    external
+    returns (bytes memory result);
+
+function manage(address[] calldata targets, bytes[] calldata data, uint256[] calldata values)
+    external
+    returns (bytes[] memory results);
+```
+
+`manage` MUST:
+
+1. Revert unless `msg.sender == manager`.
+2. Execute only from vault-owned assets.
+3. Reject delegatecall-style execution.
+4. Snapshot `ITIP20(vaultToken).totalSupply()` before execution and revert unless supply is unchanged after execution.
+5. Reject reentrant calls into user-facing passthrough callbacks.
+6. Reject calls that update owner configuration, fee configuration, policy IDs, rate providers, reward roots, distribution mode, or the manager address.
+7. Reject any attempt to use TIP-1035 implicit approval to pull assets from arbitrary users.
+8. Execute batch calls atomically.
+
+This is the integration point for external curation systems. A third-party manager or a Tempo adapter can verify curated calls and then call `MultiStrategyVault.manage(...)`. Tempo should not import a third-party user-facing deposit and withdrawal path.
+
+## Distribution Modes In Contracts
+
+Distribution modes are implemented by vault contracts, not by TIP-20.
+
+`PRO_RATA` means all net yield accrues to NAV and every share has the same pro-rata claim.
+
+`FIXED_YIELD` means shares accrue at a configured target rate. If real yield is above the target, the configured owner or fee recipient keeps the difference. If real yield is below the target, the vault contract must define whether a reserve, top-up, best-effort payout, or pause behavior applies.
+
+`MERKLE_REWARDS` means arbitrary rewards are computed offchain and claimed through cumulative proofs. The recommended leaf is:
+
+```solidity
+keccak256(abi.encode(
+    address(vaultToken),
+    address(vaultContract),
+    programId,
+    account,
+    rewardAsset,
+    cumulativeAmount
+))
+```
+
+This lets Tempo support partner campaign mechanics without making any external campaign distributor the protocol reward ledger. A compatibility adapter can claim or route partner campaign rewards into the vault contract.
+
+## Policy Integration
+
+Share transfer policy is protocol-enforced by the TIP-20 share token.
+
+Vault-level deposit and withdrawal policy is contract-enforced by `SingleStrategyVault` and `MultiStrategyVault`. Those contracts SHOULD store per-asset policy IDs and call TIP-403 for:
+
+- depositor eligibility;
+- share receiver eligibility beyond the share token's own mint check;
+- withdrawal owner eligibility;
+- withdrawal receiver eligibility;
+- asset-level allowlists and rate limits.
+
+Policy failures MUST happen before vault contracts finalize accounting or release assets.
+
+## Payment Lane and Fee AMM Integration
+
+Vault shares are ordinary TIP-20 balances, so they can be used in transfers, approvals, permits, Fee AMM routing, and payment flows wherever the corresponding TIP-20 is eligible.
+
+If deposit and withdrawal UX should receive payment-lane inclusion, TIP-1045 MUST add bounded allow-list entries for the TIP-20 passthrough selectors:
+
+- `deposit(address,uint256,address,uint256)`
+- `depositWithMemo(address,uint256,address,uint256,bytes32)`
+- `depositForShares(address,uint256,uint256,address)`
+- `withdraw(address,uint256,uint256,address,address)`
+- `withdrawWithMemo(address,uint256,uint256,address,address,bytes32)`
+- `redeem(address,uint256,uint256,address,address)`
+
+The payment-lane target is the TIP-20 share token, not the vault logic contract. `manage` and Merkle proof reward claims MUST NOT be payment-lane eligible.
+
+## Non-Goals
+
+This TIP does not:
+
+- enshrine vault accounting, asset configuration, strategy routing, fees, or rewards in a precompile;
+- require ERC-4626 or ERC-7575 compliance;
+- define a curation UI or strategy-construction product;
+- make any external partner part of the protocol trust model;
+- add a separate curator role to the TIP-20 token;
+- add a reward-updater role to the TIP-20 token;
+- define async redemption queues;
+- define migration between vault contracts.
+
+# Observability
+
+Implementations MUST emit:
+
+- `TokenCreated`: preserves compatibility with existing TIP-20 factory indexers.
+- `VaultTokenCreated`: identifies vault-backed TIP-20 tokens and the vault contract each token forwards to.
+- Ordinary TIP-20 `Transfer`, `Mint`, `Burn`, approval, memo, pause, logo, and transfer-policy events for share indexing.
+- A passthrough `Deposit` event from the TIP-20 token or vault contract that includes caller, receiver, asset, asset amount, shares, and memo.
+- A passthrough `Withdraw` event from the TIP-20 token or vault contract that includes caller, owner, receiver, asset, asset amount, shares, and memo.
+- Contract-level configuration events for asset config, fee config, policy IDs, distribution mode, reward roots, strategy config, owner, manager, and pause state.
+- `Managed` and `BatchManaged` events from `MultiStrategyVault`.
+- `RewardClaimed` events from the vault contract for cumulative reward claims.
+
+# Invariants
+
+- A vault-backed TIP-20 has exactly one immutable linked vault contract.
+- The vault contract is a smart contract, not enshrined TIP-20 accounting logic.
+- The TIP-20 share token remains the user-facing asset address.
+- `ITIP20Factory.isTIP20(token) == true` after successful creation.
+- `ITIP20VaultFactory.isVaultToken(token) == true` after successful creation.
+- `totalSupply()` equals the sum of holder balances after every successful external call.
+- Direct issuer mint and direct burn entrypoints revert.
+- The only successful share mint path is a deposit passthrough that receives a share amount from the linked vault contract.
+- The only successful share burn path is a withdrawal or redemption passthrough linked to the same vault contract.
+- TIP-20 does not compute NAV, supported assets, rates, fees, rewards, or strategy positions.
+- Vault contracts cannot mint shares except through the bound TIP-20 passthrough flow.
+- Vault contracts cannot use TIP-1035 implicit approval directly.
+- Share transfers use ordinary TIP-20 transfer policy and receive-policy behavior.
+- SingleStrategyVault has no manager role and no `manage` execution surface.
+- MultiStrategyVault exposes `manage` only for vault-owned assets and cannot change share supply during a managed batch.
+- Equal shares of the same vault-backed TIP-20 are fungible and have equal economic claims under the vault contract's configured distribution mode.
+- Payment-lane eligibility applies only to bounded TIP-20 passthrough selectors, never to direct vault contract calls, `manage`, or Merkle proof claims.


### PR DESCRIPTION
Adds TIP-1084 for vault-backed TIP-20 passthrough tokens. The protocol-enshrined piece is the TIP-20 share token and deposit/withdraw passthrough surface; custody, accounting, policies, fees, rewards, strategy routing, and manager execution live in vault smart contracts.

The proposed contract split is `SingleStrategyVault` for one configured yield source and `MultiStrategyVault` for manager-rebalanced vaults with a generic `manage` surface for external curation systems.

Validated with `git diff --check`; markdownlint is not installed locally.