### PR TITLE
Validate precompile dispatch calldata from T8

### DIFF
--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -184,7 +184,12 @@ macro_rules! dispatch {
                 $(
                     if <$iface::$calls as alloy::sol_types::SolInterface>::valid_selector(selector) {
                         type Calls = $iface::$calls;
-                        return crate::dispatch::dispatch_call($calldata, <Calls as alloy::sol_types::SolInterface>::abi_decode, |$call| match $match_call {
+                        let decode = if crate::storage::StorageCtx.spec().is_t8() {
+                            <Calls as alloy::sol_types::SolInterface>::abi_decode_validate
+                        } else {
+                            <Calls as alloy::sol_types::SolInterface>::abi_decode
+                        };
+                        return crate::dispatch::dispatch_call($calldata, decode, |$call| match $match_call {
                             $(Calls::$variant($binding) => $body,)*
                         });
                     }

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -963,6 +963,47 @@ mod tests {
     }
 
     #[test]
+    fn test_dispatch_macro_validates_calldata_from_t8() -> eyre::Result<()> {
+        alloy::sol! {
+            interface IValidateDispatchTest {
+                function account(address value) external;
+            }
+        }
+
+        let call_with_spec = |spec: TempoHardfork, calldata: &[u8]| {
+            let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
+            StorageCtx::enter(&mut storage, || {
+                dispatch!(
+                    calldata,
+                    |call| match call {
+                        IValidateDispatchTest::IValidateDispatchTestCalls {
+                            account(_) => Ok(PrecompileOutput::new(0, Bytes::from_static(b"account"), 0)),
+                        }
+                    }
+                )
+            })
+        };
+
+        let mut dirty_address_calldata = IValidateDispatchTest::accountCall {
+            value: Address::repeat_byte(0x11),
+        }
+        .abi_encode();
+        dirty_address_calldata[4] = 1;
+
+        // Pre-T8 preserves legacy unchecked ABI decoding.
+        let pre_t8 = call_with_spec(TempoHardfork::T7, &dirty_address_calldata)?;
+        assert!(!pre_t8.is_revert());
+        assert_eq!(pre_t8.bytes.as_ref(), b"account");
+
+        // T8+ rejects non-canonical ABI values through `abi_decode_validate`.
+        let t8 = call_with_spec(TempoHardfork::T8, &dirty_address_calldata)?;
+        assert!(t8.is_revert());
+        assert!(t8.bytes.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
     fn test_input_cost_returns_non_zero_for_input() {
         // Empty input should cost 0
         assert_eq!(input_cost(0), 0);


### PR DESCRIPTION
## Summary
- switch shared precompile dispatch to `abi_decode_validate` once T8 is active
- preserve pre-T8 unchecked ABI decode behavior
- add a dispatch macro regression test for dirty address calldata across T7/T8

## Testing
- cargo test -p tempo-precompiles test_dispatch_macro
- cargo check -p tempo-precompiles

Prompted by: @0xalpharush