### PR TITLE
docs(tip-1063): update feature activation spec

### DIFF
--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -101,9 +101,9 @@ contract FeatureRegistry {
 }
 ```
 
-The registry should expose read methods for nodes, indexers, and operators to inspect the active stack digest, scheduled digest, validator readiness for the scheduled digest, computed support for the scheduled digest, and the global activation quorum threshold.
+The read interface MUST expose the active stack digest, scheduled digest, validator readiness for the scheduled digest, computed support for the scheduled digest, and global activation quorum threshold.
 
-`validatorConfirmedScheduledFeatureReadiness(validator)` MUST compare the validator's latest reported digest against the current `scheduled_feature_head`. If no digest is scheduled, it MUST return `false`. `scheduledFeatureSupport()` MUST return `(0, 0)` when no digest is scheduled, and `hasScheduledFeatureQuorum()` MUST return `false` when the required count is zero.
+`validatorConfirmedScheduledFeatureReadiness(validator)` MUST compare the validator's latest report against the current `scheduled_feature_head` and return `false` when no digest is scheduled. `scheduledFeatureSupport()` MUST return `(0, 0)` when no digest is scheduled, and `hasScheduledFeatureQuorum()` MUST return `false` when the required count is zero.
 
 Registry state changes MUST be observable through events for scheduling, cancellation, validator readiness reports, and activation.
 
@@ -120,33 +120,25 @@ The registry MUST accept the scheduling transaction only if:
 
 Scheduling MUST write `scheduled_feature_head` and `scheduled_activation_epoch`, then emit an event to notify network participants. The scheduled epoch is the earliest consensus epoch in which the chain attempts to activate the target digest. Operators should upgrade before that epoch if they are running a release that does not support the scheduled digest.
 
-Feature activation occurs during pre-execution of the first block of the scheduled activation epoch. During block processing, the system caller invokes `activateScheduledFeatureHead()`. The activation call does not take an epoch argument and returns the activated digest, or `bytes32(0)` if no digest activated.
+At T9 and later, feature activation is attempted during pre-execution of the first block of each epoch. During block processing, the system caller invokes `activateScheduledFeatureHead()`. The activation call does not take an epoch argument and returns the activated digest, or `bytes32(0)` if no digest activated.
 
 For quorum checks, the active validator set is the TIP-1070 current committee exposed by the `CurrentCommittee` precompile. The feature registry MUST NOT keep a separate validator roster for feature activation and MUST NOT derive quorum membership from `ValidatorConfigV2.getActiveValidators()`.
 
 To evaluate readiness for scheduled digest `H`, the quorum check iterates the current committee public keys, resolves each public key to its validator address, and counts each validator whose `validator_confirmed_feature_head[validator] == H`. A scheduled digest has quorum when at least 80% of current committee validators have reported readiness for that exact digest. The required validator count is `ceil(4 * current_committee_size / 5)`.
 
-If quorum is satisfied at feature activation, the chain MUST set `active_feature_head` to `scheduled_feature_head`, clear the scheduled fields, emit an activation event, and return the activated digest from `activateScheduledFeatureHead()`. Protocol behavior gated by newly active features applies to block execution after activation in that block, unless a feature's own TIP specifies transition-block behavior.
+If no digest is scheduled, no activation epoch is set, or the scheduled activation epoch is still in the future, `activateScheduledFeatureHead()` MUST return `bytes32(0)` without changing registry state.
 
-If `activateScheduledFeatureHead()` returns a nonzero digest that is not present in a node's local feature cache, that node MUST fail closed before committing the activation block state. The block may be valid for binaries that support the activated digest, but an unsupported binary cannot safely evaluate post-activation protocol behavior.
+When the current epoch is greater than or equal to `scheduled_activation_epoch`, `activateScheduledFeatureHead()` evaluates quorum and clears the scheduled fields exactly once. If quorum is satisfied and the scheduled digest is not already active, the chain MUST set `active_feature_head` to `scheduled_feature_head`, emit an activation event, and return the activated digest. Otherwise, the chain MUST leave `active_feature_head` unchanged and return `bytes32(0)`. The registry owner can schedule the same or another digest for a later epoch after the missing quorum condition is resolved.
 
-If quorum is not satisfied at feature activation, the chain MUST clear `scheduled_feature_head` and `scheduled_activation_epoch`, leave `active_feature_head` unchanged, and return `bytes32(0)`. The registry owner can schedule the same or another digest for a later epoch after the missing quorum condition is resolved.
+The block executor MUST treat the activation system call as valid only if it completes successfully and returns an ABI-encoded `bytes32`. The executor MUST decode the return value before committing activation-call state changes. If the returned digest is nonzero and is not present in the node's local feature cache, that node MUST fail closed before committing the activation block state. The block may be valid for binaries that support the activated digest, but an unsupported binary cannot safely evaluate post-activation protocol behavior.
 
-Nodes derive the active feature set from registry state. Validators, RPC nodes, consensus-layer clients, and other infrastructure MUST use the same active digest when evaluating protocol behavior for a block. After feature activation, any node that validates, builds, simulates, or serves protocol behavior for later blocks MUST support the active digest.
-
-Support for the active digest is a requirement for any validator joining the current committee. Tempo does not continuously recheck quorum after activation, and loss of support after activation does not roll back the active digest.
+Protocol behavior gated by newly active features applies to block execution after activation in that block, unless a feature's own TIP specifies transition-block behavior. Nodes derive the active feature set from registry state, and any node that validates, builds, simulates, or serves post-activation protocol behavior MUST support the active digest. Tempo does not continuously recheck quorum after activation, and loss of support after activation does not roll back the active digest.
 
 ## Validator Readiness Reporting
 
 Validators indicate readiness by reporting whether they support the currently scheduled stack digest. A validator MUST report `ready = true` only if the scheduled digest is present in its local feature cache.
 
 Readiness reports MUST use the validator identity model defined by TIP-1070. A report is submitted through a system transaction in a block proposed by the validator. The registry reads the current block proposer public key, resolves that public key to the validator address, and records readiness for the currently scheduled digest.
-
-```solidity
-mapping(address validator => bytes32 feature_head) validator_confirmed_feature_head;
-
-function reportFeatureReadiness(bool ready) external;
-```
 
 Only the system caller may call `reportFeatureReadiness(bool ready)`. Arbitrary external callers MUST be rejected as unauthorized.
 
@@ -241,7 +233,9 @@ This TIP uses a hash-chain commitment instead. The digest commits to the ordered
 11. Quorum for scheduled digest `H` counts a validator if and only if its latest reported-ready digest is exactly `H`.
 12. A scheduled digest activates only if the TIP-1070 current committee has quorum readiness for that target digest.
 13. A node can import pre-activation blocks that schedule an unknown digest, but it must not report readiness for an unsupported scheduled digest.
-14. A node must not validate, build, simulate, or serve post-activation protocol behavior for a chain whose active digest is not present in the node's supported feature cache.
+14. `activateScheduledFeatureHead()` returns `bytes32(0)` when no digest activates and a nonzero digest only when it activates that digest.
+15. A block executor can commit activation-call state only after the call succeeds, its return value decodes to `bytes32`, and any nonzero returned digest is supported locally.
+16. A node must not validate, build, simulate, or serve post-activation protocol behavior for a chain whose active digest is not present in the node's supported feature cache.
 
 ## Interfaces
 
@@ -303,9 +297,6 @@ event FeatureHeadScheduleCancelled(bytes32 indexed featureHead);
 
 /// @notice Emitted when a scheduled digest becomes active during epoch processing.
 event FeatureHeadActivated(bytes32 indexed previousFeatureHead, bytes32 indexed featureHead, uint64 activationEpoch);
-
-/// @notice Emitted when active validator readiness for a digest changes.
-event FeatureHeadSupportUpdated(bytes32 indexed featureHead, uint256 support, uint256 required);
 ```
 
 ### Errors

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -1,7 +1,7 @@
 ---
 id: TIP-1063
 title: Protocol Feature Flags
-description: Defines protocol feature flags and the active feature tip used to activate them.
+description: Defines protocol feature flags and the registry used to activate them.
 authors:
 status: Draft
 related: TIP-1070
@@ -16,209 +16,225 @@ This TIP defines protocol feature flags for Tempo protocol changes, decoupling c
 
 Today, a Tempo hardfork ties protocol code and activation into the same upgrade bundle. With protocol feature flags, Tempo can ship releases when features are ready, let operators upgrade, observe validator readiness, and activate the new features per network.
 
-Protocol features are assigned feature IDs in one source-controlled ordered list. The chain stores a single cursor, `features_tip`, where feature tip `N` means feature IDs `1..=N` are active.
+Protocol features are assigned canonical names in one source-controlled ordered list. Each binary constructs a hash chain over that list, and the chain stores a `bytes32` commitment to the active feature stack. The zero digest means no protocol features are active.
 
-Activation is controlled by an onchain feature registry. The registry owner schedules a target feature tip and future activation epoch, and validators report the highest feature tip they support. Activation can be delayed or cancelled before it happens without cutting another release.
+Activation is controlled by an onchain feature registry. The registry owner schedules a target feature stack digest and future activation epoch. Validators report readiness for the scheduled digest from blocks they propose. At activation, the registry checks readiness against the TIP-1070 current committee.
 
 ## Motivation
 
-Tempo currently ships protocol changes through hardfork bundles (e.g. T3, T4, T5). This creates a waterfall process: Unrelated changes must activate at the same activation timestamp, and features that are ready early may wait for slower changes in the same bundle.
+Tempo currently ships protocol changes through hardfork bundles (e.g. T3, T4, T5). This creates a waterfall process: unrelated changes must activate at the same activation timestamp, and features that are ready early may wait for slower changes in the same bundle.
 
-Feature flags separate when code ships, when operators need to upgrade and when protocol behavior activates. This lets Tempo ship in a regular release cadence, while activating protocol behavior only after each network is ready.
+Feature flags separate when code ships, when operators need to upgrade, and when protocol behavior activates. This lets Tempo ship in a regular release cadence, while activating protocol behavior only after each network is ready.
 
-Validators report the highest feature tip they support. A feature tip MAY be activated only after it has reached validator quorum. Activation can be scheduled, delayed, or cancelled without cutting another release.
+The stack digest avoids ambiguity between releases. If `v1.9.0` and `v1.9.1` both know a feature name but implement a different ordered feature stack, their computed digests differ. A validator only reports readiness for a scheduled digest that is present in its local feature chain.
 
 ## Assumptions
 
-- TIP-1070 provides the validator identity and active-validator-set model used for support reporting and quorum checks.
-- Releases that report support for feature tip `N` agree on the source-controlled feature registry list for feature IDs `1..=N`.
-- Feature support reporting is deterministic from the binary and chain state. Operators do not locally choose which subset of supported protocol features to report.
-- Active feature tips are forward-only. Fixing, disabling, or replacing active behavior requires a new higher feature ID, or a hardfork if the feature registry mechanism cannot express the emergency change.
+- TIP-1070 provides the validator identity and current-committee model used for readiness reporting and quorum checks.
+- Releases that support a feature stack digest agree on the source-controlled ordered feature-name list that produced that digest.
+- Feature readiness reporting is deterministic from the binary and chain state. Operators do not locally choose which subset of supported protocol features to report.
+- Active feature stacks are forward-only. Fixing, disabling, or replacing active behavior requires appending a new feature name to the ordered list, or a hardfork if the feature registry mechanism cannot express the emergency change.
 
 # Specification
 
 ## Overview
 
-A protocol feature is a numbered protocol change that can be supported by a binary before it is active on the chain. Feature IDs start at `1`; feature tip `0` is reserved and means no protocol features are active.
-
-Feature IDs MUST be assigned in one ordered list:
+A protocol feature is a named protocol change that can be supported by a binary before it is active on the chain. The source-controlled feature registry is an ordered list of canonical feature names:
 
 ```text
-1: feature A
-2: feature B
-3: feature C
+tip-1063.feature-registry
+tip-10xx.some-feature
+tip-10yy.some-dependent-feature
 ```
 
-The chain MUST store `features_tip` in the feature registry. A feature tip is the highest feature ID included in the ordered list of supported feature IDs. If `features_tip == 2`, the active feature set is `{feature A, feature B}`. If `features_tip` is set to `3`, the active feature set is `{feature A, feature B, feature C}`.
+Feature ordering is the dependency model. A feature that depends on another feature MUST appear later in the ordered list.
 
-Activation is cumulative. The chain can move from feature tip `1` to feature tip `3`, but doing so activates both feature `2` and feature `3`. It MUST NOT activate feature `3` while leaving feature `2` inactive.
+Each binary derives a cumulative hash chain from the ordered list. The zero hash, `bytes32(0)`, is `NO_ACTIVE_FEATURE_HEAD` and means no protocol features are active. For every feature in order, the binary derives the next digest by hashing a domain separator, the parent digest, and the feature name.
 
-To skip or withdraw a feature ID, it MUST either become a reserved no-op slot or the deferred feature MUST move to a higher ID. This is a source-code change to the feature registry and requires a release whose binary can report support for the resulting feature tip. For example:
+The reference derivation is:
 
 ```text
-1: feature A
-2: reserved no-op
-3: feature C
+digest_0 = bytes32(0)
+digest_n = keccak256(
+  len("tempo.feature.v1") || "tempo.feature.v1" ||
+  digest_{n-1} ||
+  len(feature_name_n) || feature_name_n
+)
 ```
 
-In this example, advancing `features_tip` to `3` treats feature ID `2` as active, but ID `2` has no protocol effect. If the deferred feature is later revived, it receives a new feature ID after `3`.
+where integer lengths are encoded as unsigned 64-bit big-endian values.
 
-Once a released binary can report a feature tip, the feature IDs included in that tip MUST NOT be changed. If a feature in that range is deferred, its old ID MUST remain a reserved no-op and the deferred feature MUST receive a new ID later.
+The chain stores only the current digest, not the feature list. If `activeFeatureHead == digest_2`, then every feature name in positions `1..=2` is active and every later feature is inactive. Moving from `digest_1` to `digest_3` activates both feature `2` and feature `3`.
 
-Feature ordering is the dependency model. A feature that depends on another feature MUST receive a higher feature ID than the feature it depends on. Source-controlled metadata records human-readable feature names, TIP references, minimum supported version keys, and implementation notes keyed by `feature_id`; the chain stores only the state required for activation.
+A binary MUST maintain a local cache of every supported stack digest, including `bytes32(0)`. A binary supports a scheduled digest if and only if that digest is present in its local cache. This lets validators accept scheduled digests that are behind their highest supported digest while rejecting digests from a different or unknown feature chain.
 
-Validators report the highest feature tip they support. A validator supports target feature tip `N` when its latest reported feature tip is greater than or equal to `N`. This works because support is cumulative: support for feature tip `N` includes every lower feature ID.
+To skip or withdraw a feature before it activates, its entry MUST either become a reserved no-op feature name or the deferred feature MUST move to a later name. Once a release can support a stack digest, every feature name that contributes to that digest MUST be append-only. Changing or reordering an existing name changes every later digest and creates a distinct feature chain.
 
-Activation eligibility is bound to consensus epochs rather than wall-clock timestamps. The registry owner schedules a target feature tip and an activation epoch. Feature activation occurs during block processing for that epoch, where the chain advances `features_tip` if the current active validator set has quorum for the scheduled target. No external activation transaction is required.
+Activation eligibility is bound to consensus epochs rather than wall-clock timestamps. The registry owner schedules a target stack digest and an activation epoch. Feature activation occurs during block processing for that epoch; no external activation transaction is required.
 
 ## Feature Registry
 
-Tempo stores protocol feature activation state in an onchain feature registry. The registry stores which part of that list is active on chain. The feature IDs are mapped to feature tips by the source-controlled feature list shipped in Tempo releases.
+Tempo stores protocol feature activation state in an onchain feature registry. The registry stores the active feature stack digest, one pending scheduled digest, and the latest readiness report recorded for each validator address.
 
-The registry owner is authorized to schedule or cancel feature tip activation.
+The registry owner is authorized to schedule or cancel feature activation.
 
 The registry MUST store:
 
-- `features_tip`: the highest active protocol feature ID
-- `scheduled_features_tip`: the next target feature tip, or `0` when no tip is scheduled
-- `scheduled_activation_epoch`: the earliest epoch in which the scheduled tip may activate, or `0` when no tip is scheduled
-- `validator_supported_features_tip`: the latest supported feature tip reported by each validator
+- `active_feature_head`: the active feature stack digest
+- `scheduled_feature_head`: the next target digest, or `bytes32(0)` when no digest is scheduled
+- `scheduled_activation_epoch`: the earliest epoch in which the scheduled digest may activate, or `0` when no digest is scheduled
+- `validator_confirmed_feature_head`: the latest stack digest reported ready by each validator
 
 ```solidity
 contract FeatureRegistry {
   // --snip--
 
-  uint64 features_tip;
-  uint64 scheduled_features_tip;
+  bytes32 active_feature_head;
+  bytes32 scheduled_feature_head;
   uint64 scheduled_activation_epoch;
 
-  mapping(address validator => uint64 supported_features_tip) validator_supported_features_tip;
+  mapping(address validator => bytes32 feature_head) validator_confirmed_feature_head;
 
   // --snip--
 }
 ```
 
-The registry should expose read methods for nodes, indexers, and operators to inspect the active feature tip, scheduled feature tip, validator reports, computed support for a target feature tip, and the global activation quorum threshold. Callers should be able to determine whether a proposed feature tip has quorum before its activation epoch.
+The registry should expose read methods for nodes, indexers, and operators to inspect the active stack digest, scheduled digest, validator readiness, computed support for a target digest, and the global activation quorum threshold.
 
-Registry state changes MUST be observable through events for scheduling, cancellation, validator support updates, support changes, and activation.
+Registry state changes MUST be observable through events for scheduling, cancellation, validator readiness reports, and activation.
 
 ## Scheduling and Activation
 
-The registry owner schedules activation by submitting a registry transaction with a target feature tip and a future activation epoch. The target feature tip is the highest feature ID that should become active. Scheduling target feature tip `3` means "activate every feature ID up to `3`"; it does not mean "activate only feature `3`."
+The registry owner schedules activation by submitting a registry transaction with a target stack digest and a future activation epoch.
 
-The registry MUST accept the scheduling transaction only if the target feature tip is higher than the current `features_tip`, no other feature tip is scheduled, and the requested activation epoch is strictly greater than the current epoch.
+The registry MUST accept the scheduling transaction only if:
 
-Scheduling MUST write `scheduled_features_tip` and `scheduled_activation_epoch`, then emit an event to notify network participants. The scheduled epoch is the earliest consensus epoch in which the chain attempts to advance to the target feature tip. Operators should upgrade before that epoch if they are running a release that supports a lower feature tip.
+- the target digest is not `bytes32(0)`;
+- the target digest is not already active;
+- no other digest is scheduled; and
+- the requested activation epoch is strictly greater than the current epoch.
 
-Feature activation occurs in the first block of `scheduled_activation_epoch`. During block processing, the system caller invokes the registry activation entrypoint for the current epoch. At feature activation, the chain evaluates whether the active validator set has quorum for `scheduled_features_tip`.
+Scheduling MUST write `scheduled_feature_head` and `scheduled_activation_epoch`, then emit an event to notify network participants. The scheduled epoch is the earliest consensus epoch in which the chain attempts to activate the target digest. Operators should upgrade before that epoch if they are running a release that does not support the scheduled digest.
 
-For quorum checks, the active validator set is the effective committee for `scheduled_activation_epoch` exposed by TIP-1070. The registry MUST NOT keep a separate validator roster for feature activation and MUST NOT derive quorum membership from `ValidatorConfigV2.getActiveValidators()`.
+Feature activation occurs during pre-execution of the first block of the scheduled activation epoch. During block processing, the system caller invokes `activateScheduledFeatureHead()`. The activation call does not take an epoch argument.
 
-To evaluate support for target feature tip `N`, the quorum check iterates the active validator set and counts each validator whose `validator_supported_features_tip[validator] >= N`. A scheduled feature tip has quorum when at least 80% of active validators support it. The quorum denominator is the size of the active validator set at feature activation, and the required validator count is `ceil(4 * active_validator_count / 5)`.
+For quorum checks, the active validator set is the TIP-1070 current committee exposed by the `CurrentCommittee` precompile. The feature registry MUST NOT keep a separate validator roster for feature activation and MUST NOT derive quorum membership from `ValidatorConfigV2.getActiveValidators()`.
 
-If quorum is satisfied at feature activation, the chain MUST set `features_tip` to `scheduled_features_tip`, clear the scheduled feature tip fields, and emit an activation event. Protocol behavior gated by newly active features applies to subsequent blocks unless a feature's own TIP specifies transition-block behavior.
+To evaluate readiness for scheduled digest `H`, the quorum check iterates the current committee public keys, resolves each public key to its validator address, and counts each validator whose `validator_confirmed_feature_head[validator] == H`. A scheduled digest has quorum when at least 80% of current committee validators have reported readiness for that exact digest. The required validator count is `ceil(4 * current_committee_size / 5)`.
 
-If quorum is not satisfied at feature activation, the chain MUST clear `scheduled_features_tip` and `scheduled_activation_epoch` and leave `features_tip` unchanged. The registry owner can schedule the same or a higher feature tip for a later epoch after the missing quorum condition is resolved.
+If quorum is satisfied at feature activation, the chain MUST set `active_feature_head` to `scheduled_feature_head`, clear the scheduled fields, and emit an activation event. Protocol behavior gated by newly active features applies to block execution after activation in that block, unless a feature's own TIP specifies transition-block behavior.
 
-Nodes derive the active feature set from registry state. Validators, RPC nodes, consensus-layer clients, and other infrastructure MUST use the same active feature tip when evaluating protocol behavior for a block. After feature activation, any node that validates, builds, simulates, or serves protocol behavior for later blocks MUST support the active feature tip.
+If quorum is not satisfied at feature activation, the chain MUST clear `scheduled_feature_head` and `scheduled_activation_epoch` and leave `active_feature_head` unchanged. The registry owner can schedule the same or another digest for a later epoch after the missing quorum condition is resolved.
 
-Support for the active feature tip is a requirement for any validator joining the active validator set. Tempo does not continuously recheck quorum after activation, and loss of support after activation does not roll back the active feature tip.
+Nodes derive the active feature set from registry state. Validators, RPC nodes, consensus-layer clients, and other infrastructure MUST use the same active digest when evaluating protocol behavior for a block. After feature activation, any node that validates, builds, simulates, or serves protocol behavior for later blocks MUST support the active digest.
 
-## Validator Feature Tip Reporting
+Support for the active digest is a requirement for any validator joining the current committee. Tempo does not continuously recheck quorum after activation, and loss of support after activation does not roll back the active digest.
 
-Validators indicate feature support by reporting the highest protocol feature tip they support, e.g. a report of `3` means the validator supports the ordered feature list through feature ID `3`.
+## Validator Readiness Reporting
 
-A report MUST be deterministic from chain history and MUST NOT decrease the validator's previously reported supported feature tip.
+Validators indicate readiness by reporting whether they support the currently scheduled stack digest. A validator MUST report `ready = true` only if the scheduled digest is present in its local feature cache.
 
-Validator feature-tip reports MUST use the validator identity and authorization model defined by TIP-1070. A validator report is submitted through a system transaction and identifies the validator by public key. The registry resolves that public key to the active validator address, accepts `setSupportedFeaturesTip(publicKey, featuresTip)` only from the system caller, and rejects arbitrary external callers as unauthorized.
+Readiness reports MUST use the validator identity model defined by TIP-1070. A report is submitted through a system transaction in a block proposed by the validator. The registry reads the current block proposer public key, resolves that public key to the validator address, and records readiness for the currently scheduled digest.
 
 ```solidity
-mapping(address validator => uint64 supported_features_tip) validator_supported_features_tip;
+mapping(address validator => bytes32 feature_head) validator_confirmed_feature_head;
 
-function setSupportedFeaturesTip(bytes32 publicKey, uint64 featuresTip) external;
+function reportFeatureReadiness(bool ready) external;
 ```
 
-If `featuresTip` is greater than the validator's previous report, the registry updates `validator_supported_features_tip[validator]`.
+Only the system caller may call `reportFeatureReadiness(bool ready)`. Arbitrary external callers MUST be rejected as unauthorized.
 
-Support for a target feature tip MUST be evaluated against the active validator set. Exited validators stop contributing to quorum, and newly active validators contribute according to their latest reported supported feature tip.
+If no digest is scheduled, the report MUST be rejected. If the current block does not identify the proposer public key, the report MUST be rejected.
 
-For a target tip `N`, a validator contributes to quorum when `validator_supported_features_tip[validator] >= N`. A validator running a newer Tempo release can therefore support older scheduled tips without additional per-feature signaling.
+When a validator reports `ready = true`, the registry writes `validator_confirmed_feature_head[validator] = scheduled_feature_head` and emits a readiness event. A later ready report for a different scheduled digest overwrites the validator's previous report.
+
+When a validator reports `ready = false`, the registry clears the validator's stored readiness if and only if `validator_confirmed_feature_head[validator] == scheduled_feature_head`, then emits a readiness event. This lets a validator that rolled back or no longer supports the scheduled digest cancel its current report without clearing readiness for another digest.
+
+When building a proposed block, a node should submit a readiness report only when its local support for the scheduled digest differs from the readiness recorded for its validator address.
+
+For a scheduled digest `H`, a validator contributes to quorum when `validator_confirmed_feature_head[validator] == H`. A validator running a newer Tempo release can still report readiness for an older scheduled digest if that digest is present in its local hash chain.
 
 ## Cancellation and Supersession
 
-Before activation, the registry owner can cancel a scheduled feature tip. Cancellation MUST clear `scheduled_features_tip` and `scheduled_activation_epoch`. It does not remove feature code from released binaries; it only removes the pending onchain activation. A new target feature tip can be scheduled later.
+Before activation, the registry owner can cancel a scheduled digest. Cancellation MUST clear `scheduled_feature_head` and `scheduled_activation_epoch`. It does not remove feature code from released binaries; it only removes the pending onchain activation. A new target digest can be scheduled later.
 
-After activation, a feature cannot be cancelled or locally disabled, and the active feature tip MUST NOT be lowered. Active features are part of chain history, and removing or toggling off their code can break syncing, state assumptions, or protocol behavior where the feature was active.
+After activation, a feature cannot be cancelled or locally disabled, and the active digest MUST NOT be lowered. Active features are part of chain history, and removing or toggling off their code can break syncing, state assumptions, or protocol behavior where the feature was active.
 
-If an active feature needs to be fixed, disabled, or replaced, the change ships as a new protocol feature with a higher feature ID. The active feature tip only moves forward; historical behavior remains available for blocks where the earlier feature was active.
+If an active feature needs to be fixed, disabled, or replaced, the change ships as a new protocol feature with a later feature name. The active digest only moves forward along the source-controlled feature chain; historical behavior remains available for blocks where the earlier feature was active.
 
 ## Tooling and Operational Impact
 
-Nodes, indexers, dashboards, and operator tooling need to expose the active feature tip, scheduled feature tip, validator support reports, quorum status, and feature names for the IDs in the source-controlled feature list.
+Nodes, indexers, dashboards, and operator tooling need to expose the active digest, scheduled digest, validator readiness reports, quorum status, and the source-controlled feature names that produced known digests.
 
 Release notes must distinguish features that are supported by a binary from features that are active on a network.
 
-Before scheduling activation, operators and partners need the target feature tip, the feature IDs included up to that target, the activation epoch, the first supporting Tempo release, rollback constraints, and monitoring expectations.
+Before scheduling activation, operators and partners need the target digest, the feature names included up to that target, the activation epoch, the first supporting Tempo release, rollback constraints, and monitoring expectations.
 
 ## Threat Model
 
-The main risks are registry disagreement, false validator support, incorrect quorum calculation, rushed scheduling, and unsafe post-activation rollback.
+The main risks are registry disagreement, false validator readiness, incorrect quorum calculation, rushed scheduling, and unsafe post-activation rollback.
 
 ### Registry Agreement
 
-Threat: Validators could report the same feature tip while using different registry prefixes.
+Threat: Validators could report readiness for the same feature label while using different implementations or feature-chain prefixes.
 
-Mitigation: Feature IDs are assigned in one source-controlled ordered list, and release and audit processes must ensure that implementation, tests, generated artifacts, and operator documentation match that list.
+Mitigation: The scheduled value is a hash-chain commitment, not a numeric label. Feature names are assigned in one source-controlled ordered list, and release and audit processes must ensure that implementation, tests, generated artifacts, and operator documentation match that list.
 
 ### Validator Misreport
 
-Threat: A validator could claim support for code it is not running.
+Threat: A validator could report readiness for code it is not running.
 
-Mitigation: A node whose binary does not support the active feature tip must fail closed rather than validate, build, simulate, or serve old behavior. After activation, a validator that misreported support will fail to follow the chain rather than safely continue with old behavior.
+Mitigation: A node whose binary does not support the active digest must fail closed rather than validate, build, simulate, or serve old behavior. After activation, a validator that misreported readiness will fail to follow the chain rather than safely continue with old behavior.
 
 ### Activation Quorum
 
 Threat: Activation could use the wrong validator set, identity, or quorum denominator.
 
-Mitigation: Support reporting and quorum checks use the validator identity and active-validator-set model defined by TIP-1070. The registry activation path gates activation on quorum at the activation epoch. If quorum is missing, the scheduled feature tip MUST NOT activate and the active feature tip MUST remain unchanged.
+Mitigation: Readiness reports use the current block proposer public key, and quorum checks use the TIP-1070 current committee. The registry activation path gates activation on quorum at the activation epoch. If quorum is missing, the scheduled digest MUST NOT activate and the active digest MUST remain unchanged.
 
 ### Scheduling and Ecosystem Readiness
 
 Threat: Activation could be scheduled for the wrong target or before the ecosystem is ready.
 
-Mitigation: The registry owner can cancel or reschedule activation before the activation epoch, but cannot lower the active feature tip after activation. Release notes and activation communications must distinguish validator quorum from ecosystem readiness because RPC nodes, indexers, monitoring, and partner systems do not contribute to validator quorum.
+Mitigation: The registry owner can cancel or reschedule activation before the activation epoch, but cannot lower the active digest after activation. Release notes and activation communications must distinguish validator quorum from ecosystem readiness because RPC nodes, indexers, monitoring, and partner systems do not contribute to validator quorum.
 
 ### Post-Activation
 
 Threat: An operator could roll back or disable behavior after it becomes active chain history.
 
-Mitigation: Nodes must not validate, build, simulate, or serve post-activation protocol behavior for a chain whose active feature tip is higher than the node's supported feature tip.
+Mitigation: Nodes must not validate, build, simulate, or serve post-activation protocol behavior for a chain whose active digest is not present in the node's supported feature cache.
 
 ## Alternatives Considered
 
 ### Independent Per-Feature Toggles
 
-An alternative design is to store an unordered set of active feature IDs and let each feature activate independently.
+An alternative design is to store an unordered set of active feature names and let each feature activate independently.
 
-This TIP uses a single ordered activation list instead. An unordered feature set would require specs, implementations, audits, tests, monitoring, and operator guidance to account for many possible feature combinations and activation orders. It would also require validators to report exact supported feature sets rather than one cumulative high-water mark.
+This TIP uses a single ordered activation chain instead. An unordered feature set would require specs, implementations, audits, tests, monitoring, and operator guidance to account for many possible feature combinations and activation orders. It would also require validators to report exact supported feature sets rather than readiness for one scheduled stack digest.
 
-The tradeoff is that features do not activate in arbitrary order. If an earlier feature is deferred but a later feature should still activate, the earlier feature ID must become a reserved no-op slot.
+The tradeoff is that features do not activate in arbitrary order. If an earlier feature is deferred but a later feature should still activate, the earlier feature name must become a reserved no-op entry.
+
+### Numeric Feature Tips
+
+An earlier design stored a `uint64 featuresTip` high-water mark. This is compact, but it is ambiguous across releases if the same numeric tip refers to different implementation history.
+
+This TIP uses a hash-chain commitment instead. The digest commits to the ordered feature-name prefix and lets a node decide locally whether a scheduled target is present in its supported chain.
 
 ## Invariants
 
-1. Feature IDs are 1-indexed positions in the source-controlled feature registry. Feature tip `0` means no active, scheduled, or supported protocol feature prefix.
-2. `features_tip` is monotonic. It starts at `0` unless genesis sets a higher value and never decreases.
-3. If `features_tip == N`, every feature ID in `1..=N` is active and every feature ID greater than `N` is inactive.
-4. A reserved no-op feature ID has no protocol effect.
-5. Feature IDs included in any reportable feature tip are append-only. The meaning and canonical name of an existing feature ID must not change.
-6. The registry stores at most one pending scheduled feature tip for a network.
-7. A scheduled feature tip must be greater than the current `features_tip`, and the scheduled activation epoch must be in the future when scheduled.
-8. Only the registry owner can schedule or cancel feature tip activation.
-9. Only the system caller can record validator support reports or activate a scheduled feature tip during block processing.
-10. A validator's supported feature-tip high-water mark is monotonic and cannot decrease.
-11. Quorum for target feature tip `N` counts a validator if and only if its latest reported supported feature tip is greater than or equal to `N`.
-12. A scheduled feature tip activates only if the active validator set has quorum for that target feature tip.
-13. A node must not validate, build, simulate, or serve post-activation protocol behavior for a chain whose active feature tip is higher than the node's supported feature tip.
+1. `bytes32(0)` means no active, scheduled, or reported-ready protocol feature digest.
+2. `active_feature_head` starts at `bytes32(0)` unless genesis sets a higher value.
+3. A node supports a stack digest if and only if that digest is present in its local feature cache.
+4. Feature names included in any supported digest are append-only. The canonical name and order of an existing feature entry must not change.
+5. A reserved no-op feature name has no protocol effect.
+6. The registry stores at most one pending scheduled digest for a network.
+7. A scheduled digest must be nonzero, not already active, and have a scheduled activation epoch in the future when scheduled.
+8. Only the registry owner can schedule or cancel feature activation.
+9. Only the system caller can record validator readiness reports or activate a scheduled digest during block processing.
+10. A validator can only report readiness for the currently scheduled digest.
+11. Quorum for scheduled digest `H` counts a validator if and only if its latest reported-ready digest is exactly `H`.
+12. A scheduled digest activates only if the TIP-1070 current committee has quorum readiness for that target digest.
+13. A node must not validate, build, simulate, or serve post-activation protocol behavior for a chain whose active digest is not present in the node's supported feature cache.
 
 ## Interfaces
 
@@ -228,60 +244,60 @@ The feature registry exposes the following interface:
 
 ```solidity
 /// @title IFeatureRegistry
-/// @notice Registry for Tempo protocol feature tip scheduling.
+/// @notice Registry for Tempo feature activation scheduling.
 interface IFeatureRegistry {
-    /// @notice Returns the registry owner authorized to schedule feature tip activation.
+    /// @notice Returns the registry owner authorized to schedule feature activation.
     function owner() external view returns (address);
 
     /// @notice Returns the fixed global activation quorum threshold: 4/5, or 80%.
     function activationQuorum() external view returns (uint256 numerator, uint256 denominator);
 
-    /// @notice Returns the highest active protocol feature ID.
-    function highestActiveTip() external view returns (uint64);
+    /// @notice Returns the active feature stack digest.
+    function activeFeatureHead() external view returns (bytes32);
 
-    /// @notice Returns the scheduled feature tip and activation epoch.
-    function getActivationEpoch(uint64 featuresTip) external view returns uint64 activationEpoch;
+    /// @notice Returns the scheduled feature stack digest and earliest activation epoch.
+    function scheduledFeatureHead() external view returns (bytes32 featureHead, uint64 activationEpoch);
 
-    /// @notice Records the highest protocol feature tip reported by a validator public key. System caller only.
-    function setSupportedFeaturesTip(bytes32 publicKey, uint64 featuresTip) external;
+    /// @notice Reports whether the proposer validator is ready for the currently scheduled digest. System caller only.
+    function reportFeatureReadiness(bool ready) external;
 
-    /// @notice Schedules a higher feature tip for activation at the target epoch.
-    function scheduleFeaturesTip(uint64 featuresTip, uint64 activationEpoch) external;
+    /// @notice Schedules a feature stack digest for activation at the target epoch.
+    function scheduleFeatureHead(bytes32 featureHead, uint64 activationEpoch) external;
 
-    /// @notice Activates the scheduled feature tip during block processing. System caller only.
-    function activateScheduledFeaturesTip() external;
+    /// @notice Activates the scheduled digest during block processing. System caller only.
+    function activateScheduledFeatureHead() external;
 
-    /// @notice Cancels the scheduled feature tip before activation.
-    function cancelScheduledFeaturesTip() external;
+    /// @notice Cancels the scheduled digest before activation.
+    function cancelScheduledFeatureHead() external;
 
-    /// @notice Returns the latest feature tip reported by a validator.
-    function validatorSupportedFeaturesTip(address validator) external view returns (uint64 featuresTip);
+    /// @notice Returns whether a validator reported readiness for a digest.
+    function validatorConfirmedFeatureHead(address validator, bytes32 featureHead) external view returns (bool);
 
-    /// @notice Returns current active-validator support for a feature tip.
-    function featuresTipSupport(uint64 featuresTip) external view returns (uint256 support, uint256 required);
+    /// @notice Returns current active-validator readiness for a digest.
+    function featureHeadSupport(bytes32 featureHead) external view returns (uint256 support, uint256 required);
 
-    /// @notice Returns whether a feature tip has quorum support from the active validator set.
-    function hasFeaturesTipQuorum(uint64 featuresTip) external view returns (bool);
+    /// @notice Returns whether a digest has quorum readiness from the active validator set.
+    function hasFeatureHeadQuorum(bytes32 featureHead) external view returns (bool);
 }
 ```
 
 ### Events
 
 ```solidity
-/// @notice Emitted when a validator reports support for a feature tip.
-event SupportedFeaturesTipSet(address indexed validator, uint64 featuresTip, uint256 supportCount);
+/// @notice Emitted when a validator reports readiness for a digest.
+event FeatureReadinessReported(address indexed validator, bytes32 indexed featureHead, bool ready);
 
-/// @notice Emitted when a higher feature tip is scheduled for activation.
-event FeaturesTipScheduled(uint64 featuresTip, uint64 activationEpoch);
+/// @notice Emitted when a digest is scheduled for activation.
+event FeatureHeadScheduled(bytes32 indexed featureHead, uint64 activationEpoch);
 
-/// @notice Emitted when the scheduled feature tip is cancelled.
-event FeaturesTipScheduleCancelled(uint64 featuresTip);
+/// @notice Emitted when the scheduled digest is cancelled.
+event FeatureHeadScheduleCancelled(bytes32 indexed featureHead);
 
-/// @notice Emitted at feature activation when a scheduled feature tip becomes active.
-event FeaturesTipActivated(uint64 previousFeaturesTip, uint64 featuresTip, uint64 activationEpoch);
+/// @notice Emitted when a scheduled digest becomes active during epoch processing.
+event FeatureHeadActivated(bytes32 indexed previousFeatureHead, bytes32 indexed featureHead, uint64 activationEpoch);
 
-/// @notice Emitted when active validator support for a feature tip changes.
-event FeaturesTipSupportUpdated(uint64 featuresTip, uint256 support, uint256 required);
+/// @notice Emitted when active validator readiness for a digest changes.
+event FeatureHeadSupportUpdated(bytes32 indexed featureHead, uint256 support, uint256 required);
 ```
 
 ### Errors
@@ -290,20 +306,20 @@ event FeaturesTipSupportUpdated(uint64 featuresTip, uint256 support, uint256 req
 /// @notice Caller is not authorized to update feature registry state.
 error Unauthorized();
 
-/// @notice Feature tip is invalid or reserved.
-error InvalidFeaturesTip();
+/// @notice Feature stack digest is invalid or reserved.
+error InvalidFeatureHead();
 
-/// @notice Feature tip must be higher than the current active feature tip.
-error FeaturesTipNotIncreasing();
+/// @notice Feature stack digest is already active.
+error FeatureHeadAlreadyActive();
 
-/// @notice Validator cannot lower its reported supported feature tip.
-error SupportedFeaturesTipDecreased();
+/// @notice A digest is already scheduled for activation.
+error FeatureHeadAlreadyScheduled();
 
-/// @notice A feature tip is already scheduled for activation.
-error FeaturesTipAlreadyScheduled();
+/// @notice No digest is scheduled for activation.
+error FeatureHeadNotScheduled();
 
-/// @notice No feature tip is scheduled for activation.
-error FeaturesTipNotScheduled();
+/// @notice The current block does not include a proposer public key.
+error ProposerPublicKeyUnavailable();
 
 /// @notice Requested activation epoch is not strictly greater than the current epoch.
 error ActivationEpochNotFuture();

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -66,7 +66,9 @@ where integer lengths are encoded as unsigned 64-bit big-endian values.
 
 The chain stores only the current digest, not the feature list. If `activeFeatureHead == digest_2`, then every feature name in positions `1..=2` is active and every later feature is inactive. Moving from `digest_1` to `digest_3` activates both feature `2` and feature `3`.
 
-A binary MUST maintain a local cache of every supported stack digest, including `bytes32(0)`. A binary supports a scheduled digest if and only if that digest is present in its local cache. This lets validators accept scheduled digests that are behind their highest supported digest while rejecting digests from a different or unknown feature chain.
+A binary MUST maintain a local cache of every supported stack digest, including `bytes32(0)`. A binary supports a scheduled digest if and only if that digest is present in its local cache. This lets validators report readiness for scheduled digests that are behind their highest supported digest while treating digests from a different or unknown feature chain as unsupported.
+
+A node MUST NOT reject a block merely because the block schedules a digest that is not present in the node's local feature cache. Before activation, an unknown scheduled digest is operator-visible state; it does not change protocol behavior. A validator whose binary does not support the scheduled digest MUST NOT report readiness for it.
 
 To skip or withdraw a feature before it activates, its entry MUST either become a reserved no-op feature name or the deferred feature MUST move to a later name. Once a release can support a stack digest, every feature name that contributes to that digest MUST be append-only. Changing or reordering an existing name changes every later digest and creates a distinct feature chain.
 
@@ -99,7 +101,9 @@ contract FeatureRegistry {
 }
 ```
 
-The registry should expose read methods for nodes, indexers, and operators to inspect the active stack digest, scheduled digest, validator readiness, computed support for a target digest, and the global activation quorum threshold.
+The registry should expose read methods for nodes, indexers, and operators to inspect the active stack digest, scheduled digest, validator readiness for the scheduled digest, computed support for the scheduled digest, and the global activation quorum threshold.
+
+`validatorConfirmedScheduledFeatureReadiness(validator)` MUST compare the validator's latest reported digest against the current `scheduled_feature_head`. If no digest is scheduled, it MUST return `false`. `scheduledFeatureSupport()` MUST return `(0, 0)` when no digest is scheduled, and `hasScheduledFeatureQuorum()` MUST return `false` when the required count is zero.
 
 Registry state changes MUST be observable through events for scheduling, cancellation, validator readiness reports, and activation.
 
@@ -123,6 +127,8 @@ For quorum checks, the active validator set is the TIP-1070 current committee ex
 To evaluate readiness for scheduled digest `H`, the quorum check iterates the current committee public keys, resolves each public key to its validator address, and counts each validator whose `validator_confirmed_feature_head[validator] == H`. A scheduled digest has quorum when at least 80% of current committee validators have reported readiness for that exact digest. The required validator count is `ceil(4 * current_committee_size / 5)`.
 
 If quorum is satisfied at feature activation, the chain MUST set `active_feature_head` to `scheduled_feature_head`, clear the scheduled fields, and emit an activation event. Protocol behavior gated by newly active features applies to block execution after activation in that block, unless a feature's own TIP specifies transition-block behavior.
+
+If activation sets `active_feature_head` to a digest that is not present in a node's local feature cache, that node MUST fail closed when validating or building the activation block or any later block. The block may be valid for binaries that support the activated digest, but an unsupported binary cannot safely evaluate post-activation protocol behavior.
 
 If quorum is not satisfied at feature activation, the chain MUST clear `scheduled_feature_head` and `scheduled_activation_epoch` and leave `active_feature_head` unchanged. The registry owner can schedule the same or another digest for a later epoch after the missing quorum condition is resolved.
 
@@ -150,7 +156,7 @@ When a validator reports `ready = true`, the registry writes `validator_confirme
 
 When a validator reports `ready = false`, the registry clears the validator's stored readiness if and only if `validator_confirmed_feature_head[validator] == scheduled_feature_head`, then emits a readiness event. This lets a validator that rolled back or no longer supports the scheduled digest cancel its current report without clearing readiness for another digest.
 
-When building a proposed block, a node should submit a readiness report only when its local support for the scheduled digest differs from the readiness recorded for its validator address.
+When building a proposed block, a node should submit a readiness report only when its local support for the scheduled digest differs from the scheduled readiness recorded for its validator address.
 
 For a scheduled digest `H`, a validator contributes to quorum when `validator_confirmed_feature_head[validator] == H`. A validator running a newer Tempo release can still report readiness for an older scheduled digest if that digest is present in its local hash chain.
 
@@ -164,7 +170,7 @@ If an active feature needs to be fixed, disabled, or replaced, the change ships 
 
 ## Tooling and Operational Impact
 
-Nodes, indexers, dashboards, and operator tooling need to expose the active digest, scheduled digest, validator readiness reports, quorum status, and the source-controlled feature names that produced known digests.
+Nodes, indexers, dashboards, and operator tooling need to expose the active digest, scheduled digest, validator readiness reports for the scheduled digest, scheduled quorum status, and the source-controlled feature names that produced known digests.
 
 Release notes must distinguish features that are supported by a binary from features that are active on a network.
 
@@ -234,7 +240,8 @@ This TIP uses a hash-chain commitment instead. The digest commits to the ordered
 10. A validator can only report readiness for the currently scheduled digest.
 11. Quorum for scheduled digest `H` counts a validator if and only if its latest reported-ready digest is exactly `H`.
 12. A scheduled digest activates only if the TIP-1070 current committee has quorum readiness for that target digest.
-13. A node must not validate, build, simulate, or serve post-activation protocol behavior for a chain whose active digest is not present in the node's supported feature cache.
+13. A node can import pre-activation blocks that schedule an unknown digest, but it must not report readiness for an unsupported scheduled digest.
+14. A node must not validate, build, simulate, or serve post-activation protocol behavior for a chain whose active digest is not present in the node's supported feature cache.
 
 ## Interfaces
 
@@ -270,14 +277,14 @@ interface IFeatureRegistry {
     /// @notice Cancels the scheduled digest before activation.
     function cancelScheduledFeatureHead() external;
 
-    /// @notice Returns whether a validator reported readiness for a digest.
-    function validatorConfirmedFeatureHead(address validator, bytes32 featureHead) external view returns (bool);
+    /// @notice Returns whether a validator reported readiness for the scheduled digest.
+    function validatorConfirmedScheduledFeatureReadiness(address validator) external view returns (bool);
 
-    /// @notice Returns current active-validator readiness for a digest.
-    function featureHeadSupport(bytes32 featureHead) external view returns (uint256 support, uint256 required);
+    /// @notice Returns current active-validator readiness for the scheduled digest.
+    function scheduledFeatureSupport() external view returns (uint256 support, uint256 required);
 
-    /// @notice Returns whether a digest has quorum readiness from the active validator set.
-    function hasFeatureHeadQuorum(bytes32 featureHead) external view returns (bool);
+    /// @notice Returns whether the scheduled digest has quorum readiness from the active validator set.
+    function hasScheduledFeatureQuorum() external view returns (bool);
 }
 ```
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -16,9 +16,9 @@ This TIP defines protocol feature flags for Tempo protocol changes, decoupling c
 
 Today, a Tempo hardfork ties protocol code and activation into the same upgrade bundle. With protocol feature flags, Tempo can ship releases when features are ready, let operators upgrade, observe validator readiness, and activate the new features per network.
 
-Protocol features are assigned canonical names in one source-controlled ordered list. Each binary constructs a hash chain over that list, and the chain stores a `bytes32` commitment to the active feature stack. The zero digest means no protocol features are active.
+Protocol features are assigned canonical names in one source-controlled ordered list. Each binary constructs a hash chain over that list. A feature head is the `bytes32` digest at one tip of that chain, and the zero feature head means no protocol features are active.
 
-Activation is controlled by an onchain feature registry. The registry owner schedules a target feature stack digest and future activation epoch. Validators report readiness for the scheduled digest from blocks they propose. At activation, the registry checks readiness against the TIP-1070 current committee.
+Activation is controlled by an onchain feature registry. The registry owner schedules a target feature head and future activation epoch. Validators report readiness for the scheduled feature head from blocks they propose. At activation, the registry checks readiness against the TIP-1070 current committee.
 
 ## Motivation
 
@@ -26,14 +26,14 @@ Tempo currently ships protocol changes through hardfork bundles (e.g. T3, T4, T5
 
 Feature flags separate when code ships, when operators need to upgrade, and when protocol behavior activates. This lets Tempo ship in a regular release cadence, while activating protocol behavior only after each network is ready.
 
-The stack digest avoids ambiguity between releases. If `v1.9.0` and `v1.9.1` both know a feature name but implement a different ordered feature stack, their computed digests differ. A validator only reports readiness for a scheduled digest that is present in its local feature chain.
+The feature head avoids ambiguity between releases. If `v1.9.0` and `v1.9.1` both know a feature name but implement a different feature chain, their computed feature heads differ. A validator only reports readiness for a scheduled feature head that is present in its local feature chain.
 
 ## Assumptions
 
 - TIP-1070 provides the validator identity and current-committee model used for readiness reporting and quorum checks.
-- Releases that support a feature stack digest agree on the source-controlled ordered feature-name list that produced that digest.
+- Releases that support a feature head agree on the source-controlled ordered feature-name list that produced that head.
 - Feature readiness reporting is deterministic from the binary and chain state. Operators do not locally choose which subset of supported protocol features to report.
-- Active feature stacks are forward-only. Fixing, disabling, or replacing active behavior requires appending a new feature name to the ordered list, or a hardfork if the feature registry mechanism cannot express the emergency change.
+- Active feature heads are forward-only. Fixing, disabling, or replacing active behavior requires appending a new feature name to the ordered list, or a hardfork if the feature registry mechanism cannot express the emergency change.
 
 # Specification
 
@@ -64,28 +64,28 @@ digest_n = keccak256(
 
 where integer lengths are encoded as unsigned 64-bit big-endian values.
 
-The chain stores only the current digest, not the feature list. If `activeFeatureHead == digest_2`, then every feature name in positions `1..=2` is active and every later feature is inactive. Moving from `digest_1` to `digest_3` activates both feature `2` and feature `3`.
+The registry stores only the current feature head, not the feature list. If `activeFeatureHead == digest_2`, then every feature name in positions `1..=2` is active and every later feature is inactive. Moving from `digest_1` to `digest_3` activates both feature `2` and feature `3`.
 
-A binary MUST maintain a local cache of every supported stack digest, including `bytes32(0)`. A binary supports a scheduled digest if and only if that digest is present in its local cache. This lets validators report readiness for scheduled digests that are behind their highest supported digest while treating digests from a different or unknown feature chain as unsupported.
+A binary MUST maintain a local cache of every supported feature head, including `bytes32(0)`. A binary supports a scheduled feature head if and only if that head is present in its local cache. This lets validators report readiness for scheduled feature heads that are behind their highest supported head while treating heads from a different or unknown feature chain as unsupported.
 
-A node MUST NOT reject a block merely because the block schedules a digest that is not present in the node's local feature cache. Before activation, an unknown scheduled digest is operator-visible state; it does not change protocol behavior. A validator whose binary does not support the scheduled digest MUST NOT report readiness for it.
+A node MUST NOT reject a block merely because the block schedules a feature head that is not present in the node's local feature cache. Before activation, an unknown scheduled feature head is operator-visible state; it does not change protocol behavior. A validator whose binary does not support the scheduled feature head MUST NOT report readiness for it.
 
-To skip or withdraw a feature before it activates, its entry MUST either become a reserved no-op feature name or the deferred feature MUST move to a later name. Once a release can support a stack digest, every feature name that contributes to that digest MUST be append-only. Changing or reordering an existing name changes every later digest and creates a distinct feature chain.
+To skip or withdraw a feature before it activates, its entry MUST either become a reserved no-op feature name or the deferred feature MUST move to a later name. Once a release can support a feature head, every feature name that contributes to that head MUST be append-only. Changing or reordering an existing name changes every later head and creates a distinct feature chain.
 
-Activation eligibility is bound to consensus epochs rather than wall-clock timestamps. The registry owner schedules a target stack digest and an activation epoch. Feature activation occurs during block processing for that epoch; no external activation transaction is required.
+Activation eligibility is bound to consensus epochs rather than wall-clock timestamps. The registry owner schedules a target feature head and an activation epoch. Feature activation occurs during block processing for that epoch; no external activation transaction is required.
 
 ## Feature Registry
 
-Tempo stores protocol feature activation state in an onchain feature registry. The registry stores the active feature stack digest, one pending scheduled digest, and the latest readiness report recorded for each validator address.
+Tempo stores protocol feature activation state in an onchain feature registry. The registry stores the active feature head, one pending scheduled feature head, and the latest readiness report recorded for each validator address.
 
 The registry owner is authorized to schedule or cancel feature activation.
 
 The registry MUST store:
 
-- `active_feature_head`: the active feature stack digest
-- `scheduled_feature_head`: the next target digest, or `bytes32(0)` when no digest is scheduled
-- `scheduled_activation_epoch`: the earliest epoch in which the scheduled digest may activate, or `0` when no digest is scheduled
-- `validator_confirmed_feature_head`: the latest stack digest reported ready by each validator
+- `active_feature_head`: the active feature head
+- `scheduled_feature_head`: the next target feature head, or `bytes32(0)` when none is scheduled
+- `scheduled_activation_epoch`: the epoch in which the scheduled feature head is attempted, or `0` when none is scheduled
+- `validator_confirmed_feature_head`: the latest feature head reported ready by each validator
 
 ```solidity
 contract FeatureRegistry {
@@ -101,72 +101,72 @@ contract FeatureRegistry {
 }
 ```
 
-The read interface MUST expose the active stack digest, scheduled digest, validator readiness for the scheduled digest, computed support for the scheduled digest, and global activation quorum threshold.
+The read interface MUST expose the active feature head, scheduled feature head, validator readiness for the scheduled feature head, computed support for the scheduled feature head, and global activation quorum threshold.
 
-`validatorConfirmedScheduledFeatureReadiness(validator)` MUST compare the validator's latest report against the current `scheduled_feature_head` and return `false` when no digest is scheduled. `scheduledFeatureSupport()` MUST return `(0, 0)` when no digest is scheduled, and `hasScheduledFeatureQuorum()` MUST return `false` when the required count is zero.
+`validatorConfirmedScheduledFeatureReadiness(validator)` MUST compare the validator's latest report against the current `scheduled_feature_head` and return `false` when no feature head is scheduled. `scheduledFeatureSupport()` MUST return `(0, 0)` when no feature head is scheduled, and `hasScheduledFeatureQuorum()` MUST return `false` when the required count is zero.
 
 Registry state changes MUST be observable through events for scheduling, cancellation, validator readiness reports, and activation.
 
 ## Scheduling and Activation
 
-The registry owner schedules activation by submitting a registry transaction with a target stack digest and a future activation epoch.
+The registry owner schedules activation by submitting a registry transaction with a target feature head and a future activation epoch.
 
 The registry MUST accept the scheduling transaction only if:
 
-- the target digest is not `bytes32(0)`;
-- the target digest is not already active;
-- no other digest is scheduled; and
+- the target feature head is not `bytes32(0)`;
+- the target feature head is not already active;
+- no other feature head is scheduled; and
 - the requested activation epoch is strictly greater than the current epoch.
 
-Scheduling MUST write `scheduled_feature_head` and `scheduled_activation_epoch`, then emit an event to notify network participants. The scheduled epoch is the earliest consensus epoch in which the chain attempts to activate the target digest. Operators should upgrade before that epoch if they are running a release that does not support the scheduled digest.
+Scheduling MUST write `scheduled_feature_head` and `scheduled_activation_epoch`, then emit an event to notify network participants. The scheduled activation epoch is the consensus epoch whose first block performs the single activation attempt for that schedule. Operators should upgrade before that epoch if they are running a release that does not support the scheduled feature head.
 
-At T9 and later, feature activation is attempted during pre-execution of the first block of each epoch. During block processing, the system caller invokes `activateScheduledFeatureHead()`. The activation call does not take an epoch argument and returns the activated digest, or `bytes32(0)` if no digest activated.
+At T9 and later, the block executor invokes the activation system call during pre-execution of the first block of each epoch. The call changes registry state only when a schedule has reached its activation epoch. `activateScheduledFeatureHead()` does not take an epoch argument and returns the activated feature head, or `bytes32(0)` if no feature head activated.
 
 For quorum checks, the active validator set is the TIP-1070 current committee exposed by the `CurrentCommittee` precompile. The feature registry MUST NOT keep a separate validator roster for feature activation and MUST NOT derive quorum membership from `ValidatorConfigV2.getActiveValidators()`.
 
-To evaluate readiness for scheduled digest `H`, the quorum check iterates the current committee public keys, resolves each public key to its validator address, and counts each validator whose `validator_confirmed_feature_head[validator] == H`. A scheduled digest has quorum when at least 80% of current committee validators have reported readiness for that exact digest. The required validator count is `ceil(4 * current_committee_size / 5)`.
+To evaluate readiness for scheduled feature head `H`, the quorum check iterates the current committee public keys, resolves each public key to its validator address, and counts each validator whose `validator_confirmed_feature_head[validator] == H`. A scheduled feature head has quorum when at least 80% of current committee validators have reported readiness for that exact head. The required validator count is `ceil(4 * current_committee_size / 5)`.
 
-If no digest is scheduled, no activation epoch is set, or the scheduled activation epoch is still in the future, `activateScheduledFeatureHead()` MUST return `bytes32(0)` without changing registry state.
+If no feature head is scheduled, no activation epoch is set, or the scheduled activation epoch is still in the future, `activateScheduledFeatureHead()` MUST return `bytes32(0)` without changing registry state.
 
-When the current epoch is greater than or equal to `scheduled_activation_epoch`, `activateScheduledFeatureHead()` evaluates quorum and clears the scheduled fields exactly once. If quorum is satisfied and the scheduled digest is not already active, the chain MUST set `active_feature_head` to `scheduled_feature_head`, emit an activation event, and return the activated digest. Otherwise, the chain MUST leave `active_feature_head` unchanged and return `bytes32(0)`. The registry owner can schedule the same or another digest for a later epoch after the missing quorum condition is resolved.
+When the current epoch is greater than or equal to `scheduled_activation_epoch`, `activateScheduledFeatureHead()` evaluates quorum and clears the scheduled fields exactly once. If quorum is satisfied and the scheduled feature head is not already active, the chain MUST set `active_feature_head` to `scheduled_feature_head`, emit an activation event, and return the activated feature head. Otherwise, the chain MUST leave `active_feature_head` unchanged and return `bytes32(0)`. The registry owner can schedule the same or another feature head for a later epoch after the missing quorum condition is resolved.
 
-The block executor MUST treat the activation system call as valid only if it completes successfully and returns an ABI-encoded `bytes32`. The executor MUST decode the return value before committing activation-call state changes. If the returned digest is nonzero and is not present in the node's local feature cache, that node MUST fail closed before committing the activation block state. The block may be valid for binaries that support the activated digest, but an unsupported binary cannot safely evaluate post-activation protocol behavior.
+The block executor MUST treat the activation system call as valid only if it completes successfully and returns an ABI-encoded `bytes32`. The executor MUST decode the return value before committing activation-call state changes. If the returned feature head is nonzero and is not present in the node's local feature cache, that node MUST fail closed before committing the activation block state. The block may be valid for binaries that support the activated feature head, but an unsupported binary cannot safely evaluate post-activation protocol behavior.
 
-Protocol behavior gated by newly active features applies to block execution after activation in that block, unless a feature's own TIP specifies transition-block behavior. Nodes derive the active feature set from registry state, and any node that validates, builds, simulates, or serves post-activation protocol behavior MUST support the active digest. Tempo does not continuously recheck quorum after activation, and loss of support after activation does not roll back the active digest.
+Protocol behavior gated by newly active features applies to block execution after activation in that block, unless a feature's own TIP specifies transition-block behavior. Nodes derive the active feature set from registry state, and any node that validates, builds, simulates, or serves post-activation protocol behavior MUST support the active feature head. Tempo does not continuously recheck quorum after activation, and loss of support after activation does not roll back the active feature head.
 
 ## Validator Readiness Reporting
 
-Validators indicate readiness by reporting whether they support the currently scheduled stack digest. A validator MUST report `ready = true` only if the scheduled digest is present in its local feature cache.
+Validators indicate readiness by reporting whether they support the currently scheduled feature head. A validator MUST report `ready = true` only if the scheduled feature head is present in its local feature cache.
 
-Readiness reports MUST use the validator identity model defined by TIP-1070. A report is submitted through a system transaction in a block proposed by the validator. The registry reads the current block proposer public key, resolves that public key to the validator address, and records readiness for the currently scheduled digest.
+Readiness reports MUST use the validator identity model defined by TIP-1070. A report is submitted through a system transaction in a block proposed by the validator. The registry reads the current block proposer public key, resolves that public key to the validator address, and records readiness for the currently scheduled feature head.
 
 Only the system caller may call `reportFeatureReadiness(bool ready)`. Arbitrary external callers MUST be rejected as unauthorized.
 
-If no digest is scheduled, the report MUST be rejected. If the current block does not identify the proposer public key, the report MUST be rejected.
+If no feature head is scheduled, the report MUST be rejected. If the current block does not identify the proposer public key, the report MUST be rejected.
 
-When a validator reports `ready = true`, the registry writes `validator_confirmed_feature_head[validator] = scheduled_feature_head` and emits a readiness event. A later ready report for a different scheduled digest overwrites the validator's previous report.
+When a validator reports `ready = true`, the registry writes `validator_confirmed_feature_head[validator] = scheduled_feature_head` and emits a readiness event. A later ready report for a different scheduled feature head overwrites the validator's previous report.
 
-When a validator reports `ready = false`, the registry clears the validator's stored readiness if and only if `validator_confirmed_feature_head[validator] == scheduled_feature_head`, then emits a readiness event. This lets a validator that rolled back or no longer supports the scheduled digest cancel its current report without clearing readiness for another digest.
+When a validator reports `ready = false`, the registry clears the validator's stored readiness if and only if `validator_confirmed_feature_head[validator] == scheduled_feature_head`, then emits a readiness event. This lets a validator that rolled back or no longer supports the scheduled feature head cancel its current report without clearing readiness for another feature head.
 
-When building a proposed block, a node should submit a readiness report only when its local support for the scheduled digest differs from the scheduled readiness recorded for its validator address.
+When building a proposed block, a node should submit a readiness report only when its local support for the scheduled feature head differs from the scheduled readiness recorded for its validator address.
 
-For a scheduled digest `H`, a validator contributes to quorum when `validator_confirmed_feature_head[validator] == H`. A validator running a newer Tempo release can still report readiness for an older scheduled digest if that digest is present in its local hash chain.
+For a scheduled feature head `H`, a validator contributes to quorum when `validator_confirmed_feature_head[validator] == H`. A validator running a newer Tempo release can still report readiness for an older scheduled feature head if that head is present in its local hash chain.
 
 ## Cancellation and Supersession
 
-Before activation, the registry owner can cancel a scheduled digest. Cancellation MUST clear `scheduled_feature_head` and `scheduled_activation_epoch`. It does not remove feature code from released binaries; it only removes the pending onchain activation. A new target digest can be scheduled later.
+Before activation, the registry owner can cancel a scheduled feature head. Cancellation MUST clear `scheduled_feature_head` and `scheduled_activation_epoch`. It does not remove feature code from released binaries; it only removes the pending onchain activation. A new target feature head can be scheduled later.
 
-After activation, a feature cannot be cancelled or locally disabled, and the active digest MUST NOT be lowered. Active features are part of chain history, and removing or toggling off their code can break syncing, state assumptions, or protocol behavior where the feature was active.
+After activation, a feature cannot be cancelled or locally disabled, and the active feature head MUST NOT be lowered. Active features are part of chain history, and removing or toggling off their code can break syncing, state assumptions, or protocol behavior where the feature was active.
 
-If an active feature needs to be fixed, disabled, or replaced, the change ships as a new protocol feature with a later feature name. The active digest only moves forward along the source-controlled feature chain; historical behavior remains available for blocks where the earlier feature was active.
+If an active feature needs to be fixed, disabled, or replaced, the change ships as a new protocol feature with a later feature name. The active feature head only moves forward along the source-controlled feature chain; historical behavior remains available for blocks where the earlier feature was active.
 
 ## Tooling and Operational Impact
 
-Nodes, indexers, dashboards, and operator tooling need to expose the active digest, scheduled digest, validator readiness reports for the scheduled digest, scheduled quorum status, and the source-controlled feature names that produced known digests.
+Nodes, indexers, dashboards, and operator tooling need to expose the active feature head, scheduled feature head, validator readiness reports for the scheduled feature head, scheduled quorum status, and the source-controlled feature names that produced known feature heads.
 
 Release notes must distinguish features that are supported by a binary from features that are active on a network.
 
-Before scheduling activation, operators and partners need the target digest, the feature names included up to that target, the activation epoch, the first supporting Tempo release, rollback constraints, and monitoring expectations.
+Before scheduling activation, operators and partners need the target feature head, the feature names included up to that target, the activation epoch, the first supporting Tempo release, rollback constraints, and monitoring expectations.
 
 ## Threat Model
 
@@ -176,31 +176,31 @@ The main risks are registry disagreement, false validator readiness, incorrect q
 
 Threat: Validators could report readiness for the same feature label while using different implementations or feature-chain prefixes.
 
-Mitigation: The scheduled value is a hash-chain commitment, not a numeric label. Feature names are assigned in one source-controlled ordered list, and release and audit processes must ensure that implementation, tests, generated artifacts, and operator documentation match that list.
+Mitigation: The scheduled feature head is a hash-chain commitment, not a numeric label. Feature names are assigned in one source-controlled ordered list, and release and audit processes must ensure that implementation, tests, generated artifacts, and operator documentation match that list.
 
 ### Validator Misreport
 
 Threat: A validator could report readiness for code it is not running.
 
-Mitigation: A node whose binary does not support the active digest must fail closed rather than validate, build, simulate, or serve old behavior. After activation, a validator that misreported readiness will fail to follow the chain rather than safely continue with old behavior.
+Mitigation: A node whose binary does not support the active feature head must fail closed rather than validate, build, simulate, or serve old behavior. After activation, a validator that misreported readiness will fail to follow the chain rather than safely continue with old behavior.
 
 ### Activation Quorum
 
 Threat: Activation could use the wrong validator set, identity, or quorum denominator.
 
-Mitigation: Readiness reports use the current block proposer public key, and quorum checks use the TIP-1070 current committee. The registry activation path gates activation on quorum at the activation epoch. If quorum is missing, the scheduled digest MUST NOT activate and the active digest MUST remain unchanged.
+Mitigation: Readiness reports use the current block proposer public key, and quorum checks use the TIP-1070 current committee. The registry activation path gates activation on quorum at the activation epoch. If quorum is missing, the scheduled feature head MUST NOT activate and the active feature head MUST remain unchanged.
 
 ### Scheduling and Ecosystem Readiness
 
 Threat: Activation could be scheduled for the wrong target or before the ecosystem is ready.
 
-Mitigation: The registry owner can cancel or reschedule activation before the activation epoch, but cannot lower the active digest after activation. Release notes and activation communications must distinguish validator quorum from ecosystem readiness because RPC nodes, indexers, monitoring, and partner systems do not contribute to validator quorum.
+Mitigation: The registry owner can cancel or reschedule activation before the activation epoch, but cannot lower the active feature head after activation. Release notes and activation communications must distinguish validator quorum from ecosystem readiness because RPC nodes, indexers, monitoring, and partner systems do not contribute to validator quorum.
 
 ### Post-Activation
 
 Threat: An operator could roll back or disable behavior after it becomes active chain history.
 
-Mitigation: Nodes must not validate, build, simulate, or serve post-activation protocol behavior for a chain whose active digest is not present in the node's supported feature cache.
+Mitigation: Nodes must not validate, build, simulate, or serve post-activation protocol behavior for a chain whose active feature head is not present in the node's supported feature cache.
 
 ## Alternatives Considered
 
@@ -208,7 +208,7 @@ Mitigation: Nodes must not validate, build, simulate, or serve post-activation p
 
 An alternative design is to store an unordered set of active feature names and let each feature activate independently.
 
-This TIP uses a single ordered activation chain instead. An unordered feature set would require specs, implementations, audits, tests, monitoring, and operator guidance to account for many possible feature combinations and activation orders. It would also require validators to report exact supported feature sets rather than readiness for one scheduled stack digest.
+This TIP uses a single ordered activation chain instead. An unordered feature set would require specs, implementations, audits, tests, monitoring, and operator guidance to account for many possible feature combinations and activation orders. It would also require validators to report exact supported feature sets rather than readiness for one scheduled feature head.
 
 The tradeoff is that features do not activate in arbitrary order. If an earlier feature is deferred but a later feature should still activate, the earlier feature name must become a reserved no-op entry.
 
@@ -216,26 +216,26 @@ The tradeoff is that features do not activate in arbitrary order. If an earlier 
 
 An earlier design stored a `uint64 featuresTip` high-water mark. This is compact, but it is ambiguous across releases if the same numeric tip refers to different implementation history.
 
-This TIP uses a hash-chain commitment instead. The digest commits to the ordered feature-name prefix and lets a node decide locally whether a scheduled target is present in its supported chain.
+This TIP uses a hash-chain commitment instead. The feature head commits to the ordered feature-name prefix and lets a node decide locally whether a scheduled feature head is present in its supported chain.
 
 ## Invariants
 
-1. `bytes32(0)` means no active, scheduled, or reported-ready protocol feature digest.
+1. `bytes32(0)` means no active, scheduled, or reported-ready feature head.
 2. `active_feature_head` starts at `bytes32(0)` unless genesis sets a higher value.
-3. A node supports a stack digest if and only if that digest is present in its local feature cache.
-4. Feature names included in any supported digest are append-only. The canonical name and order of an existing feature entry must not change.
+3. A node supports a feature head if and only if that head is present in its local feature cache.
+4. Feature names included in any supported feature head are append-only. The canonical name and order of an existing feature entry must not change.
 5. A reserved no-op feature name has no protocol effect.
-6. The registry stores at most one pending scheduled digest for a network.
-7. A scheduled digest must be nonzero, not already active, and have a scheduled activation epoch in the future when scheduled.
+6. The registry stores at most one pending scheduled feature head for a network.
+7. A scheduled feature head must be nonzero, not already active, and have a scheduled activation epoch in the future when scheduled.
 8. Only the registry owner can schedule or cancel feature activation.
-9. Only the system caller can record validator readiness reports or activate a scheduled digest during block processing.
-10. A validator can only report readiness for the currently scheduled digest.
-11. Quorum for scheduled digest `H` counts a validator if and only if its latest reported-ready digest is exactly `H`.
-12. A scheduled digest activates only if the TIP-1070 current committee has quorum readiness for that target digest.
-13. A node can import pre-activation blocks that schedule an unknown digest, but it must not report readiness for an unsupported scheduled digest.
-14. `activateScheduledFeatureHead()` returns `bytes32(0)` when no digest activates and a nonzero digest only when it activates that digest.
-15. A block executor can commit activation-call state only after the call succeeds, its return value decodes to `bytes32`, and any nonzero returned digest is supported locally.
-16. A node must not validate, build, simulate, or serve post-activation protocol behavior for a chain whose active digest is not present in the node's supported feature cache.
+9. Only the system caller can record validator readiness reports or activate a scheduled feature head during block processing.
+10. A validator can only report readiness for the currently scheduled feature head.
+11. Quorum for scheduled feature head `H` counts a validator if and only if its latest reported-ready head is exactly `H`.
+12. A scheduled feature head activates only if the TIP-1070 current committee has quorum readiness for that head.
+13. A node can import pre-activation blocks that schedule an unknown feature head, but it must not report readiness for an unsupported scheduled feature head.
+14. `activateScheduledFeatureHead()` returns `bytes32(0)` when no feature head activates and a nonzero feature head only when it activates that head.
+15. A block executor can commit activation-call state only after the call succeeds, its return value decodes to `bytes32`, and any nonzero returned feature head is supported locally.
+16. A node must not validate, build, simulate, or serve post-activation protocol behavior for a chain whose active feature head is not present in the node's supported feature cache.
 
 ## Interfaces
 
@@ -253,32 +253,32 @@ interface IFeatureRegistry {
     /// @notice Returns the fixed global activation quorum threshold: 4/5, or 80%.
     function activationQuorum() external view returns (uint256 numerator, uint256 denominator);
 
-    /// @notice Returns the active feature stack digest.
+    /// @notice Returns the active feature head.
     function activeFeatureHead() external view returns (bytes32);
 
-    /// @notice Returns the scheduled feature stack digest and earliest activation epoch.
+    /// @notice Returns the scheduled feature head and activation epoch.
     function scheduledFeatureHead() external view returns (bytes32 featureHead, uint64 activationEpoch);
 
-    /// @notice Reports whether the proposer validator is ready for the currently scheduled digest. System caller only.
+    /// @notice Reports whether the proposer validator is ready for the currently scheduled feature head. System caller only.
     function reportFeatureReadiness(bool ready) external;
 
-    /// @notice Schedules a feature stack digest for activation at the target epoch.
+    /// @notice Schedules a feature head for activation at the target epoch.
     function scheduleFeatureHead(bytes32 featureHead, uint64 activationEpoch) external;
 
-    /// @notice Activates the scheduled digest during block processing. System caller only.
-    /// @return activatedFeatureHead The activated digest, or zero if no digest activated.
+    /// @notice Activates the scheduled feature head during block processing. System caller only.
+    /// @return activatedFeatureHead The activated feature head, or zero if none activated.
     function activateScheduledFeatureHead() external returns (bytes32 activatedFeatureHead);
 
-    /// @notice Cancels the scheduled digest before activation.
+    /// @notice Cancels the scheduled feature head before activation.
     function cancelScheduledFeatureHead() external;
 
-    /// @notice Returns whether a validator reported readiness for the scheduled digest.
+    /// @notice Returns whether a validator reported readiness for the scheduled feature head.
     function validatorConfirmedScheduledFeatureReadiness(address validator) external view returns (bool);
 
-    /// @notice Returns current active-validator readiness for the scheduled digest.
+    /// @notice Returns current active-validator readiness for the scheduled feature head.
     function scheduledFeatureSupport() external view returns (uint256 support, uint256 required);
 
-    /// @notice Returns whether the scheduled digest has quorum readiness from the active validator set.
+    /// @notice Returns whether the scheduled feature head has quorum readiness from the active validator set.
     function hasScheduledFeatureQuorum() external view returns (bool);
 }
 ```
@@ -286,16 +286,16 @@ interface IFeatureRegistry {
 ### Events
 
 ```solidity
-/// @notice Emitted when a validator reports readiness for a digest.
+/// @notice Emitted when a validator reports readiness for a feature head.
 event FeatureReadinessReported(address indexed validator, bytes32 indexed featureHead, bool ready);
 
-/// @notice Emitted when a digest is scheduled for activation.
+/// @notice Emitted when a feature head is scheduled for activation.
 event FeatureHeadScheduled(bytes32 indexed featureHead, uint64 activationEpoch);
 
-/// @notice Emitted when the scheduled digest is cancelled.
+/// @notice Emitted when the scheduled feature head is cancelled.
 event FeatureHeadScheduleCancelled(bytes32 indexed featureHead);
 
-/// @notice Emitted when a scheduled digest becomes active during epoch processing.
+/// @notice Emitted when a scheduled feature head becomes active during epoch processing.
 event FeatureHeadActivated(bytes32 indexed previousFeatureHead, bytes32 indexed featureHead, uint64 activationEpoch);
 ```
 
@@ -305,16 +305,16 @@ event FeatureHeadActivated(bytes32 indexed previousFeatureHead, bytes32 indexed 
 /// @notice Caller is not authorized to update feature registry state.
 error Unauthorized();
 
-/// @notice Feature stack digest is invalid or reserved.
+/// @notice Feature head is invalid or reserved.
 error InvalidFeatureHead();
 
-/// @notice Feature stack digest is already active.
+/// @notice Feature head is already active.
 error FeatureHeadAlreadyActive();
 
-/// @notice A digest is already scheduled for activation.
+/// @notice A feature head is already scheduled for activation.
 error FeatureHeadAlreadyScheduled();
 
-/// @notice No digest is scheduled for activation.
+/// @notice No feature head is scheduled for activation.
 error FeatureHeadNotScheduled();
 
 /// @notice The current block does not include a proposer public key.

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -37,18 +37,6 @@ The feature head avoids ambiguity between releases. If `v1.9.0` and `v1.9.1` bot
 
 # Specification
 
-## Activation Lifecycle
-
-Feature activation follows one forward-only path:
-
-1. A feature name is appended to the source-controlled feature list, producing a new feature head.
-2. A Tempo release ships with support for that feature head in its local cache.
-3. The registry owner schedules the feature head for a future activation epoch.
-4. Validators report readiness for the scheduled feature head from blocks they propose.
-5. On the first block of the scheduled epoch, the block executor calls `activateScheduledFeatureHead()`.
-6. The registry checks TIP-1070 current committee quorum once, clears the schedule, and either activates the feature head or leaves the active head unchanged.
-7. If a nonzero feature head activates, the block executor verifies local support before committing activation-call state.
-
 ## Feature Chain
 
 A protocol feature is a named protocol change that can be supported by a binary before it is active on the chain. The source-controlled feature registry is an ordered list of canonical feature names:
@@ -82,9 +70,18 @@ A binary MUST maintain a local cache of every supported feature head, including 
 
 A node MUST NOT reject a block merely because the block schedules a feature head that is not present in the node's local feature cache. Before activation, an unknown scheduled feature head is operator-visible state; it does not change protocol behavior. A validator whose binary does not support the scheduled feature head MUST NOT report readiness for it.
 
-To skip or withdraw a feature before it activates, its entry MUST either become a reserved no-op feature name or the deferred feature MUST move to a later name. Once a release can support a feature head, every feature name that contributes to that head MUST be append-only. Changing or reordering an existing name changes every later head and creates a distinct feature chain.
+Feature activation is performed at consensus epoch boundaries. The registry owner schedules a target feature head and an activation epoch. Feature activation occurs during block processing for that epoch; no external activation transaction is required.
 
-Activation eligibility is bound to consensus epochs rather than wall-clock timestamps. The registry owner schedules a target feature head and an activation epoch. Feature activation occurs during block processing for that epoch; no external activation transaction is required.
+## Activation Lifecycle
+
+Feature activation follows one forward-only path:
+
+1. A feature name is appended to the source-controlled feature list, producing a new feature head.
+2. A Tempo release ships with support for that feature head in its local cache.
+3. The registry owner schedules the feature head for a future activation epoch.
+4. Validators report readiness for the scheduled feature head from blocks they propose.
+5. On the first block of the scheduled epoch, the block executor calls `activateScheduledFeatureHead()`.
+6. The registry checks TIP-1070 current committee quorum once, clears the schedule, and either activates the feature head or leaves the active head unchanged.
 
 ## Feature Registry
 

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -120,17 +120,17 @@ The registry MUST accept the scheduling transaction only if:
 
 Scheduling MUST write `scheduled_feature_head` and `scheduled_activation_epoch`, then emit an event to notify network participants. The scheduled epoch is the earliest consensus epoch in which the chain attempts to activate the target digest. Operators should upgrade before that epoch if they are running a release that does not support the scheduled digest.
 
-Feature activation occurs during pre-execution of the first block of the scheduled activation epoch. During block processing, the system caller invokes `activateScheduledFeatureHead()`. The activation call does not take an epoch argument.
+Feature activation occurs during pre-execution of the first block of the scheduled activation epoch. During block processing, the system caller invokes `activateScheduledFeatureHead()`. The activation call does not take an epoch argument and returns the activated digest, or `bytes32(0)` if no digest activated.
 
 For quorum checks, the active validator set is the TIP-1070 current committee exposed by the `CurrentCommittee` precompile. The feature registry MUST NOT keep a separate validator roster for feature activation and MUST NOT derive quorum membership from `ValidatorConfigV2.getActiveValidators()`.
 
 To evaluate readiness for scheduled digest `H`, the quorum check iterates the current committee public keys, resolves each public key to its validator address, and counts each validator whose `validator_confirmed_feature_head[validator] == H`. A scheduled digest has quorum when at least 80% of current committee validators have reported readiness for that exact digest. The required validator count is `ceil(4 * current_committee_size / 5)`.
 
-If quorum is satisfied at feature activation, the chain MUST set `active_feature_head` to `scheduled_feature_head`, clear the scheduled fields, and emit an activation event. Protocol behavior gated by newly active features applies to block execution after activation in that block, unless a feature's own TIP specifies transition-block behavior.
+If quorum is satisfied at feature activation, the chain MUST set `active_feature_head` to `scheduled_feature_head`, clear the scheduled fields, emit an activation event, and return the activated digest from `activateScheduledFeatureHead()`. Protocol behavior gated by newly active features applies to block execution after activation in that block, unless a feature's own TIP specifies transition-block behavior.
 
-If activation sets `active_feature_head` to a digest that is not present in a node's local feature cache, that node MUST fail closed when validating or building the activation block or any later block. The block may be valid for binaries that support the activated digest, but an unsupported binary cannot safely evaluate post-activation protocol behavior.
+If `activateScheduledFeatureHead()` returns a nonzero digest that is not present in a node's local feature cache, that node MUST fail closed before committing the activation block state. The block may be valid for binaries that support the activated digest, but an unsupported binary cannot safely evaluate post-activation protocol behavior.
 
-If quorum is not satisfied at feature activation, the chain MUST clear `scheduled_feature_head` and `scheduled_activation_epoch` and leave `active_feature_head` unchanged. The registry owner can schedule the same or another digest for a later epoch after the missing quorum condition is resolved.
+If quorum is not satisfied at feature activation, the chain MUST clear `scheduled_feature_head` and `scheduled_activation_epoch`, leave `active_feature_head` unchanged, and return `bytes32(0)`. The registry owner can schedule the same or another digest for a later epoch after the missing quorum condition is resolved.
 
 Nodes derive the active feature set from registry state. Validators, RPC nodes, consensus-layer clients, and other infrastructure MUST use the same active digest when evaluating protocol behavior for a block. After feature activation, any node that validates, builds, simulates, or serves protocol behavior for later blocks MUST support the active digest.
 
@@ -272,7 +272,8 @@ interface IFeatureRegistry {
     function scheduleFeatureHead(bytes32 featureHead, uint64 activationEpoch) external;
 
     /// @notice Activates the scheduled digest during block processing. System caller only.
-    function activateScheduledFeatureHead() external;
+    /// @return activatedFeatureHead The activated digest, or zero if no digest activated.
+    function activateScheduledFeatureHead() external returns (bytes32 activatedFeatureHead);
 
     /// @notice Cancels the scheduled digest before activation.
     function cancelScheduledFeatureHead() external;

--- a/tips/tip-1063.md
+++ b/tips/tip-1063.md
@@ -37,7 +37,19 @@ The feature head avoids ambiguity between releases. If `v1.9.0` and `v1.9.1` bot
 
 # Specification
 
-## Overview
+## Activation Lifecycle
+
+Feature activation follows one forward-only path:
+
+1. A feature name is appended to the source-controlled feature list, producing a new feature head.
+2. A Tempo release ships with support for that feature head in its local cache.
+3. The registry owner schedules the feature head for a future activation epoch.
+4. Validators report readiness for the scheduled feature head from blocks they propose.
+5. On the first block of the scheduled epoch, the block executor calls `activateScheduledFeatureHead()`.
+6. The registry checks TIP-1070 current committee quorum once, clears the schedule, and either activates the feature head or leaves the active head unchanged.
+7. If a nonzero feature head activates, the block executor verifies local support before committing activation-call state.
+
+## Feature Chain
 
 A protocol feature is a named protocol change that can be supported by a binary before it is active on the chain. The source-controlled feature registry is an ordered list of canonical feature names:
 


### PR DESCRIPTION
Stacked on #4079.

Updates TIP-1063 to match the current activation design: feature activation uses a `bytes32` hash-chain commitment, validators report readiness for the scheduled digest with `reportFeatureReadiness(bool ready)`, activation runs in the first block of the scheduled epoch, and quorum uses the TIP-1070 current committee.

Also refreshes the feature registry interface, events, errors, invariants, and threat model around readiness reports, including `ready = false` cancellation after validator rollback.

Validation: `git diff --check`.
