### PR TITLE
perf(dex): use vec id to retrieve book_key

### DIFF
--- a/crates/contracts/src/precompiles/stablecoin_dex.rs
+++ b/crates/contracts/src/precompiles/stablecoin_dex.rs
@@ -75,6 +75,8 @@ crate::sol! {
         function pairKey(address tokenA, address tokenB) external pure returns (bytes32);
         function nextOrderId() external view returns (uint128);
         function books(bytes32 pairKey) external view returns (Orderbook memory);
+        function bookIndexForKey(bytes32 bookKey) external returns (uint32 index);
+        function bookKeyForIndex(uint32 index) external view returns (bytes32 bookKey);
         function storageCredits(address user) external view returns (uint64 credits);
 
         // Constants (exposed as view functions)

--- a/crates/node/tests/it/gas/snapshots/it__gas__stablecoin_dex__stablecoin_dex_lifecycle_gas_snapshot_t8.snap
+++ b/crates/node/tests/it/gas/snapshots/it__gas__stablecoin_dex__stablecoin_dex_lifecycle_gas_snapshot_t8.snap
@@ -3,78 +3,78 @@ source: crates/node/tests/it/gas/stablecoin_dex.rs
 expression: gas
 ---
 cancel_bid_earn_credits:
-  gas: 347041
-  storage_credits: "user1: 0 -> 3"
-  pooled_storage_credits: "DEX TIP-1060: 0 -> 5"
+  gas: 346141
+  storage_credits: "user1: 0 -> 2"
+  pooled_storage_credits: "DEX TIP-1060: 0 -> 4"
 cancel_head_bid_tracks_successor_prev:
-  gas: 342741
-  storage_credits: "user11: 0 -> 4; user12: 0 -> 1"
-  pooled_storage_credits: "DEX TIP-1060: 24 -> 27"
+  gas: 341841
+  storage_credits: "user11: 0 -> 3; user12: 0 -> 1"
+  pooled_storage_credits: "DEX TIP-1060: 20 -> 22"
 cancel_tail_bid_credits_predecessor_next:
-  gas: 342741
-  storage_credits: "user10: 0 -> 4; user9: 0 -> 1"
-  pooled_storage_credits: "DEX TIP-1060: 18 -> 21"
+  gas: 341841
+  storage_credits: "user10: 0 -> 3; user9: 0 -> 1"
+  pooled_storage_credits: "DEX TIP-1060: 16 -> 18"
 create_pair:
-  gas: 1295799
+  gas: 1295899
   storage_credits: n/a
   pooled_storage_credits: "DEX TIP-1060: 0 -> 0"
 place_ask_wallet:
-  gas: 1835985
+  gas: 1583985
   storage_credits: "user2: 0 -> 0"
-  pooled_storage_credits: "DEX TIP-1060: 7 -> 7"
+  pooled_storage_credits: "DEX TIP-1060: 6 -> 6"
 place_bid_append_same_level:
-  gas: 1341669
+  gas: 1089669
   storage_credits: "user16: 0 -> 0; user15: 0 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 3 -> 3"
 place_bid_cross_user_after_cancel_credits:
-  gas: 1336769
-  storage_credits: "user7: 0 -> 0; user6: 3 -> 3"
-  pooled_storage_credits: "DEX TIP-1060: 7 -> 7"
+  gas: 1084769
+  storage_credits: "user7: 0 -> 0; user6: 2 -> 2"
+  pooled_storage_credits: "DEX TIP-1060: 6 -> 6"
 place_bid_cross_user_after_fill_credits:
-  gas: 1336769
-  storage_credits: "user7: 0 -> 0; user4: 3 -> 3"
-  pooled_storage_credits: "DEX TIP-1060: 14 -> 14"
+  gas: 1084769
+  storage_credits: "user7: 0 -> 0; user4: 2 -> 2"
+  pooled_storage_credits: "DEX TIP-1060: 12 -> 12"
 place_bid_reuse_cancel_credits:
-  gas: 850113
-  storage_credits: "user1: 3 -> 0"
-  pooled_storage_credits: "DEX TIP-1060: 5 -> 3"
+  gas: 843113
+  storage_credits: "user1: 2 -> 0"
+  pooled_storage_credits: "DEX TIP-1060: 4 -> 3"
 place_bid_reuse_predecessor_next_credit:
-  gas: 1098169
+  gas: 846169
   storage_credits: "user9: 1 -> 0"
-  pooled_storage_credits: "DEX TIP-1060: 21 -> 21"
+  pooled_storage_credits: "DEX TIP-1060: 18 -> 18"
 place_bid_reuse_swap_credits:
-  gas: 602813
-  storage_credits: "user3: 3 -> 0"
-  pooled_storage_credits: "DEX TIP-1060: 12 -> 10"
+  gas: 595813
+  storage_credits: "user3: 2 -> 0"
+  pooled_storage_credits: "DEX TIP-1060: 10 -> 9"
 place_bid_wallet:
-  gas: 2083285
+  gas: 1831285
   storage_credits: "user1: 0 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 0 -> 0"
 place_flip_bid_wallet:
-  gas: 1586743
+  gas: 1334743
   storage_credits: "user5: 0 -> 0"
-  pooled_storage_credits: "DEX TIP-1060: 14 -> 14"
+  pooled_storage_credits: "DEX TIP-1060: 12 -> 12"
 swap_exact_in_full_ask_earn_credits:
-  gas: 388197
-  storage_credits: "user3: 0 -> 3"
-  pooled_storage_credits: "DEX TIP-1060: 8 -> 12"
+  gas: 385397
+  storage_credits: "user3: 0 -> 2"
+  pooled_storage_credits: "DEX TIP-1060: 7 -> 10"
 swap_exact_in_full_flip_bid:
-  gas: 885284
+  gas: 885684
   storage_credits: "user5: 0 -> 0"
-  pooled_storage_credits: "DEX TIP-1060: 14 -> 18"
+  pooled_storage_credits: "DEX TIP-1060: 12 -> 16"
 swap_exact_in_full_head_bid_tracks_successor_prev:
-  gas: 389685
-  storage_credits: "user13: 0 -> 4; user14: 0 -> 1"
-  pooled_storage_credits: "DEX TIP-1060: 21 -> 24"
+  gas: 386885
+  storage_credits: "user13: 0 -> 3; user14: 0 -> 1"
+  pooled_storage_credits: "DEX TIP-1060: 18 -> 20"
 swap_exact_in_partial_ask_no_credits:
-  gas: 347385
+  gas: 349485
   storage_credits: "user2: 0 -> 0"
-  pooled_storage_credits: "DEX TIP-1060: 7 -> 7"
+  pooled_storage_credits: "DEX TIP-1060: 6 -> 6"
 swap_exact_out_full_ask_earn_credits:
-  gas: 388377
-  storage_credits: "user4: 0 -> 3"
-  pooled_storage_credits: "DEX TIP-1060: 10 -> 14"
+  gas: 385577
+  storage_credits: "user4: 0 -> 2"
+  pooled_storage_credits: "DEX TIP-1060: 9 -> 12"
 withdraw_internal_balance:
   gas: 49754
   storage_credits: "user2: 0 -> 0"
-  pooled_storage_credits: "DEX TIP-1060: 7 -> 8"
+  pooled_storage_credits: "DEX TIP-1060: 6 -> 7"

--- a/crates/precompiles/src/stablecoin_dex/dispatch.rs
+++ b/crates/precompiles/src/stablecoin_dex/dispatch.rs
@@ -79,7 +79,16 @@ impl Precompile for StablecoinDEX {
                     priceToTick(call) => view(call, |c| self.price_to_tick(c.price)),
 
                     #[schedule(since = T7)]
-                    storageCredits(call) => view(call, |c| self.storage_credits(c.user))
+                    storageCredits(call) => view(call, |c| self.storage_credits(c.user)),
+
+                    #[schedule(since = T8)]
+                    bookIndexForKey(call) => mutate(call, msg_sender, |_, c| {
+                            preserve_storage_credits(self.address)?;
+                            self.book_index_for_key(c.bookKey)
+                        }),
+                    #[schedule(since = T8)]
+                    bookKeyForIndex(call) => view(call, |c| self.book_key_for_index(c.index)),
+
                 }
             }
         )

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -511,6 +511,52 @@ impl StablecoinDEX {
         self.book_keys.read()
     }
 
+    /// Returns the T8+ append-only `book_keys` index for `book_key`.
+    ///
+    /// Mutable because pre-T8 books have no stored id, so the first T8+ lookup derives the index
+    /// from `book_keys`, stores it on the orderbook, and returns it.
+    pub fn book_index_for_key(&mut self, book_key: B256) -> Result<u32> {
+        let book = self.books[book_key].read()?;
+        if !book.is_initialized() {
+            return Err(TempoPrecompileError::Fatal(format!(
+                "stablecoin DEX order references unknown book key {book_key}"
+            )));
+        }
+        if let Some(id) = book.id() {
+            return Ok(id);
+        }
+
+        let len = self.book_keys.len()?;
+        for index in 0..len {
+            let Some(handler) = self.book_keys.at(index)? else {
+                break;
+            };
+            if handler.read()? == book_key {
+                let index = u32::try_from(index).map_err(|_| {
+                    TempoPrecompileError::Fatal("stablecoin DEX book index overflow".to_string())
+                })?;
+                let mut book = book;
+                book.activate_id(index);
+                self.books[book_key].write(book)?;
+                return Ok(index);
+            }
+        }
+
+        Err(TempoPrecompileError::Fatal(format!(
+            "stablecoin DEX order references book key without T8 id {book_key}"
+        )))
+    }
+
+    /// Returns the T8+ orderbook key at append-only `book_keys` vector `index`.
+    pub fn book_key_for_index(&self, index: u32) -> Result<B256> {
+        let Some(handler) = self.book_keys.at(index as usize)? else {
+            return Err(TempoPrecompileError::Fatal(format!(
+                "stablecoin DEX order references unknown book index {index}"
+            )));
+        };
+        handler.read()
+    }
+
     /// Converts a relative tick to a scaled price. On T2+ validates [`TICK_SPACING`] alignment.
     ///
     /// # Errors
@@ -562,7 +608,12 @@ impl StablecoinDEX {
             return Err(StablecoinDEXError::pair_already_exists().into());
         }
 
-        let book = Orderbook::new(base, quote);
+        let book = if self.storage.spec().is_t8() {
+            let book_index = self.book_keys.len()? as u32;
+            Orderbook::new_with_id(base, quote, book_index)
+        } else {
+            Orderbook::new(base, quote)
+        };
         self.books[book_key].write(book)?;
         self.book_keys.push(book_key)?;
 
@@ -3515,6 +3566,73 @@ mod tests {
                 base_token,
                 quote_token,
             )]);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t8_book_index_lazy_migrates_pre_t8_pair() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T7);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            let admin = Address::random();
+            let alice = Address::random();
+            let (base_0, quote_token) =
+                setup_test_tokens(admin, alice, exchange.address, MIN_ORDER_AMOUNT)?;
+            let mut keys = Vec::new();
+            keys.push(exchange.create_pair(base_0)?);
+            assert_eq!(keys[0], compute_book_key(base_0, quote_token));
+
+            for index in 1..10 {
+                let name = Box::leak(format!("BASE{index}").into_boxed_str());
+                let base = TIP20Setup::create(name, name, admin).apply()?.address();
+                let key = exchange.create_pair(base)?;
+                assert_eq!(key, compute_book_key(base, quote_token));
+                keys.push(key);
+            }
+
+            for key in &keys {
+                assert_eq!(exchange.books[*key].read()?.id(), None);
+            }
+
+            StorageCtx.set_spec(TempoHardfork::T8);
+            for (index, key) in keys.iter().copied().enumerate() {
+                let index = index as u32;
+                assert_eq!(exchange.book_index_for_key(key)?, index);
+                assert_eq!(exchange.books[key].read()?.id(), Some(index));
+                assert_eq!(exchange.book_key_for_index(index)?, key);
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t8_create_pair_stores_book_index() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            let admin = Address::random();
+            let alice = Address::random();
+            let (base_a, _) = setup_test_tokens(admin, alice, exchange.address, MIN_ORDER_AMOUNT)?;
+            let base_b = TIP20Setup::create("BASE2", "BASE2", admin)
+                .apply()?
+                .address();
+
+            let key_a = exchange.create_pair(base_a)?;
+            let key_b = exchange.create_pair(base_b)?;
+
+            assert_eq!(exchange.books[key_a].read()?.id(), Some(0));
+            assert_eq!(exchange.books[key_b].read()?.id(), Some(1));
+            assert_eq!(exchange.book_index_for_key(key_a)?, 0);
+            assert_eq!(exchange.book_index_for_key(key_b)?, 1);
+            assert_eq!(exchange.book_key_for_index(0)?, key_a);
+            assert_eq!(exchange.book_key_for_index(1)?, key_b);
 
             Ok(())
         })

--- a/crates/precompiles/src/stablecoin_dex/order/storage.rs
+++ b/crates/precompiles/src/stablecoin_dex/order/storage.rs
@@ -16,12 +16,13 @@
 use super::{__packing_legacy_order, LegacyOrder, ORDER_VERSION_V1, Order};
 use crate::{
     error::{Result as StorageResult, TempoPrecompileError},
+    stablecoin_dex::StablecoinDEX,
     storage::{
         Handler, HandlerCache, Layout, LayoutCtx, Slot, Storable, StorableType, StorageCtx,
         StorageKey, StorageOps, packing,
     },
 };
-use alloy::primitives::{Address, B256, FixedBytes, U256};
+use alloy::primitives::{Address, FixedBytes, U256};
 use std::{
     cell::Cell,
     ops::{Index, IndexMut},
@@ -72,12 +73,12 @@ struct V1Order {
     tick: i16,
     /// Destination tick for a fully filled flip order.
     flip_tick: i16,
+    /// StablecoinDEX `book_keys` vector index identifying the trading pair.
+    book_index: u32,
     /// Reserved bytes in packed slot 0. Kept zeroed for deterministic encoding and future use.
-    _unused: FixedBytes<6>,
+    _unused: FixedBytes<2>,
     /// Physical layout marker stored in packed slot 0.
     version: OrderVersion,
-    /// Orderbook key identifying the trading pair.
-    book_key: B256,
     /// Original order amount.
     amount: u128,
     /// Remaining unfilled amount.
@@ -111,28 +112,28 @@ impl V1Order {
     }
 
     /// Converts the logical order into the compact V1 physical layout.
-    fn new(order: Order) -> Self {
-        Self {
+    fn new(order: Order) -> StorageResult<Self> {
+        Ok(Self {
             maker: order.maker,
             tick: order.tick,
             metadata: Self::metadata(order.is_bid, order.is_flip),
             flip_tick: order.flip_tick,
-            _unused: FixedBytes::<6>::ZERO,
+            book_index: StablecoinDEX::new().book_index_for_key(order.book_key)?,
+            _unused: FixedBytes::<2>::ZERO,
             version: OrderVersion::V1,
-            book_key: order.book_key,
             amount: order.amount,
             remaining: order.remaining,
             prev: order.prev,
             next: order.next,
-        }
+        })
     }
 
     /// Converts V1 storage back into the logical order, restoring `order_id` from the mapping key.
-    fn into_order(self, order_id: u128) -> Order {
-        Order {
+    fn into_order(self, order_id: u128) -> StorageResult<Order> {
+        Ok(Order {
             order_id,
             maker: self.maker,
-            book_key: self.book_key,
+            book_key: StablecoinDEX::new().book_key_for_index(self.book_index)?,
             is_bid: self.is_bid(),
             tick: self.tick,
             amount: self.amount,
@@ -141,7 +142,7 @@ impl V1Order {
             next: self.next,
             is_flip: self.is_flip(),
             flip_tick: self.flip_tick,
-        }
+        })
     }
 }
 
@@ -255,7 +256,7 @@ impl Handler<Order> for OrderHandler {
         match self.version()? {
             OrderVersion::Legacy => LegacyOrder::load(self, self.base_slot, LayoutCtx::FULL),
             OrderVersion::V1 => V1Order::load(self, self.base_slot, LayoutCtx::FULL)
-                .map(|res| res.into_order(self.order_id)),
+                .and_then(|res| res.into_order(self.order_id)),
         }
     }
 
@@ -271,19 +272,19 @@ impl Handler<Order> for OrderHandler {
 
         match self.version.get() {
             Some(OrderVersion::Legacy) => {
-                V1Order::new(value).store(self, self.base_slot, LayoutCtx::FULL)?;
+                V1Order::new(value)?.store(self, self.base_slot, LayoutCtx::FULL)?;
                 for offset in V1Order::SLOTS..LegacyOrder::SLOTS {
                     self.store(self.base_slot.wrapping_add(U256::from(offset)), U256::ZERO)?;
                 }
             }
             Some(OrderVersion::V1) => {
-                V1Order::new(value).store(self, self.base_slot, LayoutCtx::FULL)?;
+                V1Order::new(value)?.store(self, self.base_slot, LayoutCtx::FULL)?;
             }
             None => {
                 let current_slot0 = self.load(self.base_slot)?;
                 let current_version = OrderVersion::try_from(current_slot0)?;
 
-                V1Order::new(value).store(self, self.base_slot, LayoutCtx::FULL)?;
+                V1Order::new(value)?.store(self, self.base_slot, LayoutCtx::FULL)?;
                 if matches!(current_version, OrderVersion::Legacy) && !current_slot0.is_zero() {
                     for offset in V1Order::SLOTS..LegacyOrder::SLOTS {
                         self.store(self.base_slot.wrapping_add(U256::from(offset)), U256::ZERO)?;
@@ -419,20 +420,34 @@ impl StorableType for OrderMapping {
 mod tests {
     use super::*;
     use crate::{
-        stablecoin_dex::{IStablecoinDEX, StablecoinDEX},
+        stablecoin_dex::{IStablecoinDEX, Orderbook, StablecoinDEX},
         storage::{ContractStorage, Handler, StorageCtx, hashmap::HashMapStorageProvider},
         storage_credits::StorageCredits,
         test_util::TIP20Setup,
         tip20::{ITIP20, TIP20Token},
         tip403_registry::{ITIP403Registry, TIP403Registry},
     };
-    use alloy::primitives::{address, b256};
+    use alloy::primitives::{B256, address, b256};
     use proptest::prelude::*;
     use tempo_chainspec::hardfork::TempoHardfork;
 
     const TEST_MAKER: Address = address!("0x1111111111111111111111111111111111111111");
     const TEST_BOOK_KEY: B256 =
         b256!("0x0000000000000000000000000000000000000000000000000000000000000001");
+
+    fn seed_book_key(exchange: &mut StablecoinDEX, book_key: B256) -> eyre::Result<()> {
+        if !exchange.books[book_key].read()?.is_initialized() {
+            let index = exchange.book_keys.len()?;
+            exchange.book_keys.push(book_key)?;
+            exchange.books[book_key].write(Orderbook::new_with_id(
+                TEST_MAKER,
+                TEST_MAKER,
+                index as u32,
+            ))?;
+        }
+        Ok(())
+    }
+
     #[test]
     fn test_v1_order_layout_matches_tip_1062() {
         assert_eq!(__packing_v1_order::MAKER_LOC.offset_slots, 0);
@@ -441,8 +456,8 @@ mod tests {
         assert_eq!(__packing_v1_order::TICK_LOC.offset_slots, 0);
         assert_eq!(__packing_v1_order::FLIP_TICK_LOC.offset_slots, 0);
         assert_eq!(__packing_v1_order::VERSION_LOC.offset_slots, 0);
-        assert_eq!(__packing_v1_order::BOOK_KEY_LOC.offset_bytes, 0);
-        assert_eq!(__packing_v1_order::BOOK_KEY_LOC.size, 32);
+        assert_eq!(__packing_v1_order::BOOK_INDEX_LOC.offset_slots, 0);
+        assert_eq!(__packing_v1_order::BOOK_INDEX_LOC.size, 4);
         assert_eq!(
             __packing_v1_order::AMOUNT_LOC.offset_slots,
             __packing_v1_order::REMAINING_LOC.offset_slots
@@ -451,7 +466,7 @@ mod tests {
             __packing_v1_order::PREV_LOC.offset_slots,
             __packing_v1_order::NEXT_LOC.offset_slots
         );
-        assert_eq!(V1Order::SLOTS, 4);
+        assert_eq!(V1Order::SLOTS, 3);
         assert_eq!(LegacyOrder::SLOTS, 6);
     }
 
@@ -460,6 +475,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut exchange = StablecoinDEX::new();
+            seed_book_key(&mut exchange, TEST_BOOK_KEY)?;
 
             let id = 42;
             let order = Order::new_flip(
@@ -497,6 +513,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
         StorageCtx::enter(&mut storage, || {
             let mut exchange = StablecoinDEX::new();
+            seed_book_key(&mut exchange, TEST_BOOK_KEY)?;
 
             let id = 42;
             let mut order = Order::new_flip(
@@ -546,6 +563,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
         StorageCtx::enter(&mut storage, || {
             let mut exchange = StablecoinDEX::new();
+            seed_book_key(&mut exchange, TEST_BOOK_KEY)?;
 
             let id = 42;
             let order = Order::new_bid(id, TEST_MAKER, TEST_BOOK_KEY, 1000, 5);
@@ -572,6 +590,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
         StorageCtx::enter(&mut storage, || {
             let mut exchange = StablecoinDEX::new();
+            seed_book_key(&mut exchange, TEST_BOOK_KEY)?;
 
             let id = 42;
             let mut order = Order::new_flip(
@@ -660,6 +679,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
         StorageCtx::enter(&mut storage, || {
             let mut exchange = StablecoinDEX::new();
+            seed_book_key(&mut exchange, TEST_BOOK_KEY)?;
 
             let id = 42;
             let mut order = Order::new_flip(
@@ -742,6 +762,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
         StorageCtx::enter(&mut storage, || {
             let mut exchange = StablecoinDEX::new();
+            seed_book_key(&mut exchange, TEST_BOOK_KEY)?;
 
             let id = 42;
             let order = Order::new_bid(id, TEST_MAKER, TEST_BOOK_KEY, 1000, 5);
@@ -1465,6 +1486,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
         StorageCtx::enter(&mut storage, || {
             let mut exchange = StablecoinDEX::new();
+            seed_book_key(&mut exchange, TEST_BOOK_KEY)?;
 
             let id = 42;
             let base_slot = exchange.orders[id].base_slot;
@@ -1493,6 +1515,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
             let mut exchange = StablecoinDEX::new();
+            seed_book_key(&mut exchange, TEST_BOOK_KEY)?;
 
             let id = 42;
             let order = Order::new_flip(
@@ -1821,6 +1844,7 @@ mod tests {
                 .write(order_specs.len() as u128 + 1)?;
 
             for (index, order_spec) in order_specs.iter().enumerate() {
+                seed_book_key(&mut exchange, order_spec.book_key)?;
                 let id = index as u128 + 1;
                 let order = test_linked_order(id, order_spec, order_specs.len());
                 store_order_for_layout(&mut exchange, layout, mixed_offset, index, order)?;

--- a/crates/precompiles/src/stablecoin_dex/orderbook.rs
+++ b/crates/precompiles/src/stablecoin_dex/orderbook.rs
@@ -150,6 +150,10 @@ pub struct Orderbook {
     pub base: Address,
     /// Quote token address
     pub quote: Address,
+    /// (T8+) StablecoinDEX `book_keys` vector index for this orderbook.
+    pub id: u32,
+    /// (T8+) Flag that indicates whether the `id` is active or not (to distinguish from id = 0)
+    id_flag: bool,
     /// Bid orders by tick
     #[allow(dead_code)]
     bids: Mapping<i16, TickLevel>,
@@ -169,7 +173,7 @@ pub struct Orderbook {
 }
 
 impl Orderbook {
-    /// Creates a new orderbook for a token pair
+    /// Creates a new orderbook for a token pair.
     pub fn new(base: Address, quote: Address) -> Self {
         Self {
             base,
@@ -178,6 +182,30 @@ impl Orderbook {
             best_ask_tick: i16::MAX,
             ..Default::default()
         }
+    }
+
+    /// (T8+) Creates a new orderbook with its append-only book index.
+    pub fn new_with_id(base: Address, quote: Address, id: u32) -> Self {
+        Self {
+            base,
+            quote,
+            id,
+            id_flag: true,
+            best_bid_tick: i16::MIN,
+            best_ask_tick: i16::MAX,
+            ..Default::default()
+        }
+    }
+
+    /// Returns the T8+ append-only book index, if present.
+    pub fn id(&self) -> Option<u32> {
+        self.id_flag.then_some(self.id)
+    }
+
+    /// Marks this orderbook with its T8+ append-only book index.
+    pub fn activate_id(&mut self, id: u32) {
+        self.id = id;
+        self.id_flag = true;
     }
 
     /// Returns true if this orderbook is initialized


### PR DESCRIPTION
this PR further improves `V1Order` design by packing a u32 book index instead of the full B256 book key.

it adds T8-gated orderbook ids, lazily migrates pre-T8 books on first lookup, and exposes book key/index resolution helpers on the DEX ABI.

RESULT: reduces V1 order storage from 4 slots to 3 slots while preserving legacy pair compatibility across the T8 transition.