### PR TITLE
Fix provable proof trie updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8700,7 +8700,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8761,7 +8761,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8781,7 +8781,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8794,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8877,7 +8877,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8887,7 +8887,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8940,7 +8940,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8956,7 +8956,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8970,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8983,7 +8983,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9008,7 +9008,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9037,7 +9037,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9093,7 +9093,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9108,7 +9108,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9157,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9181,7 +9181,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9216,7 +9216,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9273,7 +9273,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9301,7 +9301,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9324,7 +9324,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9409,7 +9409,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9439,7 +9439,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9457,7 +9457,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9473,7 +9473,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9496,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9507,7 +9507,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9535,7 +9535,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9557,7 +9557,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9598,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "clap",
  "eyre",
@@ -9621,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9653,7 +9653,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9666,7 +9666,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9696,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9710,7 +9710,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9720,7 +9720,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9765,7 +9765,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9783,7 +9783,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9796,7 +9796,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9815,7 +9815,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9853,7 +9853,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9867,7 +9867,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "serde",
  "serde_json",
@@ -9877,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9905,7 +9905,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "bytes",
  "futures",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "bitflags 2.13.0",
  "byteorder",
@@ -9942,7 +9942,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "bindgen",
  "cc",
@@ -9951,7 +9951,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "futures",
  "metrics",
@@ -9964,7 +9964,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9973,7 +9973,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9987,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10045,7 +10045,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10070,7 +10070,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10094,7 +10094,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10109,7 +10109,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10140,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10164,7 +10164,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10232,7 +10232,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10287,7 +10287,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10358,7 +10358,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "bytes",
  "eyre",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10423,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10447,7 +10447,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10459,7 +10459,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10482,7 +10482,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10574,7 +10574,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10602,7 +10602,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10618,7 +10618,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10633,7 +10633,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10711,7 +10711,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10784,7 +10784,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10804,7 +10804,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10835,7 +10835,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10882,7 +10882,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10933,7 +10933,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.2",
@@ -10947,7 +10947,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10978,7 +10978,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11029,7 +11029,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11057,7 +11057,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11071,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11091,7 +11091,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11106,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11132,7 +11132,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11150,7 +11150,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11171,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11187,7 +11187,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11197,7 +11197,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "clap",
  "eyre",
@@ -11217,7 +11217,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11281,7 +11281,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11307,7 +11307,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11335,7 +11335,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11354,7 +11354,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -11383,7 +11383,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#2df2e934b015c1049bff4067676058fdef2f080f"
+source = "git+https://github.com/paradigmxyz/reth?branch=rkrasiuk%2Fauxiliary-state-root#99c32901e919bd8a6c9258fbcfa288b7f9348b47"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -13279,6 +13279,7 @@ dependencies = [
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
+ "reth-errors",
  "reth-ethereum-consensus",
  "reth-evm",
  "reth-evm-ethereum",
@@ -13444,6 +13445,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
+ "reth-trie",
  "reth-trie-common",
  "tempo-chainspec",
  "tempo-evm",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -31,10 +31,12 @@ reth-consensus.workspace = true
 reth-consensus-common.workspace = true
 reth-chainspec.workspace = true
 reth-ethereum-consensus.workspace = true
+reth-errors.workspace = true
 reth-evm.workspace = true
 reth-evm-ethereum.workspace = true
 reth-revm.workspace = true
 reth-primitives-traits.workspace = true
+reth-storage-api.workspace = true
 reth-trie-common.workspace = true
 reth-rpc-eth-api = { workspace = true, optional = true }
 

--- a/crates/evm/src/proof_trie.rs
+++ b/crates/evm/src/proof_trie.rs
@@ -6,8 +6,10 @@
 //! accounts present in the bundle state are streamed as proof-trie updates.
 
 use alloy_primitives::{Address, map::AddressMap};
+use reth_errors::ProviderResult;
 use reth_revm::db::states::{BundleAccount, BundleState};
-use reth_trie_common::{HashedPostState, KeccakKeyHasher, TrieInput};
+use reth_storage_api::HashedPostStateProvider;
+use reth_trie_common::{HashedPostState, HashedStorage, KeccakKeyHasher, KeyHasher, TrieInput};
 
 /// Returns the subset of `bundle_state` that should be streamed into the TIP-1082 proof trie.
 ///
@@ -20,10 +22,8 @@ pub fn filter_bundle_state_for_provable_accounts(
     provable_accounts
         .iter()
         .filter_map(|address| {
-            bundle_state
-                .account(address)
-                .cloned()
-                .map(|account| (*address, account))
+            let account = bundle_state.account(address)?;
+            has_provable_state_update(account).then(|| (*address, account.clone()))
         })
         .collect()
 }
@@ -33,8 +33,66 @@ pub fn proof_hashed_state_from_bundle_state(
     bundle_state: &BundleState,
     provable_accounts: &[Address],
 ) -> HashedPostState {
-    let filtered = filter_bundle_state_for_provable_accounts(bundle_state, provable_accounts);
-    HashedPostState::from_bundle_state::<KeccakKeyHasher>(&filtered)
+    let mut hashed_state = HashedPostState::with_capacity(provable_accounts.len());
+
+    for address in provable_accounts {
+        let Some(account) = bundle_state.account(address) else {
+            continue;
+        };
+
+        let hashed_address = KeccakKeyHasher::hash_key(address);
+
+        if account.is_info_changed() {
+            hashed_state
+                .accounts
+                .insert(hashed_address, account.info.as_ref().map(Into::into));
+        }
+
+        let mut changed_storage = account
+            .storage
+            .iter()
+            .filter(|(_, slot)| slot.is_changed())
+            .map(|(slot, value)| {
+                (
+                    KeccakKeyHasher::hash_key(&alloy_primitives::B256::from(*slot)),
+                    value.present_value,
+                )
+            })
+            .peekable();
+
+        if account.was_destroyed() {
+            hashed_state
+                .storages
+                .insert(hashed_address, HashedStorage::new(true));
+        } else if changed_storage.peek().is_some() {
+            hashed_state.storages.insert(
+                hashed_address,
+                HashedStorage::from_iter(false, changed_storage),
+            );
+        }
+    }
+
+    hashed_state
+}
+
+/// Loads full whitelisted proof-trie state and overlays whitelisted bundle-state updates.
+pub fn proof_hashed_state_from_provider_and_bundle(
+    provider: &impl HashedPostStateProvider,
+    bundle_state: &BundleState,
+    provable_accounts: &[Address],
+) -> ProviderResult<HashedPostState> {
+    let mut state = provider.hashed_post_state_for_accounts(provable_accounts)?;
+    state.extend(proof_hashed_state_from_bundle_state(
+        bundle_state,
+        provable_accounts,
+    ));
+    Ok(state)
+}
+
+fn has_provable_state_update(account: &BundleAccount) -> bool {
+    account.is_info_changed()
+        || account.was_destroyed()
+        || account.storage.values().any(|slot| slot.is_changed())
 }
 
 /// Builds sparse MPT input from whitelisted bundle-state updates.
@@ -129,6 +187,28 @@ mod tests {
     }
 
     #[test]
+    fn read_only_whitelisted_account_is_not_hashed() {
+        let address = Address::repeat_byte(0x11);
+        let account = BundleAccount::new(
+            Some(account(1)),
+            Some(account(1)),
+            [(U256::from(1), StorageSlot::new(U256::from(7)))]
+                .into_iter()
+                .collect(),
+            AccountStatus::Loaded,
+        );
+        let bundle_state = bundle_state([(address, account)]);
+
+        let filtered = filter_bundle_state_for_provable_accounts(&bundle_state, &[address]);
+        let hashed = proof_hashed_state_from_bundle_state(&bundle_state, &[address]);
+        let input = proof_trie_input_from_bundle_state(&bundle_state, &[address]);
+
+        assert!(filtered.is_empty());
+        assert!(hashed.is_empty());
+        assert!(input.state.is_empty());
+    }
+
+    #[test]
     fn whitelisted_storage_update_is_hashed() {
         let address = Address::repeat_byte(0x11);
         let slot = U256::from(1);
@@ -146,7 +226,47 @@ mod tests {
         let hashed = proof_hashed_state_from_bundle_state(&bundle_state, &[address]);
         let hashed_address = keccak256(address);
 
-        assert!(hashed.accounts.contains_key(&hashed_address));
+        assert!(!hashed.accounts.contains_key(&hashed_address));
+        assert!(hashed.storages.contains_key(&hashed_address));
+    }
+
+    #[test]
+    fn unchanged_whitelisted_storage_slot_is_not_hashed() {
+        let address = Address::repeat_byte(0x11);
+        let slot = U256::from(1);
+        let account = BundleAccount::new(
+            Some(account(1)),
+            Some(account(1)),
+            [(slot, StorageSlot::new(U256::from(7)))]
+                .into_iter()
+                .collect(),
+            AccountStatus::Changed,
+        );
+        let bundle_state = bundle_state([(address, account)]);
+
+        let hashed = proof_hashed_state_from_bundle_state(&bundle_state, &[address]);
+
+        assert!(hashed.is_empty());
+    }
+
+    #[test]
+    fn storage_update_without_account_info_change_does_not_hash_account_leaf() {
+        let address = Address::repeat_byte(0x11);
+        let slot = U256::from(1);
+        let account = BundleAccount::new(
+            Some(account(1)),
+            Some(account(1)),
+            [(slot, StorageSlot::new_changed(U256::ZERO, U256::from(7)))]
+                .into_iter()
+                .collect(),
+            AccountStatus::Changed,
+        );
+        let bundle_state = bundle_state([(address, account)]);
+        let hashed_address = keccak256(address);
+
+        let hashed = proof_hashed_state_from_bundle_state(&bundle_state, &[address]);
+
+        assert!(!hashed.accounts.contains_key(&hashed_address));
         assert!(hashed.storages.contains_key(&hashed_address));
     }
 

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -88,6 +88,7 @@ impl PayloadValidator<TempoPayloadTypes> for TempoEngineValidator {
             parent_root,
             expected_root,
             state_updates,
+            full_state_accounts: Some(provable_accounts.to_vec()),
             retain_trie_data: true,
         }))
     }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -26,7 +26,9 @@ use reth_node_builder::{
 };
 use reth_node_ethereum::EthereumNetworkBuilder;
 use reth_primitives_traits::SealedHeader;
-use reth_provider::providers::ProviderFactoryBuilder;
+use reth_provider::{
+    DatabaseProviderFactory, HashedPostStateProvider, providers::ProviderFactoryBuilder,
+};
 use reth_rpc_builder::{Identity, RethRpcModule};
 use reth_rpc_eth_api::{
     RpcNodeCore,
@@ -236,7 +238,11 @@ impl NodeTypes for TempoNode {
 }
 
 #[derive(Debug)]
-pub struct TempoAddOns<N: FullNodeTypes<Types = TempoNode>> {
+pub struct TempoAddOns<N>
+where
+    N: FullNodeTypes<Types = TempoNode>,
+    <N::Provider as DatabaseProviderFactory>::Provider: HashedPostStateProvider,
+{
     #[allow(clippy::type_complexity)]
     inner: RpcAddOns<
         NodeAdapter<N>,
@@ -252,6 +258,7 @@ pub struct TempoAddOns<N: FullNodeTypes<Types = TempoNode>> {
 impl<N> TempoAddOns<N>
 where
     N: FullNodeTypes<Types = TempoNode>,
+    <N::Provider as DatabaseProviderFactory>::Provider: HashedPostStateProvider,
 {
     /// Creates a new instance from the inner `RpcAddOns`.
     pub fn new(validator_key: Option<B256>) -> Self {
@@ -272,6 +279,7 @@ where
 impl<N> NodeAddOns<NodeAdapter<N>> for TempoAddOns<N>
 where
     N: FullNodeTypes<Types = TempoNode>,
+    <N::Provider as DatabaseProviderFactory>::Provider: HashedPostStateProvider,
 {
     type Handle = RpcHandle<NodeAdapter<N>, TempoEthApi<NodeAdapter<N>>>;
 
@@ -319,6 +327,7 @@ where
 impl<N> RethRpcAddOns<NodeAdapter<N>> for TempoAddOns<N>
 where
     N: FullNodeTypes<Types = TempoNode>,
+    <N::Provider as DatabaseProviderFactory>::Provider: HashedPostStateProvider,
 {
     type EthApi = TempoEthApi<NodeAdapter<N>>;
 
@@ -330,6 +339,7 @@ where
 impl<N> EngineValidatorAddOn<NodeAdapter<N>> for TempoAddOns<N>
 where
     N: FullNodeTypes<Types = TempoNode>,
+    <N::Provider as DatabaseProviderFactory>::Provider: HashedPostStateProvider,
 {
     type ValidatorBuilder = BasicEngineValidatorBuilder<TempoEngineValidatorBuilder>;
 
@@ -341,6 +351,7 @@ where
 impl<N> Node<N> for TempoNode
 where
     N: FullNodeTypes<Types = Self>,
+    <N::Provider as DatabaseProviderFactory>::Provider: HashedPostStateProvider,
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,
@@ -362,7 +373,11 @@ where
     }
 }
 
-impl<N: FullNodeComponents<Types = Self>> DebugNode<N> for TempoNode {
+impl<N> DebugNode<N> for TempoNode
+where
+    N: FullNodeComponents<Types = Self>,
+    <N::Provider as DatabaseProviderFactory>::Provider: HashedPostStateProvider,
+{
     type RpcBlock =
         alloy_rpc_types_eth::Block<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>, TempoHeader>;
 

--- a/crates/node/src/rpc/simulate.rs
+++ b/crates/node/src/rpc/simulate.rs
@@ -7,7 +7,7 @@ use reth_ethereum::evm::revm::database::StateProviderDatabase;
 use reth_node_api::FullNodeTypes;
 use reth_node_builder::NodeAdapter;
 use reth_primitives_traits::AlloyBlockHeader as _;
-use reth_provider::ChainSpecProvider;
+use reth_provider::{ChainSpecProvider, DatabaseProviderFactory, HashedPostStateProvider};
 use reth_rpc_eth_api::{
     RpcBlock, RpcNodeCore,
     helpers::{EthCall, LoadBlock, LoadState, SpawnBlocking},
@@ -71,11 +71,19 @@ pub trait TempoSimulateApi {
 
 /// Implementation of `tempo_simulateV1`.
 #[derive(Debug, Clone)]
-pub struct TempoSimulate<N: FullNodeTypes<Types = TempoNode>> {
+pub struct TempoSimulate<N>
+where
+    N: FullNodeTypes<Types = TempoNode>,
+    <N::Provider as DatabaseProviderFactory>::Provider: HashedPostStateProvider,
+{
     eth_api: TempoEthApi<NodeAdapter<N>>,
 }
 
-impl<N: FullNodeTypes<Types = TempoNode>> TempoSimulate<N> {
+impl<N> TempoSimulate<N>
+where
+    N: FullNodeTypes<Types = TempoNode>,
+    <N::Provider as DatabaseProviderFactory>::Provider: HashedPostStateProvider,
+{
     pub fn new(eth_api: TempoEthApi<NodeAdapter<N>>) -> Self {
         Self { eth_api }
     }
@@ -118,7 +126,11 @@ fn extract_tip20_targets(
 }
 
 #[async_trait::async_trait]
-impl<N: FullNodeTypes<Types = TempoNode>> TempoSimulateApiServer for TempoSimulate<N> {
+impl<N> TempoSimulateApiServer for TempoSimulate<N>
+where
+    N: FullNodeTypes<Types = TempoNode>,
+    <N::Provider as DatabaseProviderFactory>::Provider: HashedPostStateProvider,
+{
     async fn simulate_v1(
         &self,
         payload: alloy_rpc_types_eth::simulate::SimulatePayload<
@@ -177,7 +189,11 @@ impl<N: FullNodeTypes<Types = TempoNode>> TempoSimulateApiServer for TempoSimula
     }
 }
 
-impl<N: FullNodeTypes<Types = TempoNode>> TempoSimulate<N> {
+impl<N> TempoSimulate<N>
+where
+    N: FullNodeTypes<Types = TempoNode>,
+    <N::Provider as DatabaseProviderFactory>::Provider: HashedPostStateProvider,
+{
     /// Resolves TIP-20 token metadata for the given addresses using state at the target block.
     async fn resolve_token_metadata(
         &self,

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -38,6 +38,7 @@ reth-revm.workspace = true
 reth-storage-api.workspace = true
 reth-tasks.workspace = true
 reth-transaction-pool.workspace = true
+reth-trie.workspace = true
 reth-trie-common.workspace = true
 
 alloy-consensus.workspace = true

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -60,6 +60,7 @@ use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, PoolTransaction, TransactionPool,
     ValidPoolTransaction, error::InvalidPoolTransactionError,
 };
+use reth_trie::root_from_full_hashed_state;
 use std::{
     sync::{
         Arc,
@@ -71,7 +72,7 @@ use std::{
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_evm::{
     TempoEvmConfig, TempoNextBlockEnvAttributes, TempoStateAccess, evm::TempoEvm,
-    proof_trie::proof_trie_input_from_bundle_state,
+    proof_trie::proof_hashed_state_from_provider_and_bundle,
 };
 use tempo_payload_types::{
     TempoBuiltPayload, TempoPayloadAttributes, ValidationLatencyWorkload, marshal_persist_estimate,
@@ -1206,8 +1207,8 @@ where
 
     fn proof_root_for_payload_timestamp(
         &self,
-        state_root_provider: &impl StateRootProvider,
-        parent_header: &TempoHeader,
+        state_provider: &impl HashedPostStateProvider,
+        _parent_header: &TempoHeader,
         bundle_state: &reth_revm::db::states::bundle_state::BundleState,
         timestamp: u64,
     ) -> Result<Option<B256>, BlockExecutionError> {
@@ -1217,16 +1218,18 @@ where
         }
 
         let provable_accounts = chain_spec.provable_accounts_at_timestamp(timestamp);
-        let proof_trie_input = proof_trie_input_from_bundle_state(bundle_state, provable_accounts);
+        let proof_state = proof_hashed_state_from_provider_and_bundle(
+            state_provider,
+            bundle_state,
+            provable_accounts,
+        )
+        .map_err(BlockExecutionError::other)?;
 
-        if proof_trie_input.state.is_empty() {
-            return Ok(Some(parent_header.proof_root.unwrap_or(EMPTY_ROOT_HASH)));
+        if proof_state.is_empty() {
+            return Ok(Some(EMPTY_ROOT_HASH));
         }
 
-        // Compute the proof root through the same provider path used by the serial state-root
-        // fallback after filtering and hashing the bundle state into proof-trie input.
-        state_root_provider
-            .state_root_from_nodes(proof_trie_input)
+        root_from_full_hashed_state(proof_state)
             .map(Some)
             .map_err(BlockExecutionError::other)
     }


### PR DESCRIPTION
## Summary
- build TIP-1082 proof roots from a fully materialized hashed post-state for whitelisted accounts, then overlay bundle updates
- switch the builder proof-root path to `root_from_full_hashed_state`, avoiding proof-root database cursors
- pass `full_state_accounts` through auxiliary validation so reth computes the validator-side auxiliary root the same way
- depend on merged paradigmxyz/reth#26004 via `rkrasiuk/auxiliary-state-root#99c32901`

## Validation
- cargo fmt --check
- cargo check -p tempo-payload-builder -p tempo-node
- cargo test -p tempo-evm proof_trie --lib
- cargo test -p tempo-node validates_proof_root_against_empty_provable_state_updates --lib

Prompted by: @rkrasiuk
