### PR TITLE
refactor: simplify handler + cleanup

### DIFF
--- a/crates/precompiles/src/native_multisig/auth.rs
+++ b/crates/precompiles/src/native_multisig/auth.rs
@@ -1,0 +1,159 @@
+use alloy::primitives::{Address, B256};
+use tempo_primitives::transaction::{
+    InitMultisig, MAX_MULTISIG_NESTING_DEPTH, MultisigSignature, TempoSignature,
+};
+
+use super::NativeMultisig;
+use crate::error::TempoPrecompileError;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum NativeMultisigAuthError {
+    #[error("{0}")]
+    ValidationFailed(String),
+    #[error("Fatal precompile error: {0:?}")]
+    Fatal(String),
+}
+
+impl From<TempoPrecompileError> for NativeMultisigAuthError {
+    fn from(err: TempoPrecompileError) -> Self {
+        match err {
+            TempoPrecompileError::Fatal(err) => Self::Fatal(err),
+            err => Self::ValidationFailed(err.to_string()),
+        }
+    }
+}
+
+impl NativeMultisigAuthError {
+    fn validation_failed(reason: impl Into<String>) -> Self {
+        Self::ValidationFailed(reason.into())
+    }
+}
+
+impl NativeMultisig {
+    /// Verifies a native multisig transaction authorization against current stored configs.
+    pub fn verify_authorization(
+        &self,
+        inner_digest: B256,
+        signature: &MultisigSignature,
+        config: &InitMultisig,
+        mut load_config: impl FnMut(Address) -> Result<InitMultisig, NativeMultisigAuthError>,
+    ) -> Result<(), NativeMultisigAuthError> {
+        let mut account_path = vec![signature.account()];
+        self.verify_authorization_inner(
+            inner_digest,
+            signature,
+            config,
+            &mut account_path,
+            &mut load_config,
+        )
+        .map(|_| ())
+    }
+
+    fn verify_authorization_inner(
+        &self,
+        inner_digest: B256,
+        signature: &MultisigSignature,
+        config: &InitMultisig,
+        account_path: &mut Vec<Address>,
+        load_config: &mut impl FnMut(Address) -> Result<InitMultisig, NativeMultisigAuthError>,
+    ) -> Result<u8, NativeMultisigAuthError> {
+        config
+            .validate()
+            .map_err(NativeMultisigAuthError::validation_failed)?;
+
+        let digest = signature.digest(inner_digest);
+        let mut recovered_weight = 0u16;
+        let mut prev_owner = None;
+
+        for signature_bytes in signature.signatures() {
+            let owner_approval = TempoSignature::from_bytes(signature_bytes).map_err(|reason| {
+                NativeMultisigAuthError::validation_failed(format!(
+                    "invalid multisig owner signature: {reason}"
+                ))
+            })?;
+
+            let (owner, nested_signature) = match owner_approval {
+                TempoSignature::Primitive(primitive) => {
+                    let owner = primitive.recover_signer(&digest).map_err(|_| {
+                        NativeMultisigAuthError::validation_failed(
+                            "invalid multisig owner signature",
+                        )
+                    })?;
+                    (owner, None)
+                }
+                TempoSignature::Keychain(_) => {
+                    return Err(NativeMultisigAuthError::validation_failed(
+                        "keychain signatures cannot authorize native multisig owners",
+                    ));
+                }
+                TempoSignature::Multisig(nested_signature) => {
+                    nested_signature
+                        .validate_registered_shape()
+                        .map_err(|reason| {
+                            NativeMultisigAuthError::validation_failed(format!(
+                                "invalid nested multisig owner signature: {reason}"
+                            ))
+                        })?;
+                    (nested_signature.account(), Some(nested_signature))
+                }
+            };
+
+            if prev_owner.is_some_and(|prev| prev >= owner) {
+                return Err(NativeMultisigAuthError::validation_failed(
+                    "multisig recovered owners must be strictly ascending",
+                ));
+            }
+            prev_owner = Some(owner);
+
+            let configured_owner = config
+                .owners
+                .binary_search_by_key(&owner, |entry| entry.owner)
+                .map(|idx| &config.owners[idx])
+                .map_err(|_| {
+                    NativeMultisigAuthError::validation_failed("multisig signer is not an owner")
+                })?;
+
+            if let Some(nested_signature) = nested_signature {
+                if account_path.len() >= MAX_MULTISIG_NESTING_DEPTH {
+                    return Err(NativeMultisigAuthError::validation_failed(
+                        "native multisig nesting depth exceeded",
+                    ));
+                }
+                if account_path.contains(&owner) {
+                    return Err(NativeMultisigAuthError::validation_failed(
+                        "native multisig owner cycle detected",
+                    ));
+                }
+
+                let nested_config = load_config(owner)?;
+                account_path.push(owner);
+                self.verify_authorization_inner(
+                    digest,
+                    &nested_signature,
+                    &nested_config,
+                    account_path,
+                    load_config,
+                )?;
+                account_path.pop();
+            }
+
+            recovered_weight = recovered_weight
+                .checked_add(u16::from(configured_owner.weight))
+                .ok_or_else(|| {
+                    NativeMultisigAuthError::validation_failed(
+                        "multisig recovered owner weight overflow",
+                    )
+                })?;
+        }
+
+        if recovered_weight < u16::from(config.threshold) {
+            return Err(NativeMultisigAuthError::validation_failed(
+                "multisig signature weight below threshold",
+            ));
+        }
+
+        u8::try_from(recovered_weight).map_err(|_| {
+            NativeMultisigAuthError::validation_failed("multisig recovered owner weight overflow")
+        })
+    }
+}

--- a/crates/precompiles/src/native_multisig/mod.rs
+++ b/crates/precompiles/src/native_multisig/mod.rs
@@ -1,7 +1,9 @@
 //! Native multisig account precompile.
 
+pub mod auth;
 pub mod dispatch;
 
+pub use auth::NativeMultisigAuthError;
 pub use tempo_contracts::precompiles::INativeMultisig;
 use tempo_contracts::precompiles::{
     NATIVE_MULTISIG_ADDRESS, NativeMultisigError, NativeMultisigEvent,
@@ -92,6 +94,14 @@ impl NativeMultisig {
         Ok(header.threshold != 0 || header.owner_count != 0)
     }
 
+    pub fn get_multisig_config_id(&self, account: Address) -> Result<B256> {
+        if self.is_multisig_account(account)? {
+            Ok(account.into_word())
+        } else {
+            Ok(B256::ZERO)
+        }
+    }
+
     pub fn get_multisig_config(&self, account: Address) -> Result<INativeMultisig::MultisigConfig> {
         if !self.is_multisig_account(account)? {
             return Ok(INativeMultisig::MultisigConfig {
@@ -109,8 +119,19 @@ impl NativeMultisig {
         stored_config_to_init(stored)
     }
 
+    pub fn validate_config_id(&self, account: Address, config_id: B256) -> Result<()> {
+        if config_id == B256::ZERO
+            || config_id[..12].iter().any(|byte| *byte != 0)
+            || Address::from_word(config_id) != account
+            || self.get_multisig_config_id(account)? != config_id
+        {
+            return Err(NativeMultisigError::invalid_config().into());
+        }
+        Ok(())
+    }
+
     pub fn store_initial_config(&mut self, account: Address, config: &InitMultisig) -> Result<()> {
-        if !is_valid_multisig_account(account) {
+        if !is_valid_multisig_account(account, self.storage.spec()) {
             return Err(NativeMultisigError::invalid_account().into());
         }
         if self.is_multisig_account(account)? {

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -1,9 +1,12 @@
-use alloy_primitives::{Address, FixedBytes, hex};
+use alloy_primitives::{Address, FixedBytes, address, hex};
 use tempo_contracts::{TempoHardfork, precompiles::SYSTEM_PRECOMPILES};
 
 /// TIP20 token address prefix (12 bytes)
 /// The full address is: TIP20_TOKEN_PREFIX (12 bytes) || derived_bytes (8 bytes)
 pub const TIP20_TOKEN_PREFIX: [u8; 12] = hex!("20C000000000000000000000");
+
+/// Osaka P256VERIFY precompile address.
+const P256VERIFY_ADDRESS: Address = address!("0x0000000000000000000000000000000000000100");
 
 /// Returns `true` if `addr` has the TIP-20 token prefix.
 ///
@@ -42,6 +45,7 @@ pub trait TempoAddressExt {
     /// Returns `true` if the address is a precompile. This is the case if it is either:
     /// - A TIP-20 token address.
     /// - A system precompile active at the specified `spec` hardfork.
+    /// - A built-in EVM precompile active at the specified `spec` hardfork.
     fn is_precompile(&self, spec: TempoHardfork) -> bool;
 
     /// Returns `true` if the address matches the [TIP-1022] virtual-address format
@@ -102,6 +106,10 @@ impl TempoAddressExt for Address {
     fn is_precompile(&self, spec: TempoHardfork) -> bool {
         // Reserved low EVM precompile addresses 0x01 through 0x11.
         if self.as_slice()[..19] == [0u8; 19] && (1..=0x11).contains(&self.as_slice()[19]) {
+            return true;
+        }
+
+        if spec.is_t1c() && *self == P256VERIFY_ADDRESS {
             return true;
         }
 
@@ -200,5 +208,9 @@ mod tests {
         // Assert TIP20 prefixed addresses are classified as precompiles
         assert!(PATH_USD_ADDRESS.is_tip20());
         assert!(PATH_USD_ADDRESS.is_precompile(TempoHardfork::Genesis));
+
+        assert!(!P256VERIFY_ADDRESS.is_precompile(TempoHardfork::T1B));
+        assert!(P256VERIFY_ADDRESS.is_precompile(TempoHardfork::T1C));
+        assert!(P256VERIFY_ADDRESS.is_precompile(TempoHardfork::T8));
     }
 }

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -190,7 +190,7 @@ mod tests {
     fn test_is_precompile_address() {
         for &(address, activated) in SYSTEM_PRECOMPILES {
             assert!(address.is_precompile(activated));
-            assert!(address.is_precompile(TempoHardfork::T7));
+            assert!(address.is_precompile(TempoHardfork::T8));
 
             if activated != TempoHardfork::Genesis {
                 assert!(!address.is_precompile(TempoHardfork::Genesis));

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -100,6 +100,11 @@ impl TempoAddressExt for Address {
     }
 
     fn is_precompile(&self, spec: TempoHardfork) -> bool {
+        // Reserved low EVM precompile addresses 0x01 through 0x11.
+        if self.as_slice()[..19] == [0u8; 19] && (1..=0x11).contains(&self.as_slice()[19]) {
+            return true;
+        }
+
         self.is_tip20()
             || SYSTEM_PRECOMPILES
                 .iter()

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -23,9 +23,7 @@ pub use key_authorization::{
 pub use multisig::{
     InitMultisig, MAX_MULTISIG_NESTING_DEPTH, MAX_MULTISIG_OWNER_SIGNATURE_BYTES,
     MAX_MULTISIG_OWNERS, MULTISIG_SIGNATURE_DOMAIN, MultisigOwner, MultisigSignature,
-    SIGNATURE_TYPE_MULTISIG, derive_multisig_account, is_valid_multisig_account, multisig_digest,
-    validate_multisig_config, validate_multisig_signature_shape, verify_multisig_owner_signatures,
-    verify_trusted_multisig_owner_signatures,
+    SIGNATURE_TYPE_MULTISIG, is_valid_multisig_account, multisig_digest,
 };
 pub use tempo_transaction::{
     Call, FEE_PAYER_SIGNATURE_MARKER, MAX_WEBAUTHN_SIGNATURE_LENGTH, P256_SIGNATURE_LENGTH,

--- a/crates/primitives/src/transaction/multisig.rs
+++ b/crates/primitives/src/transaction/multisig.rs
@@ -3,13 +3,7 @@ use crate::TempoAddressExt;
 use alloc::vec::Vec;
 use alloy_primitives::{Address, B256, Bytes, keccak256};
 use core::hash::{Hash, Hasher};
-use tempo_contracts::precompiles::{
-    ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, NATIVE_MULTISIG_ADDRESS,
-    NONCE_PRECOMPILE_ADDRESS, RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS,
-    STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS,
-    TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS,
-    VALIDATOR_CONFIG_V2_ADDRESS,
-};
+use tempo_contracts::TempoHardfork;
 
 #[cfg(not(feature = "std"))]
 use once_cell::race::OnceBox as OnceLock;
@@ -104,7 +98,7 @@ impl InitMultisig {
     }
 
     /// Derives the native multisig account address for this initial config.
-    pub fn derive_account(&self) -> Result<Address, &'static str> {
+    pub fn account(&self) -> Result<Address, &'static str> {
         self.validate()?;
 
         let owner_count = encode_multisig_owner_count(self.owners.len())?;
@@ -127,9 +121,28 @@ impl InitMultisig {
         Ok(account)
     }
 
-    /// Returns the native multisig account address derived from this initial config.
-    pub fn account(&self) -> Result<Address, &'static str> {
-        self.derive_account()
+    /// Validates RPC simulation mock multisig signatures by treating the first
+    /// `signature_count` configured owners as signers.
+    pub fn validate_rpc_mock_signatures(&self, signature_count: usize) -> Result<(), &'static str> {
+        self.validate()?;
+        if signature_count == 0 {
+            return Err("multisig signatures cannot be empty");
+        }
+        if signature_count > self.owners.len() {
+            return Err("too many multisig signatures");
+        }
+
+        let mut signed_weight = 0u64;
+        for owner in self.owners.iter().take(signature_count) {
+            signed_weight = signed_weight
+                .checked_add(u64::from(owner.weight))
+                .ok_or("multisig recovered owner weight overflow")?;
+        }
+        if signed_weight < u64::from(self.threshold) {
+            return Err("multisig signature weight below threshold");
+        }
+
+        Ok(())
     }
 
     /// Decodes, verifies, and weight-accounts primitive owner approvals.
@@ -211,10 +224,10 @@ impl MultisigSignature {
     /// Performs stateless sender-recovery checks and returns the attempted multisig account.
     pub fn recover_account(&self) -> Result<Address, &'static str> {
         self.validate_shape()?;
-        if let Some(init) = &self.init {
-            if init.account()? != self.account {
-                return Err("multisig init does not derive account");
-            }
+        if let Some(init) = &self.init
+            && init.account()? != self.account
+        {
+            return Err("multisig init does not derive account");
         }
         Ok(self.account)
     }
@@ -347,29 +360,12 @@ impl Hash for MultisigSignature {
     }
 }
 
-/// Validates a native multisig config and returns its total owner weight.
-pub fn validate_multisig_config(config: &InitMultisig) -> Result<u8, &'static str> {
-    config.validate()
-}
-
-/// Validates only the stateless signature payload shape.
-pub fn validate_multisig_signature_shape(
-    signature: &MultisigSignature,
-) -> Result<(), &'static str> {
-    signature.validate_shape()
-}
-
-/// Derives the native multisig account address for an initial config.
-pub fn derive_multisig_account(config: &InitMultisig) -> Result<Address, &'static str> {
-    config.derive_account()
-}
-
 /// Returns whether an address is eligible to be a derived native multisig account.
-pub fn is_valid_multisig_account(account: Address) -> bool {
+pub fn is_valid_multisig_account(account: Address, spec: TempoHardfork) -> bool {
     !account.is_zero()
         && !account.is_tip20()
         && !account.is_virtual()
-        && !is_native_precompile_address(account)
+        && !account.is_precompile(spec)
 }
 
 /// Computes the digest that native multisig owners approve.
@@ -410,30 +406,6 @@ fn recover_multisig_owner_addresses(
         owners.push(owner);
     }
     Ok(owners)
-}
-
-/// Decodes, verifies, and weight-accounts primitive owner approvals.
-///
-/// This helper does not validate nested multisig owner approvals because that requires state access
-/// to load each nested account config.
-pub fn verify_multisig_owner_signatures(
-    digest: B256,
-    signatures: &[Bytes],
-    config: &InitMultisig,
-) -> Result<u8, &'static str> {
-    config.verify_owner_signatures(digest, signatures)
-}
-
-/// Verifies primitive owner approvals against a config already validated by trusted storage.
-///
-/// This helper does not validate nested multisig owner approvals because that requires state access
-/// to load each nested account config.
-pub fn verify_trusted_multisig_owner_signatures(
-    digest: B256,
-    signature: &MultisigSignature,
-    config: &InitMultisig,
-) -> Result<u8, &'static str> {
-    signature.verify_with_trusted_config(digest, config)
 }
 
 fn verify_recovered_multisig_owners(
@@ -493,29 +465,6 @@ fn encode_multisig_owner_count(owner_count: usize) -> Result<u8, &'static str> {
         return Err("too many multisig owners");
     }
     Ok(owner_count as u8)
-}
-
-fn is_native_precompile_address(account: Address) -> bool {
-    if account.as_slice()[..19] == [0u8; 19] && (1..=0x11).contains(&account.as_slice()[19]) {
-        return true;
-    }
-
-    [
-        TIP_FEE_MANAGER_ADDRESS,
-        TIP20_FACTORY_ADDRESS,
-        TIP403_REGISTRY_ADDRESS,
-        STABLECOIN_DEX_ADDRESS,
-        NONCE_PRECOMPILE_ADDRESS,
-        VALIDATOR_CONFIG_ADDRESS,
-        ACCOUNT_KEYCHAIN_ADDRESS,
-        VALIDATOR_CONFIG_V2_ADDRESS,
-        ADDRESS_REGISTRY_ADDRESS,
-        SIGNATURE_VERIFIER_ADDRESS,
-        TIP20_CHANNEL_RESERVE_ADDRESS,
-        RECEIVE_POLICY_GUARD_ADDRESS,
-        NATIVE_MULTISIG_ADDRESS,
-    ]
-    .contains(&account)
 }
 
 #[cfg(any(test, feature = "arbitrary"))]
@@ -721,7 +670,7 @@ mod tests {
 
         assert!(
             config_a
-                .verify_owner_signatures(digest_a, &[signature.clone()])
+                .verify_owner_signatures(digest_a, std::slice::from_ref(&signature))
                 .is_ok()
         );
         assert!(
@@ -778,7 +727,7 @@ mod tests {
         );
         assert!(
             config
-                .verify_owner_signatures(digest, &[canonical_signature.clone()])
+                .verify_owner_signatures(digest, std::slice::from_ref(&canonical_signature))
                 .is_ok()
         );
 

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -691,17 +691,12 @@ impl TempoSignature {
     }
 
     /// Get the primitive signature type, if the outer signature has one.
-    pub fn primitive_signature_type(&self) -> Option<SignatureType> {
+    pub fn signature_type(&self) -> Option<SignatureType> {
         match self {
             Self::Primitive(primitive_sig) => Some(primitive_sig.signature_type()),
             Self::Keychain(keychain_sig) => Some(keychain_sig.signature.signature_type()),
             Self::Multisig(_) => None,
         }
-    }
-
-    /// Get the primitive signature type, if the outer signature has one.
-    pub fn signature_type(&self) -> Option<SignatureType> {
-        self.primitive_signature_type()
     }
 
     /// Get the in-memory size of the signature
@@ -1982,7 +1977,6 @@ mod tests {
         ));
 
         assert_eq!(signature.signature_type(), None);
-        assert_eq!(signature.primitive_signature_type(), None);
     }
 
     #[test]

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -12,7 +12,11 @@ use revm::{
 };
 use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc};
 use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_precompiles::{storage::StorageActions, storage_credits::NonCreditableSlots};
+use tempo_precompiles::{
+    native_multisig::{NativeMultisig, NativeMultisigAuthError},
+    storage::StorageActions,
+    storage_credits::NonCreditableSlots,
+};
 use tempo_primitives::transaction::InitMultisig;
 
 /// The Tempo EVM context type.
@@ -60,18 +64,13 @@ pub struct TempoEvm<DB: Database, I> {
     pub(crate) non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
     /// Internal protocol fee hooks.
     pub(crate) fee_manager: Arc<dyn ProtocolFeeManager<DB>>,
-    /// Block-scoped cache for native multisig account markers.
+    /// Block-scoped cache for native multisig account markers and validated configs.
     ///
-    /// The marker is stateful account metadata, not transaction signature metadata. It is cached on
-    /// the EVM so repeated transactions from the same accounts do not repeatedly read the native
-    /// multisig marker storage slot. The cache is cleared when the EVM moves to a new block.
-    pub(crate) native_multisig_account_cache: HashMap<Address, bool>,
-    /// Block-scoped cache for validated native multisig configs.
-    ///
-    /// Values are inserted only after the native multisig storage path has loaded and validated the
-    /// config. The cache is cleared when the EVM moves to a new block or when a transaction directly
-    /// touches the native multisig precompile, because config updates mutate account-scoped config.
-    pub(crate) native_multisig_config_cache: HashMap<Address, InitMultisig>,
+    /// Markers are cached so repeated transactions from the same accounts do not repeatedly read
+    /// the native multisig marker storage slot. Config values are inserted only after the native
+    /// multisig storage path has loaded and validated them. Configs are cleared when a transaction
+    /// directly touches the native multisig precompile because updates mutate account-scoped config.
+    pub(crate) native_multisig_cache: NativeMultisigCache,
 }
 
 impl<DB: Database, I> TempoEvm<DB, I> {
@@ -121,8 +120,7 @@ impl<DB: Database, I> TempoEvm<DB, I> {
             skip_liquidity_check,
             actions,
             non_creditable_slots,
-            native_multisig_account_cache,
-            native_multisig_config_cache,
+            native_multisig_cache,
             ..
         } = self;
 
@@ -137,8 +135,7 @@ impl<DB: Database, I> TempoEvm<DB, I> {
             actions,
             non_creditable_slots,
             fee_manager,
-            native_multisig_account_cache,
-            native_multisig_config_cache,
+            native_multisig_cache,
         }
     }
 
@@ -168,8 +165,7 @@ impl<DB: Database, I> TempoEvm<DB, I> {
             actions,
             non_creditable_slots,
             fee_manager,
-            native_multisig_account_cache: HashMap::new(),
-            native_multisig_config_cache: HashMap::new(),
+            native_multisig_cache: NativeMultisigCache::default(),
         }
     }
 
@@ -244,8 +240,7 @@ impl<DB: Database, I> TempoEvm<DB, I> {
 
     /// Clears block-scoped execution caches.
     pub fn clear_block_caches(&mut self) {
-        self.native_multisig_account_cache.clear();
-        self.native_multisig_config_cache.clear();
+        self.native_multisig_cache.clear();
     }
 }
 
@@ -335,6 +330,81 @@ where
         &mut Self::Inspector,
     ) {
         self.inner.all_mut_inspector()
+    }
+}
+
+/// Block-scoped native multisig lookup cache.
+///
+/// Account markers and validated configs are cached separately so config invalidation can clear
+/// only configs while retaining marker hits. This avoids repeatedly reading marker storage after a
+/// transaction touches the native multisig precompile, while also avoiding a full marker-cache scan
+/// when configs must be invalidated.
+///
+/// The whole cache is cleared when the EVM moves to a new block. Configs are cleared, while marker
+/// bits are retained, after transactions that call the native multisig precompile because config
+/// updates can mutate account-scoped configs but do not clear the multisig account marker.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct NativeMultisigCache {
+    markers: HashMap<Address, bool>,
+    configs: HashMap<Address, InitMultisig>,
+}
+
+impl NativeMultisigCache {
+    /// Clears all cached markers and configs.
+    pub(crate) fn clear(&mut self) {
+        self.markers.clear();
+        self.configs.clear();
+    }
+
+    /// Clears cached configs while preserving cached account markers.
+    pub(crate) fn clear_configs(&mut self) {
+        self.configs.clear();
+    }
+
+    /// Inserts a validated native multisig config and marks the account as multisig.
+    pub(crate) fn insert_config(&mut self, account: Address, config: InitMultisig) {
+        self.markers.insert(account, true);
+        self.configs.insert(account, config);
+    }
+
+    /// Returns whether `account` is marked as a native multisig account, loading on cache miss.
+    pub(crate) fn is_multisig_account(
+        &mut self,
+        multisig: &NativeMultisig,
+        account: Address,
+    ) -> Result<bool, NativeMultisigAuthError> {
+        if let Some(is_multisig) = self.markers.get(&account) {
+            return Ok(*is_multisig);
+        }
+
+        let is_multisig = multisig.is_multisig_account(account)?;
+        self.markers.insert(account, is_multisig);
+        Ok(is_multisig)
+    }
+
+    /// Loads and caches the validated registered native multisig config for `account`.
+    pub(crate) fn load_registered_config(
+        &mut self,
+        multisig: &NativeMultisig,
+        account: Address,
+    ) -> Result<InitMultisig, NativeMultisigAuthError> {
+        if let Some(config) = self.configs.get(&account) {
+            return Ok(config.clone());
+        }
+
+        let config = multisig.load_registered_config(account)?;
+        self.insert_config(account, config.clone());
+        Ok(config)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_config(&self, account: &Address) -> Option<&InitMultisig> {
+        self.configs.get(account)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.markers.is_empty() && self.configs.is_empty()
     }
 }
 

--- a/crates/revm/src/exec.rs
+++ b/crates/revm/src/exec.rs
@@ -143,9 +143,7 @@ mod tests {
             .with_cfg(Default::default())
             .with_tx(TempoTxEnv::default());
         let mut evm = TempoEvm::new(ctx, ());
-        evm.native_multisig_account_cache
-            .insert(Address::repeat_byte(0x42), true);
-        evm.native_multisig_config_cache.insert(
+        evm.native_multisig_cache.insert_config(
             Address::repeat_byte(0x42),
             tempo_primitives::transaction::InitMultisig {
                 salt: B256::ZERO,
@@ -156,8 +154,7 @@ mod tests {
 
         // Set block with default fields
         evm.set_block(TempoBlockEnv::default());
-        assert!(evm.native_multisig_account_cache.is_empty());
-        assert!(evm.native_multisig_config_cache.is_empty());
+        assert!(evm.native_multisig_cache.is_empty());
 
         // Replay executes the current transaction and returns result with state.
         // With default tx (no calls, system tx), it should succeed.

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -2,12 +2,11 @@
 
 use std::{
     cmp::Ordering,
-    collections::HashMap,
     fmt::Debug,
     sync::{Arc, OnceLock},
 };
 
-use alloy_primitives::{Address, B256, TxKind, U256};
+use alloy_primitives::{Address, TxKind, U256};
 use reth_evm::{EvmError, EvmInternals};
 use revm::{
     Database,
@@ -39,8 +38,6 @@ use tempo_contracts::precompiles::{
     IAccountKeychain::SignatureType as PrecompileSignatureType, NATIVE_MULTISIG_ADDRESS,
     TIPFeeAMMError,
 };
-#[cfg(test)]
-use tempo_precompiles::tip_fee_manager::TipFeeManager;
 use tempo_precompiles::{
     ECRECOVER_GAS,
     account_keychain::{
@@ -48,7 +45,7 @@ use tempo_precompiles::{
         SelectorRule as PrecompileSelectorRule, TokenLimit,
     },
     error::TempoPrecompileError,
-    native_multisig::NativeMultisig,
+    native_multisig::{NativeMultisig, auth::NativeMultisigAuthError},
     nonce::{
         EXPIRING_NONCE_MAX_EXPIRY_SECS, EXPIRING_NONCE_SET_CAPACITY, INonce::getNonceCall,
         NonceManager,
@@ -107,230 +104,6 @@ const KEY_AUTH_PER_LIMIT_GAS: u64 = 22_000;
 
 /// Rounded buffer for each extra LOG3/no-data event emitted by key authorizations.
 const KEY_AUTH_EXTRA_EVENT_BUFFER: u64 = 1_500;
-
-fn map_native_multisig_error<DB: Database>(
-    err: TempoPrecompileError,
-) -> EVMError<DB::Error, TempoInvalidTransaction> {
-    match err {
-        TempoPrecompileError::Fatal(err) => {
-            EVMError::<DB::Error, TempoInvalidTransaction>::Custom(err)
-        }
-        err => TempoInvalidTransaction::NativeMultisigValidationFailed {
-            reason: err.to_string(),
-        }
-        .into(),
-    }
-}
-
-fn native_multisig_invalid_transaction_error<DB: Database>(
-    reason: impl Into<String>,
-) -> EVMError<DB::Error, TempoInvalidTransaction> {
-    TempoInvalidTransaction::NativeMultisigInvalidTransaction {
-        reason: reason.into(),
-    }
-    .into()
-}
-
-fn native_multisig_validation_failed_error<DB: Database>(
-    reason: impl Into<String>,
-) -> EVMError<DB::Error, TempoInvalidTransaction> {
-    TempoInvalidTransaction::NativeMultisigValidationFailed {
-        reason: reason.into(),
-    }
-    .into()
-}
-
-fn cached_is_native_multisig_account<DB: Database>(
-    cache: &mut HashMap<Address, bool>,
-    multisig: &NativeMultisig,
-    account: Address,
-) -> Result<bool, EVMError<DB::Error, TempoInvalidTransaction>> {
-    if let Some(is_multisig) = cache.get(&account) {
-        return Ok(*is_multisig);
-    }
-
-    let is_multisig = multisig
-        .is_multisig_account(account)
-        .map_err(map_native_multisig_error::<DB>)?;
-    cache.insert(account, is_multisig);
-    Ok(is_multisig)
-}
-
-fn cached_native_multisig_config<DB: Database>(
-    cache: &mut HashMap<Address, InitMultisig>,
-    multisig: &NativeMultisig,
-    account: Address,
-) -> Result<InitMultisig, EVMError<DB::Error, TempoInvalidTransaction>> {
-    if let Some(config) = cache.get(&account) {
-        return Ok(config.clone());
-    }
-
-    let config = multisig
-        .load_registered_config(account)
-        .map_err(map_native_multisig_error::<DB>)?;
-    cache.insert(account, config.clone());
-    Ok(config)
-}
-
-fn tx_touches_native_multisig_precompile(tx: &TempoTxEnv) -> bool {
-    tx.calls().any(
-        |(kind, _)| matches!(kind, TxKind::Call(address) if *address == NATIVE_MULTISIG_ADDRESS),
-    )
-}
-
-fn validate_rpc_multisig_mock_signatures(
-    config: &InitMultisig,
-    signature_count: usize,
-) -> Result<(), &'static str> {
-    config.validate()?;
-    if signature_count == 0 {
-        return Err("multisig signatures cannot be empty");
-    }
-    if signature_count > config.owners.len() {
-        return Err("too many multisig signatures");
-    }
-
-    let mut signed_weight = 0u64;
-    for owner in config.owners.iter().take(signature_count) {
-        signed_weight = signed_weight
-            .checked_add(u64::from(owner.weight))
-            .ok_or("multisig recovered owner weight overflow")?;
-    }
-    if signed_weight < u64::from(config.threshold) {
-        return Err("multisig signature weight below threshold");
-    }
-
-    Ok(())
-}
-
-fn verify_native_multisig_authorization<DB: Database>(
-    multisig: &NativeMultisig,
-    native_multisig_config_cache: &mut HashMap<Address, InitMultisig>,
-    inner_digest: B256,
-    signature: &MultisigSignature,
-    config: &InitMultisig,
-) -> Result<(), EVMError<DB::Error, TempoInvalidTransaction>> {
-    let mut account_path = vec![signature.account()];
-    verify_native_multisig_authorization_inner::<DB>(
-        multisig,
-        native_multisig_config_cache,
-        inner_digest,
-        signature,
-        config,
-        &mut account_path,
-    )
-    .map(|_| ())
-}
-
-fn verify_native_multisig_authorization_inner<DB: Database>(
-    multisig: &NativeMultisig,
-    native_multisig_config_cache: &mut HashMap<Address, InitMultisig>,
-    inner_digest: B256,
-    signature: &MultisigSignature,
-    config: &InitMultisig,
-    account_path: &mut Vec<Address>,
-) -> Result<u8, EVMError<DB::Error, TempoInvalidTransaction>> {
-    config
-        .validate()
-        .map_err(native_multisig_validation_failed_error::<DB>)?;
-
-    let digest = signature.digest(inner_digest);
-    let mut recovered_weight = 0u16;
-    let mut prev_owner = None;
-
-    for signature_bytes in signature.signatures() {
-        let owner_approval = TempoSignature::from_bytes(signature_bytes).map_err(|reason| {
-            native_multisig_validation_failed_error::<DB>(format!(
-                "invalid multisig owner signature: {reason}"
-            ))
-        })?;
-
-        let (owner, nested_signature) = match owner_approval {
-            TempoSignature::Primitive(primitive) => {
-                let owner = primitive.recover_signer(&digest).map_err(|_| {
-                    native_multisig_validation_failed_error::<DB>(
-                        "invalid multisig owner signature",
-                    )
-                })?;
-                (owner, None)
-            }
-            TempoSignature::Keychain(_) => {
-                return Err(native_multisig_validation_failed_error::<DB>(
-                    "keychain signatures cannot authorize native multisig owners",
-                ));
-            }
-            TempoSignature::Multisig(nested_signature) => {
-                nested_signature
-                    .validate_registered_shape()
-                    .map_err(|reason| {
-                        native_multisig_validation_failed_error::<DB>(format!(
-                            "invalid nested multisig owner signature: {reason}"
-                        ))
-                    })?;
-                (nested_signature.account(), Some(nested_signature))
-            }
-        };
-
-        if prev_owner.is_some_and(|prev| prev >= owner) {
-            return Err(native_multisig_validation_failed_error::<DB>(
-                "multisig recovered owners must be strictly ascending",
-            ));
-        }
-        prev_owner = Some(owner);
-
-        let configured_owner = config
-            .owners
-            .binary_search_by_key(&owner, |entry| entry.owner)
-            .map(|idx| &config.owners[idx])
-            .map_err(|_| {
-                native_multisig_validation_failed_error::<DB>("multisig signer is not an owner")
-            })?;
-
-        if let Some(nested_signature) = nested_signature {
-            if account_path.len() >= MAX_MULTISIG_NESTING_DEPTH {
-                return Err(native_multisig_validation_failed_error::<DB>(
-                    "native multisig nesting depth exceeded",
-                ));
-            }
-            if account_path.contains(&owner) {
-                return Err(native_multisig_validation_failed_error::<DB>(
-                    "native multisig owner cycle detected",
-                ));
-            }
-
-            let nested_config =
-                cached_native_multisig_config::<DB>(native_multisig_config_cache, multisig, owner)?;
-            account_path.push(owner);
-            verify_native_multisig_authorization_inner::<DB>(
-                multisig,
-                native_multisig_config_cache,
-                digest,
-                &nested_signature,
-                &nested_config,
-                account_path,
-            )?;
-            account_path.pop();
-        }
-
-        recovered_weight = recovered_weight
-            .checked_add(u16::from(configured_owner.weight))
-            .ok_or_else(|| {
-                native_multisig_validation_failed_error::<DB>(
-                    "multisig recovered owner weight overflow",
-                )
-            })?;
-    }
-
-    if recovered_weight < u16::from(config.threshold) {
-        return Err(native_multisig_validation_failed_error::<DB>(
-            "multisig signature weight below threshold",
-        ));
-    }
-
-    u8::try_from(recovered_weight).map_err(|_| {
-        native_multisig_validation_failed_error::<DB>("multisig recovered owner weight overflow")
-    })
-}
 
 /// Gas cost for expiring nonce transactions (replay check + insert).
 ///
@@ -1231,10 +1004,10 @@ where
         result: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
         result_gas: ResultGas,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        let clear_native_multisig_config_cache = tx_touches_native_multisig_precompile(evm.tx());
+        let clear_native_multisig_config_cache = evm.tx().targets_address(NATIVE_MULTISIG_ADDRESS);
         evm.clear();
         if clear_native_multisig_config_cache {
-            evm.native_multisig_config_cache.clear();
+            evm.native_multisig_cache.clear_configs();
         }
 
         MainnetHandler::default()
@@ -1309,8 +1082,7 @@ where
         let tx = &evm.inner.ctx.tx;
         let cfg = &evm.inner.ctx.cfg;
         let journal = &mut evm.inner.ctx.journaled_state;
-        let native_multisig_account_cache = &mut evm.native_multisig_account_cache;
-        let native_multisig_config_cache = &mut evm.native_multisig_config_cache;
+        let multisig_cache = &mut evm.native_multisig_cache;
 
         let fee_payer = tx.fee_payer().expect("pre-validated in `validate_env`");
         let fee_token = fee_manager
@@ -1372,18 +1144,14 @@ where
                     (),
                     EVMError<DB::Error, TempoInvalidTransaction>,
                 > {
-                    let caller_is_multisig = cached_is_native_multisig_account::<DB>(
-                        native_multisig_account_cache,
-                        &multisig,
-                        tx.caller(),
-                    )?;
+                    let caller_is_multisig = multisig_cache
+                        .is_multisig_account(&multisig, tx.caller())
+                        .map_err(map_native_multisig_error::<DB>)?;
 
                     if tx.has_fee_payer_signature()
-                        && cached_is_native_multisig_account::<DB>(
-                            native_multisig_account_cache,
-                            &multisig,
-                            fee_payer,
-                        )?
+                        && multisig_cache
+                            .is_multisig_account(&multisig, fee_payer)
+                            .map_err(map_native_multisig_error::<DB>)?
                     {
                         return Err(TempoInvalidTransaction::NativeMultisigFeePayerNotAllowed {
                             account: fee_payer,
@@ -1391,21 +1159,28 @@ where
                         .into());
                     }
 
-                    let mut validate_authorization_authority = |authority| {
+                    let mut validate_authorization_authority = |authority| -> Result<
+                        (),
+                        EVMError<DB::Error, TempoInvalidTransaction>,
+                    > {
                         if multisig_signature.map(|sig| sig.account()) == Some(authority) {
-                            return Err(native_multisig_invalid_transaction_error::<DB>(format!(
-                                "native multisig account {authority} cannot be used as an authorization-list authority"
-                            )));
+                            return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
+                                reason: format!(
+                                    "native multisig account {authority} cannot be used as an authorization-list authority"
+                                ),
+                            }
+                            .into());
                         }
 
-                        if cached_is_native_multisig_account::<DB>(
-                            native_multisig_account_cache,
-                            &multisig,
-                            authority,
-                        )? {
-                            return Err(native_multisig_invalid_transaction_error::<DB>(format!(
-                                "native multisig account {authority} cannot be used as an authorization-list authority"
-                            )));
+                        if multisig_cache
+                            .is_multisig_account(&multisig, authority)
+                            .map_err(map_native_multisig_error::<DB>)? {
+                            return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
+                                reason: format!(
+                                    "native multisig account {authority} cannot be used as an authorization-list authority"
+                                ),
+                            }
+                            .into());
                         }
                         Ok(())
                     };
@@ -1442,9 +1217,10 @@ where
                         return Ok(());
                     };
                     let Some(tempo_tx_env) = tempo_tx_env else {
-                        return Err(native_multisig_invalid_transaction_error::<DB>(
-                            "multisig signature requires AA transaction context",
-                        ));
+                        return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
+                            reason: "multisig signature requires AA transaction context".to_string(),
+                        }
+                        .into());
                     };
 
                     let caller_account_info = caller_account_info
@@ -1457,9 +1233,11 @@ where
                             .is_some_and(|code| code.eip7702_address().is_some());
 
                     if multisig_signature.account() != tx.caller() {
-                        return Err(native_multisig_invalid_transaction_error::<DB>(
-                            "multisig signature account does not match transaction caller",
-                        ));
+                        return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
+                            reason: "multisig signature account does not match transaction caller"
+                                .to_string(),
+                        }
+                        .into());
                     }
                     if caller_is_multisig {
                         multisig_signature.validate_registered_shape().map_err(|reason| {
@@ -1475,9 +1253,11 @@ where
                         })?;
                     }
                     if tempo_tx_env.key_authorization.is_some() {
-                        return Err(native_multisig_invalid_transaction_error::<DB>(
-                            "native multisig transactions cannot carry key_authorization",
-                        ));
+                        return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
+                            reason: "native multisig transactions cannot carry key_authorization"
+                                .to_string(),
+                        }
+                        .into());
                     }
                     if account_has_code_or_delegation {
                         return Err(TempoInvalidTransaction::NativeMultisigValidationFailed {
@@ -1488,29 +1268,26 @@ where
                     }
 
                     if caller_is_multisig {
-                        let config = cached_native_multisig_config::<DB>(
-                            native_multisig_config_cache,
-                            &multisig,
-                            multisig_signature.account(),
-                        )?;
+                        let config = multisig_cache
+                            .load_registered_config(&multisig, multisig_signature.account())
+                            .map_err(map_native_multisig_error::<DB>)?;
                         if is_rpc_simulation {
-                            validate_rpc_multisig_mock_signatures(
-                                &config,
-                                multisig_signature.signature_count(),
-                            )
+                            config
+                                .validate_rpc_mock_signatures(multisig_signature.signature_count())
                             .map_err(|reason| {
                                 TempoInvalidTransaction::NativeMultisigValidationFailed {
                                     reason: reason.to_string(),
                                 }
                             })?;
                         } else {
-                            verify_native_multisig_authorization::<DB>(
-                                &multisig,
-                                native_multisig_config_cache,
-                                tempo_tx_env.signature_hash,
-                                multisig_signature,
-                                &config,
-                            )?;
+                            multisig
+                                .verify_authorization(
+                                    tempo_tx_env.signature_hash,
+                                    multisig_signature,
+                                    &config,
+                                    |acc| { multisig_cache.load_registered_config(&multisig, acc) },
+                                )
+                                .map_err(map_native_multisig_error::<DB>)?;
                         }
                     } else {
                         let init_config = multisig_signature.init().ok_or_else(|| {
@@ -1545,29 +1322,29 @@ where
                             })?
                             != tx.caller()
                         {
-                            return Err(native_multisig_invalid_transaction_error::<DB>(
-                                "multisig_init does not derive transaction caller",
-                            ));
+                            return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
+                                reason: "multisig_init does not derive transaction caller".to_string(),
+                            }
+                            .into());
                         }
 
                         if is_rpc_simulation {
-                            validate_rpc_multisig_mock_signatures(
-                                init_config,
-                                multisig_signature.signature_count(),
-                            )
+                            init_config
+                                .validate_rpc_mock_signatures(multisig_signature.signature_count())
                             .map_err(|reason| {
                                 TempoInvalidTransaction::NativeMultisigValidationFailed {
                                     reason: reason.to_string(),
                                 }
                             })?;
                         } else {
-                            verify_native_multisig_authorization::<DB>(
-                                &multisig,
-                                native_multisig_config_cache,
-                                tempo_tx_env.signature_hash,
-                                multisig_signature,
-                                init_config,
-                            )?;
+                            multisig
+                                .verify_authorization(
+                                    tempo_tx_env.signature_hash,
+                                    multisig_signature,
+                                    init_config,
+                                    |acc| { multisig_cache.load_registered_config(&multisig, acc) },
+                                )
+                                .map_err(map_native_multisig_error::<DB>)?;
                         }
                         native_multisig_bootstrap =
                             Some((multisig_signature.account(), init_config.clone()));
@@ -2038,11 +1815,11 @@ where
                     let mut multisig = NativeMultisig::new();
                     multisig
                         .store_initial_config(account, &config)
+                        .map_err(NativeMultisigAuthError::from)
                         .map_err(map_native_multisig_error::<DB>)
                 },
             )?;
-            native_multisig_account_cache.insert(account, true);
-            native_multisig_config_cache.insert(account, config);
+            multisig_cache.insert_config(account, config);
         }
 
         // If the transaction includes a KeyAuthorization, validate and authorize the key
@@ -3158,6 +2935,19 @@ pub fn validate_time_window(
     Ok(())
 }
 
+fn map_native_multisig_error<DB: Database>(
+    err: NativeMultisigAuthError,
+) -> EVMError<DB::Error, TempoInvalidTransaction> {
+    match err {
+        NativeMultisigAuthError::Fatal(err) => {
+            EVMError::<DB::Error, TempoInvalidTransaction>::Custom(err)
+        }
+        NativeMultisigAuthError::ValidationFailed(reason) => {
+            TempoInvalidTransaction::NativeMultisigValidationFailed { reason }.into()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3183,6 +2973,7 @@ mod tests {
     use tempo_contracts::precompiles::DEFAULT_FEE_TOKEN;
     use tempo_precompiles::{
         PATH_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS, storage::ContractStorage, test_util::TIP20Setup,
+        tip_fee_manager::TipFeeManager,
     };
     use tempo_primitives::transaction::{
         Call, InitMultisig, MultisigOwner, MultisigSignature, RecoveredTempoAuthorization,
@@ -3658,7 +3449,7 @@ mod tests {
         test.validate_against_state_and_deduct_caller()
             .expect("RPC simulation should accept mock native multisig signatures");
         assert_eq!(
-            test.evm.native_multisig_config_cache.get(&account),
+            test.evm.native_multisig_cache.get_config(&account),
             Some(&config),
             "registered multisig validation should cache the validated config"
         );

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -167,6 +167,12 @@ impl TempoTxEnv {
             )))
         }
     }
+
+    /// Returns true if any top-level call targets `address`.
+    pub fn targets_address(&self, address: Address) -> bool {
+        self.calls()
+            .any(|(kind, _)| matches!(kind, TxKind::Call(target) if *target == address))
+    }
 }
 
 impl From<TxEnv> for TempoTxEnv {


### PR DESCRIPTION
this PR moves native multisig authorization and cache handling out of the EVM handler into focused helpers. Native multisig verification now lives with the precompile code, tx/config helpers live on their owning types, and the handler is left to orchestrate validation and map errors at the revm boundary.