### PR TITLE
deps: update reth from main (2026-06-29)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -189,7 +189,7 @@ dependencies = [
  "alloy-rlp",
  "num_enum",
  "serde",
- "strum",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -445,7 +445,7 @@ checksum = "2e92108767c8c95b5e521570e039e374e65198c4179a98d200412c083d6c26d5"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "http 1.4.0",
+ "http 1.4.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -504,8 +504,8 @@ dependencies = [
  "const-hex",
  "derive_more",
  "fixed-cache",
- "foldhash 0.2.0",
- "getrandom 0.4.2",
+ "foldhash",
+ "getrandom 0.4.3",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itoa",
@@ -556,10 +556,10 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru",
+ "lru 0.16.4",
  "parking_lot",
  "pin-project",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -610,7 +610,7 @@ checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -628,7 +628,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",
@@ -745,7 +745,7 @@ dependencies = [
  "jsonwebtoken",
  "rand 0.8.6",
  "serde",
- "strum",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -958,7 +958,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3 0.11.0",
- "syn 2.0.117",
+ "syn 2.0.118",
  "syn-solidity",
 ]
 
@@ -976,7 +976,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.118",
  "syn-solidity",
 ]
 
@@ -1034,7 +1034,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde_json",
  "tower",
  "tracing",
@@ -1070,7 +1070,7 @@ dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "rustls",
  "serde_json",
  "tokio",
@@ -1106,10 +1106,10 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc2cd27809c88c413e5542dbd5a8eff8c12f0086af920e881ae586d3a787d5e5"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1179,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -1203,7 +1203,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -1360,7 +1360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1398,7 +1398,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1487,7 +1487,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1528,9 +1528,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 dependencies = [
  "serde",
  "zeroize",
@@ -1573,7 +1573,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1584,7 +1584,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1622,14 +1622,14 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
@@ -1649,7 +1649,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "http 1.4.0",
+ "http 1.4.2",
  "time",
  "tokio",
  "tracing",
@@ -1708,7 +1708,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
@@ -1735,7 +1735,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -1760,7 +1760,7 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -1780,7 +1780,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "percent-encoding",
  "sha2 0.10.9",
  "time",
@@ -1810,7 +1810,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -1821,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.6"
+version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -1864,7 +1864,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -1876,16 +1876,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -1900,7 +1900,7 @@ checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1911,20 +1911,20 @@ checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.8"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
+checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -1948,13 +1948,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.15"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version 0.4.1",
  "tracing",
@@ -1970,7 +1971,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -2001,7 +2002,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -2123,7 +2124,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -2131,8 +2132,8 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 2.1.2",
- "shlex",
- "syn 2.0.117",
+ "shlex 1.3.0",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2151,19 +2152,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.4"
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.2",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.2",
 ]
 
 [[package]]
@@ -2174,9 +2196,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -2189,9 +2211,9 @@ checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -2235,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -2269,7 +2291,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "boa_interner",
  "boa_macros",
  "boa_string",
@@ -2286,7 +2308,7 @@ checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
 dependencies = [
  "aligned-vec",
  "arrayvec",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "boa_ast",
  "boa_gc",
  "boa_interner",
@@ -2368,7 +2390,7 @@ dependencies = [
  "cow-utils",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -2378,7 +2400,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "boa_ast",
  "boa_interner",
  "boa_macros",
@@ -2405,10 +2427,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "1.6.1"
+name = "bon"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -2417,31 +2464,31 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "boyer-moore-magiclen"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7441b4796eb8a7107d4cd99d829810be75f5573e1081c37faa0e8094169ea0d6"
+checksum = "43f0fdabfbc8017645223fd529c6077df2c491277e44e88ed8afd5afe54e715a"
 dependencies = [
  "debug-helper",
 ]
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -2450,9 +2497,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -2470,9 +2517,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "byte-slice-cast"
@@ -2497,7 +2550,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2508,9 +2561,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -2552,39 +2605,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver 1.0.28",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2601,14 +2621,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -2651,9 +2671,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -2675,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2767,7 +2787,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2793,9 +2813,9 @@ checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
 
 [[package]]
 name = "codspeed"
-version = "4.6.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ce4a32373a5c84f4fa785099b300b9b1796311abc122b9eb62c65fa615145d"
+checksum = "57af92d1db7f6871b7e82c79cd87f2501db66f36b0eab924be6ea83dd6b2f3f3"
 dependencies = [
  "anyhow",
  "cc",
@@ -2811,9 +2831,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-criterion-compat"
-version = "4.6.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5557c4e023f427ba208b849193c51c2ebd40534828490cd3f5f7f7fc0284ce5"
+checksum = "1d31ae2e9ab23c29fa13bdfa06d012524176f5c0f4e25ec262cd829d947ebc5e"
 dependencies = [
  "clap",
  "codspeed",
@@ -2824,9 +2844,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-criterion-compat-walltime"
-version = "4.6.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ac19f0a5c3542301e9d011d658f93c3f550698ec8ba7d7c072692e7924c401"
+checksum = "cc8605e40bab5114dcb0f76268e18880082b5798dec10757b5b58d2c3bbc7a1c"
 dependencies = [
  "anes",
  "cast",
@@ -3091,7 +3111,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "toml 0.9.12+spec-1.1.0",
 ]
 
@@ -3269,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -3324,9 +3344,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.19.0"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -3582,7 +3602,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -3643,9 +3663,9 @@ dependencies = [
 
 [[package]]
 name = "ct-codecs"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b10589d1a5e400d61f9f38f12f884cfd080ff345de8f17efda36fe0e4a02aa8"
+checksum = "49fb0c6640b4507ebd99ff67677009e381ba5eee1d14df78de4a3d16eb123c39"
 
 [[package]]
 name = "ctr"
@@ -3689,7 +3709,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3707,36 +3727,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -3750,18 +3746,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3770,9 +3755,9 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3814,14 +3799,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "debug-helper"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
+checksum = "80a4af69c60438a1a82af89d362f4729fd38db7b73f305a237636fad31ceb2bf"
 
 [[package]]
 name = "debugid"
@@ -3830,6 +3815,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3860,7 +3877,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -3883,7 +3899,7 @@ checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3894,38 +3910,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3947,7 +3932,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -3984,7 +3969,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "crypto-common 0.2.2",
 ]
 
@@ -4042,13 +4027,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4101,7 +4086,7 @@ checksum = "1ec431cd708430d5029356535259c5d645d60edd3d39c54e5eea9782d46caa7d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4167,7 +4152,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4228,22 +4213,22 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.3.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.3.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4263,7 +4248,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4327,10 +4312,10 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf022360bdbe9456eda5f35718a50476d5b2a0d51a97ed4eae27420737a6fba"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4359,6 +4344,12 @@ name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -4492,7 +4483,7 @@ checksum = "6dc7a9cb3326bafb80642c5ce99b39a2c0702d4bfa8ee8a3e773791a6cbe2407"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4570,12 +4561,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -4695,7 +4680,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4712,12 +4697,12 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 dependencies = [
  "gloo-timers",
- "send_wrapper 0.4.0",
+ "send_wrapper",
 ]
 
 [[package]]
@@ -4756,9 +4741,9 @@ dependencies = [
  "hyper",
  "jsonwebtoken",
  "once_cell",
- "prost 0.14.3",
+ "prost 0.14.4",
  "prost-types",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "secret-vault-value",
  "serde",
  "serde_json",
@@ -4773,9 +4758,9 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4826,16 +4811,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -4856,15 +4839,14 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "libgit2-sys",
  "log",
- "url",
 ]
 
 [[package]]
@@ -4883,7 +4865,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http 1.4.0",
+ "http 1.4.2",
  "js-sys",
  "pin-project",
  "serde",
@@ -4896,9 +4878,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4955,16 +4937,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.2",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -5020,7 +5002,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
- "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -5031,7 +5012,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -5040,16 +5021,18 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash 0.2.0",
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -5073,7 +5056,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.4.0",
+ "http 1.4.2",
  "httpdate",
  "mime",
  "sha1",
@@ -5085,7 +5068,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -5111,6 +5094,15 @@ name = "hex-conservative"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
 dependencies = [
  "arrayvec",
 ]
@@ -5230,9 +5222,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -5256,7 +5248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -5267,7 +5259,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -5314,25 +5306,25 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -5349,7 +5341,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "log",
@@ -5358,7 +5350,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -5384,7 +5376,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "hyper",
  "ipnet",
@@ -5446,7 +5438,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unic-langid",
 ]
 
@@ -5460,7 +5452,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5577,12 +5569,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5661,7 +5647,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5738,11 +5724,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -5768,9 +5754,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
@@ -5785,11 +5771,11 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5932,10 +5918,11 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -5945,13 +5932,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5997,7 +5984,7 @@ dependencies = [
  "quote",
  "rustc_version 0.4.1",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6025,7 +6012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6040,13 +6027,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -6078,7 +6064,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http 1.4.0",
+ "http 1.4.2",
  "jsonrpsee-core",
  "pin-project",
  "rustls",
@@ -6103,7 +6089,7 @@ dependencies = [
  "bytes",
  "futures-timer",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types",
@@ -6154,7 +6140,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6164,7 +6150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c51b7c290bb68ce3af2d029648148403863b982f138484a73f02a9dd52dbd7f"
 dependencies = [
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -6190,7 +6176,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6214,7 +6200,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6fceceeb05301cc4c065ab3bd2fa990d41ff4eb44e4ca1b30fa99c057c3e79"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -6287,9 +6273,9 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1766b89733097006f3a1388a02849865d6bc98c89273cb622e29fdd209922183"
+checksum = "dd5dc2c0d691cbf7595cde551ced329cca99c2387c2cbc97754c5d0cd045d3ee"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -6312,9 +6298,9 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -6326,7 +6312,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -6335,12 +6321,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "left-right"
@@ -6381,9 +6361,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.4+1.9.3"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
@@ -6409,9 +6389,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -6419,7 +6399,7 @@ dependencies = [
  "hkdf",
  "k256",
  "multihash",
- "quick-protobuf",
+ "prost 0.14.4",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tracing",
@@ -6439,9 +6419,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -6476,9 +6456,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -6492,7 +6472,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6541,9 +6521,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loom"
@@ -6565,6 +6545,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -6621,7 +6610,7 @@ checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6645,7 +6634,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6665,9 +6654,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
@@ -6714,7 +6703,7 @@ checksum = "161ab904c2c62e7bda0f7562bf22f96440ca35ff79e66c800cbac298f2f4f5ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6817,9 +6806,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -6845,7 +6834,7 @@ checksum = "59b43b4fd69e3437618106f7754f34021b831a514f9e1a98ae863cabcd8d8dad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6945,7 +6934,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "libc",
 ]
@@ -6956,7 +6945,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -6968,7 +6957,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -7005,7 +6994,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -7023,7 +7012,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -7154,7 +7143,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7187,7 +7176,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -7291,7 +7280,7 @@ checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
  "opentelemetry 0.31.0",
  "reqwest 0.12.28",
 ]
@@ -7304,9 +7293,9 @@ checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
  "opentelemetry 0.32.0",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
@@ -7315,12 +7304,12 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "opentelemetry 0.31.0",
  "opentelemetry-http 0.31.0",
  "opentelemetry-proto 0.31.0",
  "opentelemetry_sdk 0.31.0",
- "prost 0.14.3",
+ "prost 0.14.4",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tracing",
@@ -7332,13 +7321,13 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "opentelemetry 0.32.0",
  "opentelemetry-http 0.32.0",
  "opentelemetry-proto 0.32.0",
  "opentelemetry_sdk 0.32.1",
- "prost 0.14.3",
- "reqwest 0.13.3",
+ "prost 0.14.4",
+ "reqwest 0.13.4",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -7353,7 +7342,7 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry 0.31.0",
  "opentelemetry_sdk 0.31.0",
- "prost 0.14.3",
+ "prost 0.14.4",
  "tonic",
  "tonic-prost",
 ]
@@ -7366,16 +7355,16 @@ checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry 0.32.0",
  "opentelemetry_sdk 0.32.1",
- "prost 0.14.3",
+ "prost 0.14.4",
  "tonic",
  "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca2f98a0437b427b4b08f19f1caa3c44db885a202bc12cfea13d6c702243d68"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -7440,6 +7429,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7465,7 +7478,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7589,7 +7602,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7618,7 +7631,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7695,7 +7708,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -7728,7 +7741,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7815,7 +7828,7 @@ dependencies = [
  "flate2",
  "num",
  "paste",
- "prost 0.14.3",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -7855,7 +7868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7907,7 +7920,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7925,7 +7938,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "chrono",
  "flate2",
  "procfs-core",
@@ -7938,7 +7951,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "chrono",
  "hex",
 ]
@@ -7963,7 +7976,7 @@ checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7974,7 +7987,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -8003,7 +8016,7 @@ checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8014,7 +8027,7 @@ checksum = "c57924a81864dddafba92e1bf92f9bf82f97096c44489548a60e888e1547549b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8029,12 +8042,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -8052,24 +8065,24 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost 0.14.3",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -8143,19 +8156,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick-protobuf"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -8173,9 +8177,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -8209,9 +8213,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -8263,8 +8267,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
- "getrandom 0.4.2",
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -8353,9 +8357,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
 dependencies = [
  "rand 0.9.4",
  "rustversion",
@@ -8363,30 +8367,32 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "compact_str",
- "hashbrown 0.16.1",
- "indoc",
+ "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru",
- "strum",
+ "lru 0.18.0",
+ "palette",
+ "serde",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -8395,9 +8401,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -8407,18 +8413,19 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.16.1",
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum",
+ "serde",
+ "strum 0.28.0",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -8430,7 +8437,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -8471,7 +8478,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -8514,14 +8521,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8548,9 +8555,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "regress"
@@ -8573,7 +8580,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -8600,14 +8607,14 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -8615,7 +8622,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -8656,7 +8663,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8716,7 +8723,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8736,7 +8743,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8749,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8772,7 +8779,7 @@ dependencies = [
  "parking_lot",
  "ratatui",
  "rayon",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-runner",
@@ -8832,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8842,7 +8849,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8889,13 +8896,13 @@ checksum = "5798ae4d6b264764bc0d742468bd32c7fb515e774645d4930f95ff6311f3ae14"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8911,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +8932,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8938,7 +8945,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8951,7 +8958,7 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reth-node-api",
  "reth-tracing",
  "ringbuffer",
@@ -8963,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8982,7 +8989,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-tracing",
  "rustc-hash 2.1.2",
- "strum",
+ "strum 0.27.2",
  "sysinfo 0.38.4",
  "tempfile",
  "thiserror 2.0.18",
@@ -8992,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9018,7 +9025,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9048,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9063,7 +9070,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9088,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9112,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9136,7 +9143,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9171,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9228,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9256,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9279,7 +9286,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9304,7 +9311,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9363,7 +9370,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9393,7 +9400,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9411,13 +9418,13 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "bytes",
  "eyre",
  "futures-util",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reth-era",
  "reth-fs-util",
  "sha2 0.10.9",
@@ -9427,7 +9434,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9450,7 +9457,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9461,7 +9468,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9489,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9511,7 +9518,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9552,7 +9559,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "clap",
  "eyre",
@@ -9575,7 +9582,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9591,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9607,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9620,7 +9627,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9650,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9664,7 +9671,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9674,7 +9681,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9699,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9719,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9737,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9750,7 +9757,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9769,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9807,7 +9814,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9821,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "serde",
  "serde_json",
@@ -9831,7 +9838,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9859,7 +9866,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "bytes",
  "futures",
@@ -9879,9 +9886,9 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "byteorder",
  "crossbeam-queue",
  "dashmap",
@@ -9896,7 +9903,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "bindgen",
  "cc",
@@ -9905,7 +9912,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "futures",
  "metrics",
@@ -9918,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9927,11 +9934,11 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "futures-util",
  "if-addrs",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde_with",
  "thiserror 2.0.18",
  "tokio",
@@ -9941,7 +9948,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9999,7 +10006,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10024,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10048,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10063,7 +10070,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10077,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10094,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10118,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10186,7 +10193,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10229,7 +10236,7 @@ dependencies = [
  "reth-transaction-pool",
  "secp256k1 0.30.0",
  "serde",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
@@ -10241,7 +10248,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10288,7 +10295,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10312,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10336,11 +10343,11 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "bytes",
  "eyre",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "jemalloc_pprof",
  "jsonrpsee-server",
@@ -10351,7 +10358,7 @@ dependencies = [
  "metrics-util",
  "pprof_util",
  "procfs",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reth-fs-util",
  "reth-metrics",
  "reth-tasks",
@@ -10365,7 +10372,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10377,7 +10384,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10401,7 +10408,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10413,7 +10420,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10436,7 +10443,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10479,7 +10486,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10520,7 +10527,7 @@ dependencies = [
  "revm-state",
  "rocksdb",
  "smallvec",
- "strum",
+ "strum 0.27.2",
  "tokio",
  "tracing",
 ]
@@ -10528,7 +10535,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10556,7 +10563,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10564,7 +10571,7 @@ dependencies = [
  "modular-bitfield",
  "reth-codecs",
  "serde",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -10572,7 +10579,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10587,7 +10594,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10665,7 +10672,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10695,12 +10702,12 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-network",
  "alloy-provider",
  "dyn-clone",
- "http 1.4.0",
+ "http 1.4.2",
  "jsonrpsee",
  "metrics",
  "pin-project",
@@ -10738,7 +10745,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10758,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10789,7 +10796,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10836,7 +10843,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10857,7 +10864,7 @@ dependencies = [
  "jsonrpsee-types",
  "metrics",
  "rand 0.9.4",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -10887,10 +10894,10 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-rpc-types-engine",
- "http 1.4.0",
+ "http 1.4.2",
  "jsonrpsee-http-client",
  "pin-project",
  "tower",
@@ -10901,7 +10908,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10911,14 +10918,14 @@ dependencies = [
  "reth-errors",
  "reth-network-api",
  "serde",
- "strum",
+ "strum 0.27.2",
 ]
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936ba1aa863f2bbb2a0b5f28ea8a114058154e74969385ab27355421d56f9a03"
+checksum = "ace77dbcdd59c014fda4565ebfec76cd1fe6f5d98584b4655e8d22a947b9eee3"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10932,7 +10939,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10943,7 +10950,7 @@ dependencies = [
  "num-traits",
  "page_size",
  "rayon",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reth-chainspec",
  "reth-codecs",
  "reth-config",
@@ -10983,7 +10990,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11011,7 +11018,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11025,7 +11032,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11045,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11053,14 +11060,14 @@ dependencies = [
  "fixed-map",
  "reth-stages-types",
  "serde",
- "strum",
+ "strum 0.27.2",
  "tracing",
 ]
 
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11086,7 +11093,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11104,7 +11111,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11125,7 +11132,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11141,7 +11148,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11151,7 +11158,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "clap",
  "eyre",
@@ -11171,7 +11178,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11190,7 +11197,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11198,7 +11205,7 @@ dependencies = [
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "futures-util",
  "imbl",
  "metrics",
@@ -11235,7 +11242,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11261,7 +11268,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11289,7 +11296,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11308,7 +11315,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11337,7 +11344,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
+source = "git+https://github.com/paradigmxyz/reth?rev=015a00f#015a00f11233edf0203c902101f55fa10c71696d"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11497,9 +11504,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.41.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac492384995d832d6910920a932c000436623ec18668ff9291cb78f96c8b710f"
+checksum = "df57773f1122efc6d02e4126a2482e26936b759692d3b7a0fc649a21e4c893d9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11513,7 +11520,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "time",
 ]
 
 [[package]]
@@ -11573,7 +11579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
 dependencies = [
  "alloy-eip7928",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "nonmax",
  "revm-bytecode",
  "revm-primitives",
@@ -11709,9 +11715,9 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rpassword"
-version = "7.5.2"
+version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
 dependencies = [
  "libc",
  "rtoolbox",
@@ -11793,7 +11799,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.117",
+ "syn 2.0.118",
  "walkdir",
 ]
 
@@ -11867,7 +11873,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -11876,9 +11882,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -11892,9 +11898,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -11950,7 +11956,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs 1.0.7",
+ "webpki-root-certs 1.0.8",
  "windows-sys 0.61.2",
 ]
 
@@ -12178,7 +12184,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -12233,10 +12239,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "semver-parser"
@@ -12252,12 +12254,6 @@ checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
-
-[[package]]
-name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "send_wrapper"
@@ -12292,14 +12288,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -12343,9 +12339,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -12363,14 +12359,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12440,9 +12436,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3f15d4e239ebe08413eed880e0f9b5af4b40ee0472543320efa91d488e96a7"
+checksum = "a6287fd675f713484342a89cbf0a386abef5f15919cfad607e5e1f19e1e15331"
 dependencies = [
  "cc",
  "cfg-if",
@@ -12462,6 +12458,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -12582,9 +12584,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "arbitrary",
  "serde",
@@ -12598,9 +12600,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -12615,7 +12617,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.8.6",
@@ -12681,7 +12683,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -12693,7 +12704,19 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12750,9 +12773,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12768,7 +12791,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12788,7 +12811,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12825,7 +12848,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -12876,7 +12899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -12915,7 +12938,7 @@ dependencies = [
  "pyroscope",
  "pyroscope_pprofrs",
  "rand 0.8.6",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-commands",
@@ -12991,8 +13014,8 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures",
- "http 1.4.0",
- "reqwest 0.13.3",
+ "http 1.4.2",
+ "reqwest 0.13.4",
  "reth-evm",
  "reth-primitives-traits",
  "reth-rpc-convert",
@@ -13246,7 +13269,7 @@ dependencies = [
  "dirs-next",
  "minisign",
  "minisign-verify",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -13316,7 +13339,7 @@ dependencies = [
  "jsonrpsee",
  "p256",
  "rand 0.9.4",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reth-chainspec",
  "reth-e2e-test-utils",
  "reth-errors",
@@ -13457,7 +13480,7 @@ dependencies = [
  "alloy",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13546,7 +13569,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "poem",
  "rand_distr 0.5.1",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rustls",
  "tempo-alloy",
  "tempo-precompiles",
@@ -13685,7 +13708,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13696,7 +13719,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "test-case-core",
 ]
 
@@ -13732,7 +13755,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13743,21 +13766,21 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "thread-priority"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210811179577da3d54eb69ab0b50490ee40491a25d95b8c6011ba40771cb721"
+checksum = "8d2e834949be5111506bb252643498af1514f600d9e1dceedaa42afae155b67f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -13811,12 +13834,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -13828,15 +13850,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -13903,7 +13925,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -14004,9 +14026,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -14040,7 +14062,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -14057,7 +14079,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -14067,7 +14089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost 0.14.3",
+ "prost 0.14.4",
  "tonic",
 ]
 
@@ -14077,7 +14099,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
 dependencies = [
- "prost 0.14.3",
+ "prost 0.14.4",
  "prost-types",
  "tonic",
 ]
@@ -14110,11 +14132,11 @@ checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
@@ -14178,7 +14200,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -14386,10 +14408,10 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8840ad4d852e325d3afa7fde8a50b2412f89dce47d7eb291c0cc7f87cd040f38"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -14430,7 +14452,7 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -14458,9 +14480,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -14540,9 +14562,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -14646,11 +14668,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -14669,14 +14691,12 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.1.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+checksum = "b5574dd2f922b1a46a06a4b1dc11193a4012108fd54cf725e1816cb8183d8778"
 dependencies = [
  "anyhow",
- "cargo_metadata",
- "derive_builder",
- "regex",
+ "bon",
  "rustversion",
  "time",
  "vergen-lib",
@@ -14684,12 +14704,12 @@ dependencies = [
 
 [[package]]
 name = "vergen-git2"
-version = "9.1.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57"
+checksum = "410e2f72acce10471037150cd9c585ee7b54560f348bf70cd5fc8e87d3433e45"
 dependencies = [
  "anyhow",
- "derive_builder",
+ "bon",
  "git2",
  "rustversion",
  "time",
@@ -14699,12 +14719,12 @@ dependencies = [
 
 [[package]]
 name = "vergen-lib"
-version = "9.1.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+checksum = "8cd42fd155c2c2971f6d00face12ec245fbb604fce011ccaf2306d014c2e97ca"
 dependencies = [
  "anyhow",
- "derive_builder",
+ "bon",
  "rustversion",
 ]
 
@@ -14722,7 +14742,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -14767,27 +14787,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -14798,9 +14809,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -14808,9 +14819,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -14818,46 +14829,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -14871,18 +14860,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver 1.0.28",
 ]
 
 [[package]]
@@ -14901,9 +14878,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -14925,14 +14902,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.7",
+ "webpki-root-certs 1.0.8",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -14943,14 +14920,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -15107,7 +15084,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -15118,7 +15095,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -15466,97 +15443,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver 1.0.28",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "write16"
@@ -15582,7 +15471,7 @@ dependencies = [
  "log",
  "pharos",
  "rustc_version 0.4.1",
- "send_wrapper 0.6.0",
+ "send_wrapper",
  "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -15640,9 +15529,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -15657,28 +15546,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -15698,28 +15587,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -15754,7 +15643,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8656,7 +8656,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8716,7 +8716,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8736,7 +8736,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8749,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8832,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8895,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8911,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8938,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8963,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8992,7 +8992,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9048,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9171,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9393,7 +9393,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9411,7 +9411,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9450,7 +9450,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9511,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9552,7 +9552,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "clap",
  "eyre",
@@ -9575,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9591,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9607,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9650,7 +9650,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9664,7 +9664,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9674,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9699,7 +9699,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9737,7 +9737,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9807,7 +9807,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "serde",
  "serde_json",
@@ -9831,7 +9831,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "bytes",
  "futures",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9896,7 +9896,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "bindgen",
  "cc",
@@ -9905,7 +9905,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "futures",
  "metrics",
@@ -9918,7 +9918,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9927,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9941,7 +9941,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9999,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10024,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10063,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10077,7 +10077,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10094,7 +10094,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10118,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10186,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10241,7 +10241,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10288,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10312,7 +10312,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10336,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "bytes",
  "eyre",
@@ -10365,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10377,7 +10377,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10401,7 +10401,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10413,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10528,7 +10528,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10556,7 +10556,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10587,7 +10587,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10665,7 +10665,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10695,7 +10695,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10758,7 +10758,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10789,7 +10789,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10887,7 +10887,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10901,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10932,7 +10932,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10983,7 +10983,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11011,7 +11011,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11045,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11060,7 +11060,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11086,7 +11086,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11104,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11125,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11151,7 +11151,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "clap",
  "eyre",
@@ -11171,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11190,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11235,7 +11235,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11261,7 +11261,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11289,7 +11289,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11308,7 +11308,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11337,7 +11337,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
+source = "git+https://github.com/paradigmxyz/reth?rev=847f97a#847f97ab181f96d40879717ca5715fa47c13ebbe"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8656,7 +8656,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8716,7 +8716,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8736,7 +8736,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8749,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8832,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8895,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8911,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8938,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8963,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8992,7 +8992,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9048,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9171,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9393,7 +9393,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9411,7 +9411,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9450,7 +9450,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9511,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9552,7 +9552,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "clap",
  "eyre",
@@ -9575,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9591,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9607,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9650,7 +9650,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9664,7 +9664,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9674,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9699,7 +9699,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9737,7 +9737,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9807,7 +9807,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "serde",
  "serde_json",
@@ -9831,7 +9831,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "bytes",
  "futures",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9896,7 +9896,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "bindgen",
  "cc",
@@ -9905,7 +9905,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "futures",
  "metrics",
@@ -9918,7 +9918,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9927,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9941,7 +9941,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9999,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10024,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10063,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10077,7 +10077,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10094,7 +10094,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10118,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10186,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10241,7 +10241,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10288,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10312,7 +10312,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10336,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "bytes",
  "eyre",
@@ -10365,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10377,7 +10377,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10401,7 +10401,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10413,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10528,7 +10528,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10556,7 +10556,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10587,7 +10587,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10665,7 +10665,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10695,7 +10695,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10758,7 +10758,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10789,7 +10789,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10887,7 +10887,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10901,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10932,7 +10932,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10983,7 +10983,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11011,7 +11011,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11045,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11060,7 +11060,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11086,7 +11086,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11104,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11125,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11151,7 +11151,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "clap",
  "eyre",
@@ -11171,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11190,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11235,7 +11235,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11261,7 +11261,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11289,7 +11289,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11308,7 +11308,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11337,7 +11337,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=224b087#224b087672690ae2ef85ad706bd18f40d8e5b265"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "224b087", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "224b087", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "224b087", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "224b087", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "847f97a", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "015a00f", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,8 +327,8 @@ age = { version = "0.11", default-features = false }
 secrecy = "0.10"
 
 # build deps
-vergen = "9.1.0"
-vergen-git2 = "9.1.0"
+vergen = "10.0.1"
+vergen-git2 = "10.0.1"
 
 # [patch."https://github.com/paradigmxyz/reth"]
 # reth-basic-payload-builder = { path = "../reth/crates/payload/basic" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "224b087", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "224b087", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "224b087", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "224b087" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "224b087", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -100,7 +100,7 @@ sha2 = { workspace = true }
 base64.workspace = true
 
 [build-dependencies]
-vergen.workspace = true
+vergen = { workspace = true, features = ["build", "cargo", "emit_and_set"] }
 vergen-git2.workspace = true
 
 [features]

--- a/crates/node/build.rs
+++ b/crates/node/build.rs
@@ -1,28 +1,25 @@
 #![allow(missing_docs)]
 
 use std::{env, error::Error};
-use vergen::{BuildBuilder, CargoBuilder, Emitter};
-use vergen_git2::Git2Builder;
+use vergen::{Build, Cargo, Emitter};
+use vergen_git2::Git2;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let mut emitter = Emitter::default();
 
-    let build_builder = BuildBuilder::default().build_timestamp(true).build()?;
+    let build_builder = Build::builder().build_timestamp(true).build();
 
     emitter.add_instructions(&build_builder)?;
 
-    let cargo_builder = CargoBuilder::default()
-        .features(true)
-        .target_triple(true)
-        .build()?;
+    let cargo_builder = Cargo::builder().features(true).target_triple(true).build();
 
     emitter.add_instructions(&cargo_builder)?;
 
-    let git_builder = Git2Builder::default()
+    let git_builder = Git2::builder()
         .describe(false, true, None)
         .dirty(true)
         .sha(false)
-        .build()?;
+        .build();
 
     emitter.add_instructions(&git_builder)?;
 


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`5d027e5...015a00f`](https://github.com/paradigmxyz/reth/compare/5d027e5...015a00f)

🔗 Amp thread: https://ampcode.com/threads/T-019f11ac-b089-745c-a4f5-ca140cfd8661
**Networking**
- Advertise NAT addresses in discv5 with dual-stack support ([#25757](https://github.com/paradigmxyz/reth/pull/25757))

**RPC**
- Serialize capability retention as quantity ([#25324](https://github.com/paradigmxyz/reth/pull/25324))

**EVM**
- Enable GMP by default ([#25512](https://github.com/paradigmxyz/reth/pull/25512))

**Build**
- Bump vergen to v10 ([#25864](https://github.com/paradigmxyz/reth/pull/25864))
- Include LICENSES in Docker build context ([#25855](https://github.com/paradigmxyz/reth/pull/25855))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019f11ac-cfee-7240-b8f1-d087148e40bf
- Bumped reth git dependencies from rev `5d027e5` to `015a00f` across all workspace `reth-*` crates
- Upgraded `vergen` and `vergen-git2` from `9.1.0` to `10.0.1`
- Added explicit `vergen` feature flags (`build`, `cargo`, `emit_and_set`) in `crates/node/Cargo.toml`, since v10 no longer enables them by default
- Migrated `build.rs` to the v10 builder API: renamed `BuildBuilder`/`CargoBuilder`/`Git2Builder` to `Build`/`Cargo`/`Git2` with `::builder()` constructors
- Changed builder `.build()` calls to be infallible (removed `?`), matching the v10 API that no longer returns `Result`

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/28348728848)
