### PR TITLE
chore: drop version cache

### DIFF
--- a/crates/node/tests/it/gas/snapshots/it__gas__stablecoin_dex__stablecoin_dex_lifecycle_gas_snapshot_t8.snap
+++ b/crates/node/tests/it/gas/snapshots/it__gas__stablecoin_dex__stablecoin_dex_lifecycle_gas_snapshot_t8.snap
@@ -3,15 +3,15 @@ source: crates/node/tests/it/gas/stablecoin_dex.rs
 expression: gas
 ---
 cancel_bid_earn_credits:
-  gas: 347041
+  gas: 347141
   storage_credits: "user1: 0 -> 3"
   pooled_storage_credits: "DEX TIP-1060: 0 -> 5"
 cancel_head_bid_tracks_successor_prev:
-  gas: 342741
+  gas: 342941
   storage_credits: "user11: 0 -> 4; user12: 0 -> 1"
   pooled_storage_credits: "DEX TIP-1060: 24 -> 27"
 cancel_tail_bid_credits_predecessor_next:
-  gas: 342741
+  gas: 342941
   storage_credits: "user10: 0 -> 4; user9: 0 -> 1"
   pooled_storage_credits: "DEX TIP-1060: 18 -> 21"
 create_pair:
@@ -19,59 +19,59 @@ create_pair:
   storage_credits: n/a
   pooled_storage_credits: "DEX TIP-1060: 0 -> 0"
 place_ask_wallet:
-  gas: 1835985
+  gas: 1840385
   storage_credits: "user2: 0 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 7 -> 7"
 place_bid_append_same_level:
-  gas: 1341669
+  gas: 1346069
   storage_credits: "user16: 0 -> 0; user15: 0 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 3 -> 3"
 place_bid_cross_user_after_cancel_credits:
-  gas: 1336769
+  gas: 1341169
   storage_credits: "user7: 0 -> 0; user6: 3 -> 3"
   pooled_storage_credits: "DEX TIP-1060: 7 -> 7"
 place_bid_cross_user_after_fill_credits:
-  gas: 1336769
+  gas: 1341169
   storage_credits: "user7: 0 -> 0; user4: 3 -> 3"
   pooled_storage_credits: "DEX TIP-1060: 14 -> 14"
 place_bid_reuse_cancel_credits:
-  gas: 850113
+  gas: 854513
   storage_credits: "user1: 3 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 5 -> 3"
 place_bid_reuse_predecessor_next_credit:
-  gas: 1098169
+  gas: 1102569
   storage_credits: "user9: 1 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 21 -> 21"
 place_bid_reuse_swap_credits:
-  gas: 602813
+  gas: 607213
   storage_credits: "user3: 3 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 12 -> 10"
 place_bid_wallet:
-  gas: 2083285
+  gas: 2087685
   storage_credits: "user1: 0 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 0 -> 0"
 place_flip_bid_wallet:
-  gas: 1586743
+  gas: 1591143
   storage_credits: "user5: 0 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 14 -> 14"
 swap_exact_in_full_ask_earn_credits:
-  gas: 388197
+  gas: 388297
   storage_credits: "user3: 0 -> 3"
   pooled_storage_credits: "DEX TIP-1060: 8 -> 12"
 swap_exact_in_full_flip_bid:
-  gas: 885284
+  gas: 885384
   storage_credits: "user5: 0 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 14 -> 18"
 swap_exact_in_full_head_bid_tracks_successor_prev:
-  gas: 389685
+  gas: 389885
   storage_credits: "user13: 0 -> 4; user14: 0 -> 1"
   pooled_storage_credits: "DEX TIP-1060: 21 -> 24"
 swap_exact_in_partial_ask_no_credits:
-  gas: 347385
+  gas: 347485
   storage_credits: "user2: 0 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 7 -> 7"
 swap_exact_out_full_ask_earn_credits:
-  gas: 388377
+  gas: 388477
   storage_credits: "user4: 0 -> 3"
   pooled_storage_credits: "DEX TIP-1060: 10 -> 14"
 withdraw_internal_balance:

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -1072,11 +1072,6 @@ impl StablecoinDEX {
                     return Err(res.unwrap_err());
                 }
 
-                // Execution continues after rollback, so discard the reverted layout version cache.
-                if self.storage.spec().is_t8() {
-                    self.orders[order.order_id()].clear_version_cache();
-                }
-
                 if self.storage.spec().is_t5() {
                     self.emit_event(StablecoinDEXEvents::flip_failed(
                         order.order_id(),

--- a/crates/precompiles/src/stablecoin_dex/order/storage.rs
+++ b/crates/precompiles/src/stablecoin_dex/order/storage.rs
@@ -22,10 +22,7 @@ use crate::{
     },
 };
 use alloy::primitives::{Address, B256, FixedBytes, U256};
-use std::{
-    cell::Cell,
-    ops::{Index, IndexMut},
-};
+use std::ops::{Index, IndexMut};
 use tempo_precompiles_macros::Storable;
 
 /// Physical storage layout version for an order record.
@@ -154,9 +151,6 @@ pub(crate) struct OrderHandler {
     order_id: u128,
     /// Contract address whose storage contains the order mapping.
     address: Address,
-    /// Cached physical layout version for this record.
-    /// NOTE: Storage checkpoint rollbacks do not reset it. Clear manually if execution continues.
-    pub(crate) version: Cell<Option<OrderVersion>>,
 }
 
 impl OrderHandler {
@@ -166,7 +160,6 @@ impl OrderHandler {
             base_slot,
             order_id,
             address,
-            version: Cell::new(None),
         }
     }
 
@@ -218,24 +211,12 @@ impl OrderHandler {
         Ok(Slot::new_at_loc(self.base_slot, loc, self.address))
     }
 
-    /// Clears the cached physical storage version so the next access re-detects it from storage.
-    pub(crate) fn clear_version_cache(&self) {
-        self.version.set(None);
-    }
-
-    /// Returns the cached physical storage version, detecting and caching it if needed.
+    /// Returns the physical storage version.
     pub(crate) fn version(&self) -> StorageResult<OrderVersion> {
         if !StorageCtx.spec().is_t8() {
             return Ok(OrderVersion::Legacy);
         }
-
-        if let Some(version) = self.version.get() {
-            return Ok(version);
-        }
-
-        let version = OrderVersion::try_from(self.load(self.base_slot)?)?;
-        self.version.set(Some(version));
-        Ok(version)
+        OrderVersion::try_from(self.load(self.base_slot)?)
     }
 }
 
@@ -264,36 +245,19 @@ impl Handler<Order> for OrderHandler {
         debug_assert_eq!(value.order_id, self.order_id);
 
         if !StorageCtx.spec().is_t8() {
-            value.store(self, self.base_slot, LayoutCtx::FULL)?;
-            self.version.set(Some(OrderVersion::Legacy));
-            return Ok(());
+            return value.store(self, self.base_slot, LayoutCtx::FULL);
         }
 
-        match self.version.get() {
-            Some(OrderVersion::Legacy) => {
+        match self.version()? {
+            OrderVersion::Legacy => {
                 V1Order::new(value).store(self, self.base_slot, LayoutCtx::FULL)?;
                 for offset in V1Order::SLOTS..LegacyOrder::SLOTS {
                     self.store(self.base_slot.wrapping_add(U256::from(offset)), U256::ZERO)?;
                 }
+                Ok(())
             }
-            Some(OrderVersion::V1) => {
-                V1Order::new(value).store(self, self.base_slot, LayoutCtx::FULL)?;
-            }
-            None => {
-                let current_slot0 = self.load(self.base_slot)?;
-                let current_version = OrderVersion::try_from(current_slot0)?;
-
-                V1Order::new(value).store(self, self.base_slot, LayoutCtx::FULL)?;
-                if matches!(current_version, OrderVersion::Legacy) && !current_slot0.is_zero() {
-                    for offset in V1Order::SLOTS..LegacyOrder::SLOTS {
-                        self.store(self.base_slot.wrapping_add(U256::from(offset)), U256::ZERO)?;
-                    }
-                }
-            }
+            OrderVersion::V1 => V1Order::new(value).store(self, self.base_slot, LayoutCtx::FULL),
         }
-
-        self.version.set(Some(OrderVersion::V1));
-        Ok(())
     }
 
     /// Deletes the physical slots for the cached or detected order layout.
@@ -307,7 +271,6 @@ impl Handler<Order> for OrderHandler {
             self.store(self.base_slot.wrapping_add(U256::from(offset)), U256::ZERO)?;
         }
 
-        self.version.set(None);
         Ok(())
     }
 
@@ -542,32 +505,6 @@ mod tests {
     }
 
     #[test]
-    fn test_cached_version_field_write_skips_version_sload() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
-        StorageCtx::enter(&mut storage, || {
-            let mut exchange = StablecoinDEX::new();
-
-            let id = 42;
-            let order = Order::new_bid(id, TEST_MAKER, TEST_BOOK_KEY, 1000, 5);
-            exchange.orders[id].write(order)?;
-
-            let uncached_exchange = StablecoinDEX::new();
-            StorageCtx.reset_counters();
-            uncached_exchange.orders[id].remaining()?.write(900)?;
-            assert_eq!(StorageCtx.counter_sload(), 2);
-
-            StorageCtx.reset_counters();
-            exchange.orders[id].remaining()?.write(800)?;
-            assert_eq!(StorageCtx.counter_sload(), 1);
-
-            let loaded = exchange.orders[id].read()?;
-            assert_eq!(loaded.remaining(), 800);
-
-            Ok(())
-        })
-    }
-
-    #[test]
     fn test_t6_store_order_uses_legacy_layout() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
         StorageCtx::enter(&mut storage, || {
@@ -732,39 +669,7 @@ mod tests {
 
     fn store_legacy_order(handler: &OrderHandler, order: Order) -> StorageResult<()> {
         let mut storage = handler.clone();
-        LegacyOrder::store(&order, &mut storage, handler.base_slot, LayoutCtx::FULL)?;
-        handler.version.set(Some(OrderVersion::Legacy));
-        Ok(())
-    }
-
-    #[test]
-    fn test_clear_version_cache_redetects_after_checkpoint_revert() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
-        StorageCtx::enter(&mut storage, || {
-            let mut exchange = StablecoinDEX::new();
-
-            let id = 42;
-            let order = Order::new_bid(id, TEST_MAKER, TEST_BOOK_KEY, 1000, 5);
-            store_legacy_order(&exchange.orders[id], order)?;
-            assert_eq!(exchange.orders[id].version()?, OrderVersion::Legacy);
-
-            {
-                let _checkpoint = StorageCtx.checkpoint();
-                exchange.orders[id].write(order)?;
-                assert_eq!(exchange.orders[id].version()?, OrderVersion::V1);
-            }
-
-            assert_eq!(exchange.orders[id].version()?, OrderVersion::V1);
-            exchange.orders[id].clear_version_cache();
-            assert_eq!(exchange.orders[id].version()?, OrderVersion::Legacy);
-
-            exchange.orders[id].next()?.write(99)?;
-            let updated = exchange.orders[id].read()?;
-            assert_eq!(updated.next(), 99);
-            assert_eq!(exchange.orders[id].version()?, OrderVersion::Legacy);
-
-            Ok(())
-        })
+        LegacyOrder::store(&order, &mut storage, handler.base_slot, LayoutCtx::FULL)
     }
 
     fn legacy_order_slot(order: Order, loc: packing::FieldLocation) -> StorageResult<U256> {


### PR DESCRIPTION
this PR drops the version cache to avoid potential footguns on journal rollbacks, at the expense of extra (warm) SLOADs