### PR TITLE
Use Reth OTLP log span attribute patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11130,7 +11130,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0d303f7#0d303f75409c3b8a1b760bf275680b7c2deaa2a5"
+source = "git+https://github.com/kuyziss/reth?branch=enable-otlp-log-span-attributes#3fcfba407a310c37cfcfd5b4a91794bca46c285f"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -403,6 +403,9 @@ vergen-git2 = "10.0.1"
 # reth-trie-parallel = { path = "../reth/crates/trie/parallel" }
 # reth-trie-sparse = { path = "../reth/crates/trie/sparse" }
 
+[patch."https://github.com/paradigmxyz/reth"]
+reth-tracing-otlp = { git = "https://github.com/kuyziss/reth", branch = "enable-otlp-log-span-attributes" }
+
 [patch.crates-io]
 
 # Commonware at HEAD after PR #3588 was merged


### PR DESCRIPTION
## Summary

Use the Reth OTLP log span-attributes change for Tempo's `otlp` feature by temporarily patching `reth-tracing-otlp` to the Reth PR branch.

This intentionally does not vendor or patch OpenTelemetry PR 3466. That means OTLP log records get tracing span attributes, but not the current span name yet. We should pick that up naturally once the upstream OpenTelemetry change lands and Reth updates to a release containing it.

## Rollout notes

This PR is draft because it depends on https://github.com/paradigmxyz/reth/pull/26062.

Before merging this PR, replace the temporary `kuyziss/reth` branch patch with the upstream Reth merge commit, or remove the patch once Tempo's pinned Reth revision already includes the change.

## Validation

- `cargo +1.95.0 check -p tempo --features otlp`
