### PR TITLE
Bump tips verify Foundry hardfork to T8

### DIFF
--- a/tips/verify/README.md
+++ b/tips/verify/README.md
@@ -6,7 +6,7 @@ This directory contains Solidity spec verification tests and fuzz harnesses for 
 
 ## Profiles
 
-The checked-in `foundry.toml` uses two profiles, which default to the Tempo T6 hardfork and run against a Tempo-native EVM with enabled Rust precompiles:
+The checked-in `foundry.toml` uses two profiles, which default to the Tempo T8 hardfork and run against a Tempo-native EVM with enabled Rust precompiles:
 
 - `default`: config for standard Foundry build/fmt/ABI tasks. Lighter optimizer and fuzz/invariant settings, for quicker output.
 - `fuzz500`: config for extended invariant runs.

--- a/tips/verify/foundry.toml
+++ b/tips/verify/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-hardfork = "tempo:T7"
+hardfork = "tempo:T8"
 
 # layout and file system
 src = "src"


### PR DESCRIPTION
## Summary
- update tips/verify Foundry default hardfork from tempo:T7 to tempo:T8
- update the tips/verify README to describe the T8 default

## Why
The devnet and workflow defaults are moving to T8, but tips/verify/foundry.toml still defaulted local Foundry runs to tempo:T7. This keeps local/default spec verification aligned with the active devnet hardfork.

## Validation
- git diff --check
- rg -n 'tempo:T7|Tempo T6 hardfork|Tempo T7 hardfork' tips/verify/foundry.toml tips/verify/README.md -S returned no matches

Prompted by: @grandizzy