### PR TITLE
deps: update reth from main (2026-07-03)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8615,7 +8615,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8664,8 +8664,8 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-trie",
- "revm-database",
- "revm-state",
+ "reth-trie-sparse",
+ "revm",
  "serde",
  "tokio",
  "tokio-stream",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9130,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9215,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9278,7 +9278,6 @@ dependencies = [
  "indexmap 2.14.0",
  "metrics",
  "moka",
- "parking_lot",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
@@ -9310,8 +9309,6 @@ dependencies = [
  "reth-trie-parallel",
  "reth-trie-sparse",
  "revm",
- "revm-primitives",
- "revm-state",
  "schnellru",
  "serde_json",
  "thiserror 2.0.18",
@@ -9322,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9352,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9370,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9386,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9409,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9420,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9448,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9470,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9511,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "clap",
  "eyre",
@@ -9534,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9550,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9566,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9579,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9609,7 +9606,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9623,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9633,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9658,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9678,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9696,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9709,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9728,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9766,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9780,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "serde",
  "serde_json",
@@ -9790,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9809,8 +9806,6 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "revm",
- "revm-bytecode",
- "revm-database",
  "serde",
  "serde_json",
 ]
@@ -9818,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "bytes",
  "futures",
@@ -9838,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9855,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "bindgen",
  "cc",
@@ -9864,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "futures",
  "metrics",
@@ -9877,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9886,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9900,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9958,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9983,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10007,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10022,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10036,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10053,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10077,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10145,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10200,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10247,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10271,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10295,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "bytes",
  "eyre",
@@ -10324,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10336,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10360,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10372,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10395,7 +10390,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10438,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10475,8 +10470,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-trie",
  "reth-trie-db",
- "revm-database",
- "revm-state",
+ "revm",
  "rocksdb",
  "smallvec",
  "strum",
@@ -10487,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10515,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10531,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10546,7 +10540,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10610,7 +10604,6 @@ dependencies = [
  "reth-trie-common",
  "revm",
  "revm-inspectors",
- "revm-primitives",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -10624,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10654,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10697,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10717,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10748,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10795,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10846,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10860,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10891,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10942,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10970,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10984,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11004,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11019,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11038,14 +11031,14 @@ dependencies = [
  "reth-storage-errors",
  "reth-tokio-util",
  "reth-trie-common",
- "revm-database",
+ "revm",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11055,15 +11048,14 @@ dependencies = [
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface",
- "revm-state",
+ "revm",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11084,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11100,7 +11092,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11110,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "clap",
  "eyre",
@@ -11130,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11149,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11178,8 +11170,6 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "revm",
- "revm-interpreter",
- "revm-primitives",
  "rustc-hash 2.1.2",
  "schnellru",
  "serde",
@@ -11194,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11212,7 +11202,6 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-database",
  "tracing",
  "triehash",
 ]
@@ -11220,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11239,8 +11228,7 @@ dependencies = [
  "rayon",
  "reth-codecs",
  "reth-primitives-traits",
- "revm-database",
- "revm-state",
+ "revm",
  "serde",
  "serde_with",
 ]
@@ -11248,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11267,7 +11255,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11288,7 +11276,7 @@ dependencies = [
  "reth-tasks",
  "reth-trie",
  "reth-trie-sparse",
- "revm-state",
+ "revm",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -11296,7 +11284,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8615,7 +8615,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9130,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9215,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9319,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9367,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9508,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "clap",
  "eyre",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9606,7 +9606,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9630,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9763,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "serde",
  "serde_json",
@@ -9787,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "bytes",
  "futures",
@@ -9833,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9850,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "bindgen",
  "cc",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "futures",
  "metrics",
@@ -9872,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9881,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9978,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10140,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10242,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10266,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10290,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "bytes",
  "eyre",
@@ -10319,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10331,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10390,7 +10390,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10481,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10540,7 +10540,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10617,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10710,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10839,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10853,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10884,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10935,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10963,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10997,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11092,7 +11092,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "clap",
  "eyre",
@@ -11122,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11184,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11209,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11255,7 +11255,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11284,7 +11284,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
+source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8615,7 +8615,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9130,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9215,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9319,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9367,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9508,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "clap",
  "eyre",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9606,7 +9606,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9630,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9763,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "serde",
  "serde_json",
@@ -9787,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "bytes",
  "futures",
@@ -9833,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9850,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "bindgen",
  "cc",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "futures",
  "metrics",
@@ -9872,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9881,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9978,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10140,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10242,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10266,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10290,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "bytes",
  "eyre",
@@ -10319,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10331,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10390,7 +10390,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10481,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10540,7 +10540,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10617,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10710,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10839,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10853,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10884,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10935,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10963,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10997,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11092,7 +11092,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "clap",
  "eyre",
@@ -11122,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11184,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11209,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11255,7 +11255,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11284,7 +11284,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4b0198b#4b0198bd00e8f98f0667f059cb548c6d62da2431"
+source = "git+https://github.com/paradigmxyz/reth?rev=763241c#763241cd1dc70b0de2dd0a289ddb63c7886f1829"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8615,7 +8615,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9130,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9215,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9319,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9367,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9508,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "clap",
  "eyre",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9606,7 +9606,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9630,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9763,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "serde",
  "serde_json",
@@ -9787,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "bytes",
  "futures",
@@ -9833,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9850,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "bindgen",
  "cc",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "futures",
  "metrics",
@@ -9872,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9881,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9978,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10140,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10242,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10266,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10290,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "bytes",
  "eyre",
@@ -10319,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10331,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10390,7 +10390,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10481,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10540,7 +10540,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10617,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10710,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10839,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10853,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10884,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10935,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10963,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10997,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11092,7 +11092,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "clap",
  "eyre",
@@ -11122,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11184,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11209,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11255,7 +11255,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11283,7 +11283,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
+source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8615,7 +8615,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9130,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9215,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9319,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9367,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9508,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "clap",
  "eyre",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9606,7 +9606,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9630,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9763,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "serde",
  "serde_json",
@@ -9787,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "bytes",
  "futures",
@@ -9833,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9850,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "bindgen",
  "cc",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "futures",
  "metrics",
@@ -9872,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9881,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9978,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10140,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10242,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10266,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10290,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "bytes",
  "eyre",
@@ -10319,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10331,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10390,7 +10390,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10481,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10540,7 +10540,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10617,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10710,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10839,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10853,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10884,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10935,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10963,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10997,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11092,7 +11092,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "clap",
  "eyre",
@@ -11122,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11184,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11209,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11255,7 +11255,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11283,7 +11283,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=65ed395#65ed395aa3625edabeb179abe7374507d7d842ba"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8615,7 +8615,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9130,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9215,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9319,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9367,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9508,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "clap",
  "eyre",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9606,7 +9606,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9630,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9763,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "serde",
  "serde_json",
@@ -9787,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "bytes",
  "futures",
@@ -9833,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9850,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "bindgen",
  "cc",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "futures",
  "metrics",
@@ -9872,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9881,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9978,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10140,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10242,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10266,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10290,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "bytes",
  "eyre",
@@ -10319,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10331,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10390,7 +10390,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10481,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10540,7 +10540,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10617,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10710,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10839,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10853,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10884,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10935,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10963,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10997,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11092,7 +11092,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "clap",
  "eyre",
@@ -11122,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11184,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11209,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11255,9 +11255,8 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
- "alloy-eip7928",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -11284,7 +11283,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7511e33#7511e338f0a569c145aeee22ced9af0a2e386725"
+source = "git+https://github.com/paradigmxyz/reth?rev=48e567c#48e567c25ce76e33ee5a2d6d98c3db8885dfe5e4"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "48e567c", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "65ed395", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "763241c", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "763241c", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "763241c", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "763241c", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "0d303f7", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "4b0198b", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "763241c", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "763241c", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "763241c", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "763241c" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "763241c", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "7511e33", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1289,6 +1289,7 @@ where
             execution_output: Arc::new(execution_output),
             hashed_state: Arc::new(hashed_state),
             trie_updates,
+            changed_paths: None,
         };
 
         let payload = TempoBuiltPayload::new(


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`0d303f7...8bbc5e6`](https://github.com/paradigmxyz/reth/compare/0d303f7...8bbc5e6)

🔗 Amp thread: https://ampcode.com/threads/T-019f27c6-281e-75ce-826f-de219c36235e
**Net**
- Added dedicated eth + snap/2 stream ([#25752](https://github.com/paradigmxyz/reth/pull/25752)) with default-off snap/2 negotiation ([#25774](https://github.com/paradigmxyz/reth/pull/25774)) and wired the max pending imports setting ([#25921](https://github.com/paradigmxyz/reth/pull/25921))
- Perf: fixed hasher for peer maps ([#26031](https://github.com/paradigmxyz/reth/pull/26031)), skip no-op reputation changes ([#26032](https://github.com/paradigmxyz/reth/pull/26032)), and cache full transaction propagation encoding ([#26012](https://github.com/paradigmxyz/reth/pull/26012))

**Engine**
- Use execution version header for SSZ routes ([#25925](https://github.com/paradigmxyz/reth/pull/25925))
- Dropped parallel state root ([#26069](https://github.com/paradigmxyz/reth/pull/26069)), then restored the state root task parallelism gate ([#26080](https://github.com/paradigmxyz/reth/pull/26080))
- Perf: hash precompile metrics by fixed address ([#26070](https://github.com/paradigmxyz/reth/pull/26070))

**Trie**
- Retain sparse trie changed paths ([#25738](https://github.com/paradigmxyz/reth/pull/25738)) and with prefix sets ([#26111](https://github.com/paradigmxyz/reth/pull/26111))
- Dropped unused BlockAccessList state-root message ([#26022](https://github.com/paradigmxyz/reth/pull/26022))

**Chain State**
- Moved preserved sparse trie ownership ([#25911](https://github.com/paradigmxyz/reth/pull/25911))

**Payload**
- Include Amsterdam fields in payload id ([#25973](https://github.com/paradigmxyz/reth/pull/25973))

**RPC**
- Weight fee history rewards by receipt gas ([#26067](https://github.com/paradigmxyz/reth/pull/26067))

**Txpool**
- Account for blob tx access list size ([#26113](https://github.com/paradigmxyz/reth/pull/26113))

**DB**
- Avoid rustdoc ICE for libmdbx re-export ([#26055](https://github.com/paradigmxyz/reth/pull/26055))

**Era**
- Accept local file name variants ([#26006](https://github.com/paradigmxyz/reth/pull/26006))

**Tracing**
- Include span attributes in OTLP logs ([#26062](https://github.com/paradigmxyz/reth/pull/26062))

**Refactor**
- Use main revm crate ([#25916](https://github.com/paradigmxyz/reth/pull/25916))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019f27c6-5baf-7000-802b-0514503c70c7
- Bumped the `reth` git dependency revision from `0d303f7` to `8bbc5e6` across all `reth-*` crates in `Cargo.toml`
- Added the new required `changed_paths: None` field when constructing the execution/trie output struct in `crates/payload/builder/src/lib.rs`, adapting to an upstream reth API change

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/28657837063)
