### PR TITLE
chore: add SDK 1.10 changelog fragment

### DIFF
--- a/.changelog/sdk-crates-1-10.md
+++ b/.changelog/sdk-crates-1-10.md
@@ -1,0 +1,9 @@
+---
+tempo-alloy: minor
+tempo-primitives: minor
+tempo-contracts: minor
+tempo-chainspec: minor
+tempo-hardfork: minor
+---
+
+Bump the Tempo SDK crate set to the `1.10` minor release.


### PR DESCRIPTION
## Summary
- add one `.changelog/` fragment requesting a minor bump for the fixed Tempo SDK crate group
- leave generated crate changelogs, manifest bumps, and Cargo.lock updates to the release workflow

## Validation
- not run; changelog-fragment-only change

Prompted by: @0xrusowsky