### PR TITLE
chore(cli): raise pending import default to 100k

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8615,7 +8615,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8664,8 +8664,8 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-trie",
- "revm-database",
- "revm-state",
+ "reth-trie-sparse",
+ "revm",
  "serde",
  "tokio",
  "tokio-stream",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9130,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9215,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9278,7 +9278,6 @@ dependencies = [
  "indexmap 2.14.0",
  "metrics",
  "moka",
- "parking_lot",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
@@ -9310,8 +9309,6 @@ dependencies = [
  "reth-trie-parallel",
  "reth-trie-sparse",
  "revm",
- "revm-primitives",
- "revm-state",
  "schnellru",
  "serde_json",
  "thiserror 2.0.18",
@@ -9322,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9352,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9370,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9386,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9409,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9420,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9448,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9470,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9511,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "clap",
  "eyre",
@@ -9534,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9550,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9566,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9579,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9609,7 +9606,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9623,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9633,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9658,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9678,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9696,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9709,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9728,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9766,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9780,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "serde",
  "serde_json",
@@ -9790,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9809,8 +9806,6 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "revm",
- "revm-bytecode",
- "revm-database",
  "serde",
  "serde_json",
 ]
@@ -9818,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "bytes",
  "futures",
@@ -9838,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9855,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "bindgen",
  "cc",
@@ -9864,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "futures",
  "metrics",
@@ -9877,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9886,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9900,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9958,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9983,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10007,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10022,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10036,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10053,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10077,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10145,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10200,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10247,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10271,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10295,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "bytes",
  "eyre",
@@ -10324,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10336,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10360,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10372,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10395,7 +10390,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10438,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10475,8 +10470,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-trie",
  "reth-trie-db",
- "revm-database",
- "revm-state",
+ "revm",
  "rocksdb",
  "smallvec",
  "strum",
@@ -10487,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10515,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10531,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10546,7 +10540,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10610,7 +10604,6 @@ dependencies = [
  "reth-trie-common",
  "revm",
  "revm-inspectors",
- "revm-primitives",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -10624,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10654,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10697,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10717,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10748,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10795,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10846,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10860,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10891,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10942,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10970,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10984,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11004,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11019,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11038,14 +11031,14 @@ dependencies = [
  "reth-storage-errors",
  "reth-tokio-util",
  "reth-trie-common",
- "revm-database",
+ "revm",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11055,15 +11048,14 @@ dependencies = [
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface",
- "revm-state",
+ "revm",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11084,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11100,7 +11092,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11110,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "clap",
  "eyre",
@@ -11130,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11149,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11178,8 +11170,6 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "revm",
- "revm-interpreter",
- "revm-primitives",
  "rustc-hash 2.1.2",
  "schnellru",
  "serde",
@@ -11194,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11212,7 +11202,6 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-database",
  "tracing",
  "triehash",
 ]
@@ -11220,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11239,8 +11228,7 @@ dependencies = [
  "rayon",
  "reth-codecs",
  "reth-primitives-traits",
- "revm-database",
- "revm-state",
+ "revm",
  "serde",
  "serde_with",
 ]
@@ -11248,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11267,9 +11255,8 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
- "alloy-eip7928",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -11288,7 +11275,7 @@ dependencies = [
  "reth-tasks",
  "reth-trie",
  "reth-trie-sparse",
- "revm-state",
+ "revm",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -11296,7 +11283,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=571ecdc#571ecdc96c6a204fd8ad522af4227b6fc02dc55e"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "571ecdc", features = [
   "std",
   "optional-checks",
 ] }

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -16,6 +16,7 @@ const SNAPSHOT_API_URL: &str = "https://snapshots.tempoxyz.dev/api/snapshots";
 const MAINNET_TESTNET_EPOCH_LENGTH_BLOCKS: u64 = 21_600;
 const MINIMAL_PEER_SYNC_FINALIZED_BLOCKS: u64 = 3 * MAINNET_TESTNET_EPOCH_LENGTH_BLOCKS;
 const MINIMAL_PEER_SYNC_RETENTION_BLOCKS: u64 = MINIMAL_PEER_SYNC_FINALIZED_BLOCKS + 64;
+const DEFAULT_MAX_PENDING_POOL_IMPORTS: usize = 50_000;
 
 /// CLI arguments for telemetry configuration.
 #[derive(Debug, Clone, clap::Args)]
@@ -259,9 +260,14 @@ fn init_otlp_defaults() {
     }
 }
 
-fn init_network_defaults() {
+fn network_defaults() -> DefaultNetworkArgs {
     DefaultNetworkArgs::default()
+        .with_max_pending_pool_imports(DEFAULT_MAX_PENDING_POOL_IMPORTS)
         .with_enforce_enr_fork_id(true)
+}
+
+fn init_network_defaults() {
+    network_defaults()
         .try_init()
         .expect("failed to initialize network defaults");
 }
@@ -285,4 +291,14 @@ pub(crate) fn init_defaults() {
     init_otlp_defaults();
     init_network_defaults();
     init_discovery_defaults();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn network_defaults_raise_pending_import_limit() {
+        assert_eq!(network_defaults().max_pending_pool_imports, 50_000);
+    }
 }

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -16,7 +16,7 @@ const SNAPSHOT_API_URL: &str = "https://snapshots.tempoxyz.dev/api/snapshots";
 const MAINNET_TESTNET_EPOCH_LENGTH_BLOCKS: u64 = 21_600;
 const MINIMAL_PEER_SYNC_FINALIZED_BLOCKS: u64 = 3 * MAINNET_TESTNET_EPOCH_LENGTH_BLOCKS;
 const MINIMAL_PEER_SYNC_RETENTION_BLOCKS: u64 = MINIMAL_PEER_SYNC_FINALIZED_BLOCKS + 64;
-const DEFAULT_MAX_PENDING_POOL_IMPORTS: usize = 50_000;
+const DEFAULT_MAX_PENDING_POOL_IMPORTS: usize = 100_000;
 
 /// CLI arguments for telemetry configuration.
 #[derive(Debug, Clone, clap::Args)]
@@ -299,6 +299,6 @@ mod tests {
 
     #[test]
     fn network_defaults_raise_pending_import_limit() {
-        assert_eq!(network_defaults().max_pending_pool_imports, 50_000);
+        assert_eq!(network_defaults().max_pending_pool_imports, 100_000);
     }
 }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1289,6 +1289,7 @@ where
             execution_output: Arc::new(execution_output),
             hashed_state: Arc::new(hashed_state),
             trie_updates,
+            changed_paths: None,
         };
 
         let payload = TempoBuiltPayload::new(


### PR DESCRIPTION
Raises Tempo's default Reth `--max-pending-imports` value to 100,000 via the network defaults initializer.

This gives nodes more headroom for concurrent pending transaction imports without requiring operators to pass the flag explicitly.