### PR TITLE
Fix builder proof state provider forwarding

### DIFF
--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -213,6 +213,21 @@ impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
             .record(start.elapsed());
         result
     }
+
+    fn hashed_post_state_for_accounts(
+        &self,
+        accounts: &[Address],
+    ) -> ProviderResult<HashedPostState> {
+        let start = Instant::now();
+        let _span =
+            debug_span!(target: "payload_builder", "hashed_post_state_for_accounts").entered();
+        let result = self.inner.hashed_post_state_for_accounts(accounts);
+        drop(_span);
+        self.metrics
+            .hashed_post_state_duration_seconds
+            .record(start.elapsed());
+        result
+    }
 }
 
 impl StateRootProvider for InstrumentedFinishProvider<'_> {


### PR DESCRIPTION
## Summary
- forward `hashed_post_state_for_accounts` through `InstrumentedFinishProvider`
- keep builder proof-root full-state loading on the real state provider instead of the trait default `UnsupportedProvider`
- instrument the full-state load with the existing hashed-post-state timing metric

## Validation
- cargo fmt --check
- cargo check -p tempo-payload-builder -p tempo-node
- cargo test -p tempo-evm proof_trie --lib
- cargo test -p tempo-node validates_proof_root_against_empty_provable_state_updates --lib

Prompted by: @rkrasiuk
