### PR TITLE
fix(evm): generalize SSTORE action

### DIFF
--- a/crates/evm/src/action_replay.rs
+++ b/crates/evm/src/action_replay.rs
@@ -444,7 +444,10 @@ impl StorageActionReplayState {
         Ok(())
     }
 
-    /// Stores the value of a slot after validating the recorded pre-store value.
+    /// Stores the value of a slot after establishing its exact replay view.
+    ///
+    /// Uses [`Self::sload_exact`] to validate the recorded pre-store value against
+    /// the tx-local/cache view when available, then records the store.
     fn sstore_exact<DB: Database>(
         &mut self,
         db: &mut State<DB>,
@@ -511,7 +514,11 @@ impl StorageActionReplayState {
         })
     }
 
-    /// Returns the current value for a slot and validates that it matches the expected value.
+    /// Returns the current slot value for exact replay.
+    ///
+    /// If the tx has already touched the slot, validates that the current value matches `expected`.
+    /// On first touch, uses the EVM state cache when available and requires it to match `expected`.
+    /// When the slot is not cached, records `expected` as the current value.
     fn sload_exact<DB: Database>(
         &mut self,
         db: &mut State<DB>,
@@ -547,7 +554,11 @@ impl StorageActionReplayState {
         }
     }
 
-    /// Returns the current slot value when it is known, otherwise falls back to the recorded value.
+    /// Returns the current slot value for semantic replay.
+    ///
+    /// Like [`Self::sload_exact`], but returns the current value even when it does not match
+    /// `expected`, allowing semantic actions to rebase onto compatible prior writes.
+    /// Falls back to `expected` when the current value is not already known.
     fn sload_current_or_expected<DB: Database>(
         &mut self,
         db: &mut State<DB>,

--- a/crates/evm/src/action_replay.rs
+++ b/crates/evm/src/action_replay.rs
@@ -118,12 +118,18 @@ where
                     // as `sload_exact` is already checking it
                     let _ = self.replay_state.sload_exact(db, address, key, value)?;
                 }
-                StorageAction::Sstore(address, key, _, value) => {
+                StorageAction::Sstore(address, key, sload_value, value) => {
                     if self.replay_state.has_write(address, key) {
                         return Err(StorageActionReplayError::ActionConflict.into());
                     }
-                    self.replay_state
-                        .sstore(address, key, value, WriteKind::Store)?;
+                    self.replay_state.sstore_exact(
+                        db,
+                        address,
+                        key,
+                        sload_value,
+                        value,
+                        WriteKind::Store,
+                    )?;
                 }
                 StorageAction::Sinc(address, key, sload_value, delta) => {
                     if self.replay_state.has_store(address, key) {
@@ -418,8 +424,9 @@ impl StorageActionReplayState {
         value: U256,
         kind: WriteKind,
     ) -> Result<(), BlockExecutionError> {
-        // The transaction-start value must already be established by a load,
-        // otherwise replay would invent `original` from current state and reuse
+        // This helper only updates an already loaded tx-local slot value. First-touch
+        // absolute stores must go through `sstore_exact` with the action's recorded
+        // pre-store value; otherwise replay would invent `original` and reuse
         // gas/refund data from a different storage transition.
         let change = self
             .tx_changes
@@ -435,6 +442,22 @@ impl StorageActionReplayState {
         }
 
         Ok(())
+    }
+
+    /// Stores the value of a slot after validating the recorded pre-store value.
+    fn sstore_exact<DB: Database>(
+        &mut self,
+        db: &mut State<DB>,
+        address: Address,
+        slot: U256,
+        expected: U256,
+        value: U256,
+        kind: WriteKind,
+    ) -> Result<(), BlockExecutionError> {
+        // TODO: we can save on `self.tx_changes` lookup here
+        // by returning an entry from `self.sload_exact`
+        self.sload_exact(db, address, slot, expected)?;
+        self.sstore(address, slot, value, kind)
     }
 
     /// Records a storage slot write with a known transaction-start value.
@@ -778,6 +801,34 @@ mod tests {
             StorageActionReplayError::from_block_execution_error(&err),
             Some(StorageActionReplayError::ActionConflict)
         );
+    }
+
+    #[test]
+    fn first_touch_sstore_uses_recorded_prewrite_value() {
+        let address = Address::repeat_byte(0x42);
+        let slot = U256::from(7);
+        let mut db = state_with_storage(address, slot, U256::from(10));
+        let mut replay_state = StorageActionReplayState::default();
+
+        replay_state
+            .sstore_exact(
+                &mut db,
+                address,
+                slot,
+                U256::from(10),
+                U256::from(11),
+                WriteKind::Store,
+            )
+            .expect("first-touch store should establish the slot view");
+
+        let change = replay_state
+            .tx_changes
+            .get(&address)
+            .and_then(|slots| slots.get(&slot))
+            .expect("slot change recorded");
+        assert_eq!(change.original, U256::from(10));
+        assert_eq!(change.current, U256::from(11));
+        assert_eq!(change.write_kind, Some(WriteKind::Store));
     }
 
     #[test]


### PR DESCRIPTION
Previously, `Sstore` action required an `Sload` action recorded before it, otherwise it errored.

This PR fixes this, so that if an `SSTORE` happens without a prior `SLOAD` (for example when the slot is not updated, but just written to), we initialize it with prior storage slot value.