### PR TITLE
perf(stablecoin-dex): remove order version cell cache

### DIFF
--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -11,7 +11,7 @@ pub mod order;
 pub mod orderbook;
 
 pub use order::Order;
-use order::OrderMapping;
+use order::{OrderMapping, OrderVersion, StoredOrder};
 pub use orderbook::{
     MAX_TICK, MIN_TICK, Orderbook, PRICE_SCALE, RoundingDirection, TickLevel, base_to_quote,
     quote_to_base, tick_to_price, validate_tick_spacing,
@@ -119,13 +119,6 @@ impl StablecoinDEX {
         Ok(())
     }
 
-    /// Deletes an order and returns the number of DEX TIP-1060 credits minted.
-    fn delete_order(&mut self, order: &Order) -> Result<u64> {
-        StorageCredits::new()
-            .track_minted_credits(self.address, || self.orders[order.order_id()].delete())
-            .map(|(_, credits)| credits)
-    }
-
     /// Rewrites an order and returns the number of DEX TIP-1060 credits minted.
     fn rewrite_order(&mut self, order: Order) -> Result<u64> {
         StorageCredits::new()
@@ -133,10 +126,20 @@ impl StablecoinDEX {
             .map(|(_, credits)| credits)
     }
 
+    /// Rewrites an order using its known physical layout and returns minted DEX TIP-1060 credits.
+    fn rewrite_stored_order(&mut self, current: &StoredOrder, order: Order) -> Result<u64> {
+        StorageCredits::new()
+            .track_minted_credits(self.address, || {
+                self.orders[order.order_id()].write_for(current, order)
+            })
+            .map(|(_, credits)| credits)
+    }
+
     /// Updates an unlinked neighbor order-record and credits its maker for any minted credits.
     fn unlink_neighbor_and_credit_maker(
         &mut self,
         order_id: u128,
+        version: OrderVersion,
         update: impl FnOnce(&mut Self) -> Result<()>,
     ) -> Result<()> {
         let (_, credits) =
@@ -145,17 +148,19 @@ impl StablecoinDEX {
             return Ok(());
         }
 
-        let maker = self.orders[order_id].maker()?.read()?;
+        let maker = self.orders[order_id].maker_for_version(version).read()?;
         self.credit_dex_storage_slots(maker, credits)
     }
 
-    /// Deletes an order and tracks the maker's minted DEX TIP-1060 credits for deferred flush.
-    fn delete_order_and_track_deltas(
+    /// Deletes a versioned order and tracks the maker's minted DEX TIP-1060 credits.
+    fn delete_stored_order_and_track_deltas(
         &mut self,
         storage_credits: &mut StorageCreditDeltas,
-        order: &Order,
+        order: &StoredOrder,
     ) -> Result<()> {
-        let credits = self.delete_order(order)?;
+        let (_, credits) = StorageCredits::new().track_minted_credits(self.address, || {
+            self.orders[order.order_id()].delete_for(order)
+        })?;
         storage_credits.credit_slots(order.maker(), credits);
         Ok(())
     }
@@ -665,7 +670,16 @@ impl StablecoinDEX {
     ///
     /// On T7+, `charge_credits` spends maker credits. Keep it `false` for taker-triggered flips
     /// so takers cannot consume the maker's credit balance.
-    fn commit_order_to_book(&mut self, mut order: Order, charge_credits: bool) -> Result<()> {
+    fn commit_order_to_book(&mut self, order: Order, charge_credits: bool) -> Result<()> {
+        self.commit_order_to_book_with_current_layout(order, charge_credits, None)
+    }
+
+    fn commit_order_to_book_with_current_layout(
+        &mut self,
+        mut order: Order,
+        charge_credits: bool,
+        current: Option<&StoredOrder>,
+    ) -> Result<()> {
         let orderbook = self.books[order.book_key()].read()?;
         let mut level = self.books[order.book_key()]
             .tick_level_handler(order.tick(), order.is_bid())
@@ -719,7 +733,12 @@ impl StablecoinDEX {
             (true, spec) if spec.is_t7() => self.write_order_spending_dex_storage_credits(order),
             // T8+ flip rewrites credit deleted order slots without spending maker credits.
             (false, spec) if spec.is_t8() => {
-                let (maker, credits) = (order.maker(), self.rewrite_order(order)?);
+                let maker = order.maker();
+                let credits = if let Some(current) = current {
+                    self.rewrite_stored_order(current, order)?
+                } else {
+                    self.rewrite_order(order)?
+                };
                 self.credit_dex_storage_slots(maker, credits)
             }
             // Pre-T7 has no DEX credits; T7 non-charged writes never change credits behavior.
@@ -879,7 +898,7 @@ impl StablecoinDEX {
 
     fn flip_in_place(
         &mut self,
-        order: &Order,
+        order: &StoredOrder,
         base_token: Address,
         quote_token: Address,
     ) -> Result<()> {
@@ -923,7 +942,7 @@ impl StablecoinDEX {
         debug_assert_eq!(order.order_id(), flipped.order_id());
         debug_assert_eq!(order.book_key(), flipped.book_key());
         // In-place flips are taker-triggered, so don't spend maker credits.
-        self.commit_order_to_book(flipped, false)?;
+        self.commit_order_to_book_with_current_layout(flipped, false, Some(order))?;
 
         // Emit OrderFlipped event for flip order
         self.emit_event(StablecoinDEXEvents::OrderFlipped(
@@ -947,7 +966,7 @@ impl StablecoinDEX {
     /// Partially fill an order with the specified amount. Fill amount is denominated in base token.
     fn partial_fill_order(
         &mut self,
-        order: &mut Order,
+        order: &mut StoredOrder,
         level: &mut TickLevel,
         fill_amount: u128,
         taker: Address,
@@ -957,7 +976,7 @@ impl StablecoinDEX {
         // Update order remaining amount
         let new_remaining = order.remaining() - fill_amount;
         self.orders[order.order_id()]
-            .remaining()?
+            .remaining_for(order)
             .write(new_remaining)?;
         order.remaining = new_remaining;
 
@@ -1014,10 +1033,10 @@ impl StablecoinDEX {
         &mut self,
         storage_credits: &mut StorageCreditDeltas,
         book_key: B256,
-        order: &mut Order,
+        order: &mut StoredOrder,
         mut level: TickLevel,
         taker: Address,
-    ) -> Result<(u128, Option<(TickLevel, Order)>)> {
+    ) -> Result<(u128, Option<(TickLevel, StoredOrder)>)> {
         debug_assert_eq!(order.book_key(), book_key);
 
         let orderbook = self.books[book_key].read()?;
@@ -1072,11 +1091,6 @@ impl StablecoinDEX {
                     return Err(res.unwrap_err());
                 }
 
-                // Execution continues after rollback, so discard the reverted layout version cache.
-                if self.storage.spec().is_t8() {
-                    self.orders[order.order_id()].clear_version_cache();
-                }
-
                 if self.storage.spec().is_t5() {
                     self.emit_event(StablecoinDEXEvents::flip_failed(
                         order.order_id(),
@@ -1092,11 +1106,11 @@ impl StablecoinDEX {
             // record must be deleted to avoid leaving an orphan in storage.
             let keep_record = self.storage.spec().is_t5() && res.is_ok();
             if !keep_record {
-                self.delete_order_and_track_deltas(storage_credits, order)?;
+                self.delete_stored_order_and_track_deltas(storage_credits, order)?;
             }
         } else {
             // Non-flip filled order: always delete.
-            self.delete_order_and_track_deltas(storage_credits, order)?;
+            self.delete_stored_order_and_track_deltas(storage_credits, order)?;
         }
 
         // Advance tick if liquidity is exhausted
@@ -1125,15 +1139,16 @@ impl StablecoinDEX {
                 let new_level = self.books[book_key]
                     .tick_level_handler(tick, order.is_bid())
                     .read()?;
-                let new_order = self.orders[new_level.head].read()?;
+                let new_order = self.orders[new_level.head].read_stored()?;
 
                 Some((new_level, new_order))
             }
         } else {
             // If there are subsequent orders at tick, advance to next order
             level.head = order.next();
+            let new_order = self.orders[order.next()].read_stored()?;
             let (_, credits) = StorageCredits::new().track_minted_credits(self.address, || {
-                self.orders[order.next()].prev()?.delete()
+                self.orders[order.next()].prev_for(&new_order).delete()
             })?;
 
             let new_liquidity = level
@@ -1146,7 +1161,6 @@ impl StablecoinDEX {
                 .tick_level_handler_mut(order.tick(), order.is_bid())
                 .write(level)?;
 
-            let new_order = self.orders[order.next()].read()?;
             storage_credits.credit_slots(new_order.maker(), credits);
 
             Some((level, new_order))
@@ -1165,7 +1179,7 @@ impl StablecoinDEX {
         taker: Address,
     ) -> Result<u128> {
         let mut level = self.get_best_price_level(book_key, bid)?;
-        let mut order = self.orders[level.head].read()?;
+        let mut order = self.orders[level.head].read_stored()?;
 
         let mut total_amount_in: u128 = 0;
 
@@ -1246,7 +1260,7 @@ impl StablecoinDEX {
         taker: Address,
     ) -> Result<u128> {
         let mut level = self.get_best_price_level(book_key, bid)?;
-        let mut order = self.orders[level.head].read()?;
+        let mut order = self.orders[level.head].read_stored()?;
 
         let mut total_amount_out: u128 = 0;
 
@@ -1347,7 +1361,7 @@ impl StablecoinDEX {
     /// - `OrderDoesNotExist` — order ID not found or already fully filled
     /// - `Unauthorized` — only the order maker can cancel their order
     pub fn cancel(&mut self, sender: Address, order_id: u128) -> Result<()> {
-        let order = self.orders[order_id].read()?;
+        let order = self.orders[order_id].read_stored()?;
 
         if order.maker().is_zero() {
             return Err(StablecoinDEXError::order_does_not_exist().into());
@@ -1365,23 +1379,29 @@ impl StablecoinDEX {
     }
 
     /// Cancel an active order (already in the orderbook)
-    fn cancel_active_order(&mut self, order: Order) -> Result<()> {
+    fn cancel_active_order(&mut self, order: StoredOrder) -> Result<()> {
         let mut level = self.books[order.book_key()]
             .tick_level_handler(order.tick(), order.is_bid())
             .read()?;
 
         // Update linked list
         if order.prev() != 0 {
-            self.unlink_neighbor_and_credit_maker(order.prev(), |s| {
-                s.orders[order.prev()].next()?.write(order.next())
+            let prev_version = self.orders[order.prev()].version()?;
+            self.unlink_neighbor_and_credit_maker(order.prev(), prev_version, |s| {
+                s.orders[order.prev()]
+                    .next_for_version(prev_version)
+                    .write(order.next())
             })?;
         } else {
             level.head = order.next();
         }
 
         if order.next() != 0 {
-            self.unlink_neighbor_and_credit_maker(order.next(), |s| {
-                s.orders[order.next()].prev()?.write(order.prev())
+            let next_version = self.orders[order.next()].version()?;
+            self.unlink_neighbor_and_credit_maker(order.next(), next_version, |s| {
+                s.orders[order.next()]
+                    .prev_for_version(next_version)
+                    .write(order.prev())
             })?;
         } else {
             level.tail = order.prev();
@@ -1440,7 +1460,9 @@ impl StablecoinDEX {
         }
 
         // Clear the order from storage
-        let credits = self.delete_order(&order)?;
+        let (_, credits) = StorageCredits::new().track_minted_credits(self.address, || {
+            self.orders[order.order_id()].delete_for(&order)
+        })?;
         self.credit_dex_storage_slots(order.maker(), credits)?;
 
         // Emit OrderCancelled event
@@ -1459,7 +1481,7 @@ impl StablecoinDEX {
     /// - `OrderDoesNotExist` — order ID not found or already fully filled
     /// - `OrderNotStale` — order maker is still authorized by TIP-403 policy
     pub fn cancel_stale_order(&mut self, order_id: u128) -> Result<()> {
-        let order = self.orders[order_id].read()?;
+        let order = self.orders[order_id].read_stored()?;
 
         if order.maker().is_zero() {
             return Err(StablecoinDEXError::order_does_not_exist().into());

--- a/crates/precompiles/src/stablecoin_dex/order/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/order/mod.rs
@@ -5,7 +5,7 @@
 //! automatically place opposite-side orders when filled.
 
 mod storage;
-pub(crate) use storage::OrderMapping;
+pub(crate) use storage::{OrderMapping, OrderVersion, StoredOrder};
 
 use crate::stablecoin_dex::{IStablecoinDEX, error::OrderError};
 use alloy::primitives::{Address, B256};

--- a/crates/precompiles/src/stablecoin_dex/order/storage.rs
+++ b/crates/precompiles/src/stablecoin_dex/order/storage.rs
@@ -22,10 +22,7 @@ use crate::{
     },
 };
 use alloy::primitives::{Address, B256, FixedBytes, U256};
-use std::{
-    cell::Cell,
-    ops::{Index, IndexMut},
-};
+use std::ops::{Deref, DerefMut, Index, IndexMut};
 use tempo_precompiles_macros::Storable;
 
 /// Physical storage layout version for an order record.
@@ -145,6 +142,37 @@ impl V1Order {
     }
 }
 
+/// Logical order data paired with the physical layout version it was read from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct StoredOrder {
+    order: Order,
+    version: OrderVersion,
+}
+
+impl StoredOrder {
+    fn new(order: Order, version: OrderVersion) -> Self {
+        Self { order, version }
+    }
+
+    pub(crate) fn into_order(self) -> Order {
+        self.order
+    }
+}
+
+impl Deref for StoredOrder {
+    type Target = Order;
+
+    fn deref(&self) -> &Self::Target {
+        &self.order
+    }
+}
+
+impl DerefMut for StoredOrder {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.order
+    }
+}
+
 /// Version-aware storage handler for a single DEX order.
 #[derive(Debug, Clone)]
 pub(crate) struct OrderHandler {
@@ -154,9 +182,6 @@ pub(crate) struct OrderHandler {
     order_id: u128,
     /// Contract address whose storage contains the order mapping.
     address: Address,
-    /// Cached physical layout version for this record.
-    /// NOTE: Storage checkpoint rollbacks do not reset it. Clear manually if execution continues.
-    pub(crate) version: Cell<Option<OrderVersion>>,
 }
 
 impl OrderHandler {
@@ -166,31 +191,57 @@ impl OrderHandler {
             base_slot,
             order_id,
             address,
-            version: Cell::new(None),
         }
     }
 
-    /// Returns a storage handler for the order's maker address.
-    pub(crate) fn maker(&self) -> StorageResult<Slot<Address>> {
-        let loc = match self.version()? {
+    /// Returns a storage handler for the order's maker address using a known layout version.
+    pub(crate) fn maker_for_version(&self, version: OrderVersion) -> Slot<Address> {
+        let loc = match version {
             OrderVersion::Legacy => __packing_legacy_order::MAKER_LOC,
             OrderVersion::V1 => __packing_v1_order::MAKER_LOC,
         };
 
-        Ok(Slot::new_at_loc(self.base_slot, loc, self.address))
+        Slot::new_at_loc(self.base_slot, loc, self.address)
     }
 
     /// Returns a storage handler for the order's remaining amount.
+    #[cfg(test)]
     pub(crate) fn remaining(&self) -> StorageResult<Slot<u128>> {
-        self.u128_field(
+        Ok(self.u128_field_for(
+            self.version()?,
+            __packing_legacy_order::REMAINING_LOC,
+            __packing_v1_order::REMAINING_LOC,
+        ))
+    }
+
+    /// Returns a storage handler for the order's remaining amount using a known layout version.
+    pub(crate) fn remaining_for(&self, order: &StoredOrder) -> Slot<u128> {
+        self.u128_field_for(
+            order.version,
             __packing_legacy_order::REMAINING_LOC,
             __packing_v1_order::REMAINING_LOC,
         )
     }
 
     /// Returns a storage handler for the previous linked-list pointer.
+    #[cfg(test)]
     pub(crate) fn prev(&self) -> StorageResult<Slot<u128>> {
-        self.u128_field(
+        Ok(self.u128_field_for(
+            self.version()?,
+            __packing_legacy_order::PREV_LOC,
+            __packing_v1_order::PREV_LOC,
+        ))
+    }
+
+    /// Returns a storage handler for the previous pointer using a known layout version.
+    pub(crate) fn prev_for(&self, order: &StoredOrder) -> Slot<u128> {
+        self.prev_for_version(order.version)
+    }
+
+    /// Returns a storage handler for the previous pointer using a known layout version.
+    pub(crate) fn prev_for_version(&self, version: OrderVersion) -> Slot<u128> {
+        self.u128_field_for(
+            version,
             __packing_legacy_order::PREV_LOC,
             __packing_v1_order::PREV_LOC,
         )
@@ -198,44 +249,102 @@ impl OrderHandler {
 
     /// Returns a storage handler for the next linked-list pointer.
     pub(crate) fn next(&self) -> StorageResult<Slot<u128>> {
-        self.u128_field(
+        Ok(self.u128_field_for(
+            self.version()?,
+            __packing_legacy_order::NEXT_LOC,
+            __packing_v1_order::NEXT_LOC,
+        ))
+    }
+
+    /// Returns a storage handler for the next pointer using a known layout version.
+    pub(crate) fn next_for_version(&self, version: OrderVersion) -> Slot<u128> {
+        self.u128_field_for(
+            version,
             __packing_legacy_order::NEXT_LOC,
             __packing_v1_order::NEXT_LOC,
         )
     }
 
     /// Selects the version-specific location for a mutable `u128` field.
-    fn u128_field(
+    fn u128_field_for(
         &self,
+        version: OrderVersion,
         legacy: packing::FieldLocation,
         v1: packing::FieldLocation,
-    ) -> StorageResult<Slot<u128>> {
-        let loc = match self.version()? {
+    ) -> Slot<u128> {
+        let loc = match version {
             OrderVersion::Legacy => legacy,
             OrderVersion::V1 => v1,
         };
 
-        Ok(Slot::new_at_loc(self.base_slot, loc, self.address))
+        Slot::new_at_loc(self.base_slot, loc, self.address)
     }
 
-    /// Clears the cached physical storage version so the next access re-detects it from storage.
-    pub(crate) fn clear_version_cache(&self) {
-        self.version.set(None);
-    }
-
-    /// Returns the cached physical storage version, detecting and caching it if needed.
+    /// Returns the physical storage version by detecting it from storage.
     pub(crate) fn version(&self) -> StorageResult<OrderVersion> {
         if !StorageCtx.spec().is_t8() {
             return Ok(OrderVersion::Legacy);
         }
 
-        if let Some(version) = self.version.get() {
-            return Ok(version);
+        OrderVersion::try_from(self.load(self.base_slot)?)
+    }
+
+    /// Reads the order and returns it with the physical layout version used for decoding.
+    pub(crate) fn read_stored(&self) -> StorageResult<StoredOrder> {
+        let version = self.version()?;
+        let order = match version {
+            OrderVersion::Legacy => LegacyOrder::load(self, self.base_slot, LayoutCtx::FULL)?,
+            OrderVersion::V1 => {
+                V1Order::load(self, self.base_slot, LayoutCtx::FULL)?.into_order(self.order_id)
+            }
+        };
+
+        Ok(StoredOrder::new(order, version))
+    }
+
+    /// Deletes the physical slots using a known layout version.
+    pub(crate) fn delete_for(&mut self, order: &StoredOrder) -> StorageResult<()> {
+        self.delete_for_version(order.version)
+    }
+
+    /// Writes the order using the currently stored layout version already obtained from storage.
+    pub(crate) fn write_for(&mut self, current: &StoredOrder, value: Order) -> StorageResult<()> {
+        self.write_for_version(current.version, value, true)
+    }
+
+    fn write_for_version(
+        &mut self,
+        version: OrderVersion,
+        value: Order,
+        clear_legacy_tail: bool,
+    ) -> StorageResult<()> {
+        debug_assert_eq!(value.order_id, self.order_id);
+
+        if !StorageCtx.spec().is_t8() {
+            return value.store(self, self.base_slot, LayoutCtx::FULL);
         }
 
-        let version = OrderVersion::try_from(self.load(self.base_slot)?)?;
-        self.version.set(Some(version));
-        Ok(version)
+        V1Order::new(value).store(self, self.base_slot, LayoutCtx::FULL)?;
+        if matches!(version, OrderVersion::Legacy) && clear_legacy_tail {
+            for offset in V1Order::SLOTS..LegacyOrder::SLOTS {
+                self.store(self.base_slot.wrapping_add(U256::from(offset)), U256::ZERO)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn delete_for_version(&mut self, version: OrderVersion) -> StorageResult<()> {
+        let slot_count = match version {
+            OrderVersion::Legacy => LegacyOrder::SLOTS,
+            OrderVersion::V1 => V1Order::SLOTS,
+        };
+
+        for offset in 0..slot_count {
+            self.store(self.base_slot.wrapping_add(U256::from(offset)), U256::ZERO)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -250,65 +359,28 @@ impl StorageOps for OrderHandler {
 }
 
 impl Handler<Order> for OrderHandler {
-    /// Reads the order using the cached or detected physical layout version.
+    /// Reads the order using the detected physical layout version.
     fn read(&self) -> StorageResult<Order> {
-        match self.version()? {
-            OrderVersion::Legacy => LegacyOrder::load(self, self.base_slot, LayoutCtx::FULL),
-            OrderVersion::V1 => V1Order::load(self, self.base_slot, LayoutCtx::FULL)
-                .map(|res| res.into_order(self.order_id)),
-        }
+        self.read_stored().map(StoredOrder::into_order)
     }
 
-    /// Writes the order, migrating T8 records to V1 and updating the cached version.
+    /// Writes the order, migrating T8 records to V1.
     fn write(&mut self, value: Order) -> StorageResult<()> {
         debug_assert_eq!(value.order_id, self.order_id);
 
         if !StorageCtx.spec().is_t8() {
-            value.store(self, self.base_slot, LayoutCtx::FULL)?;
-            self.version.set(Some(OrderVersion::Legacy));
-            return Ok(());
+            return value.store(self, self.base_slot, LayoutCtx::FULL);
         }
 
-        match self.version.get() {
-            Some(OrderVersion::Legacy) => {
-                V1Order::new(value).store(self, self.base_slot, LayoutCtx::FULL)?;
-                for offset in V1Order::SLOTS..LegacyOrder::SLOTS {
-                    self.store(self.base_slot.wrapping_add(U256::from(offset)), U256::ZERO)?;
-                }
-            }
-            Some(OrderVersion::V1) => {
-                V1Order::new(value).store(self, self.base_slot, LayoutCtx::FULL)?;
-            }
-            None => {
-                let current_slot0 = self.load(self.base_slot)?;
-                let current_version = OrderVersion::try_from(current_slot0)?;
+        let current_slot0 = self.load(self.base_slot)?;
+        let current_version = OrderVersion::try_from(current_slot0)?;
 
-                V1Order::new(value).store(self, self.base_slot, LayoutCtx::FULL)?;
-                if matches!(current_version, OrderVersion::Legacy) && !current_slot0.is_zero() {
-                    for offset in V1Order::SLOTS..LegacyOrder::SLOTS {
-                        self.store(self.base_slot.wrapping_add(U256::from(offset)), U256::ZERO)?;
-                    }
-                }
-            }
-        }
-
-        self.version.set(Some(OrderVersion::V1));
-        Ok(())
+        self.write_for_version(current_version, value, !current_slot0.is_zero())
     }
 
-    /// Deletes the physical slots for the cached or detected order layout.
+    /// Deletes the physical slots for the detected order layout.
     fn delete(&mut self) -> StorageResult<()> {
-        let slot_count = match self.version()? {
-            OrderVersion::Legacy => LegacyOrder::SLOTS,
-            OrderVersion::V1 => V1Order::SLOTS,
-        };
-
-        for offset in 0..slot_count {
-            self.store(self.base_slot.wrapping_add(U256::from(offset)), U256::ZERO)?;
-        }
-
-        self.version.set(None);
-        Ok(())
+        self.delete_for_version(self.version()?)
     }
 
     fn t_read(&self) -> StorageResult<Order> {
@@ -542,7 +614,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cached_version_field_write_skips_version_sload() -> eyre::Result<()> {
+    fn test_stored_order_field_write_skips_version_sload() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
         StorageCtx::enter(&mut storage, || {
             let mut exchange = StablecoinDEX::new();
@@ -551,13 +623,13 @@ mod tests {
             let order = Order::new_bid(id, TEST_MAKER, TEST_BOOK_KEY, 1000, 5);
             exchange.orders[id].write(order)?;
 
-            let uncached_exchange = StablecoinDEX::new();
             StorageCtx.reset_counters();
-            uncached_exchange.orders[id].remaining()?.write(900)?;
+            exchange.orders[id].remaining()?.write(900)?;
             assert_eq!(StorageCtx.counter_sload(), 2);
 
+            let stored = exchange.orders[id].read_stored()?;
             StorageCtx.reset_counters();
-            exchange.orders[id].remaining()?.write(800)?;
+            exchange.orders[id].remaining_for(&stored).write(800)?;
             assert_eq!(StorageCtx.counter_sload(), 1);
 
             let loaded = exchange.orders[id].read()?;
@@ -733,12 +805,11 @@ mod tests {
     fn store_legacy_order(handler: &OrderHandler, order: Order) -> StorageResult<()> {
         let mut storage = handler.clone();
         LegacyOrder::store(&order, &mut storage, handler.base_slot, LayoutCtx::FULL)?;
-        handler.version.set(Some(OrderVersion::Legacy));
         Ok(())
     }
 
     #[test]
-    fn test_clear_version_cache_redetects_after_checkpoint_revert() -> eyre::Result<()> {
+    fn test_version_redetects_after_checkpoint_revert() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
         StorageCtx::enter(&mut storage, || {
             let mut exchange = StablecoinDEX::new();
@@ -754,8 +825,6 @@ mod tests {
                 assert_eq!(exchange.orders[id].version()?, OrderVersion::V1);
             }
 
-            assert_eq!(exchange.orders[id].version()?, OrderVersion::V1);
-            exchange.orders[id].clear_version_cache();
             assert_eq!(exchange.orders[id].version()?, OrderVersion::Legacy);
 
             exchange.orders[id].next()?.write(99)?;


### PR DESCRIPTION
Removes the in-memory order version `Cell` cache and threads known storage layout through the Stablecoin DEX hot paths instead.

This keeps storage checkpoint rollbacks from leaving stale layout state in memory while preserving the gas profile. Validated with:

- `cargo check -p tempo-precompiles`
- `cargo test -p tempo-precompiles stablecoin_dex::order::storage -- --nocapture`
- `cargo test -p tempo-node stablecoin_dex_order_gas_snapshots --test it -- --nocapture`