### PR TITLE
docs: revise TIP-1070 current committee spec

### DIFF
--- a/tips/tip-1070.md
+++ b/tips/tip-1070.md
@@ -50,16 +50,19 @@ Committee state MUST live in dedicated execution-layer state for the current eff
 This TIP defines a network parameter:
 
 ```solidity
-address constant CURRENT_COMMITTEE_ADDRESS = TBD;
+address constant CURRENT_COMMITTEE_ADDRESS = 0xC077E00000000000000000000000000000000000;
 ```
 
-Implementations SHOULD expose the committee through the dedicated system contract or precompile at `CURRENT_COMMITTEE_ADDRESS`, following the same broad model as EIP-2935's history contract: consensus writes protocol data into contract storage during block processing, and EVM callers read it through a narrow contract interface.
+Implementations MUST expose the committee through the dedicated precompile at `CURRENT_COMMITTEE_ADDRESS`, following the same broad model as EIP-2935's history contract: consensus writes protocol data into execution-layer state during block processing, and EVM callers read it through a narrow precompile interface.
 
 ## Interface
 
 The committee-state component exposes a current-only read query:
 
 ```solidity
+/// @notice Thrown when a non-system caller attempts to update committee state.
+error Unauthorized();
+
 /// @notice Get the effective committee members for the current epoch.
 /// @dev This returns the DKG outcome players selected by consensus, not the registry's active validator set.
 /// @return epoch Epoch for which the returned committee is effective.
@@ -68,12 +71,19 @@ function getCommitteeMembers()
     external
     view
     returns (uint64 epoch, bytes32[] memory publicKeys);
+
+/// @notice Set the effective committee members for the next epoch.
+/// @dev Only the protocol system caller may invoke this function.
+/// @param publicKeys Effective committee member public keys, in DKG outcome player order.
+function setCommitteeMembers(bytes32[] calldata publicKeys) external;
 ```
 
 `getCommitteeMembers()` MUST return the committee used by consensus for the epoch containing the block at which the call is evaluated.
 The returned `epoch` MUST be computed from the block number at which the call is evaluated and the chain's epoch schedule.
 
 The returned `publicKeys` MUST be ordered exactly as the `players` vector in the DKG outcome selected for that epoch. The execution-layer writer MUST NOT infer whether DKG succeeded or failed; consensus has already selected the DKG outcome whose `players` vector encodes the committee members for the rising epoch.
+
+`setCommitteeMembers(bytes32[] calldata publicKeys)` MUST revert with `Unauthorized` unless `msg.sender` is the protocol system caller. Tempo's implementation uses the zero address, `0x0000000000000000000000000000000000000000`, as the system caller for this update.
 
 ## Contract Storage
 
@@ -101,8 +111,6 @@ The system call MUST call `CURRENT_COMMITTEE_ADDRESS` from the system address wi
 function setCommitteeMembers(bytes32[] calldata publicKeys) external;
 ```
 
-The system call MUST NOT pass an epoch argument.
-
 The system call MUST read the DKG outcome from the boundary block's extra data and persist:
 
 ```text
@@ -113,7 +121,7 @@ The system call MUST overwrite the stored `bytes32[] publicKeys` array with `sel
 
 ## Activation
 
-At activation, implementations MUST deploy the committee contract at `CURRENT_COMMITTEE_ADDRESS`. Activation MUST NOT initialize the committee state from the latest DKG outcome.
+TIP-1070 activates at Tempo hardfork T8. At activation, implementations MUST deploy the committee precompile marker at `CURRENT_COMMITTEE_ADDRESS`. Activation MUST NOT initialize the committee state from the latest DKG outcome.
 
 Before the first boundary system call completes, `getCommitteeMembers()` MUST NOT return `getActiveValidators()` or any inferred fallback committee.
 


### PR DESCRIPTION
## Summary
- Fill in the CurrentCommittee precompile address and T8 activation details
- Document the implemented ABI, system-only setter authorization, and non-stored epoch behavior
- Clarify that committee state is exposed through the dedicated precompile and overwritten at epoch boundaries

## Tests
- Not run (documentation-only change)

Prompted by: @horsefacts