### PR TITLE
feat(nonce): implement TIP-1077 time wheel

### DIFF
--- a/.changelog/tip-1077-timewheel.md
+++ b/.changelog/tip-1077-timewheel.md
@@ -1,0 +1,6 @@
+---
+tempo-alloy: minor
+tempo-primitives: minor
+---
+
+Added TIP-1077 expiring nonce support for the T8 time wheel, including the 300-second expiry window while keeping pre-T8 expiring nonces on the legacy 30-second behavior.

--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -79,7 +79,7 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for R
 /// A [`TxFiller`] that populates transactions with expiring nonce fields ([TIP-1009]).
 ///
 /// Sets `nonce_key` to `U256::MAX`, `nonce` to `0`, and `valid_before` to current time + expiry window.
-/// This enables transactions to use the circular buffer replay protection instead of 2D nonce storage.
+/// This enables transactions to use expiring nonce replay protection instead of 2D nonce storage.
 ///
 /// [TIP-1009]: <https://docs.tempo.xyz/protocol/tips/tip-1009>
 #[derive(Clone, Copy, Debug)]
@@ -97,9 +97,9 @@ impl Default for ExpiringNonceFiller {
 }
 
 impl ExpiringNonceFiller {
-    /// Default expiry window in seconds (25s, within the 30s max allowed by [TIP-1009]).
+    /// Default expiry window in seconds (25s, within the 5 minute max allowed by [TIP-1077]).
     ///
-    /// [TIP-1009]: <https://docs.tempo.xyz/protocol/tips/tip-1009>
+    /// [TIP-1077]: <https://docs.tempo.xyz/protocol/tips/tip-1077>
     pub const DEFAULT_EXPIRY_SECS: u64 = 25;
 
     /// Create a new filler with a custom expiry window.

--- a/crates/node/tests/it/tempo_transaction/helpers.rs
+++ b/crates/node/tests/it/tempo_transaction/helpers.rs
@@ -28,7 +28,7 @@ use tempo_primitives::{
     SignatureType, TempoTransaction, TempoTxEnvelope,
     transaction::{
         CallScope, KeyAuthorization, SelectorRule, SignedKeyAuthorization,
-        TEMPO_EXPIRING_NONCE_KEY, TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS, TokenLimit,
+        TEMPO_EXPIRING_NONCE_KEY, TokenLimit,
         tempo_transaction::Call,
         tt_signature::{
             KeychainSignature, P256SignatureWithPreHash, PrimitiveSignature, TempoSignature,
@@ -1214,6 +1214,7 @@ pub(crate) fn build_fill_request_context(
     signer_addr: Address,
     recipient: Address,
     current_timestamp: u64,
+    expiring_nonce_max_expiry_secs: u64,
 ) -> FillRequestContext {
     let valid_before_offset = test_case
         .valid_before_offset
@@ -1223,12 +1224,12 @@ pub(crate) fn build_fill_request_context(
         .map(|offset| resolve_timestamp_offset(current_timestamp, offset));
 
     let valid_before = valid_before_offset.or_else(|| match test_case.nonce_mode {
-        NonceMode::Expiring => Some(current_timestamp + TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS / 2),
+        NonceMode::Expiring => Some(current_timestamp + expiring_nonce_max_expiry_secs / 2),
         NonceMode::ExpiringAtBoundary => {
-            Some(current_timestamp + TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS - 1)
+            Some(current_timestamp + expiring_nonce_max_expiry_secs - 1)
         }
         NonceMode::ExpiringExceedsBoundary => {
-            Some(current_timestamp + TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS + 3600)
+            Some(current_timestamp + expiring_nonce_max_expiry_secs + 3600)
         }
         NonceMode::ExpiringInPast => Some(current_timestamp.saturating_sub(1)),
         _ => None,
@@ -1297,10 +1298,16 @@ pub(crate) async fn fill_transaction_from_case(
     test_case: &FillTestCase,
     signer_addr: Address,
     current_timestamp: u64,
+    expiring_nonce_max_expiry_secs: u64,
 ) -> eyre::Result<(TempoTransaction, FillRequestContext)> {
     let recipient = Address::random();
-    let request_context =
-        build_fill_request_context(test_case, signer_addr, recipient, current_timestamp);
+    let request_context = build_fill_request_context(
+        test_case,
+        signer_addr,
+        recipient,
+        current_timestamp,
+        expiring_nonce_max_expiry_secs,
+    );
 
     let filled: serde_json::Value =
         legacy_compat::raw_request(provider, "eth_fillTransaction", &request_context.request)

--- a/crates/node/tests/it/tempo_transaction/runners.rs
+++ b/crates/node/tests/it/tempo_transaction/runners.rs
@@ -15,6 +15,7 @@ use alloy_primitives::TxKind;
 use reth_primitives_traits::transaction::TxHashRef;
 use tempo_contracts::precompiles::DEFAULT_FEE_TOKEN;
 use tempo_node::rpc::TempoTransactionRequest;
+use tempo_precompiles::nonce::expiring_nonce_max_expiry_secs_for_spec;
 use tempo_primitives::{
     SignatureType, TempoTransaction, TempoTxEnvelope,
     transaction::{
@@ -696,6 +697,7 @@ pub(super) async fn run_fill_transaction_matrix<E: TestEnv>(env: &mut E) -> eyre
     let signer = PrivateKeySigner::random();
     let signer_addr = signer.address();
     let current_timestamp = env.current_block_timestamp().await?;
+    let expiring_nonce_max_expiry_secs = expiring_nonce_max_expiry_secs_for_spec(env.hardfork());
     let fee_payer_signer = PrivateKeySigner::random();
     let scoped_fill_case = |name, num_limits, allowed_calls| {
         let case = FillTestCase::new(NonceMode::Protocol, KeyType::Secp256k1).key_authorization(
@@ -757,9 +759,14 @@ pub(super) async fn run_fill_transaction_matrix<E: TestEnv>(env: &mut E) -> eyre
     for (index, test_case) in matrix.iter().enumerate() {
         println!("[{}/{}] {}", index + 1, matrix.len(), test_case.name);
 
-        let fill_result =
-            fill_transaction_from_case(env.provider(), test_case, signer_addr, current_timestamp)
-                .await;
+        let fill_result = fill_transaction_from_case(
+            env.provider(),
+            test_case,
+            signer_addr,
+            current_timestamp,
+            expiring_nonce_max_expiry_secs,
+        )
+        .await;
         let (filled_tx, request_context) = match fill_result {
             Ok(pair) => {
                 if matches!(test_case.expected, ExpectedOutcome::Rejection) {
@@ -1752,10 +1759,17 @@ pub(super) async fn run_fill_sign_send<E: TestEnv>(
         let _ = env.fund_account(fee_payer_signer.address()).await?;
 
         let current_timestamp = env.current_block_timestamp().await?;
+        let expiring_nonce_max_expiry_secs =
+            expiring_nonce_max_expiry_secs_for_spec(env.hardfork());
 
-        let fill_result =
-            fill_transaction_from_case(env.provider(), test_case, signer_addr, current_timestamp)
-                .await;
+        let fill_result = fill_transaction_from_case(
+            env.provider(),
+            test_case,
+            signer_addr,
+            current_timestamp,
+            expiring_nonce_max_expiry_secs,
+        )
+        .await;
 
         let (mut tx, _request_context) = match fill_result {
             Ok(pair) => pair,
@@ -1806,11 +1820,18 @@ pub(super) async fn run_fill_sign_send<E: TestEnv>(
         }
 
         let current_timestamp = env.current_block_timestamp().await?;
+        let expiring_nonce_max_expiry_secs =
+            expiring_nonce_max_expiry_secs_for_spec(env.hardfork());
         let initial_protocol_nonce = env.provider().get_transaction_count(signer_addr).await?;
 
-        let fill_result =
-            fill_transaction_from_case(env.provider(), test_case, signer_addr, current_timestamp)
-                .await;
+        let fill_result = fill_transaction_from_case(
+            env.provider(),
+            test_case,
+            signer_addr,
+            current_timestamp,
+            expiring_nonce_max_expiry_secs,
+        )
+        .await;
 
         let (mut tx, request_context) = match fill_result {
             Ok(pair) => pair,

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -1,7 +1,10 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-    mpsc::{self, Receiver, Sender},
+use std::{
+    cell::RefCell,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, Receiver, Sender},
+    },
 };
 
 use alloy_primitives::B256;
@@ -18,6 +21,10 @@ use tempo_transaction_pool::best::BestTransaction;
 use tracing::trace;
 
 type PrewarmEvmState = Option<TempoEvm<StateProviderDatabase<StateProviderBox>>>;
+
+thread_local! {
+    static PREWARM_EVM_STATE: RefCell<PrewarmEvmState> = const { RefCell::new(None) };
+}
 
 /// Prewarming orchestrator that consumes source [`BestTransactions`] with bounded
 /// lookahead, prewarms buffered transactions in parallel, and produces a new
@@ -89,26 +96,24 @@ impl BestTransactionsPrewarming {
         Provider: StateProviderFactory + Clone + 'static,
     {
         let pool = executor.prewarming_pool();
+        clear_prewarm_evm_states(pool);
 
         pool.in_place_scope(|scope| {
-            let prewarm = ctx.prewarm.clone();
-            scope.spawn(move |_| {
-                pool.init::<PrewarmEvmState>(|_| prewarm.evm_for_ctx());
-            });
-
             let advance = |ctx: &mut BestTransactionsPrewarmingContext<Txs, Provider>| {
                 let Some(tx) = ctx.best_txs.next() else {
                     let _ = ctx.transactions_tx.send(None);
                     return;
                 };
-                let expiring_nonce_offset = if tx.transaction.is_expiring_nonce() {
+                let _ = ctx.transactions_tx.send(Some(tx.clone()));
+                let expiring_nonce_offset = if tx.transaction.is_expiring_nonce()
+                    && !ctx.prewarm.evm_env.cfg_env.spec.is_t8()
+                {
                     let offset = ctx.next_expiring_nonce_offset;
                     ctx.next_expiring_nonce_offset += 1;
                     Some(offset)
                 } else {
                     None
                 };
-                let _ = ctx.transactions_tx.send(Some(tx.clone()));
 
                 let prewarm = ctx.prewarm.clone();
                 let commands_tx = ctx.commands_tx.clone();
@@ -161,7 +166,7 @@ impl BestTransactionsPrewarming {
             }
         });
 
-        pool.clear();
+        clear_prewarm_evm_states(pool);
     }
 
     fn prewarm_transaction<Provider>(
@@ -175,20 +180,24 @@ impl BestTransactionsPrewarming {
             return;
         }
 
-        WorkerPool::with_worker_mut(|worker| {
-            let Some(evm) = worker.get_or_init::<PrewarmEvmState>(|| prewarm.evm_for_ctx()) else {
+        PREWARM_EVM_STATE.with(|state| {
+            let mut state = state.borrow_mut();
+            if state.is_none() {
+                *state = prewarm.evm_for_ctx();
+            }
+            let Some(evm) = state.as_mut() else {
                 return;
             };
-
             let tx_hash = *tx.hash();
+            let mut tx_env = tx.transaction.clone_tx_env();
+            if let Some(offset) = expiring_nonce_offset
+                && let Some(tempo_tx_env) = tx_env.tempo_tx_env.as_mut()
+            {
+                tempo_tx_env.expiring_nonce_idx = Some(offset);
+            }
 
             if prewarm.is_stopped() {
                 return;
-            }
-
-            let mut tx_env = tx.transaction.clone_tx_env();
-            if let Some(tempo_tx_env) = tx_env.tempo_tx_env.as_mut() {
-                tempo_tx_env.expiring_nonce_idx = expiring_nonce_offset;
             }
 
             if let Err(err) = evm.transact_raw(tx_env) {
@@ -208,6 +217,14 @@ impl BestTransactionsPrewarming {
             );
         });
     }
+}
+
+fn clear_prewarm_evm_states(pool: &WorkerPool) {
+    pool.broadcast(pool.current_num_threads(), |_| {
+        PREWARM_EVM_STATE.with(|state| {
+            *state.borrow_mut() = None;
+        });
+    });
 }
 
 impl Drop for BestTransactionsPrewarming {

--- a/crates/precompiles/src/nonce/mod.rs
+++ b/crates/precompiles/src/nonce/mod.rs
@@ -12,16 +12,131 @@ use tempo_precompiles_macros::contract;
 use crate::{
     NONCE_PRECOMPILE_ADDRESS,
     error::Result,
-    storage::{Handler, Mapping},
+    storage::{Handler, Mapping, Slot},
 };
-use alloy::primitives::{Address, B256, U256};
+use alloy::primitives::{Address, B256, U256, uint};
+use tempo_chainspec::hardfork::TempoHardfork;
 
-/// Capacity of the expiring nonce seen set (supports 10k TPS for 30 seconds).
-pub const EXPIRING_NONCE_SET_CAPACITY: u32 = 300_000;
+/// Maximum allowed skew for expiring nonce transactions before TIP-1077.
+pub const PRE_TIP_1077_MAX_EXPIRY_SECS: u64 = 30;
 
-/// Maximum allowed skew for expiring nonce transactions (30 seconds).
+/// Capacity of the pre-TIP-1077 expiring nonce seen set.
+pub const PRE_TIP_1077_EXPIRING_NONCE_SET_CAPACITY: u32 = 300_000;
+
+/// Maximum allowed skew for expiring nonce transactions (5 minutes).
 /// Transactions must have valid_before in (now, now + MAX_EXPIRY_SECS].
-pub const EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 30;
+pub const EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 300;
+
+/// Number of reusable time buckets in the expiring nonce time wheel.
+pub const EXPIRING_NONCE_BUCKET_COUNT: u64 = 301;
+
+/// Number of replay cells in each time bucket.
+pub const EXPIRING_NONCE_BUCKET_CAPACITY: u64 = 131_072;
+
+/// Number of hash bits used for each probe position.
+pub const EXPIRING_NONCE_POSITION_BITS: usize = 17;
+
+/// Maximum number of replay cells probed for one expiring nonce transaction.
+pub const EXPIRING_NONCE_MAX_PROBES: usize = 4;
+
+/// Number of replay cells reserved for the whole time wheel.
+pub const EXPIRING_NONCE_CELL_COUNT: u64 =
+    EXPIRING_NONCE_BUCKET_COUNT * EXPIRING_NONCE_BUCKET_CAPACITY;
+
+/// Base slot of the reserved direct expiring nonce replay-cell range.
+pub const EXPIRING_NONCE_CELL_BASE_SLOT: U256 =
+    uint!(0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa2400000_U256);
+
+/// End slot of the reserved direct expiring nonce replay-cell range.
+pub const EXPIRING_NONCE_CELL_END_SLOT: U256 =
+    uint!(0x387ee7e371ffafdf29537b927a83c9af016eb1493da1fe163fab229fa499ffff_U256);
+
+/// Number of 64-bit fingerprint lanes packed into a replay cell.
+pub const EXPIRING_NONCE_PACKED_SLOTS: usize = 3;
+
+const FINGERPRINT_MASK: U256 = U256::from_limbs([u64::MAX, 0, 0, 0]);
+
+/// Returns the active expiring nonce validity window for a hardfork spec.
+pub const fn expiring_nonce_max_expiry_secs_for_spec(spec: TempoHardfork) -> u64 {
+    if spec.is_t8() {
+        EXPIRING_NONCE_MAX_EXPIRY_SECS
+    } else {
+        PRE_TIP_1077_MAX_EXPIRY_SECS
+    }
+}
+
+/// Returns the nonzero 64-bit replay fingerprint for `expiring_nonce_hash`.
+pub fn expiring_nonce_fingerprint(expiring_nonce_hash: B256) -> u64 {
+    let hash = expiring_nonce_hash.as_slice();
+    let primary = u64::from_be_bytes(hash[24..32].try_into().expect("slice length is 8"));
+    if primary != 0 {
+        return primary;
+    }
+
+    let fallback = u64::from_be_bytes(hash[16..24].try_into().expect("slice length is 8"));
+    if fallback != 0 { fallback } else { 1 }
+}
+
+/// Returns the direct replay-cell slot for one deterministic probe.
+pub fn expiring_nonce_cell_slot(
+    expiring_nonce_hash: B256,
+    valid_before: u64,
+    probe: usize,
+) -> U256 {
+    debug_assert!(probe < EXPIRING_NONCE_MAX_PROBES);
+    let bucket = valid_before % EXPIRING_NONCE_BUCKET_COUNT;
+    let position = expiring_nonce_probe_position(expiring_nonce_hash, probe);
+    let cell_id = bucket * EXPIRING_NONCE_BUCKET_CAPACITY + position;
+    EXPIRING_NONCE_CELL_BASE_SLOT + U256::from(cell_id)
+}
+
+/// Returns all deterministic replay-cell slots for an expiring nonce transaction.
+pub fn expiring_nonce_probe_slots(
+    expiring_nonce_hash: B256,
+    valid_before: u64,
+) -> [U256; EXPIRING_NONCE_MAX_PROBES] {
+    core::array::from_fn(|probe| expiring_nonce_cell_slot(expiring_nonce_hash, valid_before, probe))
+}
+
+/// Encodes a TIP-1077 replay cell.
+pub fn pack_expiring_nonce_cell(valid_before: u64, fingerprints: [u64; 3]) -> U256 {
+    (U256::from(valid_before) << 192)
+        | (U256::from(fingerprints[0]) << 128)
+        | (U256::from(fingerprints[1]) << 64)
+        | U256::from(fingerprints[2])
+}
+
+/// Returns true if a packed replay cell contains the live transaction fingerprint.
+pub fn expiring_nonce_cell_contains(word: U256, valid_before: u64, fingerprint: u64) -> bool {
+    let (stored_valid_before, fingerprints) = unpack_expiring_nonce_cell(word);
+    stored_valid_before == valid_before && fingerprints.contains(&fingerprint)
+}
+
+fn expiring_nonce_probe_position(expiring_nonce_hash: B256, probe: usize) -> u64 {
+    let hash = expiring_nonce_hash.as_slice();
+    let start_bit = probe * EXPIRING_NONCE_POSITION_BITS;
+    let mut position = 0u64;
+
+    for offset in 0..EXPIRING_NONCE_POSITION_BITS {
+        let bit_index = start_bit + offset;
+        let byte = hash[bit_index / 8];
+        let bit = (byte >> (7 - (bit_index % 8))) & 1;
+        position = (position << 1) | u64::from(bit);
+    }
+
+    position
+}
+
+fn unpack_expiring_nonce_cell(word: U256) -> (u64, [u64; 3]) {
+    let valid_before = (word >> 192usize).to::<u64>();
+    let fingerprints = [
+        ((word >> 128usize) & FINGERPRINT_MASK).to::<u64>(),
+        ((word >> 64usize) & FINGERPRINT_MASK).to::<u64>(),
+        (word & FINGERPRINT_MASK).to::<u64>(),
+    ];
+
+    (valid_before, fingerprints)
+}
 
 /// NonceManager contract for managing 2D nonces as per the AA spec
 ///
@@ -30,17 +145,15 @@ pub const EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 30;
 /// contract Nonce {
 ///     mapping(address => mapping(uint256 => uint64)) public nonces;      // slot 0
 ///
-///     // Expiring nonce storage (for hash-based replay protection)
-///     mapping(bytes32 => uint64) public expiringNonceSeen;               // slot 1: txHash => expiry
-///     mapping(uint32 => bytes32) public expiringNonceRing;               // slot 2: circular buffer of tx hashes
-///     uint32 public expiringNonceRingPtr;                                // slot 3: current position (wraps at CAPACITY)
+///     // Slots 1, 2, and 3 are reserved for pre-TIP-1077 expiring nonce state.
 /// }
 /// ```
 ///
 /// - Slot 0: 2D nonce mapping - keccak256(abi.encode(nonce_key, keccak256(abi.encode(account, 0))))
-/// - Slot 1: Expiring nonce seen set - txHash => expiry timestamp
-/// - Slot 2: Expiring nonce circular buffer - index => txHash
-/// - Slot 3: Circular buffer pointer (current position, wraps at CAPACITY)
+/// - Slot 1: Reserved old expiring nonce seen set - txHash => expiry timestamp
+/// - Slot 2: Reserved old expiring nonce circular buffer - index => txHash
+/// - Slot 3: Reserved old circular buffer pointer
+/// - EXPIRING_NONCE_CELL_BASE_SLOT..=EXPIRING_NONCE_CELL_END_SLOT: TIP-1077 replay cells
 ///
 /// Note: Protocol nonce (key 0) is stored directly in account state, not here.
 /// Only user nonce keys (1-N) are managed by this precompile.
@@ -100,34 +213,72 @@ impl NonceManager {
         Ok(new_nonce)
     }
 
-    /// Checks if a hash has been seen and is still valid (not expired).
-    /// NOTE: internally used by the transaction pool.
-    pub fn is_expiring_nonce_seen(&self, hash: B256, now: u64) -> Result<bool> {
+    /// Checks if a hash is present in the pre-TIP-1077 seen mapping.
+    pub fn is_pre_tip_1077_expiring_nonce_seen(&self, hash: B256, now: u64) -> Result<bool> {
         let expiry = self.expiring_nonce_seen[hash].read()?;
         Ok(expiry != 0 && expiry > now)
     }
 
-    /// Validates and records an expiring nonce transaction. Uses a
-    /// circular buffer that overwrites expired entries as the pointer
-    /// advances. The hash is `keccak256(encode_for_signing || sender)`,
-    /// invariant to fee payer changes.
-    ///
-    /// Uses a circular buffer that overwrites expired entries as the pointer advances.
-    ///
-    /// The `expiring_nonce_hash` parameter is
-    /// (`keccak256(encode_for_signing || sender)`), which is invariant to fee payer changes.
-    ///
-    /// This is called during transaction execution to:
-    /// 1. Validate the expiry is within the allowed window
-    /// 2. Check for replay (hash already seen and not expired)
-    /// 3. Check if we can evict the entry at current pointer (must be expired or empty)
-    /// 4. Mark the hash as seen
+    /// Validates and records an expiring nonce transaction in the TIP-1077 time wheel.
     ///
     /// # Errors
     /// - `InvalidExpiringNonceExpiry` — `valid_before` not in (now, now + EXPIRING_NONCE_MAX_EXPIRY_SECS]
-    /// - `ExpiringNonceReplay` — transaction hash is already recorded and has not yet expired
-    /// - `ExpiringNonceSetFull` — the circular buffer slot holds an unexpired entry that can't be evicted
+    /// - `ExpiringNonceReplay` — transaction fingerprint is already recorded for `valid_before`
+    /// - `ExpiringNonceSetFull` — all cells on the deterministic probe path are full
     pub fn check_and_mark_expiring_nonce(
+        &mut self,
+        expiring_nonce_hash: B256,
+        valid_before: u64,
+    ) -> Result<()> {
+        if !self.storage.spec().is_t8() {
+            return self
+                .check_and_mark_pre_tip_1077_expiring_nonce(expiring_nonce_hash, valid_before);
+        }
+
+        self.check_and_mark_timewheel_expiring_nonce(expiring_nonce_hash, valid_before)
+    }
+
+    fn check_and_mark_pre_tip_1077_expiring_nonce(
+        &mut self,
+        expiring_nonce_hash: B256,
+        valid_before: u64,
+    ) -> Result<()> {
+        let now: u64 = self.storage.timestamp().saturating_to();
+
+        if valid_before <= now || valid_before > now.saturating_add(PRE_TIP_1077_MAX_EXPIRY_SECS) {
+            return Err(NonceError::invalid_expiring_nonce_expiry().into());
+        }
+
+        let seen_expiry = self.expiring_nonce_seen[expiring_nonce_hash].read()?;
+        if seen_expiry != 0 && seen_expiry > now {
+            return Err(NonceError::expiring_nonce_replay().into());
+        }
+
+        let ptr = self.expiring_nonce_ring_ptr.read()?;
+        let old_hash = self.expiring_nonce_ring[ptr].read()?;
+
+        if old_hash != B256::ZERO {
+            let old_expiry = self.expiring_nonce_seen[old_hash].read()?;
+            if old_expiry != 0 && old_expiry > now {
+                return Err(NonceError::expiring_nonce_set_full().into());
+            }
+            self.expiring_nonce_seen[old_hash].write(0)?;
+        }
+
+        self.expiring_nonce_ring[ptr].write(expiring_nonce_hash)?;
+        self.expiring_nonce_seen[expiring_nonce_hash].write(valid_before)?;
+
+        let next = if ptr + 1 >= PRE_TIP_1077_EXPIRING_NONCE_SET_CAPACITY {
+            0
+        } else {
+            ptr + 1
+        };
+        self.expiring_nonce_ring_ptr.write(next)?;
+
+        Ok(())
+    }
+
+    fn check_and_mark_timewheel_expiring_nonce(
         &mut self,
         expiring_nonce_hash: B256,
         valid_before: u64,
@@ -140,43 +291,33 @@ impl NonceManager {
             return Err(NonceError::invalid_expiring_nonce_expiry().into());
         }
 
-        // 2. Replay check: reject if hash is already seen and not expired
-        let seen_expiry = self.expiring_nonce_seen[expiring_nonce_hash].read()?;
-        if seen_expiry != 0 && seen_expiry > now {
-            return Err(NonceError::expiring_nonce_replay().into());
-        }
+        let fingerprint = expiring_nonce_fingerprint(expiring_nonce_hash);
 
-        // 3. Get current pointer (bounded in [0, CAPACITY)) and use directly as index
-        let ptr = self.expiring_nonce_ring_ptr.read()?;
-        let idx = ptr;
-        let old_hash = self.expiring_nonce_ring[idx].read()?;
+        for slot in expiring_nonce_probe_slots(expiring_nonce_hash, valid_before) {
+            let mut cell = Slot::<U256>::new(slot, NONCE_PRECOMPILE_ADDRESS);
+            let word = cell.read()?;
+            let (stored_valid_before, mut fingerprints) = unpack_expiring_nonce_cell(word);
 
-        // 4. If there's an existing entry, check if it's expired (can be evicted)
-        // Safety check: buffer is sized so entries should always be expired, but verify
-        // in case TPS exceeds expectations.
-        if old_hash != B256::ZERO {
-            let old_expiry = self.expiring_nonce_seen[old_hash].read()?;
-            if old_expiry != 0 && old_expiry > now {
-                // Entry is still valid, cannot evict - buffer is full
-                return Err(NonceError::expiring_nonce_set_full().into());
+            if stored_valid_before != valid_before {
+                cell.write(pack_expiring_nonce_cell(valid_before, [fingerprint, 0, 0]))?;
+                return Ok(());
             }
-            // Clear the old entry from seen set
-            self.expiring_nonce_seen[old_hash].write(0)?;
+
+            if fingerprints.contains(&fingerprint) {
+                return Err(NonceError::expiring_nonce_replay().into());
+            }
+
+            if let Some(empty) = fingerprints
+                .iter_mut()
+                .find(|fingerprint| **fingerprint == 0)
+            {
+                *empty = fingerprint;
+                cell.write(pack_expiring_nonce_cell(valid_before, fingerprints))?;
+                return Ok(());
+            }
         }
 
-        // 5. Insert new entry
-        self.expiring_nonce_ring[idx].write(expiring_nonce_hash)?;
-        self.expiring_nonce_seen[expiring_nonce_hash].write(valid_before)?;
-
-        // 6. Advance pointer (wraps at CAPACITY, not u32::MAX)
-        let next = if ptr + 1 >= EXPIRING_NONCE_SET_CAPACITY {
-            0
-        } else {
-            ptr + 1
-        };
-        self.expiring_nonce_ring_ptr.write(next)?;
-
-        Ok(())
+        Err(NonceError::expiring_nonce_set_full().into())
     }
 }
 
@@ -189,6 +330,7 @@ mod tests {
 
     use super::*;
     use alloy::primitives::address;
+    use tempo_chainspec::hardfork::TempoHardfork;
 
     #[test]
     fn test_get_nonce_returns_zero_for_new_key() -> eyre::Result<()> {
@@ -293,21 +435,46 @@ mod tests {
 
     // ========== Expiring Nonce Tests ==========
 
+    fn hash_with_fingerprint(fingerprint: u64) -> B256 {
+        hash_with_probe_path_and_fingerprint([0, 0, 0, 0], fingerprint)
+    }
+
+    fn hash_with_probe_path_and_fingerprint(positions: [u64; 4], fingerprint: u64) -> B256 {
+        let mut hash = [0u8; 32];
+
+        for (probe, position) in positions.into_iter().enumerate() {
+            for offset in 0..EXPIRING_NONCE_POSITION_BITS {
+                let bit = (position >> (EXPIRING_NONCE_POSITION_BITS - 1 - offset)) & 1;
+                if bit == 0 {
+                    continue;
+                }
+
+                let bit_index = probe * EXPIRING_NONCE_POSITION_BITS + offset;
+                hash[bit_index / 8] |= 1 << (7 - (bit_index % 8));
+            }
+        }
+
+        hash[24..32].copy_from_slice(&fingerprint.to_be_bytes());
+        B256::from(hash)
+    }
+
+    fn t8_storage() -> HashMapStorageProvider {
+        HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8)
+    }
+
     #[test]
     fn test_expiring_nonce_basic_flow() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
+        let mut storage = t8_storage();
         let now = 1000u64;
         storage.set_timestamp(U256::from(now));
         StorageCtx::enter(&mut storage, || {
             let mut mgr = NonceManager::new();
 
-            let tx_hash = B256::repeat_byte(0x11);
-            let valid_before = now + 20; // 20s in future, within 30s window
+            let tx_hash = hash_with_fingerprint(0x11);
+            let valid_before = now + 200;
 
-            // First tx should succeed
             mgr.check_and_mark_expiring_nonce(tx_hash, valid_before)?;
 
-            // Same tx hash should fail (replay)
             let result = mgr.check_and_mark_expiring_nonce(tx_hash, valid_before);
             assert_eq!(
                 result.unwrap_err(),
@@ -320,7 +487,7 @@ mod tests {
 
     #[test]
     fn test_expiring_nonce_expiry_validation() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
+        let mut storage = t8_storage();
         let now = 1000u64;
         storage.set_timestamp(U256::from(now));
         StorageCtx::enter(&mut storage, || {
@@ -342,90 +509,145 @@ mod tests {
                 TempoPrecompileError::NonceError(NonceError::invalid_expiring_nonce_expiry())
             );
 
-            // valid_before too far in future should fail (uses EXPIRING_NONCE_MAX_EXPIRY_SECS = 30)
-            let result = mgr.check_and_mark_expiring_nonce(tx_hash, now + 31);
+            let result = mgr
+                .check_and_mark_expiring_nonce(tx_hash, now + EXPIRING_NONCE_MAX_EXPIRY_SECS + 1);
             assert_eq!(
                 result.unwrap_err(),
                 TempoPrecompileError::NonceError(NonceError::invalid_expiring_nonce_expiry())
             );
 
             // valid_before at exactly EXPIRING_NONCE_MAX_EXPIRY_SECS should succeed
-            mgr.check_and_mark_expiring_nonce(tx_hash, now + 30)?;
+            mgr.check_and_mark_expiring_nonce(tx_hash, now + EXPIRING_NONCE_MAX_EXPIRY_SECS)?;
 
             Ok(())
         })
     }
 
     #[test]
-    fn test_expiring_nonce_expired_entry_eviction() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
+    fn test_expiring_nonce_packs_three_fingerprints_per_cell() -> eyre::Result<()> {
+        let mut storage = t8_storage();
         let now = 1000u64;
-        let valid_before = now + 20;
+        let valid_before = now + 100;
         storage.set_timestamp(U256::from(now));
         StorageCtx::enter(&mut storage, || {
             let mut mgr = NonceManager::new();
 
-            let tx_hash1 = B256::repeat_byte(0x33);
+            for fingerprint in 1..=3 {
+                mgr.check_and_mark_expiring_nonce(
+                    hash_with_fingerprint(fingerprint),
+                    valid_before,
+                )?;
+            }
 
-            // Insert first tx
-            mgr.check_and_mark_expiring_nonce(tx_hash1, valid_before)?;
+            let slot = expiring_nonce_cell_slot(hash_with_fingerprint(1), valid_before, 0);
+            let word = Slot::<U256>::new(slot, NONCE_PRECOMPILE_ADDRESS).read()?;
 
-            // Verify it's seen
-            assert!(mgr.is_expiring_nonce_seen(tx_hash1, now)?);
+            for fingerprint in 1..=3 {
+                assert!(expiring_nonce_cell_contains(
+                    word,
+                    valid_before,
+                    fingerprint
+                ));
+            }
 
-            // After expiry, it should no longer be "seen" (expired)
-            assert!(!mgr.is_expiring_nonce_seen(tx_hash1, valid_before + 1)?);
+            Ok::<_, eyre::Report>(())
+        })
+    }
 
+    #[test]
+    fn test_expiring_nonce_probe_exhaustion_rejects() -> eyre::Result<()> {
+        let mut storage = t8_storage();
+        let now = 1000u64;
+        let valid_before = now + 100;
+        storage.set_timestamp(U256::from(now));
+        StorageCtx::enter(&mut storage, || {
+            let mut mgr = NonceManager::new();
+
+            for fingerprint in 1..=(EXPIRING_NONCE_MAX_PROBES * EXPIRING_NONCE_PACKED_SLOTS) {
+                mgr.check_and_mark_expiring_nonce(
+                    hash_with_probe_path_and_fingerprint([0, 1, 2, 3], fingerprint as u64),
+                    valid_before,
+                )?;
+            }
+
+            let result = mgr.check_and_mark_expiring_nonce(
+                hash_with_probe_path_and_fingerprint([0, 1, 2, 3], 13),
+                valid_before,
+            );
+            assert_eq!(
+                result.unwrap_err(),
+                TempoPrecompileError::NonceError(NonceError::expiring_nonce_set_full())
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_expiring_nonce_reuses_same_bucket_after_expiry_window() -> eyre::Result<()> {
+        let mut storage = t8_storage();
+        let now = 1000u64;
+        let valid_before = now + 100;
+        storage.set_timestamp(U256::from(now));
+        StorageCtx::enter(&mut storage, || {
+            let mut mgr = NonceManager::new();
+            mgr.check_and_mark_expiring_nonce(hash_with_fingerprint(1), valid_before)?;
             Ok::<_, eyre::Report>(())
         })?;
 
-        // Insert second tx after first has expired - should evict first
         let new_now = valid_before + 1;
-        let new_valid_before = new_now + 20;
+        let new_valid_before = valid_before + EXPIRING_NONCE_BUCKET_COUNT;
+        assert_eq!(
+            valid_before % EXPIRING_NONCE_BUCKET_COUNT,
+            new_valid_before % EXPIRING_NONCE_BUCKET_COUNT
+        );
+        assert!(new_valid_before <= new_now + EXPIRING_NONCE_MAX_EXPIRY_SECS);
+
         storage.set_timestamp(U256::from(new_now));
         StorageCtx::enter(&mut storage, || {
             let mut mgr = NonceManager::new();
+            mgr.check_and_mark_expiring_nonce(hash_with_fingerprint(2), new_valid_before)?;
 
-            let tx_hash2 = B256::repeat_byte(0x44);
-            mgr.check_and_mark_expiring_nonce(tx_hash2, new_valid_before)?;
+            let slot = expiring_nonce_cell_slot(hash_with_fingerprint(2), new_valid_before, 0);
+            let word = Slot::<U256>::new(slot, NONCE_PRECOMPILE_ADDRESS).read()?;
+            assert!(expiring_nonce_cell_contains(
+                word,
+                new_valid_before,
+                expiring_nonce_fingerprint(hash_with_fingerprint(2))
+            ));
 
-            // tx_hash1 should now be fully evicted (since it was at ring position 0)
-            // and tx_hash2 replaces it
-            assert!(mgr.is_expiring_nonce_seen(tx_hash2, new_now)?);
-
-            Ok(())
+            Ok::<_, eyre::Report>(())
         })
     }
 
     #[test]
-    fn test_ring_buffer_pointer_wraps_at_capacity() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
+    fn test_pre_tip_1077_expiring_nonce_uses_legacy_ring_window() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T7);
         let now = 1000u64;
         storage.set_timestamp(U256::from(now));
         StorageCtx::enter(&mut storage, || {
             let mut mgr = NonceManager::new();
+            let tx_hash = B256::repeat_byte(0x42);
 
-            // Manually set pointer to just before capacity to test wrap
-            mgr.expiring_nonce_ring_ptr
-                .write(EXPIRING_NONCE_SET_CAPACITY - 1)?;
+            let too_far =
+                mgr.check_and_mark_expiring_nonce(tx_hash, now + PRE_TIP_1077_MAX_EXPIRY_SECS + 1);
+            assert_eq!(
+                too_far.unwrap_err(),
+                TempoPrecompileError::NonceError(NonceError::invalid_expiring_nonce_expiry())
+            );
 
-            // Insert a tx - pointer should wrap to 0
-            let tx_hash = B256::repeat_byte(0x77);
-            let valid_before = now + 20;
-            mgr.check_and_mark_expiring_nonce(tx_hash, valid_before)?;
+            mgr.check_and_mark_expiring_nonce(tx_hash, now + PRE_TIP_1077_MAX_EXPIRY_SECS)?;
+            assert!(mgr.is_pre_tip_1077_expiring_nonce_seen(tx_hash, now)?);
+            assert_eq!(mgr.expiring_nonce_ring_ptr.read()?, 1);
 
-            // Pointer should now be 0 (wrapped at capacity)
-            let ptr = mgr.expiring_nonce_ring_ptr.read()?;
-            assert_eq!(ptr, 0, "Pointer should wrap to 0 at capacity");
+            let timewheel_slot =
+                expiring_nonce_cell_slot(tx_hash, now + PRE_TIP_1077_MAX_EXPIRY_SECS, 0);
+            assert_eq!(
+                Slot::<U256>::new(timewheel_slot, NONCE_PRECOMPILE_ADDRESS).read()?,
+                U256::ZERO
+            );
 
-            // Insert another tx - pointer should be 1
-            let tx_hash2 = B256::repeat_byte(0x88);
-            mgr.check_and_mark_expiring_nonce(tx_hash2, valid_before)?;
-
-            let ptr = mgr.expiring_nonce_ring_ptr.read()?;
-            assert_eq!(ptr, 1, "Pointer should increment to 1 after wrap");
-
-            Ok(())
+            Ok::<_, eyre::Report>(())
         })
     }
 

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -31,8 +31,8 @@ pub const MAX_WEBAUTHN_SIGNATURE_LENGTH: usize = 2048; // 2KB max
 /// Nonce key marking an expiring nonce transaction (uses tx hash for replay protection).
 pub const TEMPO_EXPIRING_NONCE_KEY: U256 = U256::MAX;
 
-/// Maximum allowed expiry window for expiring nonce transactions (30 seconds).
-pub const TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 30;
+/// Maximum allowed expiry window for expiring nonce transactions (5 minutes).
+pub const TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 300;
 
 /// Signature type enumeration
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -509,15 +509,15 @@ mod tests {
         evm
     }
 
-    /// Create an EVM with T7 hardfork, a specific timestamp, and a funded account.
-    fn create_funded_evm_t7_with_timestamp(
+    /// Create an EVM with T8 hardfork, a specific timestamp, and a funded account.
+    fn create_funded_evm_t8_with_timestamp(
         address: Address,
         timestamp: u64,
     ) -> TempoEvm<CacheDB<EmptyDB>, ()> {
         let db = CacheDB::new(EmptyDB::new());
         let mut cfg = CfgEnv::<TempoHardfork>::default();
-        cfg.spec = TempoHardfork::T7;
-        cfg.gas_params = tempo_gas_params_with_amsterdam(TempoHardfork::T7, false);
+        cfg.spec = TempoHardfork::T8;
+        cfg.gas_params = tempo_gas_params_with_amsterdam(TempoHardfork::T8, false);
         cfg.enable_amsterdam_eip8037 = false;
 
         let mut block = TempoBlockEnv::default();
@@ -3707,13 +3707,13 @@ mod tests {
 
     /// Expiring nonce writes are charged manually by intrinsic gas and must not use TIP-1060 accounting.
     #[test]
-    fn test_expiring_nonce_indexed_path_does_not_settle_storage_credits() -> eyre::Result<()> {
+    fn test_expiring_nonce_timewheel_does_not_settle_storage_credits() -> eyre::Result<()> {
         use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
 
         let key_pair = P256KeyPair::random();
         let caller = key_pair.address;
         let timestamp = 1000u64;
-        let valid_before = timestamp + 30;
+        let valid_before = timestamp + 300;
 
         let tx = TxBuilder::new()
             .call_identity(&[])
@@ -3722,38 +3722,32 @@ mod tests {
             .gas_limit(500_000)
             .build();
         let signed_tx = key_pair.sign_tx(tx)?;
-        let unindexed_tx_env = TempoTxEnv::from_recovered_tx(&signed_tx, caller);
+        let tx_env = TempoTxEnv::from_recovered_tx(&signed_tx, caller);
 
-        let mut indexed_tx_env = unindexed_tx_env.clone();
-        indexed_tx_env
-            .tempo_tx_env
-            .as_mut()
-            .expect("expiring nonce tx must be AA")
-            .expiring_nonce_idx = Some(1);
-
-        let mut unindexed_evm = create_funded_evm_t7_with_timestamp(caller, timestamp);
-        let unindexed_result = unindexed_evm.transact_commit(unindexed_tx_env)?;
+        let mut baseline_evm = create_funded_evm_t8_with_timestamp(caller, timestamp);
+        let baseline_result = baseline_evm.transact_commit(tx_env.clone())?;
         assert!(
-            unindexed_result.is_success(),
-            "unindexed expiring nonce tx should succeed"
+            baseline_result.is_success(),
+            "baseline expiring nonce tx should succeed"
         );
 
-        let mut indexed_evm = create_funded_evm_t7_with_timestamp(caller, timestamp);
-        let indexed_result = indexed_evm.transact_commit(indexed_tx_env)?;
+        let mut credited_evm = create_funded_evm_t8_with_timestamp(caller, timestamp);
+        seed_storage_credit_balance(&mut credited_evm, NONCE_PRECOMPILE_ADDRESS, 1);
+        let credited_result = credited_evm.transact_commit(tx_env)?;
         assert!(
-            indexed_result.is_success(),
-            "indexed expiring nonce tx should succeed"
+            credited_result.is_success(),
+            "preseeded-credit expiring nonce tx should succeed"
         );
 
         assert_eq!(
-            indexed_result.tx_gas_used(),
-            unindexed_result.tx_gas_used(),
-            "pointer restore must not create a TIP-1060 settlement discount"
+            credited_result.tx_gas_used(),
+            baseline_result.tx_gas_used(),
+            "expiring nonce bookkeeping must not consume nonce storage credits for a gas discount"
         );
         assert_eq!(
-            storage_credit_balance(&indexed_evm, NONCE_PRECOMPILE_ADDRESS),
-            0,
-            "expiring nonce bookkeeping must not accrue storage credits"
+            storage_credit_balance(&credited_evm, NONCE_PRECOMPILE_ADDRESS),
+            1,
+            "expiring nonce bookkeeping must not consume pre-existing nonce storage credits"
         );
 
         Ok(())

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -47,8 +47,8 @@ use tempo_precompiles::{
     },
     error::TempoPrecompileError,
     nonce::{
-        EXPIRING_NONCE_MAX_EXPIRY_SECS, EXPIRING_NONCE_SET_CAPACITY, INonce::getNonceCall,
-        NonceManager,
+        EXPIRING_NONCE_MAX_PROBES, INonce::getNonceCall, NonceManager,
+        PRE_TIP_1077_EXPIRING_NONCE_SET_CAPACITY, expiring_nonce_max_expiry_secs_for_spec,
     },
     storage::{
         Handler as _, PrecompileStorageProvider, StorageActions, StorageCtx,
@@ -89,28 +89,22 @@ const KEY_AUTH_PER_LIMIT_GAS: u64 = 22_000;
 /// Rounded buffer for each extra LOG3/no-data event emitted by key authorizations.
 const KEY_AUTH_EXTRA_EVENT_BUFFER: u64 = 1_500;
 
-/// Gas cost for expiring nonce transactions (replay check + insert).
+/// Pre-TIP-1077 gas cost for expiring nonce transactions.
+const PRE_TIP_1077_EXPIRING_NONCE_GAS: u64 = 2 * COLD_SLOAD_COST + 100 + 3 * WARM_SSTORE_RESET;
+
+/// Gas cost for expiring nonce transactions (TIP-1077 replay check + insert).
 ///
-/// See [TIP-1009] for full specification.
+/// See [TIP-1077] for full specification.
 ///
-/// [TIP-1009]: <https://docs.tempo.xyz/protocol/tips/tip-1009>
+/// [TIP-1077]: <https://docs.tempo.xyz/protocol/tips/tip-1077>
 ///
 /// Operations charged:
-/// - 2 cold SLOADs: `seen[tx_hash]`, `ring[idx]` (unique slots per tx)
-/// - 1 warm SLOAD: `seen[old_hash]` (warm because we just read `ring[idx]` which points to it)
-/// - 3 SSTOREs at RESET price: `seen[old_hash]=0`, `ring[idx]=tx_hash`, `seen[tx_hash]=valid_before`
+/// - 4 cold SLOADs: worst-case deterministic replay-cell probe path
+/// - 1 SSTORE at RESET price: accepted replay-cell write
 ///
-/// Excluded from gas calculation:
-/// - `ring_ptr` SLOAD/SSTORE: Accessed by almost every expiring nonce tx in a block, so
-///   amortized cost approaches ~200 gas. May be moved out of EVM storage in the future.
-///
-/// Why SSTORE_RESET (2,900) instead of SSTORE_SET (20,000) for `seen[tx_hash]`:
-/// - SSTORE_SET cost exists to penalize permanent state growth
-/// - Expiring nonce data is ephemeral: evicted within 30 seconds, fixed-size buffer (300k)
-/// - No permanent state growth, so the 20k penalty doesn't apply
-///
-/// Total: 2*2100 + 100 + 3*2900 = 13,000 gas
-pub const EXPIRING_NONCE_GAS: u64 = 2 * COLD_SLOAD_COST + 100 + 3 * WARM_SSTORE_RESET;
+/// Total: 4*2100 + 2900 = 11,300 gas
+pub const EXPIRING_NONCE_GAS: u64 =
+    EXPIRING_NONCE_MAX_PROBES as u64 * COLD_SLOAD_COST + WARM_SSTORE_RESET;
 
 /// Calculates the gas cost for verifying a primitive signature.
 ///
@@ -1088,49 +1082,48 @@ where
                 actions.clone(),
                 || {
                     let mut nonce_manager = NonceManager::new();
-
-                    let prev_ptr = if let Some(expiring_nonce_idx) = tempo_tx_env.expiring_nonce_idx
+                    let prev_ptr = if !spec.is_t8()
+                        && let Some(expiring_nonce_idx) = tempo_tx_env.expiring_nonce_idx
                     {
                         let ptr = nonce_manager
                             .expiring_nonce_ring_ptr
                             .read()
                             .map_err(|err| EVMError::Custom(err.to_string()))?;
-
-                        let next = (ptr + expiring_nonce_idx as u32) % EXPIRING_NONCE_SET_CAPACITY;
-
+                        let next = (ptr + expiring_nonce_idx as u32)
+                            % PRE_TIP_1077_EXPIRING_NONCE_SET_CAPACITY;
                         nonce_manager
                             .expiring_nonce_ring_ptr
                             .write(next)
                             .map_err(|err| EVMError::Custom(err.to_string()))?;
-
                         Some(ptr)
                     } else {
                         None
                     };
 
                     nonce_manager
-                    .check_and_mark_expiring_nonce(replay_hash, valid_before)
-                    .map_err(|err| match err {
-                        TempoPrecompileError::Fatal(err) => EVMError::Custom(err),
-                        TempoPrecompileError::NonceError(
-                            tempo_contracts::precompiles::NonceError::InvalidExpiringNonceExpiry(_),
-                        ) => {
-                            let max_allowed =
-                                block_timestamp.saturating_add(EXPIRING_NONCE_MAX_EXPIRY_SECS);
-                            if valid_before <= block_timestamp {
-                                TempoInvalidTransaction::NonceManagerError(format!(
-                                    "expiring nonce transaction expired: valid_before ({valid_before}) <= block timestamp ({block_timestamp})"
-                                ))
-                                .into()
-                            } else {
-                                TempoInvalidTransaction::NonceManagerError(format!(
-                                    "expiring nonce valid_before ({valid_before}) too far in the future: must be within {EXPIRING_NONCE_MAX_EXPIRY_SECS}s of block timestamp ({block_timestamp}), max allowed is {max_allowed}"
-                                ))
-                                .into()
+                        .check_and_mark_expiring_nonce(replay_hash, valid_before)
+                        .map_err(|err| match err {
+                            TempoPrecompileError::Fatal(err) => EVMError::Custom(err),
+                            TempoPrecompileError::NonceError(
+                                tempo_contracts::precompiles::NonceError::InvalidExpiringNonceExpiry(_),
+                            ) => {
+                                let max_expiry_secs =
+                                    expiring_nonce_max_expiry_secs_for_spec(*spec);
+                                let max_allowed = block_timestamp.saturating_add(max_expiry_secs);
+                                if valid_before <= block_timestamp {
+                                    TempoInvalidTransaction::NonceManagerError(format!(
+                                        "expiring nonce transaction expired: valid_before ({valid_before}) <= block timestamp ({block_timestamp})"
+                                    ))
+                                    .into()
+                                } else {
+                                    TempoInvalidTransaction::NonceManagerError(format!(
+                                        "expiring nonce valid_before ({valid_before}) too far in the future: must be within {max_expiry_secs}s of block timestamp ({block_timestamp}), max allowed is {max_allowed}"
+                                    ))
+                                    .into()
+                                }
                             }
-                        }
-                        err => TempoInvalidTransaction::NonceManagerError(err.to_string()).into(),
-                    })?;
+                            err => TempoInvalidTransaction::NonceManagerError(err.to_string()).into(),
+                        })?;
 
                     if let Some(prev_ptr) = prev_ptr {
                         nonce_manager
@@ -2353,10 +2346,14 @@ where
     if spec.is_t1() {
         if aa_env.nonce_key == TEMPO_EXPIRING_NONCE_KEY {
             // Calculate nonce gas based on nonce type:
-            // - Expiring nonce (nonce_key == MAX, T1 active): ring buffer + seen mapping operations
+            // - Expiring nonce (nonce_key == MAX, T1 active): replay bookkeeping
             // - 2D nonce (nonce_key != 0): SLOAD + SSTORE for nonce increment
             // - Regular nonce (nonce_key == 0): no additional gas
-            batch_gas.initial_regular_gas += EXPIRING_NONCE_GAS;
+            batch_gas.initial_regular_gas += if spec.is_t8() {
+                EXPIRING_NONCE_GAS
+            } else {
+                PRE_TIP_1077_EXPIRING_NONCE_GAS
+            };
         } else if tx.nonce == 0 {
             // TIP-1000: Storage pricing updates for launch
             // Tempo transactions with any `nonce_key` and `nonce == 0` require an additional 250,000 gas

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -59,9 +59,10 @@ pub struct TempoBatchCallEnv {
     /// This is not used in actual transaction execution - the key_id is recovered from the signature.
     pub override_key_id: Option<Address>,
 
-    /// Perf optimization for expiring nonce transactions.
+    /// Deprecated pre-TIP-1077 ring-buffer prewarming hint.
     ///
-    /// Stores how many other expiring nonce transactions are there in the block before this one.
+    /// The TIP-1077 time wheel derives replay cells from the transaction hash and `valid_before`,
+    /// so this field is ignored by execution.
     pub expiring_nonce_idx: Option<usize>,
 }
 /// Tempo transaction environment.

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -28,7 +28,10 @@ use std::{
 use tempo_contracts::precompiles::ITIP20;
 use tempo_precompiles::{
     DEFAULT_FEE_TOKEN,
-    nonce::NonceManager,
+    nonce::{
+        EXPIRING_NONCE_MAX_PROBES, NonceManager, expiring_nonce_cell_contains,
+        expiring_nonce_fingerprint, expiring_nonce_probe_slots,
+    },
     storage::StorageKey,
     tip20::{TIP20Token, tip20_slots},
     tip403_registry::tip403_registry_slots,
@@ -51,8 +54,10 @@ pub struct TempoPooledTransaction {
     expiring_nonce_hash: Option<B256>,
     /// Cached slot of the 2D nonce, if any.
     nonce_key_slot: OnceLock<Option<U256>>,
-    /// Cached `expiring_nonce_seen` storage slot for expiring nonce transactions.
-    expiring_nonce_slot: OnceLock<Option<U256>>,
+    /// Cached pre-TIP-1077 `expiring_nonce_seen` storage slot.
+    pre_tip_1077_expiring_nonce_slot: OnceLock<Option<U256>>,
+    /// Cached TIP-1077 replay-cell slots for expiring nonce transactions.
+    expiring_nonce_slots: OnceLock<Option<[U256; EXPIRING_NONCE_MAX_PROBES]>>,
     /// Cached prepared [`TempoTxEnv`] for payload building.
     tx_env: OnceLock<TempoTxEnv>,
     /// Keychain key expiry timestamp (set during validation for keychain-signed txs).
@@ -117,7 +122,8 @@ impl TempoPooledTransaction {
             is_payment,
             expiring_nonce_hash,
             nonce_key_slot: OnceLock::new(),
-            expiring_nonce_slot: OnceLock::new(),
+            pre_tip_1077_expiring_nonce_slot: OnceLock::new(),
+            expiring_nonce_slots: OnceLock::new(),
             tx_env: OnceLock::new(),
             key_expiry: OnceLock::new(),
             resolved_fee_token: OnceLock::new(),
@@ -429,21 +435,50 @@ impl TempoPooledTransaction {
             .expect("expiring nonce hash must be precomputed")
     }
 
-    /// Returns the cached `expiring_nonce_seen` storage slot for this transaction.
-    pub fn expiring_nonce_slot(&self) -> Option<U256> {
-        *self.expiring_nonce_slot.get_or_init(|| {
+    /// Returns the cached TIP-1077 replay-cell storage slots for this transaction.
+    pub fn expiring_nonce_slots(&self) -> Option<[U256; EXPIRING_NONCE_MAX_PROBES]> {
+        *self.expiring_nonce_slots.get_or_init(|| {
+            let hash = self.expiring_nonce_hash()?;
+            let valid_before = self.expiring_nonce_valid_before()?;
+            Some(expiring_nonce_probe_slots(hash, valid_before))
+        })
+    }
+
+    /// Returns the pre-TIP-1077 `expiring_nonce_seen` storage slot for this transaction.
+    pub fn pre_tip_1077_expiring_nonce_slot(&self) -> Option<U256> {
+        *self.pre_tip_1077_expiring_nonce_slot.get_or_init(|| {
             let hash = self.expiring_nonce_hash()?;
             Some(NonceManager::new().expiring_nonce_seen[hash].slot())
         })
     }
 
+    /// Returns the expiring nonce transaction's `valid_before`.
+    pub fn expiring_nonce_valid_before(&self) -> Option<u64> {
+        let aa_tx = self.inner().as_aa()?;
+        aa_tx.tx().valid_before.map(core::num::NonZeroU64::get)
+    }
+
+    /// Returns the TIP-1077 replay fingerprint for this transaction.
+    pub fn expiring_nonce_fingerprint(&self) -> Option<u64> {
+        self.expiring_nonce_hash().map(expiring_nonce_fingerprint)
+    }
+
+    /// Returns whether `word` includes this transaction's TIP-1077 replay marker.
+    pub fn expiring_nonce_cell_contains(&self, word: U256) -> bool {
+        self.expiring_nonce_valid_before()
+            .zip(self.expiring_nonce_fingerprint())
+            .is_some_and(|(valid_before, fingerprint)| {
+                expiring_nonce_cell_contains(word, valid_before, fingerprint)
+            })
+    }
+
     /// Warms the global keccak cache with storage slot hashes that will be accessed
     /// during payment execution after pool validation.
     ///
-    /// Fee-path slots like `balances[fee_payer]`, `user_reward_info[fee_payer]`,
-    /// `user_tokens[fee_payer]`, and `expiring_nonce_seen[hash]` are already cached from
-    /// EVM validation. `validator_tokens[beneficiary]` depends on the block producer,
-    /// which is unknown at validation time.
+    /// Fee-path slots like `balances[fee_payer]`, `user_reward_info[fee_payer]`, and
+    /// `user_tokens[fee_payer]` are already cached from EVM validation.
+    /// `validator_tokens[beneficiary]` depends on the block producer, which is unknown at
+    /// validation time.
     pub fn precalculate_keccak_slots(&self) {
         if !self.is_payment {
             return;

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -80,10 +80,14 @@ pub struct AA2dPool {
     /// the expiring nonce transaction that should be evicted next:
     /// lowest priority first, then newest submission first when priorities tie.
     expiring_nonce_eviction_order: BTreeSet<ExpiringNonceEvictionKey>,
-    /// A mapping of `expiring_nonce_seen` slot to expiring nonce hash.
+    /// A mapping of pre-TIP-1077 `expiring_nonce_seen` slot to expiring nonce hash.
+    ///
+    /// Used to track inclusion of expiring nonce transactions before the TIP-1077 time wheel.
+    slot_to_pre_tip_1077_expiring_nonce_hash: U256Map<B256>,
+    /// A mapping of TIP-1077 replay-cell slot to expiring nonce hashes watching it.
     ///
     /// Used to track inclusion of expiring nonce transactions.
-    slot_to_expiring_nonce_hash: U256Map<B256>,
+    slot_to_expiring_nonce_hashes: U256Map<Vec<B256>>,
     /// Scratch buffer reused while processing nonce state updates.
     state_update_nonce_changes: HashMap<AASequenceId, u64>,
     /// Scratch buffer reused while processing included expiring nonce transactions.
@@ -139,7 +143,8 @@ impl AA2dPool {
             by_hash: Default::default(),
             expiring_nonce_txs: Default::default(),
             expiring_nonce_eviction_order: Default::default(),
-            slot_to_expiring_nonce_hash: Default::default(),
+            slot_to_pre_tip_1077_expiring_nonce_hash: Default::default(),
+            slot_to_expiring_nonce_hashes: Default::default(),
             state_update_nonce_changes: Default::default(),
             state_update_included_expiring_nonce_hashes: Default::default(),
             slot_to_seq_id: Default::default(),
@@ -221,7 +226,7 @@ impl AA2dPool {
         // No `by_hash` duplicate check needed here: a duplicate transaction maps to the same
         // expiring nonce hash, which `add_expiring_nonce_transaction` rejects.
         if hardfork.is_t1() && transaction.transaction.is_expiring_nonce() {
-            return self.add_expiring_nonce_transaction(transaction);
+            return self.add_expiring_nonce_transaction(transaction, hardfork);
         }
 
         if self.contains(transaction.hash()) {
@@ -424,6 +429,7 @@ impl AA2dPool {
     fn add_expiring_nonce_transaction(
         &mut self,
         transaction: Arc<ValidPoolTransaction<TempoPooledTransaction>>,
+        hardfork: tempo_chainspec::hardfork::TempoHardfork,
     ) -> PoolResult<AddedTransaction<TempoPooledTransaction>> {
         let tx_hash = *transaction.hash();
         let expiring_nonce_hash = transaction.transaction.precomputed_expiring_nonce_hash();
@@ -478,8 +484,17 @@ impl AA2dPool {
         // Insert into expiring nonce map and by_hash
         expiring_nonce_entry.insert(pending_tx);
         self.expiring_nonce_eviction_order.insert(eviction_key);
-        if let Some(slot) = transaction.transaction.expiring_nonce_slot() {
-            self.slot_to_expiring_nonce_hash
+        if hardfork.is_t8() {
+            if let Some(slots) = transaction.transaction.expiring_nonce_slots() {
+                for slot in slots {
+                    self.slot_to_expiring_nonce_hashes
+                        .entry(slot)
+                        .or_default()
+                        .push(expiring_nonce_hash);
+                }
+            }
+        } else if let Some(slot) = transaction.transaction.pre_tip_1077_expiring_nonce_slot() {
+            self.slot_to_pre_tip_1077_expiring_nonce_hash
                 .insert(slot, expiring_nonce_hash);
         }
         self.by_hash.insert(tx_hash, transaction.clone());
@@ -1252,8 +1267,28 @@ impl AA2dPool {
         pending_tx: AA2dStoredTransaction,
     ) -> Arc<ValidPoolTransaction<TempoPooledTransaction>> {
         self.by_hash.remove(pending_tx.transaction.hash());
-        if let Some(slot) = pending_tx.transaction.transaction.expiring_nonce_slot() {
-            self.slot_to_expiring_nonce_hash.remove(&slot);
+        if let Some(slots) = pending_tx.transaction.transaction.expiring_nonce_slots() {
+            let expiring_hash = pending_tx
+                .transaction
+                .transaction
+                .precomputed_expiring_nonce_hash();
+            for slot in slots {
+                if let hash_map::Entry::Occupied(mut entry) =
+                    self.slot_to_expiring_nonce_hashes.entry(slot)
+                {
+                    entry.get_mut().retain(|hash| *hash != expiring_hash);
+                    if entry.get().is_empty() {
+                        entry.remove();
+                    }
+                }
+            }
+        }
+        if let Some(slot) = pending_tx
+            .transaction
+            .transaction
+            .pre_tip_1077_expiring_nonce_slot()
+        {
+            self.slot_to_pre_tip_1077_expiring_nonce_hash.remove(&slot);
         }
         self.decrement_sender_count(pending_tx.transaction.sender());
         self.pending_count -= 1;
@@ -1336,12 +1371,29 @@ impl AA2dPool {
             if let Some(seq_id) = self.slot_to_seq_id.get(slot) {
                 changes.insert(*seq_id, value.present_value.saturating_to());
             }
-            // Detect included expiring nonce transactions via their
+            // Detect pre-TIP-1077 included expiring nonce transactions via their
             // `expiring_nonce_seen` slot being set to a non-zero value.
             if !value.present_value.is_zero()
-                && let Some(expiring_nonce_hash) = self.slot_to_expiring_nonce_hash.get(slot)
+                && let Some(expiring_nonce_hash) =
+                    self.slot_to_pre_tip_1077_expiring_nonce_hash.get(slot)
             {
                 included_expiring_nonce_hashes.push(*expiring_nonce_hash);
+            }
+            // Detect included expiring nonce transactions via their fingerprint appearing in a
+            // watched TIP-1077 replay cell.
+            if !value.present_value.is_zero()
+                && let Some(expiring_nonce_hashes) = self.slot_to_expiring_nonce_hashes.get(slot)
+            {
+                for expiring_nonce_hash in expiring_nonce_hashes {
+                    if let Some(pending_tx) = self.expiring_nonce_txs.get(expiring_nonce_hash)
+                        && pending_tx
+                            .transaction
+                            .transaction
+                            .expiring_nonce_cell_contains(value.present_value)
+                    {
+                        included_expiring_nonce_hashes.push(*expiring_nonce_hash);
+                    }
+                }
             }
         }
 
@@ -3922,7 +3974,7 @@ mod tests {
         pool.add_transaction(
             Arc::new(wrap_valid_tx(tx, TransactionOrigin::Local)),
             0,
-            TempoHardfork::T1,
+            TempoHardfork::T8,
         )
         .unwrap();
 
@@ -4394,7 +4446,7 @@ mod tests {
         pool.add_transaction(
             Arc::new(wrap_valid_tx(tx, TransactionOrigin::Local)),
             0,
-            TempoHardfork::T1,
+            TempoHardfork::T8,
         )
         .unwrap();
 
@@ -6519,6 +6571,7 @@ mod tests {
     #[test]
     fn on_state_updates_removes_included_expiring_nonce_from_eviction_index() {
         use revm::database::{AccountStatus, BundleAccount, states::StorageSlot};
+        use tempo_precompiles::nonce::pack_expiring_nonce_cell;
 
         let mut pool = AA2dPool::default();
         let sender = Address::random();
@@ -6532,14 +6585,20 @@ mod tests {
         let expiring_hash = tx
             .expiring_nonce_hash()
             .expect("expiring nonce tx must have expiring hash");
+        let valid_before = tx
+            .expiring_nonce_valid_before()
+            .expect("expiring nonce tx must have valid_before");
+        let fingerprint = tx
+            .expiring_nonce_fingerprint()
+            .expect("expiring nonce tx must have fingerprint");
         let slot = tx
-            .expiring_nonce_slot()
-            .expect("expiring nonce tx must have storage slot");
+            .expiring_nonce_slots()
+            .expect("expiring nonce tx must have storage slots")[0];
 
         pool.add_transaction(
             Arc::new(wrap_valid_tx(tx, TransactionOrigin::Local)),
             0,
-            TempoHardfork::T1,
+            TempoHardfork::T8,
         )
         .unwrap();
 
@@ -6549,7 +6608,10 @@ mod tests {
         let mut storage = HashMap::default();
         storage.insert(
             slot,
-            StorageSlot::new_changed(U256::ZERO, U256::from(123u64)),
+            StorageSlot::new_changed(
+                U256::ZERO,
+                pack_expiring_nonce_cell(valid_before, [fingerprint, 0, 0]),
+            ),
         );
         let mut state = AddressMap::default();
         state.insert(
@@ -6564,11 +6626,67 @@ mod tests {
         assert_eq!(mined[0].hash(), &tx_hash);
         assert!(!pool.contains(&tx_hash));
         assert!(pool.expiring_nonce_txs.is_empty());
-        assert!(pool.slot_to_expiring_nonce_hash.is_empty());
+        assert!(pool.slot_to_expiring_nonce_hashes.is_empty());
         assert_expiring_eviction_index_len(&pool, 0);
         pool.assert_invariants();
         assert!(pool.state_update_nonce_changes.is_empty());
         assert!(pool.state_update_included_expiring_nonce_hashes.is_empty());
+    }
+
+    #[test]
+    fn on_state_updates_ignores_unmatched_expiring_nonce_fingerprint() {
+        use revm::database::{AccountStatus, BundleAccount, states::StorageSlot};
+        use tempo_precompiles::nonce::pack_expiring_nonce_cell;
+
+        let mut pool = AA2dPool::default();
+        let sender = Address::random();
+
+        let tx = TxBuilder::aa(sender)
+            .nonce_key(U256::MAX)
+            .valid_before(123)
+            .max_fee(30_000_000_000)
+            .build();
+        let tx_hash = *tx.hash();
+        let valid_before = tx
+            .expiring_nonce_valid_before()
+            .expect("expiring nonce tx must have valid_before");
+        let fingerprint = tx
+            .expiring_nonce_fingerprint()
+            .expect("expiring nonce tx must have fingerprint");
+        let other_fingerprint = if fingerprint == 1 { 2 } else { 1 };
+        let slot = tx
+            .expiring_nonce_slots()
+            .expect("expiring nonce tx must have storage slots")[0];
+
+        pool.add_transaction(
+            Arc::new(wrap_valid_tx(tx, TransactionOrigin::Local)),
+            0,
+            TempoHardfork::T8,
+        )
+        .unwrap();
+
+        let mut storage = HashMap::default();
+        storage.insert(
+            slot,
+            StorageSlot::new_changed(
+                U256::ZERO,
+                pack_expiring_nonce_cell(valid_before, [other_fingerprint, 0, 0]),
+            ),
+        );
+        let mut state = AddressMap::default();
+        state.insert(
+            NONCE_PRECOMPILE_ADDRESS,
+            BundleAccount::new(None, None, storage, AccountStatus::Changed),
+        );
+
+        let (promoted, mined) = pool.on_state_updates(&state);
+
+        assert!(promoted.is_empty());
+        assert!(mined.is_empty());
+        assert!(pool.contains(&tx_hash));
+        assert_eq!(pool.expiring_nonce_txs.len(), 1);
+        assert!(!pool.slot_to_expiring_nonce_hashes.is_empty());
+        pool.assert_invariants();
     }
 
     /// Pool with pending limit of 2 for eviction tests.

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -644,7 +644,11 @@ where
                 transaction.transaction().fee_balance_slot();
 
                 // Precompute nonce storage slots for this transaction.
-                let _ = transaction.transaction().expiring_nonce_slot();
+                if spec.is_t8() {
+                    let _ = transaction.transaction().expiring_nonce_slots();
+                } else {
+                    let _ = transaction.transaction().pre_tip_1077_expiring_nonce_slot();
+                }
                 let _ = transaction.transaction().nonce_key_slot();
 
                 // Warm the global keccak cache with storage slot hashes for this transaction.
@@ -1683,7 +1687,8 @@ mod tests {
             TempoPooledTransaction::new(TempoTxEnvelope::from(signed).try_into_recovered().unwrap())
         };
 
-        // Expiring nonce tx should only need ~35k gas (base + EXPIRING_NONCE_GAS of 13k)
+        // Expiring nonce tx should only need ~37k gas on the pre-T8 path
+        // (base + legacy expiring nonce gas of 13k)
         // NOT 250k+ which would be required for new account creation
         // Test: 50k gas should pass for expiring nonce (would fail if 250k was required)
         let tx = create_expiring_nonce_tx(50_000);


### PR DESCRIPTION
Implements the TIP-1077 expiring nonce time wheel on top of `tip/1077`, which already includes #6593. The T8 path uses direct replay cells with packed fingerprints and 300s expiry, while pre-T8 keeps the legacy ring path and gas.

Validated with `cargo +nightly fmt --check`, `git diff --check origin/tip/1077...HEAD`, `cargo test -p tempo-precompiles nonce::tests:: --lib`, `cargo test -p tempo-transaction-pool expiring_nonce --lib`, `cargo test -p tempo-revm expiring_nonce --lib`, `cargo test -p tempo-payload-builder prewarming --lib`, and `cargo check -p tempo-node`.