### PR TITLE
chore(deps): patch reth-core codec crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8822,8 +8822,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb43f4858fef4e3b42b80954d2edf1ff67c8ad7498347083cdc7d0f6eff2f081"
+source = "git+https://github.com/paradigmxyz/reth-core?branch=mattsse%2Frlp-raw-byte-roundtrip-tests#98139deaacfdbad81e287b3ae1ae18654516fa1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8843,8 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5798ae4d6b264764bc0d742468bd32c7fb515e774645d4930f95ff6311f3ae14"
+source = "git+https://github.com/paradigmxyz/reth-core?branch=mattsse%2Frlp-raw-byte-roundtrip-tests#98139deaacfdbad81e287b3ae1ae18654516fa1a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10405,8 +10403,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59c928b2865af5bcdbce94800270b7f7798f27a22ca0aabdd2b7d3e6587c9ce"
+source = "git+https://github.com/paradigmxyz/reth-core?branch=mattsse%2Frlp-raw-byte-roundtrip-tests#98139deaacfdbad81e287b3ae1ae18654516fa1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11317,8 +11314,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1bd4ae4f54a2ba813eef082910bc646bd31cab8ed134308fa71f1068331fb84"
+source = "git+https://github.com/paradigmxyz/reth-core?branch=mattsse%2Frlp-raw-byte-roundtrip-tests#98139deaacfdbad81e287b3ae1ae18654516fa1a"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -405,6 +405,11 @@ vergen-git2 = "10.0.1"
 
 [patch.crates-io]
 
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", branch = "mattsse/rlp-raw-byte-roundtrip-tests" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", branch = "mattsse/rlp-raw-byte-roundtrip-tests" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", branch = "mattsse/rlp-raw-byte-roundtrip-tests" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", branch = "mattsse/rlp-raw-byte-roundtrip-tests" }
+
 # Commonware at HEAD after PR #3588 was merged
 commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }


### PR DESCRIPTION
Patches `reth-codecs`, `reth-codecs-derive`, `reth-primitives-traits`, and `reth-zstd-compressors` to the `reth-core` PR branch for the generated RLP encode-decode-encode assertion.

Depends on paradigmxyz/reth-core#39.