### PR TITLE
Enable samply for scheduled e2e benches

### DIFF
--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -26,6 +26,11 @@ on:
         required: false
         default: false
         type: boolean
+      samply:
+        description: "Enable samply profiling"
+        required: false
+        default: true
+        type: boolean
 
 permissions: {}
 
@@ -165,6 +170,7 @@ jobs:
       run-type: ${{ matrix.run_type }}
       run-pairs: "1"
       clickhouse-run: feature-1
+      samply: ${{ github.event_name == 'workflow_dispatch' && inputs.samply == false && 'false' || 'true' }}
     secrets:
       DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}


### PR DESCRIPTION
## Summary
- enable samply by default for `bench-e2e-scheduled.yml` runs
- add a manual dispatch `samply` toggle that defaults to enabled

## Validation
- `uv run --with pyyaml python -c "import yaml; yaml.safe_load(open('.github/workflows/bench-e2e-scheduled.yml')); print('yaml ok')"`
- `git diff --check`

Prompted by: @shekhirin