### PR TITLE
feat(bench): report payment-lane latency SLO under mixed load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13537,6 +13537,7 @@ name = "tempo-sidecar"
 version = "1.9.1"
 dependencies = [
  "alloy",
+ "alloy-consensus",
  "clap",
  "eyre",
  "futures",

--- a/bin/tempo-sidecar/Cargo.toml
+++ b/bin/tempo-sidecar/Cargo.toml
@@ -32,6 +32,7 @@ alloy = { workspace = true, default-features = false, features = [
     "signer-mnemonic",
     "rand",
 ] }
+alloy-consensus.workspace = true
 eyre.workspace = true
 futures.workspace = true
 hex = "0.4"

--- a/bin/tempo-sidecar/src/cmd/tx_latency.rs
+++ b/bin/tempo-sidecar/src/cmd/tx_latency.rs
@@ -1,6 +1,7 @@
+use alloy_consensus::transaction::TxHashRef as _;
 use crate::monitor::prometheus_metrics;
 use alloy::{
-    primitives::map::{B256Map, B256Set},
+    primitives::map::B256Map,
     providers::{Provider, ProviderBuilder, WsConnect},
 };
 use clap::Parser;
@@ -10,10 +11,15 @@ use metrics::{describe_gauge, describe_histogram, gauge, histogram};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use poem::{EndpointExt, Route, Server, get, listener::TcpListener};
 use reqwest::Url;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tempo_alloy::{TempoNetwork, primitives::TempoHeader};
+use std::{
+    collections::VecDeque,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use tempo_alloy::{TempoNetwork, primitives::{TempoHeader, TempoTxEnvelope}};
 use tokio::signal;
 use tracing::{debug, error, warn};
+
+const PAYMENT_LATENCY_WINDOW: usize = 100;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -33,21 +39,36 @@ pub struct TxLatencyArgs {
     /// Maximum age (seconds) to track pending transactions before expiring them.
     #[arg(long, default_value_t = 600)]
     max_pending_age_secs: u64,
+
+    /// Hardfork identifier for lane classification (reserved for future v2 classifier).
+    #[arg(long, default_value = "t5")]
+    hardfork: String,
+
+    /// SLO target for payment-lane landing latency in seconds.
+    #[arg(long, default_value_t = 1.0)]
+    payment_slo_target_secs: f64,
 }
 
 struct TransactionLatencyMonitor {
     rpc_url: Url,
     max_pending_age: Duration,
-    /// Keeps track of the transactions that were emitted over the pending event stream.
-    pending: B256Map<u128>,
+    /// Hash → (first_seen_millis, envelope). Envelope is None until the tx lands in a block
+    /// because subscribe_pending_transactions emits hashes only; the full envelope is resolved
+    /// from the mined block.
+    pending: B256Map<(u128, Option<TempoTxEnvelope>)>,
+    /// Rolling window of the last PAYMENT_LATENCY_WINDOW payment-lane latencies (seconds).
+    payment_latencies: VecDeque<f64>,
+    payment_slo_target_secs: f64,
 }
 
 impl TransactionLatencyMonitor {
-    fn new(rpc_url: Url, max_pending_age: Duration) -> Self {
+    fn new(rpc_url: Url, max_pending_age: Duration, payment_slo_target_secs: f64) -> Self {
         Self {
             rpc_url,
             max_pending_age,
             pending: Default::default(),
+            payment_latencies: VecDeque::new(),
+            payment_slo_target_secs,
         }
     }
 
@@ -75,7 +96,9 @@ impl TransactionLatencyMonitor {
             tokio::select! {
                 maybe_hash = stream.next() => {
                     match maybe_hash {
-                        Some(hash) => { self.pending.entry(hash).or_insert_with(Self::now_millis); }
+                        Some(hash) => {
+                            self.pending.entry(hash).or_insert_with(|| (Self::now_millis(), None));
+                        }
                         None => {
                             warn!("pending transaction stream ended; reconnecting");
                             provider = ProviderBuilder::new_with_network::<TempoNetwork>()
@@ -93,34 +116,67 @@ impl TransactionLatencyMonitor {
                 },
                 maybe_block = block_subscription.next() => {
                     if let Some(Ok(block)) = maybe_block {
-                         self.on_mined_block(block.header.inner.into_consensus(), block.transactions.hashes().collect());
+                        let header = block.header.inner.into_consensus();
+                        let mined_txs: B256Map<TempoTxEnvelope> = block
+                            .transactions
+                            .into_transactions()
+                            .map(|tx| {
+                                let hash = *tx.inner.tx_hash();
+                                let envelope = tx.inner.into_inner();
+                                (hash, envelope)
+                            })
+                            .collect();
+                        self.on_mined_block(header, mined_txs);
                     }
                 }
             }
         }
     }
 
-    fn on_mined_block(&mut self, header: TempoHeader, mined_txs: B256Set) {
+    fn on_mined_block(&mut self, header: TempoHeader, mined_txs: B256Map<TempoTxEnvelope>) {
         gauge!("tempo_tx_latency_pending_observed").set(self.pending.len() as f64);
         if self.pending.is_empty() {
             return;
         }
-        self.pending.retain(|hash, seen_at| {
-            if mined_txs.contains(hash) {
-                let latency_secs =
-                    Self::latency_seconds(*seen_at, header.timestamp_millis() as u128);
-                histogram!("tempo_tx_landing_latency_seconds").record(latency_secs);
+
+        let block_ts = header.timestamp_millis() as u128;
+        let mut payment_latencies_this_block: Vec<f64> = Vec::new();
+
+        self.pending.retain(|hash, (seen_at, _)| {
+            if let Some(envelope) = mined_txs.get(hash) {
+                let latency_secs = Self::latency_seconds(*seen_at, block_ts);
+                let lane = if envelope.is_payment() { "payment" } else { "non_payment" };
+                histogram!("tempo_tx_landing_latency_seconds", "lane" => lane).record(latency_secs);
+                if envelope.is_payment() {
+                    payment_latencies_this_block.push(latency_secs);
+                }
                 false
             } else {
                 true
             }
         });
 
+        for lat in payment_latencies_this_block {
+            if self.payment_latencies.len() >= PAYMENT_LATENCY_WINDOW {
+                self.payment_latencies.pop_front();
+            }
+            self.payment_latencies.push_back(lat);
+        }
+
+        if !self.payment_latencies.is_empty() {
+            let miss_count = self
+                .payment_latencies
+                .iter()
+                .filter(|&&lat| lat > self.payment_slo_target_secs)
+                .count();
+            let miss_rate = miss_count as f64 / self.payment_latencies.len() as f64;
+            gauge!("tempo_payment_lane_slo_miss_rate").set(miss_rate);
+        }
+
         let now = Self::now_millis();
         let max_age_millis = self.max_pending_age.as_millis();
         let before_cleanup = self.pending.len();
-        self.pending
-            .retain(|_, seen_at| now.saturating_sub(*seen_at) <= max_age_millis);
+        self.pending.retain(|_, (seen_at, _)| now.saturating_sub(*seen_at) <= max_age_millis);
 
         if self.pending.len() < before_cleanup {
             debug!(
@@ -155,11 +211,15 @@ impl TxLatencyArgs {
 
         describe_histogram!(
             "tempo_tx_landing_latency_seconds",
-            "Latency between seeing a transaction in the pool and it landing in a block"
+            "Latency between seeing a transaction in the pool and it landing in a block (lane: payment | non_payment)"
         );
         describe_gauge!(
             "tempo_tx_latency_pending_observed",
             "Number of observed pending transactions awaiting inclusion"
+        );
+        describe_gauge!(
+            "tempo_payment_lane_slo_miss_rate",
+            "Fraction of payment-lane transactions (rolling last 100) that exceeded the SLO target latency"
         );
 
         let app = Route::new().at(
@@ -169,9 +229,16 @@ impl TxLatencyArgs {
 
         let addr = format!("0.0.0.0:{}", self.port);
 
+        tracing::info!(
+            hardfork = %self.hardfork,
+            payment_slo_target_secs = self.payment_slo_target_secs,
+            "starting tx latency monitor"
+        );
+
         let mut monitor = TransactionLatencyMonitor::new(
             self.rpc_url,
             Duration::from_secs(self.max_pending_age_secs),
+            self.payment_slo_target_secs,
         );
 
         let monitor_handle = tokio::spawn(async move {


### PR DESCRIPTION
Closes #5029.

## Summary

- **Lane label on `tempo_tx_landing_latency_seconds`**: every observation now carries a `lane` label (`payment` or `non_payment`) so Prometheus/Grafana can split p50/p99 per lane.
- **SLO miss-rate gauge `tempo_payment_lane_slo_miss_rate`**: emitted each block; fraction of payment-lane transactions (rolling last 100) that exceeded the configurable `--payment-slo-target-secs` threshold (default 1.0 s).
- **Hardfork classification flag `--hardfork`** (default `t5`): logged at startup, reserved for a future v2 classifier; always uses `is_payment()` (v1) today.
- **Full-envelope extraction from mined blocks**: `pending` now stores `(first_seen_millis, Option<TempoTxEnvelope>)`; envelope is resolved from the mined block via `block.transactions.into_transactions()`.

## Changed files

- `bin/tempo-sidecar/src/cmd/tx_latency.rs` — all feature work
- `bin/tempo-sidecar/Cargo.toml` — add `alloy-consensus.workspace = true` for `TxHashRef`

## Test plan

- [ ] `cargo check -p tempo-sidecar` passes on Linux (Unix signal handlers are Linux-only; confirmed no errors in changed code paths on the host).
- [ ] Scrape `/metrics`: confirm `tempo_tx_landing_latency_seconds{lane="payment"}` and `tempo_tx_landing_latency_seconds{lane="non_payment"}` are emitted.
- [ ] Confirm `tempo_payment_lane_slo_miss_rate` updates each block and trends toward 0 under normal load.
- [ ] Confirm `--payment-slo-target-secs` and `--hardfork` CLI flags are accepted.