### PR TITLE
chore: bump main workspace version to 1.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12838,7 +12838,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -12989,7 +12989,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13052,7 +13052,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13082,7 +13082,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13096,7 +13096,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13147,7 +13147,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13194,7 +13194,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13213,7 +13213,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "eyre",
  "indenter",
@@ -13221,7 +13221,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13246,7 +13246,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13316,7 +13316,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -13354,7 +13354,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13374,7 +13374,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13407,7 +13407,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13456,7 +13456,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13489,7 +13489,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "clap",
@@ -13514,7 +13514,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "eyre",
  "jiff",
@@ -13523,7 +13523,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13566,7 +13566,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13578,7 +13578,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.9.1"
+version = "1.10.1"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.9.1"
+version = "1.10.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]


### PR DESCRIPTION
## Summary

Bumps the Cargo workspace release version on main after publishing v1.10.1.

- Updates `[workspace.package] version` from `1.9.1` to `1.10.1`.
- Updates `Cargo.lock` metadata for local packages that inherit `version.workspace`.
- Leaves explicitly versioned SDK crates unchanged; those version bumps are tracked separately.

## Context

The release workflow created and published v1.10.1, but its final "Open Cargo Version Bump PR" job failed, so this manually creates the follow-up PR it would normally open.

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
