### PR TITLE
docs(tip-1061): allow multisig access keys

### DIFF
--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -302,20 +302,38 @@ fn create_mock_tempo_sig(
     caller_addr: alloy_primitives::Address,
     is_t1c: bool,
 ) -> TempoSignature {
-    use tempo_primitives::transaction::tt_signature::{KeychainSignature, TempoSignature};
+    use tempo_primitives::transaction::{
+        MultisigSignature,
+        tt_signature::{KeychainSignature, TempoSignature},
+    };
 
-    let inner_sig = create_mock_primitive_signature(key_type, key_data.cloned());
+    let primitive_sig = create_mock_primitive_signature(key_type, key_data.cloned());
+    let multisig_sig = || {
+        MultisigSignature::new(
+            key_id.unwrap_or(caller_addr),
+            vec![primitive_sig.to_bytes()],
+            None,
+        )
+    };
 
     if key_id.is_some() {
         // For Keychain signatures, the root_key_address is the caller (account owner).
         let keychain_sig = if is_t1c {
-            KeychainSignature::new(caller_addr, inner_sig)
+            match key_type {
+                SignatureType::Multisig => KeychainSignature::new(caller_addr, multisig_sig()),
+                _ => KeychainSignature::new(caller_addr, primitive_sig),
+            }
         } else {
-            KeychainSignature::new_v1(caller_addr, inner_sig)
+            match key_type {
+                SignatureType::Multisig => KeychainSignature::new_v1(caller_addr, multisig_sig()),
+                _ => KeychainSignature::new_v1(caller_addr, primitive_sig),
+            }
         };
         TempoSignature::Keychain(keychain_sig)
+    } else if matches!(key_type, SignatureType::Multisig) {
+        TempoSignature::Multisig(multisig_sig())
     } else {
-        TempoSignature::Primitive(inner_sig)
+        TempoSignature::Primitive(primitive_sig)
     }
 }
 
@@ -402,6 +420,11 @@ fn create_mock_primitive_signature(
                 pub_key_y: alloy_primitives::B256::ZERO,
             })
         }
+        SignatureType::Multisig => PrimitiveSignature::Secp256k1(Signature::new(
+            alloy_primitives::U256::ZERO,
+            alloy_primitives::U256::ZERO,
+            false,
+        )),
     }
 }
 

--- a/crates/contracts/src/precompiles/account_keychain.rs
+++ b/crates/contracts/src/precompiles/account_keychain.rs
@@ -25,6 +25,7 @@ crate::sol! {
             Secp256k1,
             P256,
             WebAuthn,
+            Multisig,
         }
 
         /// Legacy token spending limit structure used before T3.

--- a/crates/node/tests/it/tempo_transaction/mod.rs
+++ b/crates/node/tests/it/tempo_transaction/mod.rs
@@ -47,6 +47,7 @@ pub(crate) mod types;
 use types::TestEnv;
 
 mod local;
+mod multisig_access_keys;
 mod rpc;
 
 /// Run all matrix tests and scenario runners against a single environment.

--- a/crates/node/tests/it/tempo_transaction/multisig_access_keys.rs
+++ b/crates/node/tests/it/tempo_transaction/multisig_access_keys.rs
@@ -1,0 +1,468 @@
+//! E2E coverage for native multisig accounts spending through scoped AccountKeychain access keys.
+
+use alloy::{
+    primitives::{Address, B256, Bytes, U256},
+    providers::Provider,
+    signers::{SignerSync, local::PrivateKeySigner},
+};
+use alloy_eips::Encodable2718;
+use reth_primitives_traits::transaction::TxHashRef;
+use tempo_alloy::provider::keychain::{authorize_key, tip20_transfer_policy};
+use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
+use tempo_contracts::precompiles::{
+    DEFAULT_FEE_TOKEN, account_keychain::IAccountKeychain::IAccountKeychainInstance,
+};
+use tempo_precompiles::{ACCOUNT_KEYCHAIN_ADDRESS, tip20::ITIP20::ITIP20Instance};
+use tempo_primitives::{
+    SignatureType, TempoTransaction, TempoTxEnvelope,
+    transaction::{
+        InitMultisig, KeychainSignature, MultisigOwner, MultisigSignature, PrimitiveSignature,
+        TempoSignature, multisig_digest,
+    },
+};
+
+use super::{helpers::*, local::Localnet};
+
+const TOKEN: Address = DEFAULT_FEE_TOKEN;
+const ONE_TOKEN: u64 = 1_000_000;
+const LOW_LIMIT: u64 = 1_000 * ONE_TOKEN;
+const HIGH_LIMIT: u64 = 10_000 * ONE_TOKEN;
+const SHARED_MULTISIG_FUNDING: u64 = 100_000 * ONE_TOKEN;
+const ACCESS_KEY_MULTISIG_FUNDING: u64 = 10_000 * ONE_TOKEN;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Result<()> {
+    let mut env = Localnet::new().await?;
+
+    let shared_signers = multisig_owner_signers(0x10);
+    let low_signers = multisig_owner_signers(0x20);
+    let high_signers = multisig_owner_signers(0x30);
+    let shared_config = multisig_config(B256::repeat_byte(0x51), 2, &shared_signers);
+    let low_key_config = multisig_config(B256::repeat_byte(0x52), 2, &low_signers);
+    let high_key_config = multisig_config(B256::repeat_byte(0x53), 3, &high_signers);
+    let shared_multisig = multisig_account(&shared_config)?;
+    let low_key = multisig_account(&low_key_config)?;
+    let high_key = multisig_account(&high_key_config)?;
+    let allowed_recipient = Address::random();
+    let blocked_recipient = Address::random();
+
+    fund_address_with(
+        &mut env.setup,
+        &env.provider,
+        &env.funder_signer,
+        env.funder_addr,
+        shared_multisig,
+        U256::from(SHARED_MULTISIG_FUNDING),
+        TOKEN,
+        env.chain_id,
+    )
+    .await?;
+    fund_multisig_account(&mut env, low_key).await?;
+    fund_multisig_account(&mut env, high_key).await?;
+
+    bootstrap_multisig(&mut env, &shared_config, &shared_signers).await?;
+    bootstrap_multisig(&mut env, &low_key_config, &low_signers).await?;
+    bootstrap_multisig(&mut env, &high_key_config, &high_signers).await?;
+    authorize_tiered_access_keys(
+        &mut env,
+        shared_multisig,
+        &shared_config,
+        &shared_signers,
+        low_key,
+        high_key,
+        allowed_recipient,
+    )
+    .await?;
+
+    let low_remaining_before = remaining_limit(&env.provider, shared_multisig, low_key).await?;
+    assert_eq!(low_remaining_before, U256::from(LOW_LIMIT));
+
+    let low_amount = U256::from(LOW_LIMIT / 4);
+    let allowed_balance_before = token_balance(&env.provider, allowed_recipient).await?;
+    submit_access_key_transfer(
+        &mut env,
+        shared_multisig,
+        &low_key_config,
+        &low_signers,
+        allowed_recipient,
+        low_amount,
+    )
+    .await?;
+    assert_eq!(
+        token_balance(&env.provider, allowed_recipient).await?,
+        allowed_balance_before + low_amount,
+        "low-tier access key should spend from the shared multisig within its policy"
+    );
+
+    let low_remaining_after = remaining_limit(&env.provider, shared_multisig, low_key).await?;
+    assert!(
+        low_remaining_after < low_remaining_before,
+        "successful spend should consume the low-tier key's limit"
+    );
+
+    let over_limit_tx = transfer_tx(
+        &env.provider,
+        env.chain_id,
+        shared_multisig,
+        allowed_recipient,
+        U256::from(LOW_LIMIT + ONE_TOKEN),
+    )
+    .await?;
+    let over_limit_sig = sign_aa_tx_with_multisig_access_key(
+        &over_limit_tx,
+        shared_multisig,
+        &low_key_config,
+        &low_signers,
+    )?;
+    assert_rejected(
+        &mut env,
+        over_limit_tx,
+        over_limit_sig,
+        "over low-tier limit",
+    )
+    .await?;
+
+    let wrong_recipient_tx = transfer_tx(
+        &env.provider,
+        env.chain_id,
+        shared_multisig,
+        blocked_recipient,
+        U256::from(ONE_TOKEN),
+    )
+    .await?;
+    let wrong_recipient_sig = sign_aa_tx_with_multisig_access_key(
+        &wrong_recipient_tx,
+        shared_multisig,
+        &low_key_config,
+        &low_signers,
+    )?;
+    assert_rejected(
+        &mut env,
+        wrong_recipient_tx,
+        wrong_recipient_sig,
+        "outside allowed recipient scope",
+    )
+    .await?;
+
+    let under_threshold_tx = transfer_tx(
+        &env.provider,
+        env.chain_id,
+        shared_multisig,
+        allowed_recipient,
+        U256::from(ONE_TOKEN),
+    )
+    .await?;
+    let under_threshold_sig = sign_aa_tx_with_multisig_access_key(
+        &under_threshold_tx,
+        shared_multisig,
+        &low_key_config,
+        &low_signers[..1],
+    )?;
+    assert_rejected(
+        &mut env,
+        under_threshold_tx,
+        under_threshold_sig,
+        "below low-tier key threshold",
+    )
+    .await?;
+
+    let high_amount = U256::from(LOW_LIMIT + 500 * ONE_TOKEN);
+    let high_balance_before = token_balance(&env.provider, allowed_recipient).await?;
+    submit_access_key_transfer(
+        &mut env,
+        shared_multisig,
+        &high_key_config,
+        &high_signers,
+        allowed_recipient,
+        high_amount,
+    )
+    .await?;
+    assert_eq!(
+        token_balance(&env.provider, allowed_recipient).await?,
+        high_balance_before + high_amount,
+        "higher-tier access key should spend above the low-tier limit"
+    );
+
+    Ok(())
+}
+
+fn multisig_owner_signers(base: u8) -> [PrivateKeySigner; 3] {
+    [
+        PrivateKeySigner::from_bytes(&B256::repeat_byte(base + 1)).unwrap(),
+        PrivateKeySigner::from_bytes(&B256::repeat_byte(base + 2)).unwrap(),
+        PrivateKeySigner::from_bytes(&B256::repeat_byte(base + 3)).unwrap(),
+    ]
+}
+
+fn multisig_config(salt: B256, threshold: u8, signers: &[PrivateKeySigner]) -> InitMultisig {
+    let mut owners = signers
+        .iter()
+        .map(|signer| MultisigOwner {
+            owner: signer.address(),
+            weight: 1,
+        })
+        .collect::<Vec<_>>();
+    owners.sort_by_key(|owner| owner.owner);
+
+    InitMultisig {
+        salt,
+        threshold,
+        owners,
+    }
+}
+
+async fn bootstrap_multisig(
+    env: &mut Localnet,
+    config: &InitMultisig,
+    owner_signers: &[PrivateKeySigner],
+) -> eyre::Result<()> {
+    let account = multisig_account(config)?;
+    let tx = create_basic_aa_tx(
+        env.chain_id,
+        0,
+        vec![create_balance_of_call(account)],
+        3_000_000,
+    );
+    let signature = sign_multisig_tx(&tx, config, owner_signers, true)?;
+    submit_and_mine_success(env, tx, signature, "bootstrap shared multisig").await?;
+    Ok(())
+}
+
+async fn fund_multisig_account(env: &mut Localnet, account: Address) -> eyre::Result<()> {
+    fund_address_with(
+        &mut env.setup,
+        &env.provider,
+        &env.funder_signer,
+        env.funder_addr,
+        account,
+        U256::from(ACCESS_KEY_MULTISIG_FUNDING),
+        TOKEN,
+        env.chain_id,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn authorize_tiered_access_keys(
+    env: &mut Localnet,
+    shared_multisig: Address,
+    config: &InitMultisig,
+    owner_signers: &[PrivateKeySigner],
+    low_key: Address,
+    high_key: Address,
+    allowed_recipient: Address,
+) -> eyre::Result<()> {
+    let nonce = env.provider.get_transaction_count(shared_multisig).await?;
+    let calls = vec![
+        authorize_key(
+            low_key,
+            SignatureType::Multisig,
+            tip20_transfer_policy(TOKEN, U256::from(LOW_LIMIT), vec![allowed_recipient]),
+        ),
+        authorize_key(
+            high_key,
+            SignatureType::Multisig,
+            tip20_transfer_policy(TOKEN, U256::from(HIGH_LIMIT), vec![allowed_recipient]),
+        ),
+    ];
+    let tx = create_basic_aa_tx(env.chain_id, nonce, calls, 20_000_000);
+    let signature = sign_multisig_tx(&tx, config, owner_signers, false)?;
+    submit_and_mine_success(env, tx, signature, "authorize tiered access keys").await?;
+    Ok(())
+}
+
+fn sign_multisig_tx(
+    tx: &TempoTransaction,
+    config: &InitMultisig,
+    owner_signers: &[PrivateKeySigner],
+    include_init: bool,
+) -> eyre::Result<TempoSignature> {
+    let account = multisig_account(config)?;
+    Ok(TempoSignature::Multisig(sign_multisig_digest(
+        tx.signature_hash(),
+        account,
+        config,
+        owner_signers,
+        include_init,
+    )?))
+}
+
+fn sign_multisig_digest(
+    signature_hash: B256,
+    account: Address,
+    config: &InitMultisig,
+    owner_signers: &[PrivateKeySigner],
+    include_init: bool,
+) -> eyre::Result<MultisigSignature> {
+    let digest = multisig_digest(signature_hash, account);
+    let mut approvals = owner_signers
+        .iter()
+        .map(|signer| {
+            let signature = signer.sign_hash_sync(&digest)?;
+            Ok((
+                signer.address(),
+                PrimitiveSignature::Secp256k1(signature).to_bytes(),
+            ))
+        })
+        .collect::<eyre::Result<Vec<_>>>()?;
+    approvals.sort_by_key(|(owner, _)| *owner);
+
+    let signatures = approvals
+        .into_iter()
+        .take(config.threshold as usize)
+        .map(|(_, signature)| Bytes::from(signature))
+        .collect();
+
+    Ok(MultisigSignature::new(
+        account,
+        signatures,
+        include_init.then(|| config.clone()),
+    ))
+}
+
+fn multisig_account(config: &InitMultisig) -> eyre::Result<Address> {
+    config
+        .account()
+        .map_err(|err| eyre::eyre!("invalid multisig config: {err:?}"))
+}
+
+async fn submit_access_key_transfer(
+    env: &mut Localnet,
+    shared_multisig: Address,
+    access_key_config: &InitMultisig,
+    access_key_signers: &[PrivateKeySigner],
+    recipient: Address,
+    amount: U256,
+) -> eyre::Result<()> {
+    let tx = transfer_tx(
+        &env.provider,
+        env.chain_id,
+        shared_multisig,
+        recipient,
+        amount,
+    )
+    .await?;
+    let signature = sign_aa_tx_with_multisig_access_key(
+        &tx,
+        shared_multisig,
+        access_key_config,
+        access_key_signers,
+    )?;
+    submit_and_mine_success(env, tx, signature, "access key transfer").await?;
+    Ok(())
+}
+
+fn sign_aa_tx_with_multisig_access_key(
+    tx: &TempoTransaction,
+    shared_multisig: Address,
+    access_key_config: &InitMultisig,
+    access_key_signers: &[PrivateKeySigner],
+) -> eyre::Result<TempoSignature> {
+    let access_key_account = multisig_account(access_key_config)?;
+    let signing_hash = KeychainSignature::signing_hash(tx.signature_hash(), shared_multisig);
+    let inner = sign_multisig_digest(
+        signing_hash,
+        access_key_account,
+        access_key_config,
+        access_key_signers,
+        false,
+    )?;
+    Ok(TempoSignature::Keychain(KeychainSignature::new(
+        shared_multisig,
+        inner,
+    )))
+}
+
+async fn transfer_tx(
+    provider: &impl Provider,
+    chain_id: u64,
+    from: Address,
+    to: Address,
+    amount: U256,
+) -> eyre::Result<TempoTransaction> {
+    let nonce = provider.get_transaction_count(from).await?;
+    let mut tx = create_basic_aa_tx(
+        chain_id,
+        nonce,
+        vec![create_transfer_call(TOKEN, to, amount)],
+        3_000_000,
+    );
+    tx.max_priority_fee_per_gas = TEMPO_T1_BASE_FEE as u128;
+    tx.max_fee_per_gas = TEMPO_T1_BASE_FEE as u128;
+    Ok(tx)
+}
+
+async fn assert_rejected(
+    env: &mut Localnet,
+    tx: TempoTransaction,
+    signature: TempoSignature,
+    label: &str,
+) -> eyre::Result<()> {
+    let envelope: TempoTxEnvelope = tx.into_signed(signature).into();
+    let tx_hash = *envelope.tx_hash();
+    let mut encoded = Vec::new();
+    envelope.encode_2718(&mut encoded);
+
+    let result = env.setup.node.rpc.inject_tx(encoded.into()).await;
+    if result.is_err() {
+        return Ok(());
+    }
+
+    env.setup.node.advance_block().await?;
+    let receipt: Option<serde_json::Value> = env
+        .provider
+        .raw_request("eth_getTransactionReceipt".into(), [tx_hash])
+        .await?;
+    let receipt = receipt.ok_or_else(|| eyre::eyre!("{label} receipt not found for {tx_hash}"))?;
+    let status = receipt["status"]
+        .as_str()
+        .ok_or_else(|| eyre::eyre!("{label} receipt missing status for {tx_hash}"))?;
+    assert_eq!(
+        status, "0x0",
+        "{label} transaction {tx_hash} should be rejected or revert"
+    );
+    Ok(())
+}
+
+async fn submit_and_mine_success(
+    env: &mut Localnet,
+    tx: TempoTransaction,
+    signature: TempoSignature,
+    label: &str,
+) -> eyre::Result<()> {
+    let hash = submit_and_mine_aa_tx(&mut env.setup, tx, signature).await?;
+    let receipt: Option<serde_json::Value> = env
+        .provider
+        .raw_request("eth_getTransactionReceipt".into(), [hash])
+        .await?;
+    let receipt = receipt.ok_or_else(|| eyre::eyre!("{label} receipt not found for {hash}"))?;
+    let status = receipt["status"]
+        .as_str()
+        .ok_or_else(|| eyre::eyre!("{label} receipt missing status for {hash}"))?;
+    eyre::ensure!(
+        status == "0x1",
+        "{label} reverted with status {status}: {receipt}"
+    );
+    Ok(())
+}
+
+async fn token_balance(provider: &impl Provider, account: Address) -> eyre::Result<U256> {
+    Ok(ITIP20Instance::new(TOKEN, provider)
+        .balanceOf(account)
+        .call()
+        .await?)
+}
+
+async fn remaining_limit(
+    provider: &impl Provider,
+    account: Address,
+    key: Address,
+) -> eyre::Result<U256> {
+    Ok(
+        IAccountKeychainInstance::new(ACCOUNT_KEYCHAIN_ADDRESS, provider)
+            .getRemainingLimitWithPeriod(account, key, TOKEN)
+            .call()
+            .await?
+            .remaining,
+    )
+}

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -80,6 +80,7 @@ pub enum StoredSignatureType {
     Secp256k1,
     P256,
     WebAuthn,
+    Multisig,
 }
 
 impl TryFrom<SignatureType> for StoredSignatureType {
@@ -90,6 +91,7 @@ impl TryFrom<SignatureType> for StoredSignatureType {
             SignatureType::Secp256k1 => Ok(Self::Secp256k1),
             SignatureType::P256 => Ok(Self::P256),
             SignatureType::WebAuthn => Ok(Self::WebAuthn),
+            SignatureType::Multisig => Ok(Self::Multisig),
             _ => Err(AccountKeychainError::invalid_signature_type().into()),
         }
     }
@@ -101,6 +103,7 @@ impl From<StoredSignatureType> for SignatureType {
             StoredSignatureType::Secp256k1 => Self::Secp256k1,
             StoredSignatureType::P256 => Self::P256,
             StoredSignatureType::WebAuthn => Self::WebAuthn,
+            StoredSignatureType::Multisig => Self::Multisig,
         }
     }
 }

--- a/crates/precompiles/src/signature_verifier/mod.rs
+++ b/crates/precompiles/src/signature_verifier/mod.rs
@@ -1,12 +1,17 @@
 pub mod dispatch;
 
-use crate::{SIGNATURE_VERIFIER_ADDRESS, account_keychain::AccountKeychain, error::Result};
+use crate::{
+    SIGNATURE_VERIFIER_ADDRESS,
+    account_keychain::AccountKeychain,
+    error::Result,
+    native_multisig::{NativeMultisig, NativeMultisigAuthError, auth::NativeMultisigAuthConfig},
+};
 use alloy::primitives::{Address, B256, Bytes};
 use tempo_contracts::precompiles::SignatureVerifierError;
 use tempo_precompiles_macros::contract;
 use tempo_primitives::transaction::{
     SignatureType,
-    tt_signature::{KeychainSignature, PrimitiveSignature, TempoSignature},
+    tt_signature::{KeychainInnerSignature, KeychainSignature, PrimitiveSignature, TempoSignature},
 };
 
 /// Gas cost for secp256k1 signature verification.
@@ -36,6 +41,7 @@ impl SignatureVerifier {
             SignatureType::Secp256k1 => SECP256K1_VERIFY_GAS,
             SignatureType::P256 => P256_VERIFY_GAS,
             SignatureType::WebAuthn => WEBAUTHN_VERIFY_GAS,
+            SignatureType::Multisig => return Err(SignatureVerifierError::invalid_format().into()),
         };
         self.storage.deduct_gas(verify_gas)?;
 
@@ -83,8 +89,42 @@ impl SignatureVerifier {
             return Err(SignatureVerifierError::invalid_format().into());
         }
 
-        let signing_hash = KeychainSignature::signing_hash(hash, keychain_sig.user_address);
-        let key_id = self.recover(signing_hash, keychain_sig.signature.to_bytes())?;
+        let key_id = keychain_sig
+            .key_id(&hash)
+            .map_err(|_| SignatureVerifierError::invalid_signature())?;
+
+        // A native multisig access key must additionally satisfy its current owner threshold —
+        // key_id recovery alone only yields the claimed account. Verify the quorum against the
+        // account's stored config over the keychain signing hash, same as transaction validation.
+        if let KeychainInnerSignature::Multisig(multisig_signature) = &keychain_sig.signature {
+            self.storage.deduct_gas(
+                (multisig_signature.signature_count() as u64).saturating_mul(P256_VERIFY_GAS),
+            )?;
+            let multisig = NativeMultisig::new();
+            let threshold = multisig.load_registered_threshold(key_id)?;
+            let signing_hash = KeychainSignature::signing_hash(hash, keychain_sig.user_address);
+            multisig
+                .verify_authorization(
+                    signing_hash,
+                    multisig_signature,
+                    NativeMultisigAuthConfig::Registered {
+                        account: key_id,
+                        threshold,
+                    },
+                    |acc| {
+                        multisig
+                            .load_registered_threshold(acc)
+                            .map_err(NativeMultisigAuthError::from)
+                    },
+                    |acc, owner| {
+                        multisig
+                            .read_owner_weight(acc, owner)
+                            .map_err(NativeMultisigAuthError::from)
+                    },
+                )
+                .map_err(|_| SignatureVerifierError::invalid_signature())?;
+        }
+
         Ok((keychain_sig.user_address, key_id))
     }
 }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -9,8 +9,8 @@ pub mod tt_signed;
 pub use tt_authorization::{MAGIC, RecoveredTempoAuthorization, TempoSignedAuthorization};
 // Re-export Authorization from alloy for convenience
 pub use tt_signature::{
-    KeychainSignature, KeychainVersion, KeychainVersionError, PrimitiveSignature, TempoSignature,
-    derive_p256_address,
+    KeychainInnerSignature, KeychainSignature, KeychainVersion, KeychainVersionError,
+    PrimitiveSignature, TempoSignature, derive_p256_address,
 };
 
 pub use crate::address::TIP20_TOKEN_PREFIX as TIP20_PAYMENT_PREFIX;

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -45,6 +45,7 @@ pub enum SignatureType {
     Secp256k1 = 0,
     P256 = 1,
     WebAuthn = 2,
+    Multisig = 3,
 }
 
 impl From<SignatureType> for u8 {
@@ -53,6 +54,7 @@ impl From<SignatureType> for u8 {
             SignatureType::Secp256k1 => 0,
             SignatureType::P256 => 1,
             SignatureType::WebAuthn => 2,
+            SignatureType::Multisig => 3,
         }
     }
 }
@@ -65,6 +67,7 @@ impl From<SignatureType> for AbiSignatureType {
             SignatureType::Secp256k1 => Self::Secp256k1,
             SignatureType::P256 => Self::P256,
             SignatureType::WebAuthn => Self::WebAuthn,
+            SignatureType::Multisig => Self::Multisig,
         }
     }
 }
@@ -77,6 +80,7 @@ impl TryFrom<AbiSignatureType> for SignatureType {
             AbiSignatureType::Secp256k1 => Ok(Self::Secp256k1),
             AbiSignatureType::P256 => Ok(Self::P256),
             AbiSignatureType::WebAuthn => Ok(Self::WebAuthn),
+            AbiSignatureType::Multisig => Ok(Self::Multisig),
             _ => Err(sig_type as u8),
         }
     }
@@ -99,6 +103,7 @@ impl alloy_rlp::Decodable for SignatureType {
             0 => Ok(Self::Secp256k1),
             1 => Ok(Self::P256),
             2 => Ok(Self::WebAuthn),
+            3 => Ok(Self::Multisig),
             _ => Err(alloy_rlp::Error::Custom("Invalid signature type")),
         }
     }

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -411,6 +411,91 @@ pub enum KeychainVersionError {
     V2BeforeActivation,
 }
 
+/// Signature variants that can authenticate a keychain access key.
+///
+/// This intentionally excludes nested keychain signatures.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged, rename_all = "camelCase"))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+pub enum KeychainInnerSignature {
+    Primitive(PrimitiveSignature),
+    Multisig(MultisigSignature),
+}
+
+impl From<PrimitiveSignature> for KeychainInnerSignature {
+    fn from(signature: PrimitiveSignature) -> Self {
+        Self::Primitive(signature)
+    }
+}
+
+impl From<MultisigSignature> for KeychainInnerSignature {
+    fn from(signature: MultisigSignature) -> Self {
+        Self::Multisig(signature)
+    }
+}
+
+impl KeychainInnerSignature {
+    fn from_bytes(data: &[u8]) -> Result<Self, &'static str> {
+        if data.len() > 1 && data[0] == SIGNATURE_TYPE_MULTISIG {
+            let mut sig_data = &data[1..];
+            // A keychain access key is itself a top-level multisig authorization node (depth 1), so
+            // its nested owner approvals are bounded exactly like a transaction multisig signature.
+            return match MultisigSignature::decode_with_depth(&mut sig_data, 1) {
+                Ok(signature) if sig_data.is_empty() => Ok(Self::Multisig(signature)),
+                _ => Err("Invalid Multisig signature RLP"),
+            };
+        }
+
+        PrimitiveSignature::from_bytes(data).map(Self::Primitive)
+    }
+
+    fn to_bytes(&self) -> Bytes {
+        match self {
+            Self::Primitive(signature) => signature.to_bytes(),
+            Self::Multisig(signature) => {
+                let mut bytes = Vec::with_capacity(1 + signature.length());
+                bytes.push(SIGNATURE_TYPE_MULTISIG);
+                signature.encode(&mut bytes);
+                Bytes::from(bytes)
+            }
+        }
+    }
+
+    fn encoded_length(&self) -> usize {
+        match self {
+            Self::Primitive(signature) => signature.encoded_length(),
+            Self::Multisig(signature) => 1 + signature.length(),
+        }
+    }
+
+    pub fn signature_type(&self) -> SignatureType {
+        match self {
+            Self::Primitive(signature) => signature.signature_type(),
+            Self::Multisig(_) => SignatureType::Multisig,
+        }
+    }
+
+    fn size(&self) -> usize {
+        match self {
+            Self::Primitive(signature) => signature.size(),
+            Self::Multisig(signature) => 1 + signature.size(),
+        }
+    }
+
+    fn recover_signer(
+        &self,
+        sig_hash: &B256,
+    ) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
+        match self {
+            Self::Primitive(signature) => signature.recover_signer(sig_hash),
+            Self::Multisig(signature) => signature
+                .recover_account()
+                .map_err(|_| alloy_consensus::crypto::RecoveryError::new()),
+        }
+    }
+}
+
 /// Keychain signature wrapping another signature with a user address.
 /// This allows an access key to sign on behalf of a root account.
 ///
@@ -430,8 +515,8 @@ pub enum KeychainVersionError {
 pub struct KeychainSignature {
     /// Root account address that this transaction is being executed for
     pub user_address: Address,
-    /// The actual signature from the access key (can be Secp256k1, P256, or WebAuthn, but NOT another Keychain)
-    pub signature: PrimitiveSignature,
+    /// The actual signature from the access key (primitive or native multisig, but NOT another Keychain).
+    pub signature: KeychainInnerSignature,
     /// Keychain signature version (V1 = legacy, V2 = includes user_address in sig hash)
     #[cfg_attr(feature = "serde", serde(default))]
     pub version: KeychainVersion,
@@ -454,10 +539,10 @@ impl KeychainSignature {
     /// Create a new V2 KeychainSignature (recommended).
     ///
     /// V2 signatures include the user_address in the signature hash.
-    pub fn new(user_address: Address, signature: PrimitiveSignature) -> Self {
+    pub fn new(user_address: Address, signature: impl Into<KeychainInnerSignature>) -> Self {
         Self {
             user_address,
-            signature,
+            signature: signature.into(),
             version: KeychainVersion::V2,
             cached_key_id: OnceLock::new(),
         }
@@ -467,10 +552,10 @@ impl KeychainSignature {
     ///
     /// V1 signatures do NOT include the user_address in the signature hash
     /// and are deprecated at the T1C hardfork.
-    pub fn new_v1(user_address: Address, signature: PrimitiveSignature) -> Self {
+    pub fn new_v1(user_address: Address, signature: impl Into<KeychainInnerSignature>) -> Self {
         Self {
             user_address,
-            signature,
+            signature: signature.into(),
             version: KeychainVersion::V1,
             cached_key_id: OnceLock::new(),
         }
@@ -639,9 +724,8 @@ impl TempoSignature {
             let user_address = Address::from_slice(&sig_data[0..20]);
             let inner_sig_bytes = &sig_data[20..];
 
-            // Parse inner signature using PrimitiveSignature (which doesn't support Keychain)
-            // This automatically prevents recursive keychain signatures at compile time
-            let inner_signature = PrimitiveSignature::from_bytes(inner_sig_bytes)?;
+            // Parse inner signature without allowing recursive keychain signatures.
+            let inner_signature = KeychainInnerSignature::from_bytes(inner_sig_bytes)?;
 
             return Ok(Self::Keychain(KeychainSignature {
                 user_address,

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -1383,7 +1383,9 @@ mod tests {
         // Verify the inner signature is WebAuthn
         assert!(matches!(
             keychain_sig.signature,
-            PrimitiveSignature::WebAuthn(_)
+            tempo_primitives::transaction::KeychainInnerSignature::Primitive(
+                PrimitiveSignature::WebAuthn(_)
+            )
         ));
 
         // Verify key_id recovery works correctly using the transaction signature hash

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1472,6 +1472,46 @@ where
                                 reason: format!("{e:?}"),
                             })?;
 
+                        if let tempo_primitives::transaction::KeychainInnerSignature::Multisig(
+                            multisig_signature,
+                        ) = &keychain_sig.signature
+                        {
+                            // A native multisig access key authorizes the keychain action with its
+                            // current owner threshold (TIP-1061). `access_key_addr` is the recovered
+                            // multisig account, so verify the quorum against that account's stored
+                            // config over the keychain signing hash.
+                            let multisig = NativeMultisig::new();
+                            let threshold = multisig
+                                .load_registered_threshold(access_key_addr)
+                                .map_err(NativeMultisigAuthError::from)
+                                .map_err(map_native_multisig_error::<DB>)?;
+                            let signing_hash =
+                                tempo_primitives::transaction::KeychainSignature::signing_hash(
+                                    tempo_tx_env.signature_hash,
+                                    *user_address,
+                                );
+                            multisig
+                                .verify_authorization(
+                                    signing_hash,
+                                    multisig_signature,
+                                    NativeMultisigAuthConfig::Registered {
+                                        account: access_key_addr,
+                                        threshold,
+                                    },
+                                    |acc| {
+                                        multisig
+                                            .load_registered_threshold(acc)
+                                            .map_err(NativeMultisigAuthError::from)
+                                    },
+                                    |acc, owner| {
+                                        multisig
+                                            .read_owner_weight(acc, owner)
+                                            .map_err(NativeMultisigAuthError::from)
+                                    },
+                                )
+                                .map_err(map_native_multisig_error::<DB>)?;
+                        }
+
                         // T6 adds admin delegation: a keychain signer may authorize a different
                         // child key only if the acting transaction key is itself an active admin key.
                         if key_auth.is_some() && !key.is_admin {
@@ -1701,6 +1741,7 @@ where
                     SignatureType::Secp256k1 => PrecompileSignatureType::Secp256k1,
                     SignatureType::P256 => PrecompileSignatureType::P256,
                     SignatureType::WebAuthn => PrecompileSignatureType::WebAuthn,
+                    SignatureType::Multisig => PrecompileSignatureType::Multisig,
                 };
 
                 // Handle expiry: None means never expires (store as u64::MAX)

--- a/crates/revm/src/signature_gas.rs
+++ b/crates/revm/src/signature_gas.rs
@@ -5,7 +5,8 @@ use revm::{
 use tempo_chainspec::{constants::gas::STORAGE_CREDIT_VALUE, hardfork::TempoHardfork};
 use tempo_precompiles::ECRECOVER_GAS;
 use tempo_primitives::transaction::{
-    InitMultisig, MAX_MULTISIG_NESTING_DEPTH, MultisigSignature, PrimitiveSignature, TempoSignature,
+    InitMultisig, KeychainInnerSignature, MAX_MULTISIG_NESTING_DEPTH, MultisigSignature,
+    PrimitiveSignature, TempoSignature,
 };
 
 /// Additional gas for P256 signature verification
@@ -101,6 +102,23 @@ fn native_multisig_signature_verification_gas(
     }
 }
 
+/// Gas for verifying a keychain access key's inner signature (primitive or native multisig).
+///
+/// TIP-1061 requires a native multisig access key's authorization cost to be metered in addition to
+/// normal AccountKeychain key validation, so multisig inners are charged the full owner-approval
+/// schedule (as a top-level node).
+#[inline]
+fn keychain_inner_signature_verification_gas(signature: &KeychainInnerSignature) -> u64 {
+    match signature {
+        KeychainInnerSignature::Primitive(primitive) => {
+            primitive_signature_verification_gas(primitive)
+        }
+        KeychainInnerSignature::Multisig(multisig) => {
+            native_multisig_signature_verification_gas(multisig, true, 1)
+        }
+    }
+}
+
 /// Calculates the gas cost for verifying an AA signature.
 ///
 /// For Keychain signatures, adds key validation overhead to the inner signature cost
@@ -110,7 +128,8 @@ pub(crate) fn tempo_signature_verification_gas(signature: &TempoSignature) -> u6
     match signature {
         TempoSignature::Primitive(prim_sig) => primitive_signature_verification_gas(prim_sig),
         TempoSignature::Keychain(keychain_sig) => {
-            primitive_signature_verification_gas(&keychain_sig.signature) + KEYCHAIN_VALIDATION_GAS
+            keychain_inner_signature_verification_gas(&keychain_sig.signature)
+                + KEYCHAIN_VALIDATION_GAS
         }
         TempoSignature::Multisig(multisig_sig) => {
             native_multisig_signature_verification_gas(multisig_sig, true, 1)

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -636,34 +636,25 @@ calls are charged under the active Tempo precompile storage gas schedule, and st
 writes outside owner-authorization verification require separate accounting under the active
 state-gas rules.
 
-### AccountKeychain Restrictions
+### AccountKeychain Access Keys
 
-Native multisig accounts do not support access keys.
+Native multisig accounts are primary Tempo accounts and support AccountKeychain access keys in both directions:
+
+- A native multisig account MAY authorize and use AccountKeychain access keys on its own account, under the same AccountKeychain storage, expiry, revocation, admin-key, spending-limit, call-scope, and mutator rules as any other account. AccountKeychain mutating calls (`authorizeKey`, `revokeKey`, `updateSpendingLimit`, `setAllowedCalls`, `removeAllowedCalls`, TIP-1053 nonce burn) from a native multisig account are permitted; they are authorized by the account's owner threshold (a `TempoSignature::Multisig` transaction), not gated on `multisig_accounts[msg.sender]`.
+- An initialized native multisig account MAY be authorized as an AccountKeychain access key on another account. When such a key is used, the keychain inner signature is a `TempoSignature::Multisig` and MUST satisfy the referenced account's current owner threshold over the keychain signing hash. The referenced native multisig account MUST already be initialized. Its keychain use MUST fail if the multisig authorization is invalid under the current config. This multisig authorization cost MUST be metered in addition to normal AccountKeychain key validation.
+
+Access-key rules:
+
+- AccountKeychain access keys are not native multisig owners and MUST NOT be accepted as owner approvals in `MultisigSignature.signatures`.
+- `verifyKeychain` and `verifyKeychainAdmin` MUST support native multisig access keys under the same rules as transaction validation (initialized account, active key row, current owner threshold satisfied).
 
 Transaction rule:
 
-- A transaction with `TempoSignature::Multisig` MUST NOT include `key_authorization`.
-- A multisig transaction with `key_authorization` is invalid.
+- A transaction with `TempoSignature::Multisig` MUST NOT include `key_authorization`. A native multisig account authorizes access keys on its own account through AccountKeychain mutating calls (e.g. `authorizeKey`) under its owner threshold, not through the transaction-level `key_authorization` sidecar.
 
-AccountKeychain mutator rules:
+Config update authority:
 
-- The AccountKeychain precompile MUST reject mutating calls where `multisig_accounts[msg.sender] == true`.
-- The check is against `msg.sender`.
-- The check MUST NOT depend on `tx.origin` or the outer transaction signature type.
-
-This includes every mutating AccountKeychain entrypoint, including:
-
-- both `authorizeKey` overloads
-- `revokeKey`
-- `updateSpendingLimit`
-- `setAllowedCalls`
-- `removeAllowedCalls`
-- any TIP-1053 key authorization nonce burn entrypoint
-
-Read-only behavior:
-
-- Read-only AccountKeychain calls for native multisig accounts MUST NOT return active access key state.
-- They SHOULD return the same empty or missing-key shape used for accounts with no access keys.
+- `updateMultisigConfig` MUST reject AccountKeychain access-key authority and require authorization by the current native multisig owner threshold, even when the access key is unrestricted or scoped to the native multisig precompile.
 
 ### Authorization List Restrictions
 
@@ -690,7 +681,8 @@ Signature verifier rules:
 
 - `ISignatureVerifier.recover` MUST reject `TempoSignature::Multisig` with `InvalidFormat()`.
 - `ISignatureVerifier.verify` MUST reject `TempoSignature::Multisig` with `InvalidFormat()`.
-- Multisig authorization MUST be performed by transaction validation, not by the signature verifier precompile.
+- Standalone multisig authorization MUST NOT be performed by the primitive `recover` / `verify` methods.
+- `verifyKeychain` and `verifyKeychainAdmin` MUST support native multisig access keys: they MUST verify the access key's current owner threshold over the keychain signing hash, matching transaction validation, not merely recover the claimed account.
 
 ### Multisig Account Precompile
 
@@ -919,25 +911,11 @@ validation to keep decoding and verifying irrelevant signatures, or allow unchec
 relayed in otherwise valid transactions. Rejection gives each authorization a canonical minimal
 quorum proof and lets validators stop as soon as quorum is reached.
 
-### AccountKeychain Restrictions
+### AccountKeychain Access Keys (rationale)
 
-The current AccountKeychain model is a poor fit for multisig accounts because it lets a single authorized key make calls as the parent account.
+Native multisig accounts are primary Tempo accounts, so they reuse the one AccountKeychain model rather than adding a second access-key system to the native multisig precompile. A quorum-controlled account can delegate bounded operational authority to an access key (with the usual scope, spending-limit, expiry, revocation, and admin-key controls), and an initialized multisig account can itself serve as a quorum-controlled access key on another account.
 
-For a multisig account, that would turn one primitive key into a standing ability to act as the multisig address within whatever scope was authorized.
-
-Scope checks can restrict top-level targets, selectors, and limited TIP-20 recipients.
-
-They cannot make downstream contracts distinguish a quorum-approved multisig transaction from a single-key transaction bound to the multisig `msg.sender`.
-
-Access keys bound to the multisig `msg.sender` also create durable side effects under the parent account's identity.
-
-If such a key grants a role, creates an approval, joins a vault, or mutates application state, that state belongs to the multisig account.
-
-Revoking the access key does not revoke those external permissions or unwind application state.
-
-Keeping access keys out of this TIP preserves the multisig account as a quorum-controlled identity.
-
-This TIP does not define any single-key path that executes with the multisig account's `msg.sender`.
+Owner-threshold control of the account is preserved where it matters: `updateMultisigConfig` is reachable only under the current owner threshold, never through an access key, so a delegated key can operate within its granted scope but cannot rotate the owner set or otherwise seize the account. An access key remains AccountKeychain delegation under the account's identity and does not participate in native multisig owner-threshold accounting.
 
 ## Backwards Compatibility
 
@@ -1197,7 +1175,7 @@ TBD.
 
 13. **No multisig key authorization.** A transaction with `TempoSignature::Multisig` MUST be rejected when `key_authorization` is present.
 
-14. **No AccountKeychain access.** AccountKeychain mutating calls MUST reject when `multisig_accounts[msg.sender] == true`. AccountKeychain read-only calls MUST NOT return active access key state for native multisig accounts.
+14. **AccountKeychain access keys.** Native multisig accounts support AccountKeychain access keys under the normal AccountKeychain rules in both directions: an account may authorize and use access keys on itself (mutating calls authorized by its owner threshold), and an initialized multisig account may be authorized as an access key on another account and, when used, MUST satisfy its current owner threshold. `updateMultisigConfig` MUST reject AccountKeychain access-key authority and require the current owner threshold.
 
 15. **Native multisig fee payer.** The fee payer signature path MUST NOT accept `TempoSignature::Multisig`. A recovered fee payer from `fee_payer_signature` MUST NOT be a native multisig account.
 


### PR DESCRIPTION
Updates TIP-1061 so native multisig accounts support AccountKeychain access keys under the same rules as other accounts, and initialized native multisigs can also be authorized as AccountKeychain access keys on other accounts. Keeps access keys excluded from native multisig owner approvals.