### PR TITLE
docs(tip-1085): define access-key storage credits

### DIFF
--- a/tips/tip-1085.md
+++ b/tips/tip-1085.md
@@ -116,13 +116,13 @@ The access-key storage credit debit, TIP-1060 mode selection, AccountKeychain TI
 
 ## Charging Sidecar Key Authorizations
 
-Sidecar `key_authorization` is charged differently from ordinary AccountKeychain calls:
+Sidecar `key_authorization` MUST be treated as a pre-paid analogue of TIP-1060 `Refund` mode for covered AccountKeychain rows. It pays the creditable storage-creation cost up front through intrinsic gas, records successful eligible creations as pending refund-mode creations, and settles those pending creations against the authorization account's access-key storage credits.
 
-1. The transaction handler MUST continue to include the full storage-creation charge in intrinsic gas for every storage-creating row counted by `calculate_key_authorization_gas`. On T7 this means the handler MUST add `STORAGE_CREDIT_VALUE` back to the T7 SSTORE residual so each counted row is charged as `SSTORE_CREATE_COST`.
-2. The transaction's required gas limit, floor gas, and pool validity MUST NOT depend on `access_key_storage_credits[A]`.
-3. The handler MUST NOT enable the ordinary TIP-1060 SSTORE hook for sidecar key authorization without also suppressing the already-paid gas charge. The current sidecar path runs the AccountKeychain precompile with unlimited gas and TIP-1060 accounting disabled; naively enabling the generic hook would either double charge no-credit creations or charge against an unlimited internal gas meter.
-4. During successful sidecar execution, the implementation MUST track the actual eligible zero-to-nonzero AccountKeychain storage writes attributable to the authorization account `A`. This count is based on committed physical storage transitions, not merely on the handler's predicted intrinsic slot count.
-5. After the sidecar authorization succeeds and before final transaction gas accounting, the protocol settles the tracked creations:
+The transaction handler MUST continue to include the full storage-creation charge in intrinsic gas for every storage-creating row counted by `calculate_key_authorization_gas`. On T7 this means the handler MUST add `STORAGE_CREDIT_VALUE` back to the T7 SSTORE residual so each counted row is charged as `SSTORE_CREATE_COST`. The transaction's required gas limit, floor gas, and pool validity MUST NOT depend on `access_key_storage_credits[A]`.
+
+During successful sidecar execution, the implementation MUST count the actual eligible zero-to-nonzero AccountKeychain storage writes attributable to the authorization account `A` as `sidecar_pending_creations[A]`. This count is based on committed physical storage transitions, not merely on the handler's predicted intrinsic slot count.
+
+After the sidecar authorization succeeds and before final transaction gas accounting, the protocol settles those pending creations using the same shape as TIP-1060 `Refund` settlement:
 
    ```text
    settled = min(sidecar_pending_creations[A], access_key_storage_credits[A])
@@ -130,8 +130,9 @@ Sidecar `key_authorization` is charged differently from ordinary AccountKeychain
    refund += settled * STORAGE_CREDIT_VALUE
    ```
 
-   Each settled unit MUST also move one backed AccountKeychain storage-credit unit from `A`'s access-key credit balance to one of the sidecar-created storage slots. Implementations may do this by consuming AccountKeychain TIP-1060 tokens, by moving backing out of the `access_key_storage_credits[A]` bookkeeping slot when the counter reaches zero, or by an equivalent atomic mechanism that preserves the invariants in this TIP.
-6. Only `STORAGE_CREDIT_VALUE` is refundable through this sidecar settlement. `SSTORE_SET_COST`, signature verification gas, SLOAD costs, event buffers, call-scope helper surcharges, calldata costs, and all other intrinsic-gas components remain payable.
+Each settled unit burns one access-key storage credit and reassigns its backing unit to one sidecar-created storage slot. The sidecar path MUST NOT additionally run the ordinary TIP-1060 SSTORE hook unless the already-paid intrinsic charge is suppressed. The current handler runs AccountKeychain sidecar writes with unlimited internal gas and TIP-1060 accounting disabled; enabling the generic hook naively would either double charge no-credit creations or account against the wrong gas meter.
+
+Only `STORAGE_CREDIT_VALUE` is refundable through this sidecar settlement. `SSTORE_SET_COST`, signature verification gas, SLOAD costs, event buffers, call-scope helper surcharges, calldata costs, and all other intrinsic-gas components remain payable.
 
 If the sidecar key authorization fails, reverts, or is rejected before its storage changes persist, no access-key storage credits are consumed and no sidecar refund is credited.
 

--- a/tips/tip-1085.md
+++ b/tips/tip-1085.md
@@ -98,6 +98,41 @@ Deleting non-covered AccountKeychain storage MUST NOT credit any account. In par
 
 The storage write, AccountKeychain TIP-1060 token mint, and `access_key_storage_credits[A]` increment MUST be atomic. If the execution scope reverts, all of these effects revert.
 
+## Pruning Inactive Key Storage
+
+Expiry does not itself delete AccountKeychain storage. Expired keys stop authorizing transactions and reads report inactive state where applicable, but their spending-limit and call-scope rows remain in AccountKeychain storage until an explicit cleanup operation clears them. This TIP therefore adds a chunked pruning API:
+
+```solidity
+/// @notice Clears obsolete restriction storage for an expired or revoked access key.
+/// @dev The key row is never deleted; it remains as the replay/tombstone guard.
+///      Missing or already-cleared rows are ignored, so callers may retry safely.
+/// @param keyId The inactive access key whose restriction storage is pruned.
+/// @param limitTokens Spending-limit token rows to clear. These must be supplied
+///        by the caller because spending_limits is a mapping and is not enumerable.
+/// @param scopeTargets Call-scope target subtrees to clear. Each target subtree
+///        includes its selector set and recipient sets.
+/// @return credits The number of access-key storage credits minted by this call.
+function pruneInactiveKeyStorage(
+    address keyId,
+    address[] calldata limitTokens,
+    address[] calldata scopeTargets
+) external returns (uint64 credits);
+```
+
+`pruneInactiveKeyStorage` MUST be guarded by the same root/admin authorization rules as other AccountKeychain admin mutators and operates on the caller account `account`. It MUST reject active keys. A key is prunable if the stored key row is revoked or if its expiry is at or before the current block timestamp. Missing keys and the root key are not prunable.
+
+The function MUST NOT delete or zero the `keys[account][keyId]` row. For revoked keys, the tombstone remains the replay guard. For expired keys, the stale key row remains non-authorizing because the expiry check continues to fail.
+
+For each `token` in `limitTokens`, the function clears the physical `spending_limits[spending_limit_key(account, keyId)][token]` row or rows used by the active hardfork's spending-limit layout. `spending_limits` is a mapping and is not enumerable, so the precompile cannot discover all token rows by itself. A caller that wants to clear every limit row MUST supply every token that may have been configured for the key. Duplicate token entries SHOULD be ignored after the first occurrence.
+
+For each `target` in `scopeTargets`, the function clears the full call-scope subtree for that target under `key_scopes[spending_limit_key(account, keyId)]`: the target-set entry, the target's selector set, and every recipient set under those selectors. AccountKeychain does not persist arbitrary calldata predicates; call scopes consist of target addresses, 4-byte selectors, and optional recipient address sets for constrained selectors. Clearing a target subtree clears all persisted call-scope data for that target. The top-level target set makes target subtrees enumerable once a target is named, but the API remains caller-chunked so cleanup can fit within the transaction gas limit. Duplicate target entries SHOULD be ignored after the first occurrence.
+
+After processing `scopeTargets`, if the top-level target set is empty, the function MUST also clear the key's scoped-mode marker. This lets callers fully clear scoped-deny-all keys by calling `pruneInactiveKeyStorage(keyId, limitTokens, [])` when no target rows exist, and lets the final target-pruning chunk clear the remaining key-level scope row.
+
+The function is intentionally chunked instead of "clear all". A single key can accumulate limits or scope targets across multiple transactions, and a later full cleanup may exceed the transaction gas limit. `pruneInactiveKeyStorage` MUST therefore make progress only over caller-supplied chunks and MUST be idempotent: missing, already-pruned, or empty rows do not revert and do not mint credits.
+
+`credits` MUST equal the number of covered physical storage slots that changed from nonzero to zero during the call and minted `access_key_storage_credits[account]`. If `access_key_storage_credits[account]` is saturated, the returned `credits` still reports the number of eligible slots cleared, while the stored balance remains saturated.
+
 ## Charging Created Storage in User-Metered Calls
 
 For ordinary AccountKeychain ABI calls executed during user EVM execution, each eligible access-key storage creation attributable to account `A` MUST use the following rules:
@@ -159,6 +194,8 @@ This function is read-only and does not expose any ability to transfer, mint, bu
 
 This TIP changes effective gas costs for AccountKeychain operations that create covered access-key storage. An account with access-key storage credits may pay less net gas to authorize a later key or recreate call-scope or spending-limit storage. An account without credits still pays the full TIP-1000 storage creation cost.
 
+This TIP also adds `pruneInactiveKeyStorage` as an explicit cleanup path for expired or revoked key restrictions. Expiry remains lazy: no storage is deleted automatically when a key expires.
+
 Existing access-key authorization encoding, signature validation, admin-key rules, witness rules, call-scope semantics, spending-limit enforcement, and revocation behavior are unchanged.
 
 For sidecar `key_authorization`, gas-limit requirements are unchanged. The transaction must still provide enough gas for the full intrinsic charge, and credits only affect the final net cost through settlement after successful authorization.
@@ -166,6 +203,8 @@ For sidecar `key_authorization`, gas-limit requirements are unchanged. The trans
 # Tooling
 
 Wallets, SDKs, and gas estimators MUST continue to size sidecar `key_authorization` gas limits using the worst-case intrinsic gas calculation. They MAY display `AccountKeychain.storageCredits(account)` as an expected refund source, but they MUST NOT subtract those credits from the required gas limit.
+
+Wallets and maintenance tools SHOULD track the tokens and scope targets they configure for each access key so they can later call `pruneInactiveKeyStorage` with complete chunks. Existing chain state does not provide an enumerable list of spending-limit tokens, so tooling that did not record configured tokens may need user or application hints to clear all limit rows.
 
 Indexers and debugging tools SHOULD surface `storageCredits(address)` next to existing AccountKeychain key, limit, scope, and witness state. No transaction encoding changes are required.
 
@@ -183,3 +222,5 @@ No new events are required. Access-key storage credits are derived protocol acco
 6. **Actual-write settlement:** sidecar refunds MUST be bounded by actual persisted eligible zero-to-nonzero storage writes, not by an upper-bound or heuristic intrinsic-gas slot count.
 7. **Atomicity and revert consistency:** covered storage writes, access-key credit updates, AccountKeychain TIP-1060 backing changes, and sidecar settlement refunds MUST revert or persist together according to the execution boundary that owns the write.
 8. **Excluded storage isolation:** witness rows, transient transaction-key/origin rows, credit bookkeeping rows, non-creditable fee-bookkeeping slots, and revocation tombstone writes MUST NOT mint or consume access-key storage credits except for the explicit bookkeeping backing rules in this TIP.
+9. **Pruning safety:** `pruneInactiveKeyStorage` MUST NOT change whether a key is active, revoked, expired, or replay-protected. It may clear only covered restriction rows for keys that are already inactive.
+10. **Chunked cleanup:** any subset of inactive key limits or scope targets may be pruned independently. Repeating a pruning call over already-cleared rows MUST NOT mint additional credits.

--- a/tips/tip-1085.md
+++ b/tips/tip-1085.md
@@ -1,0 +1,184 @@
+---
+id: TIP-1085
+title: AccountKeychain Access-Key Storage Credits
+description: Adds account-attributed reusable storage credits to AccountKeychain access-key storage and applies them to intrinsic-metered key authorizations.
+authors: Tanishk Goyal (@tanishkgoyal)
+status: Draft
+related: TIP-1000, TIP-1011, TIP-1049, TIP-1053, TIP-1060, TIP-1064, TIP-1066
+protocolVersion: T7
+---
+
+# TIP-1085: AccountKeychain Access-Key Storage Credits
+
+## Abstract
+
+This TIP adds account-level reusable storage accounting to the AccountKeychain precompile. When an AccountKeychain operation deletes physical access-key restriction storage attributable to an account, that account earns access-key storage credits. When the same account later creates AccountKeychain storage for access-key authorization or restriction updates, those credits can offset the `STORAGE_CREDIT_VALUE` portion of the TIP-1000 storage creation cost.
+
+The transaction sidecar `key_authorization` path is handled specially. Existing key authorizations are charged through intrinsic gas in the transaction handler and the handler executes the AccountKeychain writes with generic TIP-1060 accounting disabled. This TIP preserves the worst-case intrinsic gas requirement and applies account credits as a post-authorization refund, so gas-limit validity does not depend on the account's credit balance at inclusion time.
+
+## Motivation
+
+TIP-1060 gives the AccountKeychain precompile a precompile-level storage credit balance when AccountKeychain-owned storage is deleted. That prevents repeated AccountKeychain storage churn from being charged as net-new state growth at the precompile level, but it does not decide which account should receive the benefit when one account deletes keychain storage and another account later creates keychain storage.
+
+StablecoinDEX order storage credits (TIP-1064) and TIP-20 channel storage credits (TIP-1066) add that missing user-attribution layer for their respective precompiles. AccountKeychain needs the same layer for access-key storage: an account that removes call-scope or spending-limit storage should be able to reuse that freed storage for later access-key setup, without making the underlying AccountKeychain TIP-1060 balance available to unrelated accounts.
+
+Access-key authorizations have an additional wrinkle. They are not ordinary gas-metered precompile calls during user execution. A transaction may carry a `key_authorization` sidecar, the handler includes its expected storage writes in intrinsic gas, and the handler then performs the AccountKeychain writes before user execution with TIP-1060 storage-credit accounting disabled to avoid double charging. This TIP therefore defines explicit credit settlement for that path instead of relying on ordinary TIP-1060 mode selection.
+
+## Assumptions
+
+- TIP-1060 is active. This TIP is scheduled for T7 because it relies on `STORAGE_CREDIT_VALUE`, the T7 SSTORE residual split, and AccountKeychain-owned TIP-1060 storage credits.
+- AccountKeychain storage is physically owned by `ACCOUNT_KEYCHAIN_ADDRESS`; account-level ownership is a logical attribution layer defined by this TIP.
+- Access-key rows remain tombstoned on revoke to preserve replay protection. Revocation does not clear the key row and therefore does not mint an access-key storage credit for that row.
+- `key_authorization` intrinsic gas remains a worst-case upfront charge. Implementations MUST NOT lower the transaction's required intrinsic gas based on current access-key storage credit balances.
+- Access-key storage credits are account-local, non-transferable, and cannot be spent by another account.
+
+## Threat Model
+
+- **Account admin:** the account root key or an active admin access key can create and remove access-key configuration. The protocol assumes these callers are authorized to spend that account's access-key storage credits.
+- **Other accounts:** may create and delete their own AccountKeychain storage but must not be able to consume credits attributed to another account.
+- **Transaction builders and wallets:** may simulate with stale credit balances. For sidecar `key_authorization`, stale balances must not make an otherwise valid gas limit invalid at inclusion time.
+- **AccountKeychain implementation:** trusted to classify physical storage slots correctly and keep user-level credits backed by AccountKeychain-owned TIP-1060 backing.
+
+---
+
+# Specification
+
+## Terminology
+
+- **Access-key storage credit**: A protocol-maintained `uint64` counter associated with one account in the AccountKeychain precompile.
+- **AccountKeychain TIP-1060 token**: A precompile-level storage credit owned by `ACCOUNT_KEYCHAIN_ADDRESS` under TIP-1060.
+- **Eligible access-key storage creation**: A zero-to-nonzero AccountKeychain storage write attributable to an account's access-key configuration and covered by this TIP.
+- **Creditable access-key storage deletion**: A nonzero-to-zero AccountKeychain storage write attributable to an account's access-key configuration and covered by this TIP.
+- **Sidecar key authorization**: A transaction-level `key_authorization` payload processed by the handler before user EVM execution.
+
+## State
+
+The AccountKeychain precompile MUST maintain:
+
+```text
+access_key_storage_credits: mapping(address account => uint64 credits)
+```
+
+Implementations MAY choose any internal layout for this mapping, but it is AccountKeychain-owned persistent state. Creating or updating an account's `access_key_storage_credits` counter, including the first creation of that counter's backing storage slot, is subject to normal TIP-1000 state gas and TIP-1060 rules when performed during user-metered EVM execution.
+
+When `access_key_storage_credits[account]` changes from `0` to a nonzero value, the AccountKeychain precompile MUST consume one AccountKeychain TIP-1060 token for the bookkeeping slot. When the counter later returns to zero during user-metered EVM execution, the bookkeeping slot may be cleared and the AccountKeychain precompile obtains a TIP-1060 token. One of the account's access-key storage credits is therefore effectively stored in the slot occupied by the `access_key_storage_credits[account]` value, matching the accounting pattern in TIP-1064 and TIP-1066.
+
+If `access_key_storage_credits[account] == type(uint64).max`, additional credits for that account MUST saturate at `type(uint64).max`.
+
+## Covered Storage
+
+Eligible access-key storage is AccountKeychain-owned persistent storage attributable to a single account's access-key configuration:
+
+1. Active `keys[account][keyId]` rows created when an access key is authorized.
+2. `spending_limits[spending_limit_key(account, keyId)][token]` physical slots used for spending-limit state.
+3. `key_scopes[spending_limit_key(account, keyId)]` physical slots used for call-scope mode, target sets, selector sets, recipient sets, and the storage rows backing those sets.
+
+The account owner for all rows keyed by `spending_limit_key(account, keyId)` is `account`. Implementations do not need to recover `account` from the hash; the AccountKeychain mutator that writes the row already knows the account it is modifying.
+
+The following storage is not eligible and MUST NOT mint, consume, credit, or debit access-key storage credits:
+
+1. `access_key_storage_credits` bookkeeping rows, except for the backing-token mechanics described in [State](#state).
+2. `key_authorization_witnesses[account][witness]` rows. Witness burns are revocation handles and must remain persistent.
+3. `transaction_key`, `tx_origin`, and any other transient AccountKeychain storage.
+4. Revocation tombstone writes to `keys[account][keyId]`. A revoke changes the active key row into a nonzero tombstone; it does not free a physical slot.
+5. Transaction-local protocol slots marked non-creditable by TIP-1060, including the current transaction's AccountKeychain fee-token spending-limit `remaining` slot when that slot may be recreated by fee bookkeeping with TIP-1060 accounting disabled.
+6. Protocol/system writes performed outside user-metered EVM execution unless this TIP explicitly defines sidecar settlement for them.
+
+## Crediting Deleted Storage
+
+When a user-metered AccountKeychain operation changes covered storage attributable to account `A` from nonzero to zero:
+
+1. Apply the normal AccountKeychain state transition.
+2. TIP-1060 credits `ACCOUNT_KEYCHAIN_ADDRESS` with one AccountKeychain TIP-1060 token for the physical storage deletion.
+3. Increment `access_key_storage_credits[A]` by one, saturating at `type(uint64).max`.
+
+Deleted storage is counted at the physical slot level. Clearing one packed field only credits storage if the entire physical storage slot changes from nonzero to zero. Clearing one set element credits only the physical value, position, vector, or metadata slots that actually become zero.
+
+Deleting non-covered AccountKeychain storage MUST NOT credit any account. In particular, revoking a key does not credit the account for the key row because the tombstone remains live, and burning a key-authorization witness does not credit the account because the witness row remains part of the replay-prevention set.
+
+The storage write, AccountKeychain TIP-1060 token mint, and `access_key_storage_credits[A]` increment MUST be atomic. If the execution scope reverts, all of these effects revert.
+
+## Charging Created Storage in User-Metered Calls
+
+For ordinary AccountKeychain ABI calls executed during user EVM execution, each eligible access-key storage creation attributable to account `A` MUST use the following rules:
+
+1. If `access_key_storage_credits[A] > 0`:
+   - Decrement `access_key_storage_credits[A]` by one.
+   - Execute the covered storage creation in TIP-1060 Direct mode for `ACCOUNT_KEYCHAIN_ADDRESS`, bounded so exactly one AccountKeychain TIP-1060 token can be consumed for this storage creation.
+   - The consumed token covers `STORAGE_CREDIT_VALUE`; any `SSTORE_SET_COST` residual charged by the SSTORE gas function remains payable.
+2. Otherwise:
+   - Leave `access_key_storage_credits[A]` unchanged.
+   - Execute the covered storage creation in TIP-1060 Preserve mode for `ACCOUNT_KEYCHAIN_ADDRESS`, so the transaction pays the full TIP-1000 storage creation cost and AccountKeychain TIP-1060 tokens are not consumed.
+
+Before creating AccountKeychain storage that is not eligible for access-key storage credits, the precompile MUST select TIP-1060 Preserve mode. In particular, creating or recreating an `access_key_storage_credits[A]` bookkeeping row MUST NOT itself consume one of `A`'s access-key storage credits.
+
+The access-key storage credit debit, TIP-1060 mode selection, AccountKeychain TIP-1060 token debit if any, and covered storage write MUST be atomic. If the operation reverts, all credit, token, mode, and storage changes made in the same execution scope MUST revert.
+
+## Charging Sidecar Key Authorizations
+
+Sidecar `key_authorization` is charged differently from ordinary AccountKeychain calls:
+
+1. The transaction handler MUST continue to include the full storage-creation charge in intrinsic gas for every storage-creating row counted by `calculate_key_authorization_gas`. On T7 this means the handler MUST add `STORAGE_CREDIT_VALUE` back to the T7 SSTORE residual so each counted row is charged as `SSTORE_CREATE_COST`.
+2. The transaction's required gas limit, floor gas, and pool validity MUST NOT depend on `access_key_storage_credits[A]`.
+3. The handler MUST NOT enable the ordinary TIP-1060 SSTORE hook for sidecar key authorization without also suppressing the already-paid gas charge. The current sidecar path runs the AccountKeychain precompile with unlimited gas and TIP-1060 accounting disabled; naively enabling the generic hook would either double charge no-credit creations or charge against an unlimited internal gas meter.
+4. During successful sidecar execution, the implementation MUST track the actual eligible zero-to-nonzero AccountKeychain storage writes attributable to the authorization account `A`. This count is based on committed physical storage transitions, not merely on the handler's predicted intrinsic slot count.
+5. After the sidecar authorization succeeds and before final transaction gas accounting, the protocol settles the tracked creations:
+
+   ```text
+   settled = min(sidecar_pending_creations[A], access_key_storage_credits[A])
+   access_key_storage_credits[A] -= settled
+   refund += settled * STORAGE_CREDIT_VALUE
+   ```
+
+   Each settled unit MUST also move one backed AccountKeychain storage-credit unit from `A`'s access-key credit balance to one of the sidecar-created storage slots. Implementations may do this by consuming AccountKeychain TIP-1060 tokens, by moving backing out of the `access_key_storage_credits[A]` bookkeeping slot when the counter reaches zero, or by an equivalent atomic mechanism that preserves the invariants in this TIP.
+6. Only `STORAGE_CREDIT_VALUE` is refundable through this sidecar settlement. `SSTORE_SET_COST`, signature verification gas, SLOAD costs, event buffers, call-scope helper surcharges, calldata costs, and all other intrinsic-gas components remain payable.
+
+If the sidecar key authorization fails, reverts, or is rejected before its storage changes persist, no access-key storage credits are consumed and no sidecar refund is credited.
+
+If the sidecar key authorization succeeds but later user EVM execution reverts, the sidecar authorization remains outside the user-call checkpoint. The corresponding access-key storage credit debit and refund MUST remain as well, because the covered keychain storage creation persisted.
+
+Sidecar key authorization MUST NOT mint access-key storage credits from any nonzero-to-zero writes it performs. Valid key authorizations create fresh key rows and restriction rows; any defensive cleanup of stale rows happens outside user-metered TIP-1060 accounting and MUST NOT create user credits.
+
+If a future hardfork classifies sidecar `STORAGE_CREDIT_VALUE` charges as state gas under TIP-1016, settled access-key storage credits MUST return the same gas dimension that was charged. Until then, the settlement is credited through the transaction refund counter in the same way as TIP-1060 Refund-mode settlement.
+
+## Query Interface
+
+The AccountKeychain interface MUST expose:
+
+```solidity
+/// @notice Returns the number of reusable access-key storage credits owned by an account.
+/// @param account The account whose access-key storage credit balance is queried.
+/// @return credits The number of storage credits available to the account.
+function storageCredits(address account) external view returns (uint64 credits);
+```
+
+This function is read-only and does not expose any ability to transfer, mint, burn, or set storage credits.
+
+## Compatibility
+
+This TIP changes effective gas costs for AccountKeychain operations that create covered access-key storage. An account with access-key storage credits may pay less net gas to authorize a later key or recreate call-scope or spending-limit storage. An account without credits still pays the full TIP-1000 storage creation cost.
+
+Existing access-key authorization encoding, signature validation, admin-key rules, witness rules, call-scope semantics, spending-limit enforcement, and revocation behavior are unchanged.
+
+For sidecar `key_authorization`, gas-limit requirements are unchanged. The transaction must still provide enough gas for the full intrinsic charge, and credits only affect the final net cost through settlement after successful authorization.
+
+# Tooling
+
+Wallets, SDKs, and gas estimators MUST continue to size sidecar `key_authorization` gas limits using the worst-case intrinsic gas calculation. They MAY display `AccountKeychain.storageCredits(account)` as an expected refund source, but they MUST NOT subtract those credits from the required gas limit.
+
+Indexers and debugging tools SHOULD surface `storageCredits(address)` next to existing AccountKeychain key, limit, scope, and witness state. No transaction encoding changes are required.
+
+# Observability
+
+No new events are required. Access-key storage credits are derived protocol accounting, and emitting per-slot credit events would add gas and indexing noise to key-management operations. The `storageCredits(address)` view, transaction receipts, gas-used values, and existing AccountKeychain events are sufficient to monitor and debug the feature.
+
+# Invariants
+
+1. **Account attribution:** an access-key storage credit is credited to and spendable only by the account whose AccountKeychain storage was deleted. Credits cannot move between accounts.
+2. **Backing solvency:** every outstanding `access_key_storage_credits[A]` unit MUST be backed by one AccountKeychain-owned storage-credit backing unit, represented either by live AccountKeychain bookkeeping storage or by an AccountKeychain TIP-1060 token.
+3. **One credit, one creation:** one access-key storage credit can offset at most one eligible access-key storage creation and only for `STORAGE_CREDIT_VALUE`.
+4. **No key-row revocation credit:** revoking a key MUST NOT mint an access-key storage credit for the key row unless a future hardfork changes replay protection so the physical key row is actually freed without losing tombstone semantics.
+5. **Sidecar intrinsic stability:** sidecar `key_authorization` intrinsic gas MUST include the full storage-creation charge regardless of credit balance. Credits affect only post-authorization settlement.
+6. **Actual-write settlement:** sidecar refunds MUST be bounded by actual persisted eligible zero-to-nonzero storage writes, not by an upper-bound or heuristic intrinsic-gas slot count.
+7. **Atomicity and revert consistency:** covered storage writes, access-key credit updates, AccountKeychain TIP-1060 backing changes, and sidecar settlement refunds MUST revert or persist together according to the execution boundary that owns the write.
+8. **Excluded storage isolation:** witness rows, transient transaction-key/origin rows, credit bookkeeping rows, non-creditable fee-bookkeeping slots, and revocation tombstone writes MUST NOT mint or consume access-key storage credits except for the explicit bookkeeping backing rules in this TIP.


### PR DESCRIPTION
## Summary

Adds TIP-1085 for AccountKeychain access-key storage credits. The TIP mirrors the user-attributed TIP-1060 benefit pattern from StablecoinDEX and TIP-20 channel storage credits, while spelling out the special handling for intrinsic-metered sidecar `key_authorization` writes.

## Impact

The proposal defines account-local reusable storage credits for covered AccountKeychain access-key storage, excludes tombstones, witnesses, transient rows, and non-creditable fee bookkeeping, and keeps sidecar key-authorization gas limits stable by applying credits only through post-authorization settlement.

## Validation

- `git diff --cached --check`
- Markdown-only change; no runtime tests run.