### PR TITLE
docs(tip-1077): pack replay fingerprints

### DIFF
--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -66,21 +66,41 @@ expiring nonce transactions with the same `valid_before`, or grind transaction c
 full-cell or fingerprint collisions. Packed 64-bit fingerprints trade lower probe pressure for
 higher false-replay collision probability than a 192-bit fingerprint.
 
-The packed design leaves three censorship vectors:
+Builders and validators are untrusted for transaction ordering but trusted to execute the canonical
+state transition rules. A block containing a replay, an expired expiring nonce transaction, or a
+transaction whose probe path is exhausted is invalid.
+
+### Known Censorship Vectors
+
+The current design leaves three censorship vectors. All of these vectors are
+mitigated by the fact that users can trivially switch to other nonce methods,
+like protocol or 2D nonces.
 
 1. **Probe-path exhaustion:** an attacker can submit individual transactions that occupy all cells
    on a victim's deterministic probe path for the same `valid_before`, causing
    `ExpiringNonceSetFull` until the victim transaction expires.
+
+    While this attack is fairly trivial, it requires the attacker to generate
+    and submit 12 real transactions prior to the victim's single transaction,
+    making the attack not economically sensible.
+
 2. **Single-target false replay:** an attacker can grind a transaction whose `position_0` and
    fingerprint match a particular visible victim transaction. This is roughly an 82-bit target, and
    inclusion of the attacker transaction first causes the victim to be rejected as replay.
-3. **Pool-wide false replay:** an attacker can target `position_0` plus fingerprint for any visible
-   transaction in the pool. This birthday-style attack scales down by the number of viable targets,
-   so broad censorship is easier than censoring one specific transaction.
 
-Builders and validators are untrusted for transaction ordering but trusted to execute the canonical
-state transition rules. A block containing a replay, an expired expiring nonce transaction, or a
-transaction whose probe path is exhausted is invalid.
+    This attack requires significant mining resources to be even be considered,
+    and even then is not really feasible. At 1 EH/s there is a ~0.012% chance of
+    finding a collision for a particular transaction within a 5 minute window.
+
+3. **Pool-wide false replay:** an attacker can target `position_0` plus
+   fingerprint for any visible transaction in the pool. This birthday-style
+   attack scales down the target space to roughly 66.7-bits, so broad random
+   censorship (griefing) is easier than censoring one specific transaction.
+
+   This attack requires fewer resources than the previous, but it cannot target
+   particular transactions and is therefore only viable for griefing. At 1 EH/s
+   the attacker will land ~2.48 transactions per 5 minute window from a pool of
+   20k transactions, rendering the attack far more expensive than it is useful.
 
 ---
 
@@ -120,6 +140,7 @@ old ring entries.
 `keccak256(EXPIRING_NONCE_CELL_SLOT_DOMAIN)` by clearing the low 22 bits.
 `EXPIRING_NONCE_CELL_END_SLOT` is
 `EXPIRING_NONCE_CELL_BASE_SLOT + EXPIRING_NONCE_CELL_COUNT - 1`.
+
 The domain documents how the range was selected; implementations MUST use the fixed constants and
 MUST NOT compute this hash while processing transactions.
 
@@ -136,6 +157,10 @@ contract Nonce {
     // seen mapping, ring mapping, and ring pointer.
 }
 ```
+
+Slots 1, 2, and 3 MUST remain reserved forever unless a later hardfork explicitly migrates or
+clears the old ring state. Reusing those slots for unrelated fields risks reading stale pre-fork
+data.
 
 Replay cells are not stored in a Solidity-style mapping. For `cell_id` in
 `[0, EXPIRING_NONCE_CELL_COUNT)`, the corresponding storage slot is:
@@ -189,10 +214,6 @@ else:
 
 The zero value is reserved as the empty-slot marker. The fallback path is reached with probability
 `2^-64`, and the final `fingerprint = 1` case is reached with probability `2^-128`.
-
-Slots 1, 2, and 3 MUST remain reserved forever unless a later hardfork explicitly migrates or
-clears the old ring state. Reusing those slots for unrelated fields risks reading stale pre-fork
-data.
 
 ## Cell Selection
 
@@ -280,9 +301,12 @@ Under the time-wheel design this is local congestion, not global table exhaustio
 ## Gas Pricing
 
 Expiring nonce bookkeeping is charged as a static AA intrinsic regular gas surcharge, not by
-relying on dynamic metering inside the precompile storage provider. This follows the TIP-1009
-implementation pattern: expiring nonce gas is added to AA intrinsic gas during initial transaction
-validation and deducted up front, before the replay table is touched.
+relying on dynamic metering inside the precompile storage provider.
+
+This follows the TIP-1009 implementation pattern: expiring nonce gas is added to
+AA intrinsic gas during initial transaction validation and deducted up front,
+before the replay table is touched. By charging a static amount we avoid
+uncertainty in the pre-execution transaction validity checks.
 
 The static surcharge covers the worst-case four-probe path plus one reset-price write:
 
@@ -294,42 +318,18 @@ EXPIRING_NONCE_GAS = EXPIRING_NONCE_MAX_PROBES * COLD_SLOAD_COST
                    = 11_300
 ```
 
-Every expiring nonce transaction pays this value as intrinsic regular gas regardless of how many
-cells are actually read. Implementations MUST include `EXPIRING_NONCE_GAS` in the transaction's
-initial AA gas calculation and MUST reject the transaction before execution if the gas limit is
-below the resulting intrinsic gas. Implementations MUST NOT add a second dynamic replay-table gas
-charge during `check_and_mark_expiring_nonce`.
-
-The underlying storage work for a transaction that accepts on probe `p` is:
-
-| Accepted probe count | Modeled storage work |
-| ---: | ---: |
-| 1 | 5,000 |
-| 2 | 7,100 |
-| 4 | 11,300 |
-
 This charge intentionally does not apply TIP-1000 permanent new-slot pricing to first-touch replay
 cells. Expiring nonce cells are bounded temporary protocol state, not user-created permanent state.
 The maximum table footprint is capped by `EXPIRING_NONCE_BUCKET_COUNT *
 EXPIRING_NONCE_BUCKET_CAPACITY`.
 
-The replay insertion function MAY return or record the accepted probe count for metrics, but gas
-does not depend on that value. The EVM handler MUST charge the static `EXPIRING_NONCE_GAS` value
-explicitly as AA intrinsic regular gas while keeping replay-cell writes exempt from
-TIP-1000/TIP-1060 state accounting. With the chosen capacity and the 20k TPS sizing assumption, the
-expected accepted transaction reads about 1.000135 cells, but still pays the static 11,300 gas
-surcharge.
+Every expiring nonce transaction pays `EXPIRING_NONCE_GAS` as intrinsic regular gas regardless of how many
+cells are actually read. Implementations MUST include `EXPIRING_NONCE_GAS` in the transaction's
+initial AA gas calculation and MUST reject the transaction before execution if the gas limit is
+below the resulting intrinsic gas. Implementations MUST NOT add a second dynamic replay-table gas
+charge during `check_and_mark_expiring_nonce`.
 
 No expiring nonce insertion or later overwrite mints or consumes TIP-1060 storage credits.
-
-The time-wheel lookup performs no Keccak beyond the canonical replay hash `H`. If `H` has already
-been computed by transaction validation or pool deduplication, deriving `bucket`, `position_i`,
-`fingerprint`, `cell_id`, and `slot` requires only slicing and arithmetic:
-
-```text
-steady-state lookup keccaks after H = 0
-steady-state lookup keccaks total   = 1, if H must be computed
-```
 
 During the temporary hardfork migration dual-check, implementations still perform the old
 `expiringNonceSeen[H]` mapping lookup until `old_seen_cutoff`; that compatibility check adds one
@@ -344,41 +344,14 @@ EXPIRING_NONCE_MIGRATION_GAS = EXPIRING_NONCE_GAS + COLD_SLOAD_COST
 
 ## Parameter Selection
 
-At 20,000 expiring nonce transactions per second and a 5-minute validity window, the live replay
-set is:
-
-```text
-20_000 * 300 = 6_000_000 records
-```
-
-The time wheel does not size one bucket for all 6 million live records. With constant load across
-the 300 valid `valid_before` seconds, each exact `valid_before` bucket receives about 20,000
-records:
-
-```text
-6_000_000 / 300 = 20_000 records per live bucket
-```
-
-The bucket count must be greater than the maximum expiry window so that two different
-`valid_before` values in the same bucket cannot both be live:
-
-```text
-minimum bucket count = EXPIRING_NONCE_MAX_EXPIRY_SECS + 1
-                     = 300 + 1
-                     = 301
-```
-
 The wheel has two independent dimensions:
 
 - `EXPIRING_NONCE_BUCKET_COUNT` separates expiry seconds. It only needs to be greater than the
-  maximum expiry window, so 301 buckets covers a 300 second window.
+  maximum expiry window so that two different `valid_before` values in the same
+  bucket cannot both be live. So 301 buckets covers a 300 second window.
+
 - `EXPIRING_NONCE_BUCKET_CAPACITY` controls how many packed cells are available within one exact
   `valid_before` second. Each cell has three 64-bit fingerprint slots.
-
-Rounding the time-bucket count from 301 to 512 would not reduce same-second collisions: each exact
-`valid_before` second would still use one bucket with 131,072 cells. It would only reserve 211
-additional time buckets, increasing the 131,072-cell full-table footprint from 2.35 GiB to
-4.00 GiB.
 
 The table below models random hash placement inside one bucket with three packed fingerprint slots
 per cell and `EXPIRING_NONCE_MAX_PROBES = 4`. "First-probe misses" means the first selected cell
@@ -415,19 +388,14 @@ At the chosen 131,072-cell capacity, varying `EXPIRING_NONCE_MAX_PROBES` gives:
 | 4 | ~2.7 | 1.000135 | ~1.24e-10 | ~8.27e-17 |
 | 5 | ~2.7 | 1.000135 | ~5.33e-14 | ~8.27e-17 |
 
-This TIP chooses 301 time buckets and 131,072 cells per bucket. The bucket count is the minimum
-that preserves the cheap expiry proof for a 300 second window, and the packed cell count keeps the
-per-`valid_before` slot load at 5.09% with about 1.000135 replay-cell reads per attempted
-transaction at 20k TPS.
+This TIP chooses 301 time buckets, 131,072 cells per bucket, and a max probes of 4.
 
-Smaller tables reduce the maximum footprint but increase average reads and tail risk. In
-particular, 65,536 cells per bucket would halve the footprint to 1.18 GiB but double slot load to
-10.17%, and 32,768 cells per bucket pushes slot load above 20%, where probe length and
-probe-exhaustion risk become more sensitive to traffic bursts or adversarial hash selection.
+The bucket count is the minimum that preserves the cheap expiry proof for a 300 second window.
 
-Larger tables reduce collisions but mostly buy marginal latency improvement at the cost of much
-larger bounded state. The 16,777,216-cell parameter explored in implementation experiments has
-negligible first-probe misses but a 301 GiB slot+value full-table footprint with a 5-minute window.
+The packed cell count keeps the per-`valid_before` slot load at 5.09% with about
+1.000135 replay-cell reads per attempted transaction at 20k TPS.
+
+The max probes provides negligible chance of probe exhaustion at 20k TPS.
 
 ## Hardfork Migration
 

--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -15,7 +15,8 @@ protocolVersion: TBD
 This TIP replaces TIP-1009's expiring nonce circular buffer with a fixed time-wheel replay table
 and increases the maximum expiring nonce validity window from 30 seconds to 5 minutes.
 `valid_before` selects one of 301 reusable time buckets, and the sender-scoped transaction replay
-hash directly selects a deterministic probe path inside that bucket.
+hash directly selects a deterministic probe path inside that bucket. Each replay cell packs up to
+three live 64-bit replay fingerprints for the selected `valid_before`.
 
 The table is sized at 131,072 cells per bucket, for 39,452,672 total cells. A fully populated table
 is 1.18 GiB of cell values, or 2.35 GiB when counted as `(storage slot, storage value)` pairs.
@@ -62,7 +63,8 @@ replay algorithm.
 
 Users and relayers are untrusted. They may replay old signed transactions, submit many independent
 expiring nonce transactions with the same `valid_before`, or grind transaction contents to seek
-cell collisions.
+full-cell or fingerprint collisions. Packed 64-bit fingerprints trade lower probe pressure for
+higher false-replay collision probability than a 192-bit fingerprint.
 
 Builders and validators are untrusted for transaction ordering but trusted to execute the canonical
 state transition rules. A block containing a replay, an expired expiring nonce transaction, or a
@@ -80,13 +82,14 @@ EXPIRING_NONCE_MAX_EXPIRY_SECS = 300
 EXPIRING_NONCE_BUCKET_COUNT    = 301
 EXPIRING_NONCE_BUCKET_CAPACITY = 131_072
 EXPIRING_NONCE_POSITION_BITS   = 17
-EXPIRING_NONCE_MAX_PROBES      = 5
+EXPIRING_NONCE_MAX_PROBES      = 4
 
 EXPIRING_NONCE_CELL_COUNT      = 39_452_672
 EXPIRING_NONCE_CELL_BASE_SLOT  = 0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa2400000
 EXPIRING_NONCE_CELL_END_SLOT   = 0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa499ffff
 EXPIRING_NONCE_CELL_SLOT_DOMAIN = "tempo.expiringNonceCells.v1"
-EXPIRING_NONCE_FINGERPRINT_BITS = 192
+EXPIRING_NONCE_FINGERPRINT_BITS = 64
+EXPIRING_NONCE_PACKED_SLOTS     = 3
 ```
 
 `EXPIRING_NONCE_MAX_EXPIRY_SECS` increases TIP-1009's maximum expiry from 30 seconds to
@@ -96,7 +99,8 @@ old ring entries.
 `EXPIRING_NONCE_BUCKET_COUNT` MUST be greater than `EXPIRING_NONCE_MAX_EXPIRY_SECS`.
 `EXPIRING_NONCE_BUCKET_CAPACITY` MUST be a power of two.
 `EXPIRING_NONCE_POSITION_BITS` MUST equal `log2(EXPIRING_NONCE_BUCKET_CAPACITY)`.
-`EXPIRING_NONCE_POSITION_BITS * EXPIRING_NONCE_MAX_PROBES` MUST be less than or equal to 256.
+`EXPIRING_NONCE_POSITION_BITS * EXPIRING_NONCE_MAX_PROBES` MUST be less than or equal to 128.
+`EXPIRING_NONCE_PACKED_SLOTS * EXPIRING_NONCE_FINGERPRINT_BITS` MUST equal 192.
 `EXPIRING_NONCE_CELL_COUNT` MUST equal
 `EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY`.
 
@@ -137,18 +141,42 @@ Solidity mapping layout.
 Each replay cell stores:
 
 ```text
-cell = valid_before_u64 || replay_fingerprint_192
+cell = valid_before_u64 || fingerprint_slot_0 || fingerprint_slot_1 || fingerprint_slot_2
 ```
 
 where:
 
 ```text
 stored_valid_before = high 64 bits of cell
-stored_fingerprint  = low 192 bits of cell
-fingerprint         = low 192 bits of H
+fingerprint_slot_j  = one 64-bit lane in the low 192 bits of cell
+fingerprint         = nonzero 64-bit value derived from H
 ```
 
-A zero storage word has `stored_valid_before == 0` and is reusable.
+The fingerprint slots are encoded left-to-right after `valid_before_u64`. `fingerprint_slot_0`
+occupies the high 64 bits of the low 192-bit payload, `fingerprint_slot_1` occupies the middle
+64 bits, and `fingerprint_slot_2` occupies the low 64 bits.
+
+A zero storage word has `stored_valid_before == 0` and all fingerprint slots empty. Within a cell
+whose `stored_valid_before` equals the transaction's `valid_before`, a fingerprint slot equal to
+zero is empty. If `stored_valid_before` does not equal the transaction's `valid_before`, all three
+fingerprint slots are treated as empty, even if the stored low 192 bits are nonzero.
+
+The replay fingerprint is derived from bytes that do not overlap the probe-position chunks:
+
+```text
+primary_fingerprint  = uint64_be(H[24..32])
+fallback_fingerprint = uint64_be(H[16..24])
+
+if primary_fingerprint != 0:
+    fingerprint = primary_fingerprint
+else if fallback_fingerprint != 0:
+    fingerprint = fallback_fingerprint
+else:
+    fingerprint = 1
+```
+
+The zero value is reserved as the empty-slot marker. The fallback path is reached with probability
+`2^-64`, and the final `fingerprint = 1` case is reached with probability `2^-128`.
 
 Slots 1, 2, and 3 MUST remain reserved forever unless a later hardfork explicitly migrates or
 clears the old ring state. Reusing those slots for unrelated fields risks reading stale pre-fork
@@ -182,9 +210,9 @@ cell_id_i  = bucket * EXPIRING_NONCE_BUCKET_CAPACITY + position_i
 slot_i     = EXPIRING_NONCE_CELL_BASE_SLOT + cell_id_i
 ```
 
-With the chosen constants, the five probe positions are `H[0..17]`, `H[17..34]`, `H[34..51]`,
-`H[51..68]`, and `H[68..85]`. Since `EXPIRING_NONCE_BUCKET_CAPACITY` is `2^17`, each 17-bit chunk
-selects one cell in the bucket without modulo bias or rejection sampling.
+With the chosen constants, the four probe positions are `H[0..17]`, `H[17..34]`, `H[34..51]`,
+and `H[51..68]`. Since `EXPIRING_NONCE_BUCKET_CAPACITY` is `2^17`, each 17-bit chunk selects one
+cell in the bucket without modulo bias or rejection sampling.
 
 ## Replay Algorithm
 
@@ -201,21 +229,28 @@ T < V <= T + EXPIRING_NONCE_MAX_EXPIRY_SECS
 Then the Nonce precompile executes:
 
 ```text
-fingerprint = H[8..32]
+fingerprint = nonzero_fingerprint64(H)
 
 for i in 0..EXPIRING_NONCE_MAX_PROBES:
     cell_id = cell_id_i
     slot = EXPIRING_NONCE_CELL_BASE_SLOT + cell_id
     word = sload(slot)
     stored_v = high_64_bits(word)
-    stored_f = low_192_bits(word)
+    slots = low_192_bits(word) split into three 64-bit fingerprint slots
 
     if stored_v != V:
-        sstore(slot, V || fingerprint)
+        sstore(slot, V || fingerprint || 0 || 0)
         accept
 
-    if stored_f == fingerprint:
-        reject ExpiringNonceReplay
+    for slot_fingerprint in slots:
+        if slot_fingerprint == fingerprint:
+            reject ExpiringNonceReplay
+
+    for slot_index in 0..EXPIRING_NONCE_PACKED_SLOTS:
+        if slots[slot_index] == 0:
+            slots[slot_index] = fingerprint
+            sstore(slot, V || slots[0] || slots[1] || slots[2])
+            accept
 
     continue
 
@@ -226,9 +261,9 @@ reject ExpiringNonceSetFull
 different `valid_before` values in the same bucket differ by at least 301 seconds, while expiring
 nonce transactions are live for at most 300 seconds.
 
-`ExpiringNonceSetFull` means the transaction's own deterministic probe path is full of different
-live fingerprints for the same `valid_before`. Under the time-wheel design this is local
-congestion, not global table exhaustion.
+`ExpiringNonceSetFull` means every cell in the transaction's deterministic probe path has the same
+live `valid_before` and all three fingerprint slots occupied by different nonzero fingerprints.
+Under the time-wheel design this is local congestion, not global table exhaustion.
 
 ## Gas Pricing
 
@@ -259,7 +294,7 @@ Examples:
 | ---: | ---: |
 | 1 | 5,000 |
 | 2 | 7,100 |
-| 5 | 13,400 |
+| 4 | 11,300 |
 
 This charge intentionally does not apply TIP-1000 permanent new-slot pricing to first-touch replay
 cells. Expiring nonce cells are bounded temporary protocol state, not user-created permanent state.
@@ -269,8 +304,8 @@ EXPIRING_NONCE_BUCKET_CAPACITY`.
 The replay insertion function MUST return the accepted probe count, and the EVM handler MUST charge
 the formula above explicitly as regular gas while keeping replay-cell writes exempt from
 TIP-1000/TIP-1060 state accounting. With the chosen capacity and the 20k TPS sizing assumption, the
-expected accepted transaction reads about 1.085 cells and pays about 5,179 gas for TIP-1077 replay
-bookkeeping.
+expected accepted transaction reads about 1.000135 cells and pays about 5,000.3 gas for TIP-1077
+replay bookkeeping.
 
 No expiring nonce insertion or later overwrite mints or consumes TIP-1060 storage credits.
 
@@ -323,15 +358,19 @@ The wheel has two independent dimensions:
 
 - `EXPIRING_NONCE_BUCKET_COUNT` separates expiry seconds. It only needs to be greater than the
   maximum expiry window, so 301 buckets covers a 300 second window.
-- `EXPIRING_NONCE_BUCKET_CAPACITY` controls collision probability within one exact
-  `valid_before` second.
+- `EXPIRING_NONCE_BUCKET_CAPACITY` controls how many packed cells are available within one exact
+  `valid_before` second. Each cell has three 64-bit fingerprint slots.
 
 Rounding the time-bucket count from 301 to 512 would not reduce same-second collisions: each exact
 `valid_before` second would still use one bucket with 131,072 cells. It would only reserve 211
 additional time buckets, increasing the 131,072-cell full-table footprint from 2.35 GiB to
 4.00 GiB.
 
-The table below models random hash placement inside one bucket.
+The table below models random hash placement inside one bucket with three packed fingerprint slots
+per cell and `EXPIRING_NONCE_MAX_PROBES = 4`. "First-probe misses" means the first selected cell
+already has all three fingerprint slots occupied for the same `valid_before`. "Random false
+replays" estimates accidental rejection of a distinct transaction due to a 64-bit fingerprint match
+with an occupied slot on its probe path.
 
 `Slot+value bloat` counts the full logical table as `(storage slot, storage value)` pairs:
 
@@ -339,32 +378,42 @@ The table below models random hash placement inside one bucket.
 slot+value bytes = 301 buckets * cells_per_bucket * 64
 ```
 
-| Cells per bucket | Load at 20k TPS | First-probe misses per 20k txs | Avg reads per attempted tx | Probe-exhausted txs per 20k | Max slot+value bloat |
-| ---: | ---: | ---: | ---: | ---: | ---: |
-| 16,777,216 | 0.12% | ~12 | 1.0006 | ~0 | 301.00 GiB |
-| 1,048,576 | 1.91% | ~191 | 1.0097 | ~0 | 18.81 GiB |
-| 524,288 | 3.81% | ~381 | 1.0196 | ~0 | 9.41 GiB |
-| 262,144 | 7.63% | ~763 | 1.0402 | ~0.009 | 4.70 GiB |
-| 131,072 | 15.26% | ~1,526 | 1.0850 | ~0.28 | 2.35 GiB |
-| 65,536 | 30.52% | ~3,052 | 1.1925 | ~8.8 | 1.18 GiB |
-| 32,768 | 61.04% | ~6,103 | 1.5139 | ~282 | 602.00 MiB |
-| 25,000 | 80.00% | ~8,000 | 1.8232 | ~1,092 | 459.29 MiB |
-| 20,000 | 100.00% | ~10,000 | 2.2832 | ~3,333 | 367.43 MiB |
-| 16,384 | 122.07% | overloaded | overloaded | overloaded | 301.00 MiB |
+| Cells per bucket | Slot load at 20k TPS | First-probe misses per 20k txs | Avg reads per attempted tx | Probe-exhausted txs per 20k | Random false replays per 20k | Max slot+value bloat |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 16,777,216 | 0.04% | ~1.41e-6 | 1.000000 | ~9.74e-36 | ~6.46e-19 | 301.00 GiB |
+| 1,048,576 | 0.64% | ~0.00571 | 1.000000 | ~2.61e-21 | ~1.03e-17 | 18.81 GiB |
+| 524,288 | 1.27% | ~0.0452 | 1.000002 | ~1.01e-17 | ~2.07e-17 | 9.41 GiB |
+| 262,144 | 2.54% | ~0.353 | 1.000018 | ~3.73e-14 | ~4.14e-17 | 4.70 GiB |
+| 131,072 | 5.09% | ~2.7 | 1.000135 | ~1.24e-10 | ~8.27e-17 | 2.35 GiB |
+| 65,536 | 10.17% | ~19.8 | 1.000991 | ~3.36e-7 | ~1.66e-16 | 1.18 GiB |
+| 32,768 | 20.35% | ~134 | 1.006782 | ~6.33e-4 | ~3.34e-16 | 602.00 MiB |
+| 25,000 | 26.67% | ~273 | 1.014047 | ~0.0104 | ~4.43e-16 | 459.29 MiB |
+| 20,000 | 33.33% | ~483 | 1.025429 | ~0.0965 | ~5.64e-16 | 367.43 MiB |
+| 16,384 | 40.69% | ~793 | 1.043170 | ~0.665 | ~7.07e-16 | 301.00 MiB |
+
+At the chosen 131,072-cell capacity, varying `EXPIRING_NONCE_MAX_PROBES` gives:
+
+| Max probes | First-probe misses per 20k txs | Avg reads per attempted tx | Probe-exhausted txs per 20k | Random false replays per 20k |
+| ---: | ---: | ---: | ---: | ---: |
+| 1 | ~2.7 | 1.000000 | ~2.7 | ~8.27e-17 |
+| 2 | ~2.7 | 1.000135 | ~8.21e-4 | ~8.27e-17 |
+| 3 | ~2.7 | 1.000135 | ~3.04e-7 | ~8.27e-17 |
+| 4 | ~2.7 | 1.000135 | ~1.24e-10 | ~8.27e-17 |
+| 5 | ~2.7 | 1.000135 | ~5.33e-14 | ~8.27e-17 |
 
 This TIP chooses 301 time buckets and 131,072 cells per bucket. The bucket count is the minimum
-that preserves the cheap expiry proof for a 300 second window, and the cell count keeps the
-per-`valid_before` load at 15.26% with about 1.085 replay-cell reads per attempted transaction at
-20k TPS.
+that preserves the cheap expiry proof for a 300 second window, and the packed cell count keeps the
+per-`valid_before` slot load at 5.09% with about 1.000135 replay-cell reads per attempted
+transaction at 20k TPS.
 
 Smaller tables reduce the maximum footprint but increase average reads and tail risk. In
-particular, 65,536 cells per bucket would halve the footprint to 1.18 GiB but double load to
-30.52%, and 32,768 cells per bucket pushes load above 60%, where probe length and probe-exhaustion
-risk become much more sensitive to traffic bursts or adversarial hash selection.
+particular, 65,536 cells per bucket would halve the footprint to 1.18 GiB but double slot load to
+10.17%, and 32,768 cells per bucket pushes slot load above 20%, where probe length and
+probe-exhaustion risk become more sensitive to traffic bursts or adversarial hash selection.
 
 Larger tables reduce collisions but mostly buy marginal latency improvement at the cost of much
 larger bounded state. The 16,777,216-cell parameter explored in implementation experiments has
-negligible collisions but a 301 GiB slot+value full-table footprint with a 5-minute window.
+negligible first-probe misses but a 301 GiB slot+value full-table footprint with a 5-minute window.
 
 ## Hardfork Migration
 
@@ -390,10 +439,11 @@ At the activation block:
 The transaction pool can keep deduplicating expiring nonce transactions by `H`. Today it also uses
 the unique `expiringNonceSeen[H]` slot to notice when a pooled transaction was included. With
 TIP-1077 there is no unique per-transaction slot: each transaction has a probe path through shared
-replay cells, and another transaction may write a different fingerprint into one of those cells. If
-the pool keeps inclusion tracking from state updates, it should watch the probe-path cells and
-remove a transaction only when the written word is that transaction's exact `V || H[8..32]` value,
-not merely because a watched cell became non-zero.
+replay cells, and another transaction may write another packed fingerprint into one of those cells.
+If the pool keeps inclusion tracking from state updates, it should watch the probe-path cells and
+remove a transaction only when the updated word has that transaction's `valid_before` and contains
+that transaction's derived 64-bit fingerprint in one of the three packed slots, not merely because a
+watched cell became non-zero.
 
 To preserve replay protection across the hardfork boundary, implementations MUST perform a
 temporary dual replay check:
@@ -496,24 +546,26 @@ second. Both are required.
 The time wheel could store cells in a flat Solidity-style mapping:
 
 ```text
-expiringNonceCells[cell_id] = valid_before || fingerprint
+expiringNonceCells[cell_id] =
+    valid_before || fingerprint_slot_0 || fingerprint_slot_1 || fingerprint_slot_2
 ```
 
 This keeps the storage layout familiar, but every probed cell requires computing
 `keccak256(cell_id || mapping_slot)` before the `SLOAD`. At the chosen capacity, the expected
-accepted transaction reads about 1.085 cells, so mapping layout would add about 1.085 Keccak
-computations per accepted transaction on average and up to 5 in the worst probe path. The direct
+accepted transaction reads about 1.000135 cells, so mapping layout would add about 1.000135 Keccak
+computations per accepted transaction on average and up to 4 in the worst probe path. The direct
 slot range preserves the same bounded table and probe behavior while making each probe slot
 derivable with integer addition.
 
 ### Larger Time Wheel
 
 A larger time wheel reduces collisions and makes first-cell prewarming more reliable. The
-16,777,216-cell-per-bucket design has an expected first-cell collision rate near zero at 20k TPS.
+16,777,216-cell-per-bucket design has an expected first-cell miss rate near zero at 20k TPS.
 
 Its cost is a much larger bounded state footprint: 301 GiB when counted as slot+value pairs. It
 also creates a long first-touch period where most transactions write previously empty cells. This
-TIP chooses a smaller 2.35 GiB slot+value footprint and accepts a modest average probe rate instead.
+TIP chooses a smaller 2.35 GiB slot+value footprint and relies on packed fingerprint slots to keep
+the average probe rate near one read.
 
 # Observability
 
@@ -541,16 +593,18 @@ Nodes SHOULD expose metrics for:
    `valid_before > block.timestamp + 300` MUST be rejected.
 4. **Bucket expiry proof.** Within a bucket, `stored_valid_before != tx.valid_before` MUST imply the
    stored record is not live.
-5. **Collision handling.** A live collision with a different fingerprint MUST probe the next
-   deterministic cell, up to `EXPIRING_NONCE_MAX_PROBES`.
-6. **Probe exhaustion.** If all probed cells contain different live fingerprints for the same
+5. **Packed insertion.** A cell with the transaction's `valid_before`, no matching fingerprint, and
+   at least one empty fingerprint slot MUST store the transaction's fingerprint in that cell.
+6. **Collision handling.** A live collision with a full cell of different fingerprints MUST probe
+   the next deterministic cell, up to `EXPIRING_NONCE_MAX_PROBES`.
+7. **Probe exhaustion.** If all probed cells contain three different live fingerprints for the same
    `valid_before`, the transaction MUST be rejected with `ExpiringNonceSetFull`.
-7. **Bounded state.** New replay state MUST be limited to
+8. **Bounded state.** New replay state MUST be limited to
    `EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY` cells in the reserved direct slot
    range.
-8. **No explicit cleanup dependency.** Replay correctness MUST NOT depend on offchain pruning,
+9. **No explicit cleanup dependency.** Replay correctness MUST NOT depend on offchain pruning,
    MEV services, or TIP-1060 storage credits.
-9. **No nonce mutation.** Expiring nonce transactions MUST NOT increment protocol nonces or 2D
+10. **No nonce mutation.** Expiring nonce transactions MUST NOT increment protocol nonces or 2D
    nonces.
-10. **Storage layout hygiene.** Old ring slots 1, 2, and 3 MUST remain reserved after activation,
+11. **Storage layout hygiene.** Old ring slots 1, 2, and 3 MUST remain reserved after activation,
     and future Nonce precompile fields MUST NOT overlap the direct replay-cell slot range.

--- a/tips/tip-1077.md
+++ b/tips/tip-1077.md
@@ -66,6 +66,18 @@ expiring nonce transactions with the same `valid_before`, or grind transaction c
 full-cell or fingerprint collisions. Packed 64-bit fingerprints trade lower probe pressure for
 higher false-replay collision probability than a 192-bit fingerprint.
 
+The packed design leaves three censorship vectors:
+
+1. **Probe-path exhaustion:** an attacker can submit individual transactions that occupy all cells
+   on a victim's deterministic probe path for the same `valid_before`, causing
+   `ExpiringNonceSetFull` until the victim transaction expires.
+2. **Single-target false replay:** an attacker can grind a transaction whose `position_0` and
+   fingerprint match a particular visible victim transaction. This is roughly an 82-bit target, and
+   inclusion of the attacker transaction first causes the victim to be rejected as replay.
+3. **Pool-wide false replay:** an attacker can target `position_0` plus fingerprint for any visible
+   transaction in the pool. This birthday-style attack scales down by the number of viable targets,
+   so broad censorship is easier than censoring one specific transaction.
+
 Builders and validators are untrusted for transaction ordering but trusted to execute the canonical
 state transition rules. A block containing a replay, an expired expiring nonce transaction, or a
 transaction whose probe path is exhausted is invalid.
@@ -267,30 +279,30 @@ Under the time-wheel design this is local congestion, not global table exhaustio
 
 ## Gas Pricing
 
-Expiring nonce bookkeeping is charged as explicit AA intrinsic regular gas, not by relying on
-dynamic metering inside the precompile storage provider.
+Expiring nonce bookkeeping is charged as a static AA intrinsic regular gas surcharge, not by
+relying on dynamic metering inside the precompile storage provider. This follows the TIP-1009
+implementation pattern: expiring nonce gas is added to AA intrinsic gas during initial transaction
+validation and deducted up front, before the replay table is touched.
 
-The common first-cell path is one cold read and one reset-price write:
-
-```text
-EXPIRING_NONCE_BASE_GAS = COLD_SLOAD_COST + WARM_SSTORE_RESET
-                        = 2_100 + 2_900
-                        = 5_000
-```
-
-For an accepted transaction, let `probes` be the number of replay cells read before the transaction
-is accepted. Implementations MUST charge:
+The static surcharge covers the worst-case four-probe path plus one reset-price write:
 
 ```text
-EXPIRING_NONCE_GAS(probes) = EXPIRING_NONCE_BASE_GAS
-                           + (probes - 1) * COLD_SLOAD_COST
+EXPIRING_NONCE_GAS = EXPIRING_NONCE_MAX_PROBES * COLD_SLOAD_COST
+                   + WARM_SSTORE_RESET
 
-                           = probes * 2_100 + 2_900
+                   = 4 * 2_100 + 2_900
+                   = 11_300
 ```
 
-Examples:
+Every expiring nonce transaction pays this value as intrinsic regular gas regardless of how many
+cells are actually read. Implementations MUST include `EXPIRING_NONCE_GAS` in the transaction's
+initial AA gas calculation and MUST reject the transaction before execution if the gas limit is
+below the resulting intrinsic gas. Implementations MUST NOT add a second dynamic replay-table gas
+charge during `check_and_mark_expiring_nonce`.
 
-| Probe count | Expiring nonce gas |
+The underlying storage work for a transaction that accepts on probe `p` is:
+
+| Accepted probe count | Modeled storage work |
 | ---: | ---: |
 | 1 | 5,000 |
 | 2 | 7,100 |
@@ -301,11 +313,12 @@ cells. Expiring nonce cells are bounded temporary protocol state, not user-creat
 The maximum table footprint is capped by `EXPIRING_NONCE_BUCKET_COUNT *
 EXPIRING_NONCE_BUCKET_CAPACITY`.
 
-The replay insertion function MUST return the accepted probe count, and the EVM handler MUST charge
-the formula above explicitly as regular gas while keeping replay-cell writes exempt from
+The replay insertion function MAY return or record the accepted probe count for metrics, but gas
+does not depend on that value. The EVM handler MUST charge the static `EXPIRING_NONCE_GAS` value
+explicitly as AA intrinsic regular gas while keeping replay-cell writes exempt from
 TIP-1000/TIP-1060 state accounting. With the chosen capacity and the 20k TPS sizing assumption, the
-expected accepted transaction reads about 1.000135 cells and pays about 5,000.3 gas for TIP-1077
-replay bookkeeping.
+expected accepted transaction reads about 1.000135 cells, but still pays the static 11,300 gas
+surcharge.
 
 No expiring nonce insertion or later overwrite mints or consumes TIP-1060 storage credits.
 
@@ -324,8 +337,9 @@ old mapping-slot hash and one extra cold read during the migration window only. 
 accepted during that window therefore pay:
 
 ```text
-EXPIRING_NONCE_MIGRATION_GAS(probes) = EXPIRING_NONCE_GAS(probes) + COLD_SLOAD_COST
-                                     = EXPIRING_NONCE_GAS(probes) + 2_100
+EXPIRING_NONCE_MIGRATION_GAS = EXPIRING_NONCE_GAS + COLD_SLOAD_COST
+                             = 11_300 + 2_100
+                             = 13_400
 ```
 
 ## Parameter Selection


### PR DESCRIPTION
Updates TIP-1077 to pack three nonzero 64-bit replay fingerprints per cell and set max probes to 4. Recomputes probe exhaustion, average reads, random false-replay probability, and gas examples for the packed-cell design.

Adds brief censorship-vector coverage for probe-path exhaustion, single-target position_0+fingerprint false replay, and pool-wide position_0+fingerprint targeting. Specifies expiring nonce gas as a fixed AA intrinsic surcharge, matching the static deduction pattern used by the current expiring nonce implementation.