### PR TITLE
chore: bump vergen to v10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc2cd27809c88c413e5542dbd5a8eff8c12f0086af920e881ae586d3a787d5e5"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2420,7 +2420,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2574,39 +2574,6 @@ dependencies = [
  "libc",
  "once_cell",
  "serde",
-]
-
-[[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver 1.0.28",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3732,36 +3699,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -3780,22 +3723,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -3918,37 +3850,6 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
  "syn 2.0.117",
 ]
 
@@ -4351,7 +4252,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf022360bdbe9456eda5f35718a50476d5b2a0d51a97ed4eae27420737a6fba"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4877,19 +4778,6 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
-name = "git2"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
 
 [[package]]
 name = "git2"
@@ -5821,7 +5709,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
@@ -8692,7 +8580,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8719,7 +8607,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8752,7 +8640,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8772,7 +8660,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8785,7 +8673,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8868,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8878,7 +8766,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8931,7 +8819,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8947,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8961,7 +8849,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8974,7 +8862,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8999,7 +8887,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9028,7 +8916,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9054,7 +8942,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9084,7 +8972,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9099,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9124,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9148,7 +9036,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9172,7 +9060,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9207,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9264,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9292,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9315,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9340,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9399,7 +9287,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9429,7 +9317,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9447,7 +9335,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9463,7 +9351,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9486,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9497,7 +9385,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9525,7 +9413,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9547,7 +9435,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9588,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "clap",
  "eyre",
@@ -9611,7 +9499,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9627,7 +9515,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9643,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9656,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9686,7 +9574,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9700,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9710,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9735,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9755,7 +9643,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9773,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9786,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9805,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9843,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9857,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "serde",
  "serde_json",
@@ -9867,7 +9755,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9895,7 +9783,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "bytes",
  "futures",
@@ -9915,7 +9803,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9932,7 +9820,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "bindgen",
  "cc",
@@ -9941,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "futures",
  "metrics",
@@ -9954,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9963,7 +9851,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9977,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10035,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10060,7 +9948,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10084,7 +9972,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10099,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10113,7 +10001,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10130,7 +10018,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10154,7 +10042,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10222,7 +10110,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10270,14 +10158,14 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "url",
- "vergen 9.1.0",
- "vergen-git2 9.1.0",
+ "vergen",
+ "vergen-git2",
 ]
 
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10324,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10348,7 +10236,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10372,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "bytes",
  "eyre",
@@ -10401,7 +10289,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10413,7 +10301,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10437,7 +10325,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10449,7 +10337,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10472,7 +10360,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10515,7 +10403,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10564,7 +10452,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10592,7 +10480,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10608,7 +10496,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10623,7 +10511,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10701,7 +10589,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10731,7 +10619,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10774,7 +10662,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10794,7 +10682,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10825,7 +10713,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10872,7 +10760,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10923,7 +10811,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10937,7 +10825,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10968,7 +10856,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11019,7 +10907,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11047,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11061,7 +10949,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11081,7 +10969,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11096,7 +10984,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11122,7 +11010,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11140,7 +11028,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11161,7 +11049,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11177,7 +11065,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11187,7 +11075,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "clap",
  "eyre",
@@ -11207,7 +11095,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11226,7 +11114,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11271,7 +11159,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11297,7 +11185,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11325,7 +11213,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11344,7 +11232,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11373,7 +11261,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?branch=centaur%2Fbump-vergen-v10-1782632668#afd00190dc2c73c8e7be1a32afdac5036e2542e6"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -12268,10 +12156,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "semver-parser"
@@ -12402,7 +12286,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13391,8 +13275,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "url",
- "vergen 10.0.1",
- "vergen-git2 10.0.1",
+ "vergen",
+ "vergen-git2",
 ]
 
 [[package]]
@@ -14420,7 +14304,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8840ad4d852e325d3afa7fde8a50b2412f89dce47d7eb291c0cc7f87cd040f38"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14703,21 +14587,6 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
-dependencies = [
- "anyhow",
- "cargo_metadata",
- "derive_builder",
- "regex",
- "rustversion",
- "time",
- "vergen-lib 9.1.0",
-]
-
-[[package]]
-name = "vergen"
 version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5574dd2f922b1a46a06a4b1dc11193a4012108fd54cf725e1816cb8183d8778"
@@ -14726,22 +14595,7 @@ dependencies = [
  "bon",
  "rustversion",
  "time",
- "vergen-lib 10.0.1",
-]
-
-[[package]]
-name = "vergen-git2"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57"
-dependencies = [
- "anyhow",
- "derive_builder",
- "git2 0.20.4",
- "rustversion",
- "time",
- "vergen 9.1.0",
- "vergen-lib 9.1.0",
+ "vergen-lib",
 ]
 
 [[package]]
@@ -14752,22 +14606,11 @@ checksum = "410e2f72acce10471037150cd9c585ee7b54560f348bf70cd5fc8e87d3433e45"
 dependencies = [
  "anyhow",
  "bon",
- "git2 0.21.0",
+ "git2",
  "rustversion",
  "time",
- "vergen 10.0.1",
- "vergen-lib 10.0.1",
-]
-
-[[package]]
-name = "vergen-lib"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
+ "vergen",
+ "vergen-lib",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2405,6 +2405,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling 0.23.0",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3860,7 +3885,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -4865,6 +4889,18 @@ dependencies = [
  "libgit2-sys",
  "log",
  "url",
+]
+
+[[package]]
+name = "git2"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "libgit2-sys",
+ "log",
 ]
 
 [[package]]
@@ -10234,8 +10270,8 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "url",
- "vergen",
- "vergen-git2",
+ "vergen 9.1.0",
+ "vergen-git2 9.1.0",
 ]
 
 [[package]]
@@ -11497,9 +11533,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.41.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac492384995d832d6910920a932c000436623ec18668ff9291cb78f96c8b710f"
+checksum = "df57773f1122efc6d02e4126a2482e26936b759692d3b7a0fc649a21e4c893d9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11513,7 +11549,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "time",
 ]
 
 [[package]]
@@ -13356,8 +13391,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "url",
- "vergen",
- "vergen-git2",
+ "vergen 10.0.1",
+ "vergen-git2 10.0.1",
 ]
 
 [[package]]
@@ -13811,12 +13846,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -13828,15 +13862,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -14679,7 +14713,20 @@ dependencies = [
  "regex",
  "rustversion",
  "time",
- "vergen-lib",
+ "vergen-lib 9.1.0",
+]
+
+[[package]]
+name = "vergen"
+version = "10.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5574dd2f922b1a46a06a4b1dc11193a4012108fd54cf725e1816cb8183d8778"
+dependencies = [
+ "anyhow",
+ "bon",
+ "rustversion",
+ "time",
+ "vergen-lib 10.0.1",
 ]
 
 [[package]]
@@ -14690,11 +14737,26 @@ checksum = "d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57"
 dependencies = [
  "anyhow",
  "derive_builder",
- "git2",
+ "git2 0.20.4",
  "rustversion",
  "time",
- "vergen",
- "vergen-lib",
+ "vergen 9.1.0",
+ "vergen-lib 9.1.0",
+]
+
+[[package]]
+name = "vergen-git2"
+version = "10.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410e2f72acce10471037150cd9c585ee7b54560f348bf70cd5fc8e87d3433e45"
+dependencies = [
+ "anyhow",
+ "bon",
+ "git2 0.21.0",
+ "rustversion",
+ "time",
+ "vergen 10.0.1",
+ "vergen-lib 10.0.1",
 ]
 
 [[package]]
@@ -14705,6 +14767,17 @@ checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
 dependencies = [
  "anyhow",
  "derive_builder",
+ "rustversion",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "10.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd42fd155c2c2971f6d00face12ec245fbb604fce011ccaf2306d014c2e97ca"
+dependencies = [
+ "anyhow",
+ "bon",
  "rustversion",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,8 +327,8 @@ age = { version = "0.11", default-features = false }
 secrecy = "0.10"
 
 # build deps
-vergen = "9.1.0"
-vergen-git2 = "9.1.0"
+vergen = "10.0.1"
+vergen-git2 = "10.0.1"
 
 # [patch."https://github.com/paradigmxyz/reth"]
 # reth-basic-payload-builder = { path = "../reth/crates/payload/basic" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "centaur/bump-vergen-v10-1782632668", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -100,7 +100,7 @@ sha2 = { workspace = true }
 base64.workspace = true
 
 [build-dependencies]
-vergen.workspace = true
+vergen = { workspace = true, features = ["build", "cargo", "emit_and_set"] }
 vergen-git2.workspace = true
 
 [features]

--- a/crates/node/build.rs
+++ b/crates/node/build.rs
@@ -1,28 +1,25 @@
 #![allow(missing_docs)]
 
 use std::{env, error::Error};
-use vergen::{BuildBuilder, CargoBuilder, Emitter};
-use vergen_git2::Git2Builder;
+use vergen::{Build, Cargo, Emitter};
+use vergen_git2::Git2;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let mut emitter = Emitter::default();
 
-    let build_builder = BuildBuilder::default().build_timestamp(true).build()?;
+    let build_builder = Build::builder().build_timestamp(true).build();
 
     emitter.add_instructions(&build_builder)?;
 
-    let cargo_builder = CargoBuilder::default()
-        .features(true)
-        .target_triple(true)
-        .build()?;
+    let cargo_builder = Cargo::builder().features(true).target_triple(true).build();
 
     emitter.add_instructions(&cargo_builder)?;
 
-    let git_builder = Git2Builder::default()
+    let git_builder = Git2::builder()
         .describe(false, true, None)
         .dirty(true)
         .sha(false)
-        .build()?;
+        .build();
 
     emitter.add_instructions(&git_builder)?;
 


### PR DESCRIPTION
Bumps Tempo's direct `vergen` and `vergen-git2` build dependencies to `10.0.1` and updates `crates/node/build.rs` for the v10 API (`Build`, `Cargo`, and `Git2`).

Also enables the explicit `build`, `cargo`, and `emit_and_set` features needed by `vergen` v10. The lockfile resolves `revm-inspectors` to `0.41.0` because `0.41.1` pins `time =0.3.47`, which conflicts with `vergen-git2` v10 requiring `time ^0.3.51`.

Validation:
- `cargo check -p tempo-node`
- `rustfmt --edition 2024 --check crates/node/build.rs`
- `git diff --check`

Prompted by: @DaniPopes

Blocked on: https://github.com/paradigmxyz/reth/pull/25864