### PR TITLE
Use StageX for reproducible build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,9 +221,50 @@ jobs:
             ${{ steps.prepare.outputs.binary_name }}.sha256
           if-no-files-found: error
 
+  github-reproducible-build:
+    name: GitHub Reproducible Build
+    needs: get-version
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
+    uses: ./.github/workflows/reproducible-build.yml
+    with:
+      ref: ${{ github.sha }}
+
+  verify-reproducible-builds:
+    name: Verify Reproducible Builds
+    needs: [github-reproducible-build]
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
+    runs-on: depot-ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require Argo reproducible verifier
+        env:
+          EXPECTED_COMMIT: ${{ needs.github-reproducible-build.outputs.commit }}
+          EXPECTED_TARGET: ${{ needs.github-reproducible-build.outputs.target }}
+          EXPECTED_SHA256: ${{ needs.github-reproducible-build.outputs.binary_sha256 }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          curl --fail --silent --show-error \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/commits/${EXPECTED_COMMIT}/status" \
+            --output commit-status.json
+
+          state=$(jq -r '.statuses[] | select(.context == "argo/repro-verify") | .state' commit-status.json | head -n 1)
+          description=$(jq -r '.statuses[] | select(.context == "argo/repro-verify") | .description' commit-status.json | head -n 1)
+
+          [[ "$state" == "success" ]] || {
+            echo "Argo reproducible verifier has not marked ${EXPECTED_COMMIT} successful; state=${state:-missing}; description=${description:-missing}" >&2
+            exit 1
+          }
+
+          echo "GitHub reproducible build produced $EXPECTED_TARGET $EXPECTED_SHA256"
+          echo "Argo reproducible verifier marked $EXPECTED_COMMIT successful"
+
   create-release:
     name: Create Release
-    needs: [get-version, build-release]
+    needs: [get-version, build-release, verify-reproducible-builds]
     if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
     runs-on: depot-ubuntu-latest
     permissions:
@@ -368,7 +409,7 @@ jobs:
             --body-file "$body_file"
   upload-cloudflare:
     name: Upload to R2 bucket
-    needs: [get-version, build-release]
+    needs: [get-version, build-release, verify-reproducible-builds]
     if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
     runs-on: depot-ubuntu-latest
     permissions:

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -1,7 +1,7 @@
 name: Reproducible Build
 
 # Builds the byte-deterministic `tempo` binary for x86_64-unknown-linux-gnu
-# from the pinned Dockerfile.reproducible recipe.
+# from the StageX-based Dockerfile.reproducible recipe.
 
 permissions: {}
 
@@ -23,6 +23,23 @@ on:
         type: string
         required: false
         default: "main"
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref (branch, tag, or full SHA) to build reproducibly"
+        type: string
+        required: false
+        default: ""
+    outputs:
+      commit:
+        description: "Commit that was built"
+        value: ${{ jobs.build.outputs.commit }}
+      target:
+        description: "Rust target that was built"
+        value: ${{ jobs.build.outputs.target }}
+      binary_sha256:
+        description: "SHA-256 of the reproducible tempo binary"
+        value: ${{ jobs.build.outputs.binary_sha256 }}
 
 jobs:
   build:
@@ -30,6 +47,10 @@ jobs:
     runs-on: depot-ubuntu-latest-16
     permissions:
       contents: read
+    outputs:
+      commit: ${{ steps.cfg.outputs.commit }}
+      target: ${{ steps.cfg.outputs.target }}
+      binary_sha256: ${{ steps.hash.outputs.binary_sha256 }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -37,7 +58,7 @@ jobs:
           # `inputs.ref` is empty on push events (push has no inputs);
           # checkout falls back to github.sha — the pushed commit. On
           # workflow_dispatch it's the user-chosen ref (defaulted to main).
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -49,9 +70,12 @@ jobs:
           # confused with a real release asset (which uses v-prefixed tags).
           SHORT=$(git rev-parse --short=7 HEAD)
           SHA=$(git rev-parse HEAD)
-          echo "version=sha-$SHORT"                       >> "$GITHUB_OUTPUT"
-          echo "artifact=reproducible-hash-${SHA}"        >> "$GITHUB_OUTPUT"
-          echo "bin=tempo-sha-${SHORT}-x86_64-unknown-linux-gnu" >> "$GITHUB_OUTPUT"
+          TARGET=x86_64-unknown-linux-gnu
+          echo "version=sha-$SHORT"                 >> "$GITHUB_OUTPUT"
+          echo "artifact=reproducible-hash-${SHA}"  >> "$GITHUB_OUTPUT"
+          echo "bin=tempo-sha-${SHORT}-${TARGET}"   >> "$GITHUB_OUTPUT"
+          echo "commit=$SHA"                        >> "$GITHUB_OUTPUT"
+          echo "target=$TARGET"                     >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -59,9 +83,8 @@ jobs:
       - name: Build reproducible binary
         env:
           VERSION: ${{ steps.cfg.outputs.version }}
-        # Retry the docker build a few times to absorb the dominant transient
-        # failure (snapshot.debian.org throttling/503s during apt-get inside
-        # the Dockerfile).
+        # Retry the docker build a few times to absorb transient registry or
+        # network failures while pulling StageX package layers.
         run: |
           set -euo pipefail
           for attempt in 1 2 3; do
@@ -90,10 +113,12 @@ jobs:
           echo "commit            = $(git rev-parse HEAD)"
           echo "version           = ${{ steps.cfg.outputs.version }}"
           echo "binary            = $BIN"
+          echo "target            = ${{ steps.cfg.outputs.target }}"
           echo "SOURCE_DATE_EPOCH = $(git log -1 --pretty=%ct)"
           cat "${BIN}.reproducible.sha256"
           echo "::endgroup::"
           echo "checksum=${BIN}.reproducible.sha256" >> "$GITHUB_OUTPUT"
+          awk '{ print "binary_sha256="$1 }' "${BIN}.reproducible.sha256" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -14,8 +14,12 @@
 # Output (with `--target artifacts -o type=local,dest=./out`):
 #   ./out/tempo                              the reproducible binary
 #
+# StageX composes build dependencies from deterministic OCI package layers. The
+# Rust pallet is musl-hosted; the GNU target is linked through StageX's
+# x86_64-linux-gnu cross-GCC/glibc layer.
+#
 # Reproducibility-critical decisions:
-#   * Pinned base image digest (rust 1.96.0 on Debian Bookworm).
+#   * Pinned StageX image references.
 #   * `cargo --locked` so registry deps cannot drift.
 #   * RUSTFLAGS strip every source of nondeterminism we know about:
 #     SOURCE_DATE_EPOCH for build timestamps, --remap-path-prefix for the
@@ -23,50 +27,18 @@
 #     the linker's GNU build-id note, symbol-mangling-version=v0 for stable
 #     mangling, and -C metadata= to remove the per-build hash that influences
 #     symbol names.
-#   * JEMALLOC_OVERRIDE points jemalloc-sys at the system static archive so
-#     it doesn't recompile its bundled C with embedded timestamps.
 #   * `[profile.reproducible]` (defined in Cargo.toml) disables incremental,
 #     emits no debuginfo, and inherits `release`'s fat LTO + 1 codegen-unit.
 
-ARG RUST_TOOLCHAIN=1.96.0
-FROM rust:${RUST_TOOLCHAIN}-bookworm@sha256:64d9b7f60e3abb08d477cad983d0a3743acc53a19369ba4482510184c9c807e5 AS builder
+FROM stagex/pallet-rust@sha256:59d4d0c9e232a05ecb99348f7216b521af1b914a430059dbdb9130018f2afde1 AS builder
+
+COPY --from=stagex/core-clang@sha256:498cdb41678fa060561131e49bb96f42b788098de00f6d5caca80f3fe0272170 . /
+COPY --from=stagex/core-mold@sha256:bd94fefd849b665d2577b9a79fa7a8bd9ba6a08df125f7b3a86a22aecd537579 . /
+COPY --from=stagex/core-pkgconf@sha256:510abfd0f0897b710ad350e39bda7676045a3cce8e723316a6d6e9651e9560b9 . /
+COPY --from=stagex/core-cross-x86_64-gnu-gcc@sha256:9aaf8b67e14f30663fdf8107d31e7cd7a29f1a1676d59b58e53c3d3d0cc3e921 . /
 
 ARG SOURCE_DATE_EPOCH
 ARG VERSION
-# Pinned snapshot of the Debian package archive. Bumping this is the *only*
-# legitimate reason for a Debian-side byte change between two builds of the
-# same source tree. Without it, an `apt-get install libjemalloc-dev` between
-# two Debian point releases will silently pull in different upstream bytes
-# and break byte-equality with the original release build.
-#
-# Pick a snapshot >= the date the release was built. The value is intentionally
-# defaulted here so an external rebuilder running `docker build` from a
-# checked-out tag with no extra args reproduces what CI did at that tag.
-ARG DEBIAN_SNAPSHOT=20260501T000000Z
-
-# Repoint apt at snapshot.debian.org and disable the validity check (snapshots
-# carry stale Release files by design). The base image's pinned-by-digest
-# `/etc/apt/sources.list` is overwritten wholesale so subsequent `apt-get`
-# calls in this stage are deterministic regardless of which sources-list
-# format the upstream image happened to ship with.
-RUN echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ bookworm main" \
-        > /etc/apt/sources.list && \
-    echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/ bookworm-security main" \
-        >> /etc/apt/sources.list && \
-    echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ bookworm-updates main" \
-        >> /etc/apt/sources.list && \
-    rm -f /etc/apt/sources.list.d/debian.sources
-
-# Build-time system dependencies, installed from the pinned snapshot above.
-RUN apt-get -o Acquire::Check-Valid-Until=false update && \
-    apt-get install -y --no-install-recommends \
-        libjemalloc-dev \
-        libclang-dev \
-        clang \
-        libssl-dev \
-        pkg-config \
-        mold && \
-    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY . .
@@ -74,8 +46,10 @@ COPY . .
 ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} \
     LC_ALL=C \
     TZ=UTC \
-    JEMALLOC_OVERRIDE=/usr/lib/x86_64-linux-gnu/libjemalloc.a \
-    RUSTFLAGS="-C symbol-mangling-version=v0 -C strip=none -C link-arg=-Wl,--build-id=none -C link-arg=-fuse-ld=mold -C metadata= --remap-path-prefix /app=. --remap-path-prefix /usr/local/cargo/registry=/registry --remap-path-prefix /usr/local/rustup=/rustup"
+    CC=x86_64-linux-gnu-gcc \
+    CXX=x86_64-linux-gnu-g++ \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc \
+    RUSTFLAGS="-C symbol-mangling-version=v0 -C strip=none -C link-arg=-Wl,--build-id=none -C metadata= --remap-path-prefix /app=. --remap-path-prefix /usr/local/cargo/registry=/registry --remap-path-prefix /usr/local/rustup=/rustup --remap-path-prefix /usr/lib/cargo=/cargo --remap-path-prefix /usr/lib/rustlib=/rustlib"
 
 RUN cargo build --locked --bin tempo \
         --features asm-keccak,jemalloc,otlp \

--- a/scripts/reproducible-build.sh
+++ b/scripts/reproducible-build.sh
@@ -15,8 +15,6 @@
 # Inputs (env):
 #   VERSION       — informational tag baked into the build context (default: dev)
 #   OUT_DIR       — where the built binary lands (default: ./out)
-#   DEBIAN_SNAPSHOT — pin the Debian apt snapshot used inside the image
-#                     (default: the value baked into Dockerfile.reproducible)
 #
 # Output:
 #   $OUT_DIR/tempo   — the byte-deterministic binary
@@ -27,7 +25,6 @@ cd "$(git rev-parse --show-toplevel)"
 
 VERSION="${VERSION:-dev}"
 OUT_DIR="${OUT_DIR:-./out}"
-DEBIAN_SNAPSHOT="${DEBIAN_SNAPSHOT:-}"
 
 SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"
 COMMIT="$(git rev-parse HEAD)"
@@ -39,8 +36,8 @@ printf '  commit              = %s\n' "$COMMIT"
 printf '  version             = %s\n' "$VERSION"
 printf '  SOURCE_DATE_EPOCH   = %s\n' "$SOURCE_DATE_EPOCH"
 printf '  Dockerfile          = Dockerfile.reproducible\n'
+printf '  target              = x86_64-unknown-linux-gnu\n'
 printf '  out_dir             = %s\n' "$OUT_DIR"
-[[ -n "$DEBIAN_SNAPSHOT" ]] && printf '  DEBIAN_SNAPSHOT     = %s (override)\n' "$DEBIAN_SNAPSHOT"
 echo "::endgroup::"
 
 mkdir -p "$OUT_DIR"
@@ -49,9 +46,6 @@ build_args=(
   --build-arg "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
   --build-arg "VERSION=$VERSION"
 )
-if [[ -n "$DEBIAN_SNAPSHOT" ]]; then
-  build_args+=( --build-arg "DEBIAN_SNAPSHOT=$DEBIAN_SNAPSHOT" )
-fi
 
 docker build \
   --platform linux/amd64 \


### PR DESCRIPTION
## Summary
- replace the Debian/Rust reproducible build image and apt snapshot setup with pinned StageX image layers
- keep the reproducible binary target on x86_64-unknown-linux-gnu by adding StageX's pinned x86_64-linux-gnu cross-GCC/glibc layer
- make reproducible-build.yml reusable and expose commit/target/sha256 outputs
- gate release creation and R2 upload on the existing Argo verifier's `argo/repro-verify` GitHub commit status

## Testing
- bash -n scripts/reproducible-build.sh
- git diff --check

Note: full Docker/BuildKit validation was not available in this sandbox because the Docker daemon is not reachable.

Prompted by: @0xalpharush