### PR TITLE
fix(builder): require nonzero nonce key for parallel prewarming

### DIFF
--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -474,7 +474,7 @@ fn is_parallel_candidate(tx: &BestTransaction) -> bool {
         && tx
             .transaction
             .nonce_key()
-            .is_some()
+            .is_some_and(|nonce_key| !nonce_key.is_zero())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Require payment-lane parallel prewarming candidates to have a non-zero nonce_key

## Tests
- cargo fmt --check

Prompted by: @shekhirin