### PR TITLE
bump workspace version to 1.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12885,7 +12885,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13036,7 +13036,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13097,7 +13097,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13126,7 +13126,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13140,7 +13140,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13191,7 +13191,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13236,7 +13236,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13255,7 +13255,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "eyre",
  "indenter",
@@ -13263,7 +13263,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13276,7 +13276,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13346,7 +13346,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -13384,7 +13384,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13404,7 +13404,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13436,7 +13436,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13485,7 +13485,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13518,7 +13518,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "clap",
@@ -13543,7 +13543,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "eyre",
  "jiff",
@@ -13552,7 +13552,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13594,7 +13594,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13606,7 +13606,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.9.1"
+version = "1.10.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]


### PR DESCRIPTION
## Summary

Bumps only the Cargo workspace package version for the release branch so the replacement `v1.10.1` tag can pass the release workflow version check.

- Updates `[workspace.package] version` from `1.9.1` to `1.10.1`.
- Updates `Cargo.lock` metadata for local packages that inherit `version.workspace`.
- Leaves explicitly versioned publishable crates unchanged for a follow-up release.

## Context

The `v1.10.0` release is already immutable and was published without assets after the release workflow failed the Cargo version check. `v1.10.1` is the clean patch-release path.

## Validation

- `cargo metadata --locked --offline --no-deps --format-version 1`
