### PR TITLE
perf(primitives): seed expiring nonce hash during AA recovery

### DIFF
--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -298,7 +298,9 @@ impl alloy_consensus::transaction::SignerRecoverable for TempoTxEnvelope {
             Self::Eip7702(tx) => {
                 alloy_consensus::transaction::SignerRecoverable::recover_signer(tx)
             }
-            Self::AA(tx) => alloy_consensus::transaction::SignerRecoverable::recover_signer(tx),
+            Self::AA(tx) => tx
+                .recover_signer_with_expiring_nonce_hash()
+                .map(|(signer, _)| signer),
         }
     }
 

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -371,7 +371,7 @@ impl TempoTransaction {
     /// Calculate the signing hash for this transaction
     /// This is the hash that should be signed by the sender
     pub fn signature_hash(&self) -> B256 {
-        let mut buf = Vec::new();
+        let mut buf = Vec::with_capacity(self.payload_len_for_signature());
         self.encode_for_signing(&mut buf);
         keccak256(&buf)
     }

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -759,7 +759,7 @@ impl From<Signature> for TempoSignature {
 
 /// Derives a P256 address from public key coordinates
 pub fn derive_p256_address(pub_key_x: &B256, pub_key_y: &B256) -> Address {
-    let hash = keccak256([pub_key_x.as_slice(), pub_key_y.as_slice()].concat());
+    let hash = keccak256(concat::<64>(&[pub_key_x.as_slice(), pub_key_y.as_slice()]));
 
     // Take last 20 bytes as address
     Address::from_slice(&hash[12..])

--- a/crates/primitives/src/transaction/tt_signed.rs
+++ b/crates/primitives/src/transaction/tt_signed.rs
@@ -555,6 +555,7 @@ mod serde_impl {
 mod tests {
     use super::*;
     use crate::transaction::{
+        TempoTxEnvelope,
         tempo_transaction::Call,
         tt_authorization::tests::{generate_secp256k1_keypair, sign_hash},
         tt_signature::PrimitiveSignature,
@@ -903,6 +904,34 @@ mod tests {
             Some(signed.expiring_nonce_hash(expected_address))
         );
         assert_eq!(signed.signature_hash(), sig_hash);
+    }
+
+    #[test]
+    fn test_envelope_recover_signer_seeds_expiring_nonce_hash() {
+        let (signing_key, expected_address) = generate_secp256k1_keypair();
+
+        let mut tx = make_tx();
+        tx.nonce_key = U256::MAX;
+
+        let placeholder =
+            TempoSignature::Primitive(PrimitiveSignature::Secp256k1(Signature::test_signature()));
+        let temp_signed = AASigned::new_unhashed(tx.clone(), placeholder);
+        let sig_hash = temp_signed.signature_hash();
+
+        let signature = sign_hash(&signing_key, &sig_hash);
+        let envelope = TempoTxEnvelope::AA(AASigned::new_unhashed(tx, signature));
+
+        let recovered = envelope.recover_signer().unwrap();
+        assert_eq!(recovered, expected_address);
+
+        let aa = envelope.as_aa().unwrap();
+        assert_eq!(
+            aa.expiring_nonce_hash.get().copied(),
+            Some((
+                expected_address,
+                unique_tx_identifier_from_signable(aa.tx(), expected_address)
+            ))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Uses the existing `recover_signer_with_expiring_nonce_hash` helper from generic AA envelope recovery, so `try_into_recovered()` seeds the expiring-nonce hash before pooled transaction construction.

This extends the same optimization already used by raw pool decoding in #6175, while keeping AA tx hashes lazy and avoiding the older no-win preallocation changes.

Local release microbench for expiring AA recovery followed by `TempoPooledTransaction::new()`:

| case | `main` | this PR |
| --- | ---: | ---: |
| `small recover+pool_new` | `15.30 us` | `14.86 us` |
| `heavy recover+pool_new` | `22.35 us` | `18.25 us` |
