### PR TITLE
fix(evm): batch DEX execution microbench workflows

### DIFF
--- a/crates/evm/benches/dex_execution.rs
+++ b/crates/evm/benches/dex_execution.rs
@@ -43,7 +43,7 @@ use tempo_primitives::{TempoAddressExt, TempoTxEnvelope};
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 const PARTICIPANT_MINT_AMOUNT: u128 = 1_000_000_000_000_000_000;
-const DEX_BENCH_TX_COUNT: usize = 1_024;
+const DEX_SCENARIO_COUNT: usize = 256;
 const DEX_ORDER_AMOUNT: u128 = 1_000_000_000;
 const DEX_TX_GAS_LIMIT: u64 = 20_000_000;
 const DEX_BASE_TOKEN_SALT: B256 = B256::ZERO;
@@ -111,13 +111,6 @@ fn seed_dex_cache_db(
                 };
                 quote.mint(admin, mint.clone())?;
                 base.mint(admin, mint)?;
-
-                let approve = ITIP20::approveCall {
-                    spender: STABLECOIN_DEX_ADDRESS,
-                    amount: U256::MAX,
-                };
-                quote.approve(*participant, approve.clone())?;
-                base.approve(*participant, approve)?;
             }
 
             StablecoinDEX::new().initialize()?;
@@ -258,6 +251,9 @@ fn dex_bench_workloads() -> Vec<DexBenchWorkload> {
             .abi_encode(),
         )
     };
+    let ask_tick = |idx: usize| 1_500 - idx as i16 * 10;
+    let bid_tick = |idx: usize| -1_500 + idx as i16 * 10;
+    let signer = |idx: usize| &signers[idx % signers.len()];
 
     let workload = |name, transactions| DexBenchWorkload {
         name,
@@ -267,11 +263,94 @@ fn dex_bench_workloads() -> Vec<DexBenchWorkload> {
     let many_single_call = |call: Bytes| {
         signers
             .iter()
-            .take(DEX_BENCH_TX_COUNT)
+            .take(4 * DEX_SCENARIO_COUNT)
             .map(|signer| sign_dex_call(signer, call.clone()))
             .collect()
     };
-    let one_multicall = |calls| vec![sign_dex_calls(&signers[0], calls)];
+
+    let cancel_orders = |flip: bool| {
+        (0..DEX_SCENARIO_COUNT)
+            .map(|idx| {
+                let tick = bid_tick(idx);
+                let place_order = if flip {
+                    place_flip(true, tick, tick + 10)
+                } else {
+                    place(true, tick)
+                };
+                sign_dex_calls(signer(idx), vec![place_order, cancel(idx as u128 + 1)])
+            })
+            .collect()
+    };
+    let partial_fill_asks = |flip: bool| {
+        (0..DEX_SCENARIO_COUNT)
+            .map(|idx| {
+                let tick = ask_tick(idx);
+                let place_order = if flip {
+                    place_flip(false, tick, tick - 10)
+                } else {
+                    place(false, tick)
+                };
+                sign_dex_calls(
+                    signer(idx),
+                    vec![place_order, swap_in(quote_token, base_token, fill)],
+                )
+            })
+            .collect()
+    };
+    let full_fill_asks = |flip: bool| {
+        (0..DEX_SCENARIO_COUNT)
+            .map(|idx| {
+                let tick = ask_tick(idx);
+                let place_order = if flip {
+                    place_flip(false, tick, tick - 10)
+                } else {
+                    place(false, tick)
+                };
+                sign_dex_calls(
+                    signer(idx),
+                    vec![place_order, swap_out(quote_token, base_token, amount)],
+                )
+            })
+            .collect()
+    };
+    let three_asks_fill_two_and_half = |flip: bool| {
+        (0..DEX_SCENARIO_COUNT)
+            .flat_map(|idx| {
+                let tick = ask_tick(idx);
+                let place_order = || {
+                    if flip {
+                        place_flip(false, tick, tick - 10)
+                    } else {
+                        place(false, tick)
+                    }
+                };
+                [
+                    sign_dex_calls(
+                        signer(idx * 2),
+                        vec![place_order(), place_order(), place_order()],
+                    ),
+                    sign_dex_call(
+                        signer(idx * 2 + 1),
+                        swap_out(quote_token, base_token, amount * 2 + amount / 2),
+                    ),
+                ]
+            })
+            .collect()
+    };
+    let flip_bid_full_fill = || {
+        (0..DEX_SCENARIO_COUNT)
+            .map(|idx| {
+                let tick = bid_tick(idx);
+                sign_dex_calls(
+                    signer(idx),
+                    vec![
+                        place_flip(true, tick, tick + 10),
+                        swap_in(base_token, quote_token, amount),
+                    ],
+                )
+            })
+            .collect()
+    };
 
     vec![
         workload("dex_place_ask_orders", many_single_call(place(false, 0))),
@@ -279,37 +358,24 @@ fn dex_bench_workloads() -> Vec<DexBenchWorkload> {
             "dex_place_flip_ask_orders",
             many_single_call(place_flip(false, 0, -10)),
         ),
+        workload("dex_cancel_orders", cancel_orders(false)),
+        workload("dex_cancel_flip_orders", cancel_orders(true)),
+        workload("dex_partial_fill_asks_exact_in", partial_fill_asks(false)),
         workload(
-            "dex_cancel_orders",
-            one_multicall(vec![place(true, -60), cancel(1)]),
+            "dex_partial_fill_flip_asks_exact_in",
+            partial_fill_asks(true),
         ),
-        workload(
-            "dex_partial_fill_asks_exact_in",
-            one_multicall(vec![
-                place(false, 100),
-                swap_in(quote_token, base_token, fill),
-            ]),
-        ),
+        workload("dex_full_fill_asks_exact_out", full_fill_asks(false)),
+        workload("dex_full_fill_flip_asks_exact_out", full_fill_asks(true)),
         workload(
             "dex_three_asks_fill_two_and_half",
-            vec![
-                sign_dex_calls(
-                    &signers[0],
-                    vec![place(false, 70), place(false, 70), place(false, 70)],
-                ),
-                sign_dex_call(
-                    &signers[1],
-                    swap_out(quote_token, base_token, amount * 2 + amount / 2),
-                ),
-            ],
+            three_asks_fill_two_and_half(false),
         ),
         workload(
-            "dex_flip_bid_full_fill",
-            one_multicall(vec![
-                place_flip(true, 20, 30),
-                swap_in(base_token, quote_token, amount),
-            ]),
+            "dex_three_flip_asks_fill_two_and_half",
+            three_asks_fill_two_and_half(true),
         ),
+        workload("dex_flip_bid_full_fill", flip_bid_full_fill()),
     ]
 }
 fn dex_order_execution(c: &mut Criterion) {

--- a/crates/evm/benches/dex_execution.rs
+++ b/crates/evm/benches/dex_execution.rs
@@ -254,6 +254,13 @@ fn dex_bench_workloads() -> Vec<DexBenchWorkload> {
     let ask_tick = |idx: usize| 1_500 - idx as i16 * 10;
     let bid_tick = |idx: usize| -1_500 + idx as i16 * 10;
     let signer = |idx: usize| &signers[idx % signers.len()];
+    let place_order = |flip: bool, is_bid: bool, tick: i16| {
+        if flip {
+            place_flip(is_bid, tick, tick + if is_bid { 10 } else { -10 })
+        } else {
+            place(is_bid, tick)
+        }
+    };
 
     let workload = |name, transactions| DexBenchWorkload {
         name,
@@ -267,67 +274,41 @@ fn dex_bench_workloads() -> Vec<DexBenchWorkload> {
             .map(|signer| sign_dex_call(signer, call.clone()))
             .collect()
     };
+    let scenario_txs = |build_calls: &dyn Fn(usize) -> Vec<Bytes>| {
+        (0..DEX_SCENARIO_COUNT)
+            .map(|idx| sign_dex_calls(signer(idx), build_calls(idx)))
+            .collect()
+    };
 
     let cancel_orders = |flip: bool| {
-        (0..DEX_SCENARIO_COUNT)
-            .map(|idx| {
-                let tick = bid_tick(idx);
-                let place_order = if flip {
-                    place_flip(true, tick, tick + 10)
-                } else {
-                    place(true, tick)
-                };
-                sign_dex_calls(signer(idx), vec![place_order, cancel(idx as u128 + 1)])
-            })
-            .collect()
+        scenario_txs(&|idx| {
+            let tick = bid_tick(idx);
+            vec![place_order(flip, true, tick), cancel(idx as u128 + 1)]
+        })
     };
-    let partial_fill_asks = |flip: bool| {
-        (0..DEX_SCENARIO_COUNT)
-            .map(|idx| {
-                let tick = ask_tick(idx);
-                let place_order = if flip {
-                    place_flip(false, tick, tick - 10)
-                } else {
-                    place(false, tick)
-                };
-                sign_dex_calls(
-                    signer(idx),
-                    vec![place_order, swap_in(quote_token, base_token, fill)],
-                )
-            })
-            .collect()
-    };
-    let full_fill_asks = |flip: bool| {
-        (0..DEX_SCENARIO_COUNT)
-            .map(|idx| {
-                let tick = ask_tick(idx);
-                let place_order = if flip {
-                    place_flip(false, tick, tick - 10)
-                } else {
-                    place(false, tick)
-                };
-                sign_dex_calls(
-                    signer(idx),
-                    vec![place_order, swap_out(quote_token, base_token, amount)],
-                )
-            })
-            .collect()
+    let fill_asks = |flip: bool, full: bool| {
+        scenario_txs(&|idx| {
+            let tick = ask_tick(idx);
+            let fill_call = if full {
+                swap_out(quote_token, base_token, amount)
+            } else {
+                swap_in(quote_token, base_token, fill)
+            };
+            vec![place_order(flip, false, tick), fill_call]
+        })
     };
     let three_asks_fill_two_and_half = |flip: bool| {
         (0..DEX_SCENARIO_COUNT)
             .flat_map(|idx| {
                 let tick = ask_tick(idx);
-                let place_order = || {
-                    if flip {
-                        place_flip(false, tick, tick - 10)
-                    } else {
-                        place(false, tick)
-                    }
-                };
                 [
                     sign_dex_calls(
                         signer(idx * 2),
-                        vec![place_order(), place_order(), place_order()],
+                        vec![
+                            place_order(flip, false, tick),
+                            place_order(flip, false, tick),
+                            place_order(flip, false, tick),
+                        ],
                     ),
                     sign_dex_call(
                         signer(idx * 2 + 1),
@@ -338,18 +319,13 @@ fn dex_bench_workloads() -> Vec<DexBenchWorkload> {
             .collect()
     };
     let flip_bid_full_fill = || {
-        (0..DEX_SCENARIO_COUNT)
-            .map(|idx| {
-                let tick = bid_tick(idx);
-                sign_dex_calls(
-                    signer(idx),
-                    vec![
-                        place_flip(true, tick, tick + 10),
-                        swap_in(base_token, quote_token, amount),
-                    ],
-                )
-            })
-            .collect()
+        scenario_txs(&|idx| {
+            let tick = bid_tick(idx);
+            vec![
+                place_order(true, true, tick),
+                swap_in(base_token, quote_token, amount),
+            ]
+        })
     };
 
     vec![
@@ -360,13 +336,13 @@ fn dex_bench_workloads() -> Vec<DexBenchWorkload> {
         ),
         workload("dex_cancel_orders", cancel_orders(false)),
         workload("dex_cancel_flip_orders", cancel_orders(true)),
-        workload("dex_partial_fill_asks_exact_in", partial_fill_asks(false)),
+        workload("dex_partial_fill_asks_exact_in", fill_asks(false, false)),
         workload(
             "dex_partial_fill_flip_asks_exact_in",
-            partial_fill_asks(true),
+            fill_asks(true, false),
         ),
-        workload("dex_full_fill_asks_exact_out", full_fill_asks(false)),
-        workload("dex_full_fill_flip_asks_exact_out", full_fill_asks(true)),
+        workload("dex_full_fill_asks_exact_out", fill_asks(false, true)),
+        workload("dex_full_fill_flip_asks_exact_out", fill_asks(true, true)),
         workload(
             "dex_three_asks_fill_two_and_half",
             three_asks_fill_two_and_half(false),

--- a/crates/evm/benches/dex_execution.rs
+++ b/crates/evm/benches/dex_execution.rs
@@ -270,12 +270,12 @@ fn dex_bench_workloads() -> Vec<DexBenchWorkload> {
     let many_single_call = |call: Bytes| {
         signers
             .iter()
-            .take(4 * DEX_SCENARIO_COUNT)
+            .take(4 * DEX_SCENARIO_TX_COUNT)
             .map(|signer| sign_dex_call(signer, call.clone()))
             .collect()
     };
     let scenario_txs = |build_calls: &dyn Fn(usize) -> Vec<Bytes>| {
-        (0..DEX_SCENARIO_COUNT)
+        (0..DEX_SCENARIO_TX_COUNT)
             .map(|idx| sign_dex_calls(signer(idx), build_calls(idx)))
             .collect()
     };
@@ -298,7 +298,7 @@ fn dex_bench_workloads() -> Vec<DexBenchWorkload> {
         })
     };
     let three_asks_fill_two_and_half = |flip: bool| {
-        (0..DEX_SCENARIO_COUNT)
+        (0..DEX_SCENARIO_TX_COUNT)
             .flat_map(|idx| {
                 let tick = ask_tick(idx);
                 [

--- a/crates/evm/benches/dex_execution.rs
+++ b/crates/evm/benches/dex_execution.rs
@@ -43,7 +43,7 @@ use tempo_primitives::{TempoAddressExt, TempoTxEnvelope};
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 const PARTICIPANT_MINT_AMOUNT: u128 = 1_000_000_000_000_000_000;
-const DEX_SCENARIO_COUNT: usize = 256;
+const DEX_SCENARIO_TX_COUNT: usize = 256;
 const DEX_ORDER_AMOUNT: u128 = 1_000_000_000;
 const DEX_TX_GAS_LIMIT: u64 = 20_000_000;
 const DEX_BASE_TOKEN_SALT: B256 = B256::ZERO;


### PR DESCRIPTION
this PR batches the DEX execution microbench workflows so codespeed measures repeated scenarios instead of single sub-ms transactions.

the simple benches still run 1024 txs, while cancel, fill, and flip workflows now run 256 repeated scenarios with varied ticks to reduce cross-workflow interference.

this should improve signal quality for dex-related performance comparisons.