### PR TITLE
Propagate proposer public key to block env

### DIFF
--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -171,6 +171,7 @@ impl ConfigureEvm for TempoEvmConfig {
                     .info
                     .epoch_length()
                     .unwrap_or(NonZeroU64::MIN),
+                proposer_public_key: header.consensus_context.map(|ctx| ctx.proposer),
             },
         })
     }
@@ -225,6 +226,7 @@ impl ConfigureEvm for TempoEvmConfig {
                     .info
                     .epoch_length()
                     .unwrap_or(NonZeroU64::MIN),
+                proposer_public_key: attributes.consensus_context.map(|ctx| ctx.proposer),
             },
         })
     }
@@ -314,8 +316,8 @@ mod tests {
     use std::collections::HashMap;
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_primitives::{
-        BlockBody, SubBlockMetadata, subblock::SubBlockVersion,
-        transaction::envelope::TEMPO_SYSTEM_TX_SIGNATURE,
+        BlockBody, SubBlockMetadata, TempoConsensusContext, ed25519::PublicKey,
+        subblock::SubBlockVersion, transaction::envelope::TEMPO_SYSTEM_TX_SIGNATURE,
     };
 
     #[test]
@@ -362,6 +364,21 @@ mod tests {
 
         // Verify Tempo-specific field
         assert_eq!(evm_env.block_env.timestamp_millis_part, 500);
+        assert_eq!(evm_env.block_env.proposer_public_key, None);
+
+        let proposer = PublicKey::from_seed([0xab; 32]);
+        let evm_env = evm_config
+            .evm_env(&TempoHeader {
+                consensus_context: Some(TempoConsensusContext {
+                    epoch: 1,
+                    view: 2,
+                    parent_view: 1,
+                    proposer,
+                }),
+                ..header
+            })
+            .unwrap();
+        assert_eq!(evm_env.block_env.proposer_public_key, Some(proposer));
     }
 
     /// Test that evm_env sets 30M gas limit cap for T1 hardfork as per [TIP-1000].
@@ -455,6 +472,24 @@ mod tests {
 
         // Verify Tempo-specific field
         assert_eq!(evm_env.block_env.timestamp_millis_part, 750);
+        assert_eq!(evm_env.block_env.proposer_public_key, None);
+
+        let proposer = PublicKey::from_seed([0xcd; 32]);
+        let evm_env = evm_config
+            .next_evm_env(
+                &parent,
+                &TempoNextBlockEnvAttributes {
+                    consensus_context: Some(TempoConsensusContext {
+                        epoch: 1,
+                        view: 2,
+                        parent_view: 1,
+                        proposer,
+                    }),
+                    ..attributes
+                },
+            )
+            .unwrap();
+        assert_eq!(evm_env.block_env.proposer_public_key, Some(proposer));
     }
 
     #[test]

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -11,6 +11,8 @@ use alloy_evm::{
 };
 use alloy_primitives::{Address, B256, U256, uint};
 
+use crate::ed25519::PublicKey;
+
 /// Tempo EVM block environment.
 #[derive(Debug, Clone, PartialEq, derive_more::Deref, derive_more::DerefMut)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -25,6 +27,9 @@ pub struct TempoBlockEnv {
 
     /// Number of blocks in a consensus epoch.
     pub epoch_length: NonZeroU64,
+
+    /// Proposer's Ed25519 public key. `Some` only for post-T4 blocks.
+    pub proposer_public_key: Option<PublicKey>,
 }
 
 impl Default for TempoBlockEnv {
@@ -33,6 +38,7 @@ impl Default for TempoBlockEnv {
             inner: Default::default(),
             timestamp_millis_part: 0,
             epoch_length: NonZeroU64::MIN,
+            proposer_public_key: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
- add optional proposer public key to `TempoBlockEnv`
- populate it from consensus context for executed and newly-built block envs
- cover both propagation paths in existing EVM env tests

Prompted by: @klkvr

## Tests
- `cargo test -p tempo-primitives -p tempo-evm proposer_public_key --all-features` (compiled, filter matched 0 tests)
- `cargo test -p tempo-evm test_evm_env --all-features`
- `cargo test -p tempo-evm test_next_evm_env --all-features`
- `cargo fmt --check`