### PR TITLE
deps: update reth from main (2026-06-29)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,7 +1163,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1174,7 +1174,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2405,6 +2405,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling 0.20.11",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2549,39 +2574,6 @@ dependencies = [
  "libc",
  "once_cell",
  "serde",
-]
-
-[[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver 1.0.28",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3860,7 +3852,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -3894,37 +3885,6 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
  "syn 2.0.117",
 ]
 
@@ -4279,7 +4239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4782,8 +4742,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4856,15 +4816,14 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
- "url",
 ]
 
 [[package]]
@@ -5475,7 +5434,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5871,7 +5830,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7041,7 +7000,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8656,7 +8615,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8716,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8736,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8749,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8832,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8842,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8895,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8911,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8938,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8963,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8992,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9018,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9048,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9063,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9088,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9112,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9136,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9171,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9228,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9256,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9279,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9304,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9363,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9393,7 +9352,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9411,7 +9370,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9427,7 +9386,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9450,7 +9409,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9461,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9489,7 +9448,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9511,7 +9470,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9552,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "clap",
  "eyre",
@@ -9575,7 +9534,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9591,7 +9550,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9607,7 +9566,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9620,7 +9579,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9650,7 +9609,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9664,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9674,7 +9633,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9699,7 +9658,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9719,7 +9678,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9737,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9750,7 +9709,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9769,7 +9728,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9807,7 +9766,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9821,7 +9780,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "serde",
  "serde_json",
@@ -9831,7 +9790,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9859,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "bytes",
  "futures",
@@ -9879,7 +9838,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9896,7 +9855,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "bindgen",
  "cc",
@@ -9905,7 +9864,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "futures",
  "metrics",
@@ -9918,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9927,7 +9886,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9941,7 +9900,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9999,7 +9958,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10024,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10048,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10063,7 +10022,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10077,7 +10036,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10094,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10118,7 +10077,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10186,7 +10145,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10241,7 +10200,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10288,7 +10247,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10312,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10336,7 +10295,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "bytes",
  "eyre",
@@ -10365,7 +10324,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10377,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10401,7 +10360,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10413,7 +10372,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10436,7 +10395,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10479,7 +10438,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10528,7 +10487,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10556,7 +10515,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10572,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10587,7 +10546,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10665,7 +10624,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10695,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10738,7 +10697,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10758,7 +10717,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10789,7 +10748,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10836,7 +10795,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10887,7 +10846,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10901,7 +10860,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10932,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10983,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11011,7 +10970,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11025,7 +10984,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11045,7 +11004,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11060,7 +11019,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11086,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11104,7 +11063,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11125,7 +11084,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11141,7 +11100,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11151,7 +11110,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "clap",
  "eyre",
@@ -11171,7 +11130,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11190,7 +11149,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11235,7 +11194,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11261,7 +11220,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11289,7 +11248,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11308,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11337,7 +11296,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=5d027e5#5d027e5ff72f31270b862f8e000d1cc79621be2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11497,9 +11456,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.41.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac492384995d832d6910920a932c000436623ec18668ff9291cb78f96c8b710f"
+checksum = "df57773f1122efc6d02e4126a2482e26936b759692d3b7a0fc649a21e4c893d9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11513,7 +11472,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "time",
 ]
 
 [[package]]
@@ -11871,7 +11829,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11951,7 +11909,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12233,10 +12191,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "semver-parser"
@@ -12603,7 +12557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12879,7 +12833,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13812,12 +13766,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -13829,15 +13782,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -14670,14 +14623,12 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.1.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+checksum = "b5574dd2f922b1a46a06a4b1dc11193a4012108fd54cf725e1816cb8183d8778"
 dependencies = [
  "anyhow",
- "cargo_metadata",
- "derive_builder",
- "regex",
+ "bon",
  "rustversion",
  "time",
  "vergen-lib",
@@ -14685,12 +14636,12 @@ dependencies = [
 
 [[package]]
 name = "vergen-git2"
-version = "9.1.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57"
+checksum = "410e2f72acce10471037150cd9c585ee7b54560f348bf70cd5fc8e87d3433e45"
 dependencies = [
  "anyhow",
- "derive_builder",
+ "bon",
  "git2",
  "rustversion",
  "time",
@@ -14700,12 +14651,12 @@ dependencies = [
 
 [[package]]
 name = "vergen-lib"
-version = "9.1.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+checksum = "8cd42fd155c2c2971f6d00face12ec245fbb604fce011ccaf2306d014c2e97ca"
 dependencies = [
  "anyhow",
- "derive_builder",
+ "bon",
  "rustversion",
 ]
 
@@ -15000,7 +14951,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "5d027e5", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,7 +217,7 @@ alloy-contract = { version = "2.1.0", default-features = false }
 alloy-eip7928 = { version = "0.4.5", default-features = false }
 alloy-eips = { version = "2.1.0", default-features = false }
 alloy-evm = { version = "0.37.1", default-features = false }
-revm-inspectors = "0.41.1"
+revm-inspectors = "=0.41.0"
 alloy-genesis = { version = "2.1.0", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-abi = { version = "1.6.0", default-features = false }
@@ -327,8 +327,8 @@ age = { version = "0.11", default-features = false }
 secrecy = "0.10"
 
 # build deps
-vergen = "9.1.0"
-vergen-git2 = "9.1.0"
+vergen = { version = "10.0.1", features = ["build", "cargo", "emit_and_set"] }
+vergen-git2 = "10.0.1"
 
 # [patch."https://github.com/paradigmxyz/reth"]
 # reth-basic-payload-builder = { path = "../reth/crates/payload/basic" }

--- a/crates/node/build.rs
+++ b/crates/node/build.rs
@@ -1,28 +1,25 @@
 #![allow(missing_docs)]
 
 use std::{env, error::Error};
-use vergen::{BuildBuilder, CargoBuilder, Emitter};
-use vergen_git2::Git2Builder;
+use vergen::{Build, Cargo, Emitter};
+use vergen_git2::Git2;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let mut emitter = Emitter::default();
 
-    let build_builder = BuildBuilder::default().build_timestamp(true).build()?;
+    let build_builder = Build::builder().build_timestamp(true).build();
 
     emitter.add_instructions(&build_builder)?;
 
-    let cargo_builder = CargoBuilder::default()
-        .features(true)
-        .target_triple(true)
-        .build()?;
+    let cargo_builder = Cargo::builder().features(true).target_triple(true).build();
 
     emitter.add_instructions(&cargo_builder)?;
 
-    let git_builder = Git2Builder::default()
+    let git_builder = Git2::builder()
         .describe(false, true, None)
         .dirty(true)
         .sha(false)
-        .build()?;
+        .build();
 
     emitter.add_instructions(&git_builder)?;
 


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`5d027e5...0d303f7`](https://github.com/paradigmxyz/reth/compare/5d027e5...0d303f7)

🔗 Amp thread: https://ampcode.com/threads/T-019f1307-9a91-7038-9893-dad280fbdb21
- **Bootnode/Networking**: Advertise NAT addresses in discv5 with dual-stack support ([#25757](https://github.com/paradigmxyz/reth/pull/25757))
- **RPC**: Serialize capability retention as quantity ([#25324](https://github.com/paradigmxyz/reth/pull/25324))
- **EVM**: Enable GMP by default ([#25512](https://github.com/paradigmxyz/reth/pull/25512))
- **Perf**: Windowed conversion of transactions ([#25783](https://github.com/paradigmxyz/reth/pull/25783))
- **Docker**: Include LICENSES in Docker build context ([#25855](https://github.com/paradigmxyz/reth/pull/25855))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019f1307-b60e-703a-90cc-8a6e3ddc48f8
- **Bumped Reth git dependency revision** from `5d027e5` to `0d303f7` across all `reth-*` workspace dependencies in `Cargo.toml`.
- **Pinned `revm-inspectors`** to exact version `=0.41.0` (from `0.41.1`).
- **Upgraded `vergen` and `vergen-git2`** from `9.1.0` to `10.0.1`, adding explicit features (`build`, `cargo`, `emit_and_set`) to `vergen`.
- **Migrated `crates/node/build.rs` to the vergen 10 builder API**: renamed `BuildBuilder`/`CargoBuilder`/`Git2Builder` to `Build`/`Cargo`/`Git2` with `::builder()` entry points.
- **Changed builder finalization to be infallible**: `.build()` now returns the value directly instead of a `Result`, removing the `?` operator on builder construction.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/28366502773)
