### PR TITLE
feat: add TIP-403 exemption for fee manager

### DIFF
--- a/crates/node/tests/it/tip_fee_manager.rs
+++ b/crates/node/tests/it/tip_fee_manager.rs
@@ -502,36 +502,11 @@ async fn test_fee_payer_transfer_whitelist_post_t1c() -> eyre::Result<()> {
         .await?;
     assert!(receipt.status(), "changeTransferPolicyId should succeed");
 
-    // T1C requires both sender and FeeManager whitelisted — fee_payer is whitelisted
-    // but FeeManager is not, so the tx should be rejected at the pool level.
+    // TIP-1042 exempts the FeeManager recipient check during fee collection. The fee payer is
+    // whitelisted as a sender, so the tx should go through even though FeeManager is not listed.
     let tx = TransactionRequest::default()
         .to(Address::ZERO)
         .value(U256::ZERO);
-    let result = fee_payer_provider.send_transaction(tx).await;
-    let err = result.unwrap_err().to_string();
-    assert!(
-        err.contains("PolicyForbids"),
-        "expected PolicyForbids error, got: {err}"
-    );
-
-    // Whitelist FeeManager — now fee_payer's tx should go through
-    registry
-        .modifyPolicyWhitelist(policy_id, TIP_FEE_MANAGER_ADDRESS, true)
-        .gas(1_000_000)
-        .send()
-        .await?
-        .get_receipt()
-        .await?;
-
-    // Re-fetch nonce from chain since the rejected tx above desynchronized
-    // the provider's internal nonce tracker.
-    let nonce = fee_payer_provider
-        .get_transaction_count(fee_payer_addr)
-        .await?;
-    let tx = TransactionRequest::default()
-        .to(Address::ZERO)
-        .value(U256::ZERO)
-        .nonce(nonce);
     let receipt = fee_payer_provider
         .send_transaction(tx)
         .await?

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1140,14 +1140,18 @@ impl TIP20Token {
         Ok(())
     }
 
-    /// Check whether a user is authorized by the token's [`TIP403Registry`] policy for a given role.
+    /// Check whether users are authorized by the token's [`TIP403Registry`] policy for the given
+    /// roles.
     ///
     /// # Errors
-    /// - `PolicyForbids` — user is not authorized for the requested role by the active transfer policy
-    pub fn ensure_authorized_as(&self, user: Address, role: AuthRole) -> Result<()> {
+    /// - `PolicyForbids` — a user is not authorized for the requested role by the active transfer policy
+    pub fn ensure_authorized_as(&self, user_auth: &[(Address, AuthRole)]) -> Result<()> {
         let policy_id = self.transfer_policy_id()?;
-        if !TIP403Registry::new().is_authorized_as(policy_id, user, role)? {
-            return Err(TIP20Error::policy_forbids().into());
+        let registry = TIP403Registry::new();
+        for &(user, role) in user_auth {
+            if !registry.is_authorized_as(policy_id, user, role)? {
+                return Err(TIP20Error::policy_forbids().into());
+            }
         }
         Ok(())
     }
@@ -1274,7 +1278,7 @@ impl TIP20Token {
                 self.check_and_update_spending_limit(addr, amount)?;
             }
         } else {
-            self.ensure_authorized_as(destination.target, AuthRole::recipient())?;
+            self.ensure_authorized_as(&[(destination.target, AuthRole::recipient())])?;
         }
 
         self._transfer(RECEIVE_POLICY_GUARD_ADDRESS, &destination, amount)?;

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -161,7 +161,10 @@ impl TIP20ChannelReserve {
             return Err(TIP20ChannelReserveError::channel_already_exists().into());
         }
 
-        token.ensure_authorized_as(Recipient::resolve(call.payee)?.target, AuthRole::Recipient)?;
+        token.ensure_authorized_as(&[(
+            Recipient::resolve(call.payee)?.target,
+            AuthRole::Recipient,
+        )])?;
         token.system_transfer_from(self.address, msg_sender, U256::from(call.deposit))?;
 
         self.write_channel_state_spending_credit(
@@ -226,7 +229,7 @@ impl TIP20ChannelReserve {
             .expect("cumulative amount already checked to be increasing");
 
         let mut token = TIP20Token::from_address(call.descriptor.token)?;
-        token.ensure_authorized_as(call.descriptor.payer, AuthRole::Sender)?;
+        token.ensure_authorized_as(&[(call.descriptor.payer, AuthRole::Sender)])?;
 
         state.settled = cumulative;
         self.channel_states[channel_id].write(state)?;
@@ -283,10 +286,10 @@ impl TIP20ChannelReserve {
 
             state.deposit = next_deposit;
             let mut token = TIP20Token::from_address(call.descriptor.token)?;
-            token.ensure_authorized_as(
+            token.ensure_authorized_as(&[(
                 Recipient::resolve(call.descriptor.payee)?.target,
                 AuthRole::Recipient,
-            )?;
+            )])?;
             token.system_transfer_from(
                 self.address,
                 msg_sender,
@@ -401,7 +404,7 @@ impl TIP20ChannelReserve {
 
         let mut token = TIP20Token::from_address(call.descriptor.token)?;
         if !delta.is_zero() {
-            token.ensure_authorized_as(call.descriptor.payer, AuthRole::Sender)?;
+            token.ensure_authorized_as(&[(call.descriptor.payer, AuthRole::Sender)])?;
             token.transfer(
                 self.address,
                 ITIP20::transferCall {

--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -2,7 +2,7 @@ use crate::{
     error::{Result, TempoPrecompileError},
     storage::{Handler, StorageAction, StorageCtx, StorageKey},
     tip_fee_manager::{ITIPFeeAMM, TIPFeeAMMError, TIPFeeAMMEvent, TipFeeManager},
-    tip20::{ITIP20, TIP20Token, validate_usd_currency},
+    tip20::{ITIP20, Recipient, TIP20Error, TIP20Token, validate_usd_currency},
     tip403_registry::AuthRole,
 };
 use alloy::{
@@ -10,6 +10,7 @@ use alloy::{
     sol_types::SolValue,
 };
 use tempo_precompiles_macros::Storable;
+use tempo_primitives::TempoAddressExt;
 
 /// Fee multiplier for fee swaps: 0.9970 scaled by 10000 (30 bps fee).
 pub const M: U256 = uint!(9970_U256);
@@ -190,6 +191,17 @@ impl TipFeeManager {
             return Err(TIPFeeAMMError::invalid_amount().into());
         }
 
+        let mut validator_tip20_token = TIP20Token::from_address(validator_token)?;
+        let mut user_tip20_token = TIP20Token::from_address(user_token)?;
+        if self.storage.spec().is_t8() {
+            let recipient = Recipient::resolve(to)?;
+            recipient.validate()?;
+            validator_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
+            validator_tip20_token.ensure_authorized_as(self.address, AuthRole::recipient())?;
+            user_tip20_token.ensure_authorized_as(self.address, AuthRole::sender())?;
+            user_tip20_token.ensure_authorized_as(recipient.target, AuthRole::recipient())?;
+        }
+
         let pool_id = self.pool_id(user_token, validator_token);
         let mut pool = self.pools[pool_id].read()?;
 
@@ -225,25 +237,21 @@ impl TipFeeManager {
             }
         }
 
-        self.pools[pool_id].write(pool)?;
-
         let amount_in = U256::from(amount_in);
         let amount_out = U256::from(amount_out);
-        TIP20Token::from_address(validator_token)?.system_transfer_from(
-            self.address,
-            msg_sender,
-            amount_in,
-        )?;
+        validator_tip20_token.system_transfer_from(self.address, msg_sender, amount_in)?;
 
         // collect_fee_pre_tx creates FeeManager balance slots for free; do not convert them into storage credits.
         StorageCtx.set_tip1060_storage_credit_minting(false);
-        TIP20Token::from_address(user_token)?.transfer(
+        user_tip20_token.transfer(
             self.address,
             ITIP20::transferCall {
                 to,
                 amount: amount_out,
             },
         )?;
+
+        self.pools[pool_id].write(pool)?;
 
         self.emit_event(TIPFeeAMMEvent::rebalance_swap(
             user_token,
@@ -294,15 +302,15 @@ impl TipFeeManager {
         validate_usd_currency(user_token)?;
         validate_usd_currency(validator_token)?;
 
-        let user_tip20_token = TIP20Token::from_address(user_token)?;
+        let mut validator_tip20_token = TIP20Token::from_address(validator_token)?;
         if self.storage.spec().is_t8() {
+            if to.is_zero() || to.is_tip20() || to.is_virtual() {
+                return Err(TIP20Error::invalid_recipient().into());
+            }
+            let user_tip20_token = TIP20Token::from_address(user_token)?;
             user_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
             user_tip20_token.ensure_authorized_as(self.address, AuthRole::recipient())?;
             user_tip20_token.ensure_authorized_as(to, AuthRole::recipient())?;
-        }
-
-        let mut validator_tip20_token = TIP20Token::from_address(validator_token)?;
-        if self.storage.spec().is_t8() {
             validator_tip20_token.ensure_authorized_as(to, AuthRole::recipient())?;
         }
 
@@ -689,7 +697,7 @@ impl TipFeeManager {
 mod tests {
     use alloy::primitives::Address;
     use tempo_chainspec::hardfork::TempoHardfork;
-    use tempo_contracts::precompiles::TIP20Error;
+    use tempo_primitives::{MasterId, UserTag};
 
     use super::*;
     use crate::{
@@ -910,6 +918,68 @@ mod tests {
     }
 
     #[test]
+    fn test_mint_requires_caller_sender_on_user_token() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+        let admin = Address::random();
+        let caller = Address::random();
+        StorageCtx::enter(&mut storage, || {
+            let mut user_token = TIP20Setup::create("UserToken", "UTK", admin).apply()?;
+            let validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin)
+                .with_issuer(admin)
+                .with_mint(caller, U256::from(10000))
+                .apply()?;
+
+            set_whitelist_policy(&mut user_token, admin, vec![admin, TIP_FEE_MANAGER_ADDRESS])?;
+
+            let mut amm = TipFeeManager::new();
+            let result = amm.mint(
+                caller,
+                user_token.address(),
+                validator_token.address(),
+                U256::from(10000),
+                admin,
+            );
+            assert!(matches!(
+                result,
+                Err(TempoPrecompileError::TIP20(TIP20Error::PolicyForbids(_)))
+            ));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_mint_requires_to_recipient_on_user_token() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+        let admin = Address::random();
+        let to = Address::random();
+        StorageCtx::enter(&mut storage, || {
+            let mut user_token = TIP20Setup::create("UserToken", "UTK", admin).apply()?;
+            let validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin)
+                .with_issuer(admin)
+                .with_mint(admin, U256::from(10000))
+                .apply()?;
+
+            set_whitelist_policy(&mut user_token, admin, vec![admin, TIP_FEE_MANAGER_ADDRESS])?;
+
+            let mut amm = TipFeeManager::new();
+            let result = amm.mint(
+                admin,
+                user_token.address(),
+                validator_token.address(),
+                U256::from(10000),
+                to,
+            );
+            assert!(matches!(
+                result,
+                Err(TempoPrecompileError::TIP20(TIP20Error::PolicyForbids(_)))
+            ));
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_mint_requires_to_recipient_on_validator_token() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
         let admin = Address::random();
@@ -943,6 +1013,35 @@ mod tests {
             assert!(matches!(
                 result,
                 Err(TempoPrecompileError::TIP20(TIP20Error::PolicyForbids(_)))
+            ));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_mint_rejects_virtual_lp_recipient() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+        let admin = Address::random();
+        let virtual_to = Address::new_virtual(MasterId::ZERO, UserTag::ZERO);
+        StorageCtx::enter(&mut storage, || {
+            let user_token = TIP20Setup::create("UserToken", "UTK", admin).apply()?;
+            let validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin)
+                .with_issuer(admin)
+                .with_mint(admin, U256::from(10000))
+                .apply()?;
+
+            let mut amm = TipFeeManager::new();
+            let result = amm.mint(
+                admin,
+                user_token.address(),
+                validator_token.address(),
+                U256::from(10000),
+                virtual_to,
+            );
+            assert!(matches!(
+                result,
+                Err(TempoPrecompileError::TIP20(TIP20Error::InvalidRecipient(_)))
             ));
 
             Ok(())
@@ -1002,6 +1101,53 @@ mod tests {
                 &mut validator_token,
                 admin,
                 vec![lp, TIP_FEE_MANAGER_ADDRESS, to],
+            )?;
+
+            let mut amm = TipFeeManager::new();
+            let pool_id = setup_pool_with_liquidity(
+                &mut amm,
+                user_token.address(),
+                validator_token.address(),
+                U256::from(10000),
+                U256::from(10000),
+            )?;
+            amm.set_liquidity_balances(pool_id, lp, U256::from(10000))?;
+
+            let result = amm.burn(
+                lp,
+                user_token.address(),
+                validator_token.address(),
+                U256::from(1000),
+                to,
+            );
+            assert!(matches!(
+                result,
+                Err(TempoPrecompileError::TIP20(TIP20Error::PolicyForbids(_)))
+            ));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_burn_requires_lp_sender_authorization_on_validator_token() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+        let admin = Address::random();
+        let lp = Address::random();
+        let to = Address::random();
+        StorageCtx::enter(&mut storage, || {
+            let mut user_token = TIP20Setup::create("UserToken", "UTK", admin).apply()?;
+            let mut validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin).apply()?;
+
+            set_whitelist_policy(
+                &mut user_token,
+                admin,
+                vec![lp, TIP_FEE_MANAGER_ADDRESS, to],
+            )?;
+            set_whitelist_policy(
+                &mut validator_token,
+                admin,
+                vec![TIP_FEE_MANAGER_ADDRESS, to],
             )?;
 
             let mut amm = TipFeeManager::new();
@@ -1438,6 +1584,118 @@ mod tests {
             assert_eq!(
                 U256::from(pool.reserve_validator_token),
                 liquidity + amount_in
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_rebalance_swap_requires_fee_manager_sender_on_user_token_before_reserve_update()
+    -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+        let admin = Address::random();
+        let to = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mint_amount = uint!(10000000_U256);
+            let mut amm = TipFeeManager::new();
+            let amm_address = amm.address;
+
+            let mut user_token = TIP20Setup::create("UserToken", "UTK", admin)
+                .with_issuer(admin)
+                .with_mint(amm_address, mint_amount)
+                .apply()?;
+            let validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin)
+                .with_issuer(admin)
+                .with_mint(admin, mint_amount)
+                .apply()?;
+
+            set_whitelist_policy(&mut user_token, admin, vec![to])?;
+
+            let liquidity = uint!(100000_U256);
+            let pool_id = setup_pool_with_liquidity(
+                &mut amm,
+                user_token.address(),
+                validator_token.address(),
+                liquidity,
+                liquidity,
+            )?;
+            let before = amm.pools[pool_id].read()?;
+
+            let result = amm.rebalance_swap(
+                admin,
+                user_token.address(),
+                validator_token.address(),
+                uint!(1000_U256),
+                to,
+            );
+            assert!(matches!(
+                result,
+                Err(TempoPrecompileError::TIP20(TIP20Error::PolicyForbids(_)))
+            ));
+
+            let after = amm.pools[pool_id].read()?;
+            assert_eq!(after.reserve_user_token, before.reserve_user_token);
+            assert_eq!(
+                after.reserve_validator_token,
+                before.reserve_validator_token
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_rebalance_swap_requires_fee_manager_recipient_on_validator_token_before_reserve_update()
+    -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+        let admin = Address::random();
+        let to = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mint_amount = uint!(10000000_U256);
+            let mut amm = TipFeeManager::new();
+            let amm_address = amm.address;
+
+            let user_token = TIP20Setup::create("UserToken", "UTK", admin)
+                .with_issuer(admin)
+                .with_mint(amm_address, mint_amount)
+                .apply()?;
+            let mut validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin)
+                .with_issuer(admin)
+                .with_mint(admin, mint_amount)
+                .apply()?;
+
+            set_whitelist_policy(&mut validator_token, admin, vec![admin])?;
+
+            let liquidity = uint!(100000_U256);
+            let pool_id = setup_pool_with_liquidity(
+                &mut amm,
+                user_token.address(),
+                validator_token.address(),
+                liquidity,
+                liquidity,
+            )?;
+            let before = amm.pools[pool_id].read()?;
+
+            let result = amm.rebalance_swap(
+                admin,
+                user_token.address(),
+                validator_token.address(),
+                uint!(1000_U256),
+                to,
+            );
+            assert!(matches!(
+                result,
+                Err(TempoPrecompileError::TIP20(TIP20Error::PolicyForbids(_)))
+            ));
+
+            let after = amm.pools[pool_id].read()?;
+            assert_eq!(after.reserve_user_token, before.reserve_user_token);
+            assert_eq!(
+                after.reserve_validator_token,
+                before.reserve_validator_token
             );
 
             Ok(())

--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -295,12 +295,16 @@ impl TipFeeManager {
         validate_usd_currency(validator_token)?;
 
         let user_tip20_token = TIP20Token::from_address(user_token)?;
-        user_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
-        user_tip20_token.ensure_authorized_as(self.address, AuthRole::recipient())?;
-        user_tip20_token.ensure_authorized_as(to, AuthRole::recipient())?;
+        if self.storage.spec().is_t8() {
+            user_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
+            user_tip20_token.ensure_authorized_as(self.address, AuthRole::recipient())?;
+            user_tip20_token.ensure_authorized_as(to, AuthRole::recipient())?;
+        }
 
         let mut validator_tip20_token = TIP20Token::from_address(validator_token)?;
-        validator_tip20_token.ensure_authorized_as(to, AuthRole::recipient())?;
+        if self.storage.spec().is_t8() {
+            validator_tip20_token.ensure_authorized_as(to, AuthRole::recipient())?;
+        }
 
         let pool_id = self.pool_id(user_token, validator_token);
         let mut pool = self.pools[pool_id].read()?;
@@ -432,10 +436,14 @@ impl TipFeeManager {
         validate_usd_currency(validator_token)?;
 
         let mut user_tip20_token = TIP20Token::from_address(user_token)?;
-        user_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
+        if self.storage.spec().is_t8() {
+            user_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
+        }
 
         let mut validator_tip20_token = TIP20Token::from_address(validator_token)?;
-        validator_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
+        if self.storage.spec().is_t8() {
+            validator_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
+        }
 
         let pool_id = self.pool_id(user_token, validator_token);
         // Check user has sufficient liquidity
@@ -874,7 +882,7 @@ mod tests {
 
     #[test]
     fn test_mint_requires_fee_manager_recipient_on_user_token() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
         let admin = Address::random();
         StorageCtx::enter(&mut storage, || {
             let mut user_token = TIP20Setup::create("UserToken", "UTK", admin).apply()?;
@@ -903,7 +911,7 @@ mod tests {
 
     #[test]
     fn test_mint_requires_to_recipient_on_validator_token() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
         let admin = Address::random();
         let to = Address::random();
         StorageCtx::enter(&mut storage, || {
@@ -981,7 +989,7 @@ mod tests {
 
     #[test]
     fn test_burn_requires_lp_sender_authorization_on_both_tokens() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
         let admin = Address::random();
         let lp = Address::random();
         let to = Address::random();

--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -3,6 +3,7 @@ use crate::{
     storage::{Handler, StorageAction, StorageCtx, StorageKey},
     tip_fee_manager::{ITIPFeeAMM, TIPFeeAMMError, TIPFeeAMMEvent, TipFeeManager},
     tip20::{ITIP20, TIP20Token, validate_usd_currency},
+    tip403_registry::AuthRole,
 };
 use alloy::{
     primitives::{Address, B256, U256, keccak256, uint},
@@ -293,6 +294,14 @@ impl TipFeeManager {
         validate_usd_currency(user_token)?;
         validate_usd_currency(validator_token)?;
 
+        let user_tip20_token = TIP20Token::from_address(user_token)?;
+        user_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
+        user_tip20_token.ensure_authorized_as(self.address, AuthRole::recipient())?;
+        user_tip20_token.ensure_authorized_as(to, AuthRole::recipient())?;
+
+        let mut validator_tip20_token = TIP20Token::from_address(validator_token)?;
+        validator_tip20_token.ensure_authorized_as(to, AuthRole::recipient())?;
+
         let pool_id = self.pool_id(user_token, validator_token);
         let mut pool = self.pools[pool_id].read()?;
         let mut total_supply = self.get_total_supply(pool_id)?;
@@ -341,7 +350,7 @@ impl TipFeeManager {
         }
 
         // Transfer validator tokens from user
-        let _ = TIP20Token::from_address(validator_token)?.system_transfer_from(
+        let _ = validator_tip20_token.system_transfer_from(
             self.address,
             msg_sender,
             amount_validator_token,
@@ -422,6 +431,12 @@ impl TipFeeManager {
         validate_usd_currency(user_token)?;
         validate_usd_currency(validator_token)?;
 
+        let mut user_tip20_token = TIP20Token::from_address(user_token)?;
+        user_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
+
+        let mut validator_tip20_token = TIP20Token::from_address(validator_token)?;
+        validator_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
+
         let pool_id = self.pool_id(user_token, validator_token);
         // Check user has sufficient liquidity
         let balance = self.get_liquidity_balances(pool_id, msg_sender)?;
@@ -485,7 +500,7 @@ impl TipFeeManager {
         self.pools[pool_id].write(pool)?;
 
         // Transfer tokens to user
-        let _ = TIP20Token::from_address(user_token)?.transfer(
+        let _ = user_tip20_token.transfer(
             self.address,
             ITIP20::transferCall {
                 to,
@@ -493,7 +508,7 @@ impl TipFeeManager {
             },
         )?;
 
-        let _ = TIP20Token::from_address(validator_token)?.transfer(
+        let _ = validator_tip20_token.transfer(
             self.address,
             ITIP20::transferCall {
                 to,
@@ -670,10 +685,12 @@ mod tests {
 
     use super::*;
     use crate::{
+        TIP_FEE_MANAGER_ADDRESS,
         error::TempoPrecompileError,
         storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
         test_util::TIP20Setup,
         tip_fee_manager::TIPFeeAMMError,
+        tip403_registry::{ITIP403Registry, TIP403Registry},
     };
 
     /// Integer square root using the Babylonian method
@@ -707,6 +724,30 @@ mod tests {
         let liquidity = sqrt(user_amount * validator_amount);
         amm.total_supply[pool_id].write(liquidity)?;
         Ok(pool_id)
+    }
+
+    fn set_whitelist_policy(
+        token: &mut TIP20Token,
+        admin: Address,
+        accounts: Vec<Address>,
+    ) -> Result<u64> {
+        let mut registry = TIP403Registry::new();
+        registry.initialize()?;
+        let policy_id = registry.create_policy_with_accounts(
+            admin,
+            ITIP403Registry::createPolicyWithAccountsCall {
+                admin,
+                policyType: ITIP403Registry::PolicyType::WHITELIST,
+                accounts,
+            },
+        )?;
+        token.change_transfer_policy_id(
+            admin,
+            ITIP20::changeTransferPolicyIdCall {
+                newPolicyId: policy_id,
+            },
+        )?;
+        Ok(policy_id)
     }
 
     #[test]
@@ -832,6 +873,75 @@ mod tests {
     }
 
     #[test]
+    fn test_mint_requires_fee_manager_recipient_on_user_token() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let admin = Address::random();
+        StorageCtx::enter(&mut storage, || {
+            let mut user_token = TIP20Setup::create("UserToken", "UTK", admin).apply()?;
+            let validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin)
+                .with_issuer(admin)
+                .with_mint(admin, U256::from(10000))
+                .apply()?;
+            set_whitelist_policy(&mut user_token, admin, vec![admin])?;
+
+            let mut amm = TipFeeManager::new();
+            let result = amm.mint(
+                admin,
+                user_token.address(),
+                validator_token.address(),
+                U256::from(10000),
+                admin,
+            );
+            assert!(matches!(
+                result,
+                Err(TempoPrecompileError::TIP20(TIP20Error::PolicyForbids(_)))
+            ));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_mint_requires_to_recipient_on_validator_token() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let admin = Address::random();
+        let to = Address::random();
+        StorageCtx::enter(&mut storage, || {
+            let mut user_token = TIP20Setup::create("UserToken", "UTK", admin).apply()?;
+            let mut validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin)
+                .with_issuer(admin)
+                .with_mint(admin, U256::from(10000))
+                .apply()?;
+
+            set_whitelist_policy(
+                &mut user_token,
+                admin,
+                vec![admin, TIP_FEE_MANAGER_ADDRESS, to],
+            )?;
+            set_whitelist_policy(
+                &mut validator_token,
+                admin,
+                vec![admin, TIP_FEE_MANAGER_ADDRESS],
+            )?;
+
+            let mut amm = TipFeeManager::new();
+            let result = amm.mint(
+                admin,
+                user_token.address(),
+                validator_token.address(),
+                U256::from(10000),
+                to,
+            );
+            assert!(matches!(
+                result,
+                Err(TempoPrecompileError::TIP20(TIP20Error::PolicyForbids(_)))
+            ));
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_burn_rejects_non_usd_tokens() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         let admin = Address::random();
@@ -865,6 +975,49 @@ mod tests {
                 result,
                 Err(TempoPrecompileError::TIP20(TIP20Error::InvalidCurrency(_)))
             ));
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_burn_requires_lp_sender_authorization_on_both_tokens() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let admin = Address::random();
+        let lp = Address::random();
+        let to = Address::random();
+        StorageCtx::enter(&mut storage, || {
+            let mut user_token = TIP20Setup::create("UserToken", "UTK", admin).apply()?;
+            let mut validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin).apply()?;
+
+            set_whitelist_policy(&mut user_token, admin, vec![TIP_FEE_MANAGER_ADDRESS, to])?;
+            set_whitelist_policy(
+                &mut validator_token,
+                admin,
+                vec![lp, TIP_FEE_MANAGER_ADDRESS, to],
+            )?;
+
+            let mut amm = TipFeeManager::new();
+            let pool_id = setup_pool_with_liquidity(
+                &mut amm,
+                user_token.address(),
+                validator_token.address(),
+                U256::from(10000),
+                U256::from(10000),
+            )?;
+            amm.set_liquidity_balances(pool_id, lp, U256::from(10000))?;
+
+            let result = amm.burn(
+                lp,
+                user_token.address(),
+                validator_token.address(),
+                U256::from(1000),
+                to,
+            );
+            assert!(matches!(
+                result,
+                Err(TempoPrecompileError::TIP20(TIP20Error::PolicyForbids(_)))
+            ));
+
             Ok(())
         })
     }

--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -2,7 +2,7 @@ use crate::{
     error::{Result, TempoPrecompileError},
     storage::{ContractStorage, Handler, StorageAction, StorageCtx, StorageKey},
     tip_fee_manager::{ITIPFeeAMM, TIPFeeAMMError, TIPFeeAMMEvent, TipFeeManager},
-    tip20::{ITIP20, TIP20Error, TIP20Token, validate_usd_currency},
+    tip20::{ITIP20, TIP20Token, validate_usd_currency},
     tip403_registry::AuthRole,
 };
 use alloy::{
@@ -10,7 +10,6 @@ use alloy::{
     sol_types::SolValue,
 };
 use tempo_precompiles_macros::Storable;
-use tempo_primitives::TempoAddressExt;
 
 /// Fee multiplier for fee swaps: 0.9970 scaled by 10000 (30 bps fee).
 pub const M: U256 = uint!(9970_U256);
@@ -296,9 +295,6 @@ impl TipFeeManager {
         let user_token = TIP20Token::from_address(user_token)?;
         let mut validator_token = TIP20Token::from_address(validator_token)?;
         if self.storage.spec().is_t8() {
-            if to.is_zero() || to.is_tip20() || to.is_virtual() {
-                return Err(TIP20Error::invalid_recipient().into());
-            }
             user_token.ensure_authorized_as(&[
                 (msg_sender, AuthRole::sender()),
                 (self.address, AuthRole::recipient()),
@@ -687,7 +683,6 @@ impl TipFeeManager {
 mod tests {
     use alloy::primitives::Address;
     use tempo_chainspec::hardfork::TempoHardfork;
-    use tempo_primitives::{MasterId, UserTag};
 
     use super::*;
     use crate::{
@@ -696,6 +691,7 @@ mod tests {
         storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
         test_util::TIP20Setup,
         tip_fee_manager::TIPFeeAMMError,
+        tip20::TIP20Error,
         tip403_registry::{ITIP403Registry, TIP403Registry},
     };
 
@@ -1003,35 +999,6 @@ mod tests {
             assert!(matches!(
                 result,
                 Err(TempoPrecompileError::TIP20(TIP20Error::PolicyForbids(_)))
-            ));
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_mint_rejects_virtual_lp_recipient() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
-        let admin = Address::random();
-        let virtual_to = Address::new_virtual(MasterId::ZERO, UserTag::ZERO);
-        StorageCtx::enter(&mut storage, || {
-            let user_token = TIP20Setup::create("UserToken", "UTK", admin).apply()?;
-            let validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin)
-                .with_issuer(admin)
-                .with_mint(admin, U256::from(10000))
-                .apply()?;
-
-            let mut amm = TipFeeManager::new();
-            let result = amm.mint(
-                admin,
-                user_token.address(),
-                validator_token.address(),
-                U256::from(10000),
-                virtual_to,
-            );
-            assert!(matches!(
-                result,
-                Err(TempoPrecompileError::TIP20(TIP20Error::InvalidRecipient(_)))
             ));
 
             Ok(())

--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -2,7 +2,7 @@ use crate::{
     error::{Result, TempoPrecompileError},
     storage::{Handler, StorageAction, StorageCtx, StorageKey},
     tip_fee_manager::{ITIPFeeAMM, TIPFeeAMMError, TIPFeeAMMEvent, TipFeeManager},
-    tip20::{ITIP20, Recipient, TIP20Error, TIP20Token, validate_usd_currency},
+    tip20::{ITIP20, TIP20Error, TIP20Token, validate_usd_currency},
     tip403_registry::AuthRole,
 };
 use alloy::{
@@ -191,17 +191,6 @@ impl TipFeeManager {
             return Err(TIPFeeAMMError::invalid_amount().into());
         }
 
-        let mut validator_tip20_token = TIP20Token::from_address(validator_token)?;
-        let mut user_tip20_token = TIP20Token::from_address(user_token)?;
-        if self.storage.spec().is_t8() {
-            let recipient = Recipient::resolve(to)?;
-            recipient.validate()?;
-            validator_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
-            validator_tip20_token.ensure_authorized_as(self.address, AuthRole::recipient())?;
-            user_tip20_token.ensure_authorized_as(self.address, AuthRole::sender())?;
-            user_tip20_token.ensure_authorized_as(recipient.target, AuthRole::recipient())?;
-        }
-
         let pool_id = self.pool_id(user_token, validator_token);
         let mut pool = self.pools[pool_id].read()?;
 
@@ -241,10 +230,12 @@ impl TipFeeManager {
 
         let amount_in = U256::from(amount_in);
         let amount_out = U256::from(amount_out);
+        let mut validator_tip20_token = TIP20Token::from_address(validator_token)?;
         validator_tip20_token.system_transfer_from(self.address, msg_sender, amount_in)?;
 
         // collect_fee_pre_tx creates FeeManager balance slots for free; do not convert them into storage credits.
         StorageCtx.set_tip1060_storage_credit_minting(false);
+        let mut user_tip20_token = TIP20Token::from_address(user_token)?;
         user_tip20_token.transfer(
             self.address,
             ITIP20::transferCall {
@@ -1584,118 +1575,6 @@ mod tests {
             assert_eq!(
                 U256::from(pool.reserve_validator_token),
                 liquidity + amount_in
-            );
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_rebalance_swap_requires_fee_manager_sender_on_user_token_before_reserve_update()
-    -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
-        let admin = Address::random();
-        let to = Address::random();
-
-        StorageCtx::enter(&mut storage, || {
-            let mint_amount = uint!(10000000_U256);
-            let mut amm = TipFeeManager::new();
-            let amm_address = amm.address;
-
-            let mut user_token = TIP20Setup::create("UserToken", "UTK", admin)
-                .with_issuer(admin)
-                .with_mint(amm_address, mint_amount)
-                .apply()?;
-            let validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin)
-                .with_issuer(admin)
-                .with_mint(admin, mint_amount)
-                .apply()?;
-
-            set_whitelist_policy(&mut user_token, admin, vec![to])?;
-
-            let liquidity = uint!(100000_U256);
-            let pool_id = setup_pool_with_liquidity(
-                &mut amm,
-                user_token.address(),
-                validator_token.address(),
-                liquidity,
-                liquidity,
-            )?;
-            let before = amm.pools[pool_id].read()?;
-
-            let result = amm.rebalance_swap(
-                admin,
-                user_token.address(),
-                validator_token.address(),
-                uint!(1000_U256),
-                to,
-            );
-            assert!(matches!(
-                result,
-                Err(TempoPrecompileError::TIP20(TIP20Error::PolicyForbids(_)))
-            ));
-
-            let after = amm.pools[pool_id].read()?;
-            assert_eq!(after.reserve_user_token, before.reserve_user_token);
-            assert_eq!(
-                after.reserve_validator_token,
-                before.reserve_validator_token
-            );
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_rebalance_swap_requires_fee_manager_recipient_on_validator_token_before_reserve_update()
-    -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
-        let admin = Address::random();
-        let to = Address::random();
-
-        StorageCtx::enter(&mut storage, || {
-            let mint_amount = uint!(10000000_U256);
-            let mut amm = TipFeeManager::new();
-            let amm_address = amm.address;
-
-            let user_token = TIP20Setup::create("UserToken", "UTK", admin)
-                .with_issuer(admin)
-                .with_mint(amm_address, mint_amount)
-                .apply()?;
-            let mut validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin)
-                .with_issuer(admin)
-                .with_mint(admin, mint_amount)
-                .apply()?;
-
-            set_whitelist_policy(&mut validator_token, admin, vec![admin])?;
-
-            let liquidity = uint!(100000_U256);
-            let pool_id = setup_pool_with_liquidity(
-                &mut amm,
-                user_token.address(),
-                validator_token.address(),
-                liquidity,
-                liquidity,
-            )?;
-            let before = amm.pools[pool_id].read()?;
-
-            let result = amm.rebalance_swap(
-                admin,
-                user_token.address(),
-                validator_token.address(),
-                uint!(1000_U256),
-                to,
-            );
-            assert!(matches!(
-                result,
-                Err(TempoPrecompileError::TIP20(TIP20Error::PolicyForbids(_)))
-            ));
-
-            let after = amm.pools[pool_id].read()?;
-            assert_eq!(after.reserve_user_token, before.reserve_user_token);
-            assert_eq!(
-                after.reserve_validator_token,
-                before.reserve_validator_token
             );
 
             Ok(())

--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{Result, TempoPrecompileError},
-    storage::{Handler, StorageAction, StorageCtx, StorageKey},
+    storage::{ContractStorage, Handler, StorageAction, StorageCtx, StorageKey},
     tip_fee_manager::{ITIPFeeAMM, TIPFeeAMMError, TIPFeeAMMEvent, TipFeeManager},
     tip20::{ITIP20, TIP20Error, TIP20Token, validate_usd_currency},
     tip403_registry::AuthRole,
@@ -230,13 +230,13 @@ impl TipFeeManager {
 
         let amount_in = U256::from(amount_in);
         let amount_out = U256::from(amount_out);
-        let mut validator_tip20_token = TIP20Token::from_address(validator_token)?;
-        validator_tip20_token.system_transfer_from(self.address, msg_sender, amount_in)?;
+        let mut validator_token = TIP20Token::from_address(validator_token)?;
+        validator_token.system_transfer_from(self.address, msg_sender, amount_in)?;
 
         // collect_fee_pre_tx creates FeeManager balance slots for free; do not convert them into storage credits.
         StorageCtx.set_tip1060_storage_credit_minting(false);
-        let mut user_tip20_token = TIP20Token::from_address(user_token)?;
-        user_tip20_token.transfer(
+        let mut user_token = TIP20Token::from_address(user_token)?;
+        user_token.transfer(
             self.address,
             ITIP20::transferCall {
                 to,
@@ -245,8 +245,8 @@ impl TipFeeManager {
         )?;
 
         self.emit_event(TIPFeeAMMEvent::rebalance_swap(
-            user_token,
-            validator_token,
+            user_token.address(),
+            validator_token.address(),
             msg_sender,
             amount_in,
             amount_out,
@@ -293,19 +293,21 @@ impl TipFeeManager {
         validate_usd_currency(user_token)?;
         validate_usd_currency(validator_token)?;
 
-        let mut validator_tip20_token = TIP20Token::from_address(validator_token)?;
+        let user_token = TIP20Token::from_address(user_token)?;
+        let mut validator_token = TIP20Token::from_address(validator_token)?;
         if self.storage.spec().is_t8() {
             if to.is_zero() || to.is_tip20() || to.is_virtual() {
                 return Err(TIP20Error::invalid_recipient().into());
             }
-            let user_tip20_token = TIP20Token::from_address(user_token)?;
-            user_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
-            user_tip20_token.ensure_authorized_as(self.address, AuthRole::recipient())?;
-            user_tip20_token.ensure_authorized_as(to, AuthRole::recipient())?;
-            validator_tip20_token.ensure_authorized_as(to, AuthRole::recipient())?;
+            user_token.ensure_authorized_as(&[
+                (msg_sender, AuthRole::sender()),
+                (self.address, AuthRole::recipient()),
+                (to, AuthRole::recipient()),
+            ])?;
+            validator_token.ensure_authorized_as(&[(to, AuthRole::recipient())])?;
         }
 
-        let pool_id = self.pool_id(user_token, validator_token);
+        let pool_id = self.pool_id(user_token.address(), validator_token.address());
         let mut pool = self.pools[pool_id].read()?;
         let mut total_supply = self.get_total_supply(pool_id)?;
 
@@ -353,7 +355,7 @@ impl TipFeeManager {
         }
 
         // Transfer validator tokens from user
-        let _ = validator_tip20_token.system_transfer_from(
+        let _ = validator_token.system_transfer_from(
             self.address,
             msg_sender,
             amount_validator_token,
@@ -392,8 +394,8 @@ impl TipFeeManager {
         self.emit_event(TIPFeeAMMEvent::mint(
             msg_sender,
             to,
-            user_token,
-            validator_token,
+            user_token.address(),
+            validator_token.address(),
             amount_validator_token,
             liquidity,
         ))?;
@@ -434,17 +436,14 @@ impl TipFeeManager {
         validate_usd_currency(user_token)?;
         validate_usd_currency(validator_token)?;
 
-        let mut user_tip20_token = TIP20Token::from_address(user_token)?;
+        let mut user_token = TIP20Token::from_address(user_token)?;
+        let mut validator_token = TIP20Token::from_address(validator_token)?;
         if self.storage.spec().is_t8() {
-            user_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
+            user_token.ensure_authorized_as(&[(msg_sender, AuthRole::sender())])?;
+            validator_token.ensure_authorized_as(&[(msg_sender, AuthRole::sender())])?;
         }
 
-        let mut validator_tip20_token = TIP20Token::from_address(validator_token)?;
-        if self.storage.spec().is_t8() {
-            validator_tip20_token.ensure_authorized_as(msg_sender, AuthRole::sender())?;
-        }
-
-        let pool_id = self.pool_id(user_token, validator_token);
+        let pool_id = self.pool_id(user_token.address(), validator_token.address());
         // Check user has sufficient liquidity
         let balance = self.get_liquidity_balances(pool_id, msg_sender)?;
         if balance < liquidity {
@@ -507,7 +506,7 @@ impl TipFeeManager {
         self.pools[pool_id].write(pool)?;
 
         // Transfer tokens to user
-        let _ = user_tip20_token.transfer(
+        let _ = user_token.transfer(
             self.address,
             ITIP20::transferCall {
                 to,
@@ -515,7 +514,7 @@ impl TipFeeManager {
             },
         )?;
 
-        let _ = validator_tip20_token.transfer(
+        let _ = validator_token.transfer(
             self.address,
             ITIP20::transferCall {
                 to,
@@ -526,8 +525,8 @@ impl TipFeeManager {
         // Emit Burn event
         self.emit_event(TIPFeeAMMEvent::burn(
             msg_sender,
-            user_token,
-            validator_token,
+            user_token.address(),
+            validator_token.address(),
             amount_user_token,
             amount_validator_token,
             liquidity,

--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -237,6 +237,8 @@ impl TipFeeManager {
             }
         }
 
+        self.pools[pool_id].write(pool)?;
+
         let amount_in = U256::from(amount_in);
         let amount_out = U256::from(amount_out);
         validator_tip20_token.system_transfer_from(self.address, msg_sender, amount_in)?;
@@ -250,8 +252,6 @@ impl TipFeeManager {
                 amount: amount_out,
             },
         )?;
-
-        self.pools[pool_id].write(pool)?;
 
         self.emit_event(TIPFeeAMMEvent::rebalance_swap(
             user_token,

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -170,7 +170,7 @@ impl TipFeeManager {
 
         // TIP-1042: T8 fee collection exempts FeeManager recipient authorization.
         if self.storage.spec().is_t8() {
-            tip20_token.ensure_authorized_as(fee_payer, AuthRole::sender())?;
+            tip20_token.ensure_authorized_as(&[(fee_payer, AuthRole::sender())])?;
         } else {
             tip20_token.ensure_transfer_authorized(fee_payer, self.address)?;
         }

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -11,6 +11,7 @@ use crate::{
     tip_fee_manager::amm::{FeeRoute, Pool, compute_amount_out},
     tip20::{ITIP20, TIP20Token, validate_usd_currency},
     tip20_factory::TIP20Factory,
+    tip403_registry::AuthRole,
 };
 use alloy::primitives::{Address, B256, U256, uint};
 pub use tempo_contracts::precompiles::{
@@ -167,8 +168,9 @@ impl TipFeeManager {
 
         let mut tip20_token = TIP20Token::from_address(user_token)?;
 
-        // Ensure that user and FeeManager are authorized to interact with the token
-        tip20_token.ensure_transfer_authorized(fee_payer, self.address)?;
+        // Fee collection only authorizes the fee payer. The FeeManager recipient side is
+        // intentionally exempt; public AMM operations still enforce FeeManager policy checks.
+        tip20_token.ensure_authorized_as(fee_payer, AuthRole::sender())?;
         tip20_token.transfer_fee_pre_tx(fee_payer, max_amount)?;
 
         if !skip_liquidity_check {
@@ -329,6 +331,7 @@ mod tests {
         storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
         test_util::TIP20Setup,
         tip20::{ITIP20, TIP20Token},
+        tip403_registry::{ITIP403Registry, TIP403Registry},
     };
 
     #[test]
@@ -509,6 +512,55 @@ mod tests {
             let result =
                 fee_manager.collect_fee_pre_tx(user, token.address(), max_amount, validator, false);
             assert!(result.is_ok());
+            assert_eq!(result?, token.address());
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_collect_fee_pre_tx_exempts_fee_manager_recipient_policy() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let user = Address::random();
+        let validator = Address::random();
+        let beneficiary = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let max_amount = U256::from(10000);
+            let mut token = TIP20Setup::create("Test", "TST", user)
+                .with_issuer(user)
+                .with_mint(user, U256::from(u64::MAX))
+                .with_approval(user, TIP_FEE_MANAGER_ADDRESS, U256::MAX)
+                .apply()?;
+
+            let mut registry = TIP403Registry::new();
+            registry.initialize()?;
+            let policy_id = registry.create_policy_with_accounts(
+                user,
+                ITIP403Registry::createPolicyWithAccountsCall {
+                    admin: user,
+                    policyType: ITIP403Registry::PolicyType::WHITELIST,
+                    accounts: vec![user],
+                },
+            )?;
+            token.change_transfer_policy_id(
+                user,
+                ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: policy_id,
+                },
+            )?;
+
+            let mut fee_manager = TipFeeManager::new();
+            fee_manager.set_validator_token(
+                validator,
+                IFeeManager::setValidatorTokenCall {
+                    token: token.address(),
+                },
+                beneficiary,
+            )?;
+
+            let result =
+                fee_manager.collect_fee_pre_tx(user, token.address(), max_amount, validator, false);
             assert_eq!(result?, token.address());
 
             Ok(())

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -168,9 +168,16 @@ impl TipFeeManager {
 
         let mut tip20_token = TIP20Token::from_address(user_token)?;
 
-        // Fee collection only authorizes the fee payer. The FeeManager recipient side is
-        // intentionally exempt; public AMM operations still enforce FeeManager policy checks.
-        tip20_token.ensure_authorized_as(fee_payer, AuthRole::sender())?;
+        if self.storage.spec().is_t8() {
+            // TIP-1042: fee collection only authorizes the fee payer. The FeeManager recipient
+            // side is intentionally exempt; public AMM operations still enforce FeeManager policy
+            // checks.
+            tip20_token.ensure_authorized_as(fee_payer, AuthRole::sender())?;
+        } else {
+            // Preserve pre-TIP-1042 historical execution: fee collection checked both the fee
+            // payer sender side and FeeManager recipient side.
+            tip20_token.ensure_transfer_authorized(fee_payer, self.address)?;
+        }
         tip20_token.transfer_fee_pre_tx(fee_payer, max_amount)?;
 
         if !skip_liquidity_check {
@@ -520,7 +527,7 @@ mod tests {
 
     #[test]
     fn test_collect_fee_pre_tx_exempts_fee_manager_recipient_policy() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
         let user = Address::random();
         let validator = Address::random();
         let beneficiary = Address::random();
@@ -562,6 +569,58 @@ mod tests {
             let result =
                 fee_manager.collect_fee_pre_tx(user, token.address(), max_amount, validator, false);
             assert_eq!(result?, token.address());
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_collect_fee_pre_tx_pre_t8_requires_fee_manager_recipient_policy() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T7);
+        let user = Address::random();
+        let validator = Address::random();
+        let beneficiary = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let max_amount = U256::from(10000);
+            let mut token = TIP20Setup::create("Test", "TST", user)
+                .with_issuer(user)
+                .with_mint(user, U256::from(u64::MAX))
+                .with_approval(user, TIP_FEE_MANAGER_ADDRESS, U256::MAX)
+                .apply()?;
+
+            let mut registry = TIP403Registry::new();
+            registry.initialize()?;
+            let policy_id = registry.create_policy_with_accounts(
+                user,
+                ITIP403Registry::createPolicyWithAccountsCall {
+                    admin: user,
+                    policyType: ITIP403Registry::PolicyType::WHITELIST,
+                    accounts: vec![user],
+                },
+            )?;
+            token.change_transfer_policy_id(
+                user,
+                ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: policy_id,
+                },
+            )?;
+
+            let mut fee_manager = TipFeeManager::new();
+            fee_manager.set_validator_token(
+                validator,
+                IFeeManager::setValidatorTokenCall {
+                    token: token.address(),
+                },
+                beneficiary,
+            )?;
+
+            let result =
+                fee_manager.collect_fee_pre_tx(user, token.address(), max_amount, validator, false);
+            assert!(matches!(
+                result,
+                Err(TempoPrecompileError::TIP20(TIP20Error::PolicyForbids(_)))
+            ));
 
             Ok(())
         })

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -168,14 +168,10 @@ impl TipFeeManager {
 
         let mut tip20_token = TIP20Token::from_address(user_token)?;
 
+        // TIP-1042: T8 fee collection exempts FeeManager recipient authorization.
         if self.storage.spec().is_t8() {
-            // TIP-1042: fee collection only authorizes the fee payer. The FeeManager recipient
-            // side is intentionally exempt; public AMM operations still enforce FeeManager policy
-            // checks.
             tip20_token.ensure_authorized_as(fee_payer, AuthRole::sender())?;
         } else {
-            // Preserve pre-TIP-1042 historical execution: fee collection checked both the fee
-            // payer sender side and FeeManager recipient side.
             tip20_token.ensure_transfer_authorized(fee_payer, self.address)?;
         }
         tip20_token.transfer_fee_pre_tx(fee_payer, max_amount)?;

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -178,26 +178,24 @@ where
         // Pre-T8 fee collection checked TIP_FEE_MANAGER_ADDRESS as the fee-token recipient.
         // TIP-1042 exempts that recipient side, so T8+ invalidation only tracks fee-payer sender
         // authorization.
-        let fee_collection_checks_fee_manager = !spec.is_t8();
-        let fee_manager_blacklisted: Vec<u64> = if fee_collection_checks_fee_manager {
-            updates
-                .blacklist_additions
-                .iter()
-                .filter(|(_, account)| *account == TIP_FEE_MANAGER_ADDRESS)
-                .map(|(policy_id, _)| *policy_id)
-                .collect()
+        let is_t8 = spec.is_t8();
+        let (fee_manager_blacklisted, fee_manager_unwhitelisted): (Vec<u64>, Vec<u64>) = if !is_t8 {
+            (
+                updates
+                    .blacklist_additions
+                    .iter()
+                    .filter(|(_, account)| *account == TIP_FEE_MANAGER_ADDRESS)
+                    .map(|(policy_id, _)| *policy_id)
+                    .collect(),
+                updates
+                    .whitelist_removals
+                    .iter()
+                    .filter(|(_, account)| *account == TIP_FEE_MANAGER_ADDRESS)
+                    .map(|(policy_id, _)| *policy_id)
+                    .collect(),
+            )
         } else {
-            Vec::new()
-        };
-        let fee_manager_unwhitelisted: Vec<u64> = if fee_collection_checks_fee_manager {
-            updates
-                .whitelist_removals
-                .iter()
-                .filter(|(_, account)| *account == TIP_FEE_MANAGER_ADDRESS)
-                .map(|(policy_id, _)| *policy_id)
-                .collect()
-        } else {
-            Vec::new()
+            (Vec::new(), Vec::new())
         };
 
         // Re-check liquidity for all pooled txs when an active validator changes token.

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -403,8 +403,9 @@ where
                     }
                 }
 
-                // Pre-T8 only: check if the fee manager recipient was blacklisted on this
-                // token's recipient policy.
+                // Check if the fee manager (recipient) was blacklisted on this token's
+                // recipient policy — the tx would fail at execution since the fee
+                // transfer to TIP_FEE_MANAGER_ADDRESS would be rejected.
                 let recipient_evicted = !sender_evicted
                     && !fee_manager_blacklisted.is_empty()
                     && get_recipient_policy_ids(provider, fee_token, spec)
@@ -446,7 +447,7 @@ where
                     }
                 }
 
-                // Pre-T8 only: check if the fee manager recipient was un-whitelisted on this
+                // Check if the fee manager (recipient) was un-whitelisted on this
                 // token's recipient policy.
                 let recipient_evicted = !sender_evicted
                     && !fee_manager_unwhitelisted.is_empty()

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -175,21 +175,30 @@ where
         // so eviction matches events emitted with sub-policy IDs.
         let mut policy_cache: AddressMap<Vec<u64>> = AddressMap::default();
 
-        // Pre-collect policy IDs where TIP_FEE_MANAGER_ADDRESS (the fee recipient) was
-        // blacklisted or un-whitelisted. This is constant across all txs so we compute
-        // it once instead of re-scanning the updates list per transaction.
-        let fee_manager_blacklisted: Vec<u64> = updates
-            .blacklist_additions
-            .iter()
-            .filter(|(_, account)| *account == TIP_FEE_MANAGER_ADDRESS)
-            .map(|(policy_id, _)| *policy_id)
-            .collect();
-        let fee_manager_unwhitelisted: Vec<u64> = updates
-            .whitelist_removals
-            .iter()
-            .filter(|(_, account)| *account == TIP_FEE_MANAGER_ADDRESS)
-            .map(|(policy_id, _)| *policy_id)
-            .collect();
+        // Pre-T8 fee collection checked TIP_FEE_MANAGER_ADDRESS as the fee-token recipient.
+        // TIP-1042 exempts that recipient side, so T8+ invalidation only tracks fee-payer sender
+        // authorization.
+        let fee_collection_checks_fee_manager = !spec.is_t8();
+        let fee_manager_blacklisted: Vec<u64> = if fee_collection_checks_fee_manager {
+            updates
+                .blacklist_additions
+                .iter()
+                .filter(|(_, account)| *account == TIP_FEE_MANAGER_ADDRESS)
+                .map(|(policy_id, _)| *policy_id)
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let fee_manager_unwhitelisted: Vec<u64> = if fee_collection_checks_fee_manager {
+            updates
+                .whitelist_removals
+                .iter()
+                .filter(|(_, account)| *account == TIP_FEE_MANAGER_ADDRESS)
+                .map(|(policy_id, _)| *policy_id)
+                .collect()
+        } else {
+            Vec::new()
+        };
 
         // Re-check liquidity for all pooled txs when an active validator changes token.
         // Leverages the per-tx `has_enough_liquidity` check, which passes if ANY validator pair has
@@ -396,9 +405,8 @@ where
                     }
                 }
 
-                // Check if the fee manager (recipient) was blacklisted on this token's
-                // recipient policy — the tx would fail at execution since the fee
-                // transfer to TIP_FEE_MANAGER_ADDRESS would be rejected.
+                // Pre-T8 only: check if the fee manager recipient was blacklisted on this
+                // token's recipient policy.
                 let recipient_evicted = !sender_evicted
                     && !fee_manager_blacklisted.is_empty()
                     && get_recipient_policy_ids(provider, fee_token, spec)
@@ -440,7 +448,7 @@ where
                     }
                 }
 
-                // Check if the fee manager (recipient) was un-whitelisted on this
+                // Pre-T8 only: check if the fee manager recipient was un-whitelisted on this
                 // token's recipient policy.
                 let recipient_evicted = !sender_evicted
                     && !fee_manager_unwhitelisted.is_empty()
@@ -1331,7 +1339,8 @@ fn get_sender_policy_ids(
 /// For simple (non-compound) policies, the transfer policy applies symmetrically to both
 /// sender and recipient, so the set contains just the policy ID. For compound policies
 /// (TIP-1015) it contains both the compound root and the recipient sub-policy, since
-/// fee transfer authorization checks the fee manager via `AuthRole::Recipient`.
+/// pre-T8 fee transfer authorization checks the fee manager via `AuthRole::Recipient`.
+/// T8+ fee collection exempts the FeeManager recipient side, so this returns `None`.
 ///
 /// Unlike `get_sender_policy_ids` this is uncached — it's only called on the rare path
 /// where the fee manager itself is blacklisted or un-whitelisted.
@@ -1340,6 +1349,10 @@ fn get_recipient_policy_ids(
     fee_token: Address,
     spec: TempoHardfork,
 ) -> Option<Vec<u64>> {
+    if spec.is_t8() {
+        return None;
+    }
+
     provider.with_read_only_storage_ctx(spec, StorageActions::disabled(), || {
         let policy_id = TIP20Token::from_address(fee_token)
             .and_then(|t| t.transfer_policy_id())
@@ -2431,9 +2444,9 @@ mod tests {
         );
     }
 
-    /// `get_recipient_policy_ids` returns the compound root and recipient sub-policy.
+    /// Pre-T8, `get_recipient_policy_ids` returns the compound root and recipient sub-policy.
     #[test]
-    fn recipient_policy_ids_includes_recipient_sub_policy() {
+    fn recipient_policy_ids_includes_recipient_sub_policy_pre_t8() {
         let fee_token = address!("20C0000000000000000000000000000000000001");
         let compound_policy_id: u64 = 5;
         let sender_sub: u64 = 3;
@@ -2473,7 +2486,7 @@ mod tests {
             .unwrap();
 
         let mut state = provider.latest().unwrap();
-        let ids = get_recipient_policy_ids(&mut state, fee_token, TempoHardfork::default())
+        let ids = get_recipient_policy_ids(&mut state, fee_token, TempoHardfork::T7)
             .expect("should resolve policy IDs");
 
         assert!(
@@ -2490,9 +2503,9 @@ mod tests {
         );
     }
 
-    /// For simple (non-compound) policies, `get_recipient_policy_ids` returns just the root.
+    /// For simple (non-compound) policies, pre-T8 `get_recipient_policy_ids` returns just the root.
     #[test]
-    fn recipient_policy_ids_simple_policy() {
+    fn recipient_policy_ids_simple_policy_pre_t8() {
         let fee_token = address!("20C0000000000000000000000000000000000001");
         let simple_policy_id: u64 = 7;
 
@@ -2523,10 +2536,33 @@ mod tests {
             .unwrap();
 
         let mut state = provider.latest().unwrap();
-        let ids = get_recipient_policy_ids(&mut state, fee_token, TempoHardfork::default())
+        let ids = get_recipient_policy_ids(&mut state, fee_token, TempoHardfork::T7)
             .expect("should resolve policy IDs");
 
         assert_eq!(ids, vec![simple_policy_id]);
+    }
+
+    #[test]
+    fn recipient_policy_ids_exempt_on_t8() {
+        let fee_token = address!("20C0000000000000000000000000000000000001");
+        let simple_policy_id: u64 = 7;
+
+        let provider = MockEthProvider::default().with_chain_spec(std::sync::Arc::unwrap_or_clone(
+            tempo_chainspec::spec::MODERATO.clone(),
+        ));
+
+        let transfer_policy_id_packed =
+            U256::from(simple_policy_id) << (tip20_slots::TRANSFER_POLICY_ID_OFFSET * 8);
+        provider.add_account(
+            fee_token,
+            ExtendedAccount::new(0, U256::ZERO).extend_storage([(
+                tip20_slots::TRANSFER_POLICY_ID.into(),
+                transfer_policy_id_packed,
+            )]),
+        );
+
+        let mut state = provider.latest().unwrap();
+        assert!(get_recipient_policy_ids(&mut state, fee_token, TempoHardfork::T8).is_none());
     }
 
     #[test]

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -179,6 +179,7 @@ where
         // TIP-1042 exempts that recipient side, so T8+ invalidation only tracks fee-payer sender
         // authorization.
         let is_t8 = spec.is_t8();
+        // NOTE: We can remove this logic after T8 activation
         let (fee_manager_blacklisted, fee_manager_unwhitelisted): (Vec<u64>, Vec<u64>) = if !is_t8 {
             (
                 updates


### PR DESCRIPTION
This PR implements TIP-1042 which updates `FeeAMM` 403 policy behavior.

Fee collection now checks only the fee payer as an authorized sender and no longer requires the `FeeManager` to be an authorized recipient. Public AMM operations keep `FeeManager` policy enforcement, with additional `mint`/`burn` gates that pin LP authorization across the liquidity lifecycle.