### PR TITLE
Mirror reth release Cargo version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           tag="${{ needs.get-version.outputs.version }}"
           tag=${tag#v}
-          cargo_ver=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "tempo").version')
+          cargo_ver=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
           [[ "$tag" == "$cargo_ver"* ]] || { echo "Tag $tag doesn't match the Cargo version $cargo_ver"; exit 1; }
 
   build-release:


### PR DESCRIPTION
## Summary
- Mirror reth release.yml by reading the Cargo version from `cargo metadata` package index 0.
- Preserve the existing tag-prefix compatibility for rc releases.

## Validation
- `tag=v1.9.1; tag=${tag#v}; cargo_ver=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version'); [[ "$tag" == "$cargo_ver"* ]]`\n- `tag=v1.9.1-rc.1; tag=${tag#v}; cargo_ver=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version'); [[ "$tag" == "$cargo_ver"* ]]`\n\nPrompted by: @shekhirin