### PR TITLE
Add CREATE2 multisig recovery derivation

### DIFF
--- a/crates/primitives/src/transaction/multisig.rs
+++ b/crates/primitives/src/transaction/multisig.rs
@@ -43,6 +43,25 @@ pub const MAX_MULTISIG_OWNER_SIGNATURE_BYTES: usize = 1 + MAX_WEBAUTHN_SIGNATURE
 
 const MULTISIG_ACCOUNT_DOMAIN: &[u8] = b"tempo:multisig:account";
 
+/// Canonical factory address used to anchor native multisig account derivation to CREATE2.
+pub const MULTISIG_RECOVERY_FACTORY: Address = Address::new([
+    0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xe8, 0xb4, 0x7b, 0x3e, 0x21, 0x30, 0x21, 0x3b, 0x80, 0x22,
+    0x12, 0x43, 0x94, 0x97,
+]);
+
+/// Keccak256 hash of the canonical `TempoMultisigRecoveryWallet` EVM creation code.
+///
+/// Committed constant used in native multisig account derivation. It must equal
+/// `keccak256(TempoMultisigRecoveryWallet.creationCode)` from the canonical build (Solidity 0.8.34,
+/// optimizer enabled with 200 runs, via-IR, Cancun, `bytecode_hash = "none"`, `cbor_metadata =
+/// false`). Regenerate with `tips/verify/gen_recovery_init_code_hash.sh` after any change to
+/// `tips/verify/src/TempoMultisigRecovery.sol`; a mismatch means Tempo derives a different address
+/// than the recovery factory would deploy, making cross-chain recovery impossible.
+pub const MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH: B256 = B256::new([
+    0xc3, 0x66, 0x2d, 0x32, 0x91, 0x07, 0xe9, 0x81, 0x50, 0x1c, 0xe1, 0x41, 0x01, 0x4f, 0x6e, 0x1c,
+    0xf0, 0xfa, 0x3d, 0xd7, 0x63, 0xde, 0x02, 0x41, 0xc8, 0x0a, 0x01, 0xcd, 0x7f, 0x71, 0x0b, 0xb1,
+]);
+
 /// Native multisig config validation error.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum MultisigConfigError {
@@ -307,8 +326,24 @@ impl InitMultisig {
 
     /// Derives the native multisig account address for this initial config.
     pub fn account(&self) -> Result<Address, MultisigConfigError> {
-        self.validate()?;
+        let account_salt = self.account_salt()?;
 
+        let mut input = [0u8; 1 + 20 + 32 + 32];
+        input[0] = 0xff;
+        input[1..21].copy_from_slice(MULTISIG_RECOVERY_FACTORY.as_slice());
+        input[21..53].copy_from_slice(account_salt.as_slice());
+        input[53..85].copy_from_slice(MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH.as_slice());
+
+        let account = Address::from_slice(&keccak256(input)[12..]);
+        if account.is_zero() {
+            return Err(MultisigConfigError::DerivedAccountZero);
+        }
+        Ok(account)
+    }
+
+    /// Derives the CREATE2 salt used by cross-chain recovery wallets for this config.
+    pub fn account_salt(&self) -> Result<B256, MultisigConfigError> {
+        self.validate()?;
         let owner_count =
             u8::try_from(self.owners.len()).expect("validated multisig owner count fits in u8");
         let mut input = Vec::with_capacity(
@@ -323,11 +358,7 @@ impl InitMultisig {
             input.push(owner.weight);
         }
 
-        let account = Address::from_slice(&keccak256(input)[12..]);
-        if account.is_zero() {
-            return Err(MultisigConfigError::DerivedAccountZero);
-        }
-        Ok(account)
+        Ok(keccak256(input))
     }
 
     /// Returns the configured weight for an owner, if present.
@@ -1033,6 +1064,24 @@ mod tests {
             nonzero_salt.account().unwrap()
         );
         zero_salt.validate().expect("zero salt is valid");
+    }
+
+    #[test]
+    fn account_derivation_matches_create2_recovery_wallet() {
+        let owner = Address::from([0x11; 20]);
+        let config = sorted_secp_config(&[(owner, 1)], 1);
+        let account_salt = config.account_salt().unwrap();
+
+        let mut input = [0u8; 85];
+        input[0] = 0xff;
+        input[1..21].copy_from_slice(MULTISIG_RECOVERY_FACTORY.as_slice());
+        input[21..53].copy_from_slice(account_salt.as_slice());
+        input[53..85].copy_from_slice(MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH.as_slice());
+
+        assert_eq!(
+            config.account().unwrap(),
+            Address::from_slice(&keccak256(input)[12..])
+        );
     }
 
     #[test]

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -33,6 +33,13 @@ pub const SIGNATURE_TYPE_MULTISIG: u8 = 0x05;
 /// Domain prefix for native multisig owner approvals.
 pub const MULTISIG_SIGNATURE_DOMAIN: &[u8] = b"tempo:multisig:signature";
 
+/// Canonical factory address used to anchor native multisig account derivation to CREATE2.
+pub const MULTISIG_RECOVERY_FACTORY: Address = 0x0000000000FfE8b47B3e2130213b802212439497;
+
+/// Keccak256 hash of the canonical TempoMultisigRecoveryWallet EVM creation code.
+pub const MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH: B256 =
+    0xc3662d329107e981501ce141014f6e1cf0fa3dd763de0241c80a01cd7f710bb1;
+
 /// Maximum number of owners allowed in a native multisig config.
 pub const MAX_MULTISIG_OWNERS: usize = 255;
 
@@ -52,6 +59,8 @@ pub const MAX_MULTISIG_OWNER_SIGNATURE_BYTES: usize = 2049;
 
 - `SIGNATURE_TYPE_MULTISIG` is a new Tempo signature type byte in the `TempoSignature` byte-encoding namespace.
 - `MULTISIG_SIGNATURE_DOMAIN` is used only inside the owner approval digest. It is distinct from the wire signature type byte.
+- `MULTISIG_RECOVERY_FACTORY` is the canonical CREATE2 deployer for recovery wallets on EVM chains.
+- `MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH` commits to the recovery wallet creation code used in the CREATE2 derivation. The canonical build uses Solidity 0.8.34, optimizer enabled, via-IR enabled, Cancun EVM version, and no compiler metadata (`bytecode_hash = "none"`, `cbor_metadata = false`).
 - `MAX_MULTISIG_OWNERS` bounds stored config size and precompile config update/read work.
 - `MAX_MULTISIG_THRESHOLD` bounds the configured quorum a single native multisig account can require. Because owner weights are nonzero, it also bounds the number of owner approvals needed to satisfy one multisig authorization node.
 - `MAX_MULTISIG_SIGNATURES` bounds the number of owner approvals submitted in one native multisig signature.
@@ -220,10 +229,11 @@ Decoding rules:
 
 ### Multisig Identity
 
-The initial multisig configuration determines the native multisig account address:
+The initial multisig configuration determines the native multisig account address. First derive the
+CREATE2 salt:
 
 ```text
-account = address(keccak256(
+account_salt = keccak256(
   "tempo:multisig:account" ||
   salt ||
   uint8(threshold) ||
@@ -233,25 +243,48 @@ account = address(keccak256(
   owners[1].owner ||
   uint8(owners[1].weight) ||
   ...
+)
+```
+
+Then derive the account address using the CREATE2 address formula:
+
+```text
+account = address(keccak256(
+  0xff ||
+  MULTISIG_RECOVERY_FACTORY ||
+  account_salt ||
+  MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH
 )[12:32])
 ```
+
+This is equivalent to the address that would be created by:
+
+```text
+CREATE2(
+  deployer = MULTISIG_RECOVERY_FACTORY,
+  salt = account_salt,
+  init_code = TempoMultisigRecoveryWallet.creationCode
+)
+```
+
+Tempo native multisig bootstrap does not deploy this EVM bytecode. The formula is used so the same address can be materialized by a recovery wallet on other EVM chains.
 
 Account derivation rules:
 
 - A derived account equal to `address(0)` is invalid.
-- `salt` is part of account derivation. The same `(threshold, owners)` with different `salt` values MUST derive distinct account addresses, except with negligible address-collision probability.
+- `salt` is part of `account_salt`. The same `(threshold, owners)` with different `salt` values MUST derive distinct account addresses, except with negligible address-collision probability.
 - `salt` MAY be any 32-byte value, including `bytes32(0)`.
 - `owners` MUST be sorted in strictly ascending `owner` address order before hashing.
 - Duplicate owner addresses, zero owner addresses, and zero owner weights are invalid.
-- `owners.len()` is part of account derivation. This one-byte encoding supports owner counts from 1 through 255.
+- `owners.len()` is part of `account_salt`. This one-byte encoding supports owner counts from 1 through 255.
 - Owner uniqueness is by `owner` address.
 
-Fixed-width integer fields included in the account derivation hash input use fixed-width big-endian unsigned byte encoding, not RLP integer encoding. The `uint8` fields are encoded as one byte.
+Fixed-width integer fields included in the `account_salt` hash input use fixed-width big-endian unsigned byte encoding, not RLP integer encoding. The `uint8` fields are encoded as one byte.
 
 The domain string literal in account derivation is encoded as the exact ASCII bytes shown, with no length prefix.
 
 - Account derivation does not include `chain_id`.
-- The same `(salt, threshold, owners)` triple derives the same multisig account address across Tempo chains.
+- The same `(salt, threshold, owners)` triple derives the same multisig account address across Tempo chains and across EVM chains that deploy the canonical recovery factory and wallet creation code.
 
 Derived account rules:
 
@@ -275,6 +308,31 @@ These checks apply only to native account state. External contract balances, rol
 Funds sent to an uninitialized derived multisig address can be claimed by any transaction that provides the matching initial config and valid threshold owner approvals.
 
 The derived account address is stable. Owner, weight, and threshold updates mutate the current config stored for the account, but they do not change `account`.
+
+### Cross-chain Recovery
+
+The CREATE2-style account derivation enables recovery of funds accidentally sent to the multisig address on non-Tempo EVM chains.
+
+Recovery contract requirements:
+
+- The canonical `TempoMultisigRecoveryFactory` MUST be deployed at `MULTISIG_RECOVERY_FACTORY`, at the identical address on every supported EVM chain, using a deterministic keyless deployment (e.g. a CREATE2 singleton deployer). Funds sent to a native multisig address on a chain where the factory is absent, or where a different contract occupies `MULTISIG_RECOVERY_FACTORY`, are not recoverable through this mechanism.
+- The factory MUST deploy `TempoMultisigRecoveryWallet` with `CREATE2` using `salt = account_salt`, and MUST bind the wallet to that salt in the same transaction (the wallet records it once at deployment).
+- The factory MUST expose the predicted wallet address for an `account_salt`.
+- The deployed wallet address MUST equal `derive_multisig_account(init)`.
+- `MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH` MUST equal `keccak256` of the canonical `TempoMultisigRecoveryWallet` creation code (Solidity 0.8.34, optimizer enabled with 200 runs, via-IR, Cancun, no metadata). A mismatch makes the Tempo-derived address differ from the address the factory deploys to, so recovery becomes impossible; regenerate with `tips/verify/gen_recovery_init_code_hash.sh`.
+- The wallet MUST recompute `account_salt` from `InitMultisig` using the same account derivation payload rules as this TIP, and MUST reject any recovery whose `init` does not re-derive the `account_salt` bound at deployment. Without this binding any caller could recover with an arbitrary owner set and drain the wallet.
+- The wallet MUST verify threshold owner signatures against a recovery-specific digest that includes the destination chain ID, wallet address, `account_salt`, wallet nonce, and requested calls.
+- The wallet MUST reject duplicate, unsorted, non-owner, malformed, or below-threshold signatures.
+- The wallet MUST restrict recovery execution to asset transfers: native-value transfers (empty calldata) and the standard ERC-20 `transfer`, ERC-721 `safeTransferFrom`, and ERC-1155 `safeTransferFrom` / `safeBatchTransferFrom` selectors. It MUST reject approvals, governance, bridging, and any other arbitrary call.
+
+Recovery authorization is based on the immutable initial config committed to by `account_salt`. Tempo config updates do not change `account_salt` or the recovery wallet address, so on other chains the wallet is always authorized by the *initial* owner set and threshold, never the current Tempo config. Two consequences follow, and both are accepted (this matches the cross-chain model of counterfactually-deployed Safe accounts):
+
+- Rotating owners out on Tempo does not rotate them on other chains: the initial owner set retains the ability to recover assets from the address on every chain where the factory is deployed, and losing the initial key set makes non-Tempo assets unrecoverable.
+- Because recovery is restricted to asset transfers, a compromised initial owner set can move assets held at the address but cannot use it for governance, voting, bridging, approvals, or arbitrary calls.
+
+Deployments that need latest-config recovery MUST add an external proof or attestation for the current Tempo config, such as a Tempo checkpoint, oracle, or light-client proof over `(account, config_version, threshold, owners)`.
+
+The baseline recovery contract in this TIP supports secp256k1 owner signatures. P256, WebAuthn, and nested multisig recovery on generic EVM chains require chain-specific verifier support and are outside the baseline recovery contract.
 
 ### Owner Approval Digest
 
@@ -976,6 +1034,8 @@ This TIP does not define any single-key path that executes with the multisig acc
 - Reject bootstrap when the account derived from `signature.init` was computed with omitted owner count.
 - Reject bootstrap when the account derived from `signature.init` was computed with omitted `salt`.
 - Reject bootstrap when the derived account is `address(0)`.
+- Confirm `derive_multisig_account(init)` matches the CREATE2 formula using `MULTISIG_RECOVERY_FACTORY`, `salt = account_salt`, and `MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH`.
+- Reject bootstrap when `signature.account` was computed directly from `account_salt` instead of the CREATE2 formula.
 - Confirm the same `(salt, threshold, owners)` triple derives the same account across different `chain_id` values.
 - Confirm the same `(threshold, owners)` with two different `salt` values derives two distinct accounts.
 - Accept bootstrap with `salt == bytes32(0)`.
@@ -1164,6 +1224,18 @@ This TIP does not define any single-key path that executes with the multisig acc
 
 - Reject `0x05 || rlp([account, signatures, init?])` in `ISignatureVerifier.recover`.
 - Reject `0x05 || rlp([account, signatures, init?])` in `ISignatureVerifier.verify`.
+
+### Cross-chain Recovery
+
+- Confirm the recovery factory deploys `TempoMultisigRecoveryWallet` at `derive_multisig_account(init)` using `CREATE2`.
+- Confirm ETH or ERC-20 funds sent to the undeployed recovery wallet address can be swept after deployment with valid threshold signatures from the initial config.
+- Reject recovery with a modified `salt`, owner list, owner weight, or threshold.
+- Reject recovery whose `init` does not re-derive the wallet's deployment `account_salt` (a caller-supplied owner set for a different config, signed by that config's owners, must not drain the wallet).
+- Reject recovery with duplicate, unsorted, non-owner, malformed, or below-threshold signatures.
+- Reject recovery calls that are not native-value transfers or standard ERC-20/721/1155 transfer selectors (e.g. `approve`, arbitrary contract calls).
+- Confirm ERC-20 `transfer` and ERC-721/1155 `safeTransferFrom` recoveries succeed for assets held by the wallet.
+- Confirm recovery signatures are not replayable across chain IDs, wallet addresses, account salts, nonces, or requested call sets.
+- Confirm Tempo config updates do not change `derive_multisig_account(init)` or baseline recovery authorization.
 
 ## Reference Implementation
 

--- a/tips/verify/gen_recovery_init_code_hash.sh
+++ b/tips/verify/gen_recovery_init_code_hash.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Regenerates MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH (committed in tip-1061.md and the
+# tempo-primitives multisig module) from the canonical standard-EVM build of
+# TempoMultisigRecoveryWallet. The recovery contracts must build under standard Cancun (not the
+# tempo hardfork the rest of tips/verify uses), so this uses an isolated Foundry config.
+#
+# Usage: tips/verify/gen_recovery_init_code_hash.sh
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/src"
+cp "$here/src/TempoMultisigRecovery.sol" "$tmp/src/"
+cat > "$tmp/foundry.toml" <<'TOML'
+[profile.default]
+solc = "0.8.34"
+evm_version = "cancun"
+optimizer = true
+via_ir = true
+bytecode_hash = "none"
+cbor_metadata = false
+TOML
+forge inspect --root "$tmp" src/TempoMultisigRecovery.sol:TempoMultisigRecoveryWallet bytecode \
+  | cast keccak

--- a/tips/verify/src/TempoMultisigRecovery.sol
+++ b/tips/verify/src/TempoMultisigRecovery.sol
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.34;
+
+/// @notice CREATE2 factory for native multisig recovery wallets on non-Tempo EVM chains.
+contract TempoMultisigRecoveryFactory {
+
+    error DeploymentFailed();
+
+    event RecoveryWalletDeployed(bytes32 indexed accountSalt, address indexed wallet);
+
+    bytes32 public constant WALLET_INIT_CODE_HASH =
+        keccak256(type(TempoMultisigRecoveryWallet).creationCode);
+
+    function walletAddress(bytes32 accountSalt) public view returns (address) {
+        bytes32 digest = keccak256(
+            abi.encodePacked(bytes1(0xff), address(this), accountSalt, WALLET_INIT_CODE_HASH)
+        );
+        return address(uint160(uint256(digest)));
+    }
+
+    function deploy(bytes32 accountSalt) public returns (address wallet) {
+        wallet = walletAddress(accountSalt);
+        if (wallet.code.length != 0) {
+            return wallet;
+        }
+
+        bytes memory creationCode = type(TempoMultisigRecoveryWallet).creationCode;
+        assembly {
+            wallet := create2(0, add(creationCode, 0x20), mload(creationCode), accountSalt)
+        }
+        if (wallet == address(0)) {
+            revert DeploymentFailed();
+        }
+        // Bind the freshly deployed wallet to the config committed to by `accountSalt`. Only this
+        // factory can CREATE2 a wallet at this address, and it always initializes in the same
+        // transaction, so `recover` can trust the stored salt as the wallet's true config.
+        TempoMultisigRecoveryWallet(payable(wallet)).initialize(accountSalt);
+        emit RecoveryWalletDeployed(accountSalt, wallet);
+    }
+
+}
+
+/// @notice Minimal recovery wallet for assets sent to a native multisig address on EVM chains.
+contract TempoMultisigRecoveryWallet {
+
+    struct Owner {
+        address owner;
+        uint8 weight;
+    }
+
+    struct InitMultisig {
+        bytes32 salt;
+        uint8 threshold;
+        Owner[] owners;
+    }
+
+    struct Call {
+        address target;
+        uint256 value;
+        bytes data;
+    }
+
+    error InvalidConfig();
+    error InvalidSignature();
+    error InvalidThreshold();
+    error InvalidOwner();
+    error CallFailed(uint256 index, bytes returndata);
+    error AlreadyInitialized();
+    error UnsupportedCall(uint256 index);
+
+    // Standard token transfer selectors. Recovery is limited to these (plus native-value sweeps)
+    // so a compromised or malicious initial owner set cannot use the cross-chain address for
+    // governance, bridging, approvals, or any other arbitrary call — only asset recovery.
+    bytes4 internal constant ERC20_TRANSFER = 0xa9059cbb; // transfer(address,uint256)
+    bytes4 internal constant ERC721_SAFE_TRANSFER_FROM = 0x42842e0e; // safeTransferFrom(a,a,u256)
+    bytes4 internal constant ERC721_SAFE_TRANSFER_FROM_DATA = 0xb88d4fde; // safeTransferFrom(a,a,u,b)
+    bytes4 internal constant ERC1155_SAFE_TRANSFER_FROM = 0xf242432a; // safeTransferFrom(a,a,u,u,b)
+    bytes4 internal constant ERC1155_SAFE_BATCH_TRANSFER_FROM = 0x2eb2c2d6; // safeBatchTransferFrom
+
+    uint256 public nonce;
+
+    /// @notice CREATE2 salt committing to the immutable initial config this wallet recovers for.
+    /// @dev Set once by the factory in the same transaction as deployment. `recover` requires the
+    /// supplied config to re-derive this salt, so a caller cannot recover with an arbitrary config.
+    bytes32 public accountSalt;
+
+    bytes internal constant ACCOUNT_DOMAIN = "tempo:multisig:account";
+    bytes internal constant RECOVERY_DOMAIN = "tempo:multisig:recovery";
+    uint256 internal constant MAX_OWNERS = 255;
+
+    receive() external payable { }
+
+    /// @notice Binds this wallet to the config committed to by `salt`. Callable once.
+    /// @dev Permissionless but safe: only the factory can CREATE2 a wallet at this address, and it
+    /// always calls this in the same transaction as deployment, so the wallet is never observable
+    /// in a deployed-but-uninitialized state.
+    function initialize(bytes32 salt) external {
+        if (accountSalt != bytes32(0) || salt == bytes32(0)) {
+            revert AlreadyInitialized();
+        }
+        accountSalt = salt;
+    }
+
+    function recover(
+        InitMultisig calldata init,
+        bytes[] calldata signatures,
+        Call[] calldata calls
+    )
+        external
+        payable
+    {
+        // Bind the supplied config to the one this wallet was deployed for. Without this check any
+        // caller could pass their own owner set + signatures and drain the wallet.
+        if (deriveAccountSalt(init) != accountSalt) {
+            revert InvalidConfig();
+        }
+        bytes32 digest = recoveryDigest(accountSalt, calls);
+        verifyOwnerSignatures(init, digest, signatures);
+        unchecked {
+            ++nonce;
+        }
+
+        for (uint256 i = 0; i < calls.length; ++i) {
+            if (!_isAllowedRecoveryCall(calls[i])) {
+                revert UnsupportedCall(i);
+            }
+            (bool ok, bytes memory returndata) =
+                calls[i].target.call{ value: calls[i].value }(calls[i].data);
+            if (!ok) {
+                revert CallFailed(i, returndata);
+            }
+        }
+    }
+
+    /// @notice Restricts recovery to native-value sweeps and standard ERC-20/721/1155 transfers.
+    /// @dev A data-carrying call must target a standard transfer selector and send no value; an
+    /// empty-calldata call is a native-value sweep. Everything else (approvals, governance,
+    /// bridging, arbitrary calls) is rejected.
+    function _isAllowedRecoveryCall(Call calldata call_) internal pure returns (bool) {
+        if (call_.data.length == 0) {
+            return true;
+        }
+        if (call_.value != 0 || call_.data.length < 4) {
+            return false;
+        }
+        bytes4 selector = bytes4(call_.data[:4]);
+        return selector == ERC20_TRANSFER || selector == ERC721_SAFE_TRANSFER_FROM
+            || selector == ERC721_SAFE_TRANSFER_FROM_DATA || selector == ERC1155_SAFE_TRANSFER_FROM
+            || selector == ERC1155_SAFE_BATCH_TRANSFER_FROM;
+    }
+
+    function deriveAccountSalt(InitMultisig calldata init) public pure returns (bytes32) {
+        validateConfig(init);
+
+        bytes memory input = abi.encodePacked(
+            ACCOUNT_DOMAIN, init.salt, init.threshold, uint8(init.owners.length)
+        );
+        for (uint256 i = 0; i < init.owners.length; ++i) {
+            input = abi.encodePacked(input, init.owners[i].owner, init.owners[i].weight);
+        }
+
+        return keccak256(input);
+    }
+
+    function recoveryDigest(
+        bytes32 accountSalt,
+        Call[] calldata calls
+    )
+        public
+        view
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encodePacked(
+                RECOVERY_DOMAIN, block.chainid, address(this), accountSalt, nonce, hashCalls(calls)
+            )
+        );
+    }
+
+    function hashCalls(Call[] calldata calls) public pure returns (bytes32) {
+        bytes32[] memory callHashes = new bytes32[](calls.length);
+        for (uint256 i = 0; i < calls.length; ++i) {
+            callHashes[i] =
+                keccak256(abi.encode(calls[i].target, calls[i].value, keccak256(calls[i].data)));
+        }
+        return keccak256(abi.encodePacked(callHashes));
+    }
+
+    function validateConfig(InitMultisig calldata init) internal pure {
+        if (init.threshold == 0 || init.owners.length == 0 || init.owners.length > MAX_OWNERS) {
+            revert InvalidThreshold();
+        }
+
+        uint256 totalWeight;
+        address previousOwner;
+        for (uint256 i = 0; i < init.owners.length; ++i) {
+            Owner calldata owner = init.owners[i];
+            if (owner.owner == address(0) || owner.owner <= previousOwner || owner.weight == 0) {
+                revert InvalidOwner();
+            }
+            previousOwner = owner.owner;
+            totalWeight += owner.weight;
+        }
+        if (totalWeight > type(uint8).max || init.threshold > totalWeight) {
+            revert InvalidThreshold();
+        }
+    }
+
+    function verifyOwnerSignatures(
+        InitMultisig calldata init,
+        bytes32 digest,
+        bytes[] calldata signatures
+    )
+        internal
+        pure
+    {
+        if (signatures.length == 0 || signatures.length > MAX_OWNERS) {
+            revert InvalidSignature();
+        }
+
+        uint256 recoveredWeight;
+        address previousSigner;
+        for (uint256 i = 0; i < signatures.length; ++i) {
+            address signer = recoverSigner(digest, signatures[i]);
+            if (signer <= previousSigner) {
+                revert InvalidSignature();
+            }
+            previousSigner = signer;
+
+            uint256 ownerIndex = findOwner(init.owners, signer);
+            recoveredWeight += init.owners[ownerIndex].weight;
+        }
+
+        if (recoveredWeight < init.threshold) {
+            revert InvalidThreshold();
+        }
+    }
+
+    function findOwner(Owner[] calldata owners, address signer) internal pure returns (uint256) {
+        for (uint256 i = 0; i < owners.length; ++i) {
+            if (owners[i].owner == signer) {
+                return i;
+            }
+        }
+        revert InvalidOwner();
+    }
+
+    function recoverSigner(
+        bytes32 digest,
+        bytes calldata signature
+    )
+        internal
+        pure
+        returns (address)
+    {
+        if (signature.length != 65) {
+            revert InvalidSignature();
+        }
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := calldataload(signature.offset)
+            s := calldataload(add(signature.offset, 0x20))
+            v := byte(0, calldataload(add(signature.offset, 0x40)))
+        }
+        if (v < 27) {
+            v += 27;
+        }
+        address signer = ecrecover(digest, v, r, s);
+        if (signer == address(0)) {
+            revert InvalidSignature();
+        }
+        return signer;
+    }
+
+}

--- a/tips/verify/test/TempoMultisigRecovery.t.sol
+++ b/tips/verify/test/TempoMultisigRecovery.t.sol
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.13 <0.9.0;
+
+import {
+    TempoMultisigRecoveryFactory,
+    TempoMultisigRecoveryWallet
+} from "../src/TempoMultisigRecovery.sol";
+import { Test } from "forge-std/Test.sol";
+
+contract TempoMultisigRecoveryTest is Test {
+
+    TempoMultisigRecoveryFactory factory;
+
+    uint256 ownerAKey = 0xA11CE;
+    uint256 ownerBKey = 0xB0B;
+    uint256 ownerCKey = 0xCA11;
+
+    function setUp() public {
+        factory = new TempoMultisigRecoveryFactory();
+    }
+
+    function testDeploysAtCreate2AddressAndSweepsPrefundedEth() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        address predicted = factory.walletAddress(accountSalt);
+        address recipient = address(0xBEEF);
+
+        vm.deal(predicted, 1 ether);
+        assertEq(predicted.balance, 1 ether);
+
+        address deployed = factory.deploy(accountSalt);
+        assertEq(deployed, predicted);
+
+        TempoMultisigRecoveryWallet wallet = TempoMultisigRecoveryWallet(payable(deployed));
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] = TempoMultisigRecoveryWallet.Call({ target: recipient, value: 1 ether, data: "" });
+
+        bytes32 digest = wallet.recoveryDigest(accountSalt, calls);
+        bytes[] memory signatures = _sortedSignatures(ownerAKey, ownerBKey, digest);
+
+        wallet.recover(init, signatures, calls);
+
+        assertEq(recipient.balance, 1 ether);
+        assertEq(predicted.balance, 0);
+        assertEq(wallet.nonce(), 1);
+    }
+
+    function testRejectsBelowThresholdRecovery() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        TempoMultisigRecoveryWallet wallet =
+            TempoMultisigRecoveryWallet(payable(factory.deploy(accountSalt)));
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](0);
+
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = _sign(ownerAKey, wallet.recoveryDigest(accountSalt, calls));
+
+        vm.expectRevert(TempoMultisigRecoveryWallet.InvalidThreshold.selector);
+        wallet.recover(init, signatures, calls);
+    }
+
+    function testRejectsRecoveryWithMismatchedConfig() public {
+        // Deploy the legitimate wallet (bound to `victim`'s config) and fund it.
+        TempoMultisigRecoveryWallet.InitMultisig memory victim = _initConfig();
+        bytes32 victimSalt = _deriveAccountSalt(victim);
+        address walletAddr = factory.deploy(victimSalt);
+        vm.deal(walletAddr, 1 ether);
+        TempoMultisigRecoveryWallet wallet = TempoMultisigRecoveryWallet(payable(walletAddr));
+
+        // Attacker supplies their own single-owner config and signs the wallet's real digest.
+        uint256 attackerKey = 0xBAD;
+        TempoMultisigRecoveryWallet.InitMultisig memory attacker;
+        attacker.salt = bytes32("attacker");
+        attacker.threshold = 1;
+        attacker.owners = new TempoMultisigRecoveryWallet.Owner[](1);
+        attacker.owners[0] =
+            TempoMultisigRecoveryWallet.Owner({ owner: vm.addr(attackerKey), weight: 1 });
+
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] =
+            TempoMultisigRecoveryWallet.Call({ target: address(0xBEEF), value: 1 ether, data: "" });
+
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = _sign(attackerKey, wallet.recoveryDigest(wallet.accountSalt(), calls));
+
+        // The config does not re-derive this wallet's deployment salt, so recovery is rejected and
+        // the funds are untouched.
+        vm.expectRevert(TempoMultisigRecoveryWallet.InvalidConfig.selector);
+        wallet.recover(attacker, signatures, calls);
+        assertEq(walletAddr.balance, 1 ether);
+    }
+
+    function testRejectsNonTransferCall() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        TempoMultisigRecoveryWallet wallet =
+            TempoMultisigRecoveryWallet(payable(factory.deploy(accountSalt)));
+
+        // A non-transfer call (here ERC-20 approve) is rejected even with a valid quorum, so a
+        // compromised owner set cannot use the cross-chain address for approvals, governance, or
+        // bridging — only asset transfers.
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] = TempoMultisigRecoveryWallet.Call({
+            target: address(0xDEAD),
+            value: 0,
+            data: abi.encodeWithSignature("approve(address,uint256)", address(0xBEEF), 1)
+        });
+
+        bytes[] memory signatures =
+            _sortedSignatures(ownerAKey, ownerBKey, wallet.recoveryDigest(accountSalt, calls));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(TempoMultisigRecoveryWallet.UnsupportedCall.selector, uint256(0))
+        );
+        wallet.recover(init, signatures, calls);
+    }
+
+    function testSweepsErc20ViaTransfer() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        address walletAddr = factory.deploy(accountSalt);
+        TempoMultisigRecoveryWallet wallet = TempoMultisigRecoveryWallet(payable(walletAddr));
+
+        MockERC20 token = new MockERC20();
+        token.mint(walletAddr, 1000);
+        address recipient = address(0xBEEF);
+
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] = TempoMultisigRecoveryWallet.Call({
+            target: address(token),
+            value: 0,
+            data: abi.encodeWithSignature("transfer(address,uint256)", recipient, 1000)
+        });
+
+        bytes[] memory signatures =
+            _sortedSignatures(ownerAKey, ownerBKey, wallet.recoveryDigest(accountSalt, calls));
+        wallet.recover(init, signatures, calls);
+
+        assertEq(token.balanceOf(recipient), 1000);
+        assertEq(token.balanceOf(walletAddr), 0);
+    }
+
+    function _initConfig()
+        internal
+        view
+        returns (TempoMultisigRecoveryWallet.InitMultisig memory init)
+    {
+        init.salt = bytes32("native-multisig");
+        init.threshold = 2;
+        init.owners = new TempoMultisigRecoveryWallet.Owner[](3);
+        init.owners[0] = TempoMultisigRecoveryWallet.Owner({ owner: vm.addr(ownerAKey), weight: 1 });
+        init.owners[1] = TempoMultisigRecoveryWallet.Owner({ owner: vm.addr(ownerBKey), weight: 1 });
+        init.owners[2] = TempoMultisigRecoveryWallet.Owner({ owner: vm.addr(ownerCKey), weight: 1 });
+
+        for (uint256 i = 0; i < init.owners.length; ++i) {
+            for (uint256 j = i + 1; j < init.owners.length; ++j) {
+                if (init.owners[j].owner < init.owners[i].owner) {
+                    TempoMultisigRecoveryWallet.Owner memory owner = init.owners[i];
+                    init.owners[i] = init.owners[j];
+                    init.owners[j] = owner;
+                }
+            }
+        }
+
+        for (uint256 i = 1; i < init.owners.length; ++i) {
+            assertLt(uint160(init.owners[i - 1].owner), uint160(init.owners[i].owner));
+        }
+    }
+
+    function _deriveAccountSalt(TempoMultisigRecoveryWallet.InitMultisig memory init)
+        internal
+        pure
+        returns (bytes32)
+    {
+        bytes memory input = abi.encodePacked(
+            "tempo:multisig:account", init.salt, init.threshold, uint8(init.owners.length)
+        );
+        for (uint256 i = 0; i < init.owners.length; ++i) {
+            input = abi.encodePacked(input, init.owners[i].owner, init.owners[i].weight);
+        }
+        return keccak256(input);
+    }
+
+    function _sign(uint256 privateKey, bytes32 digest) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _sortedSignatures(
+        uint256 leftKey,
+        uint256 rightKey,
+        bytes32 digest
+    )
+        internal
+        pure
+        returns (bytes[] memory signatures)
+    {
+        signatures = new bytes[](2);
+        if (vm.addr(leftKey) < vm.addr(rightKey)) {
+            signatures[0] = _sign(leftKey, digest);
+            signatures[1] = _sign(rightKey, digest);
+        } else {
+            signatures[0] = _sign(rightKey, digest);
+            signatures[1] = _sign(leftKey, digest);
+        }
+    }
+
+}
+
+contract MockERC20 {
+
+    mapping(address => uint256) public balanceOf;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+}


### PR DESCRIPTION
## Summary

- Switch TIP-1061 native multisig account derivation to the CREATE2 formula anchored by a canonical recovery factory and wallet init-code hash.
- Add a baseline Solidity `TempoMultisigRecoveryFactory` and `TempoMultisigRecoveryWallet` for non-Tempo EVM recovery.
- Document cross-chain recovery semantics, including the initial-config authorization limitation after owner/threshold rotations.
- Add focused Rust and Foundry tests for the CREATE2 derivation and recovery sweep path.

Prompted by: @legion2002

## Validation

- `rustup run nightly cargo fmt --check`
- `cargo test -p tempo-primitives account_derivation_matches_create2_recovery_wallet --lib`
- `forge fmt --root /private/tmp --check /private/tmp/tempo-pr6640-rebase/tips/verify/src/TempoMultisigRecovery.sol /private/tmp/tempo-pr6640-rebase/tips/verify/test/TempoMultisigRecovery.t.sol`
- `forge test` for `TempoMultisigRecovery.t.sol` using a temporary standard-EVM Foundry config with Solidity 0.8.34, via-IR, optimizer, Cancun, and no compiler metadata
- `forge inspect ... TempoMultisigRecoveryWallet bytecode | cast keccak` with the same no-metadata config => `0xe6c8b6d3bebba0c75aa40ab105ddf7d0aed491c07feec1af35f7e372d4237e9f`