### PR TITLE
docs(tip-1062): specify book index order storage

### DIFF
--- a/tips/tip-1062.md
+++ b/tips/tip-1062.md
@@ -11,17 +11,19 @@ related: TIP-1056
 
 ## Abstract
 
-This TIP changes the Stablecoin DEX order storage model from a single fixed `Order` struct layout to a versioned layout behind the existing `orders` mapping starting at the T6 hardfork. The mapping key remains the canonical order ID, and the first storage word for each T6+ order carries a version discriminator. Legacy orders remain readable as version `0`; T6+ orders use version `1`.
+This TIP changes the Stablecoin DEX order storage model from a single fixed `Order` struct layout to a versioned layout behind the existing `orders` mapping starting at the T8 hardfork. The mapping key remains the canonical order ID, and the first storage word for each T8+ order carries a version discriminator. Legacy orders remain readable as version `0`; T8+ orders use version `1`.
 
 ## Motivation
 
-The current DEX order layout uses 6 storage slots per order. A packed layout can store the same active order state in 4 slots by using the mapping key as the canonical `orderId` instead of storing `orderId` inside the value, and by rearranging the remaining fields:
+The current DEX order layout uses 6 storage slots per order. A packed layout can store the same active order state in 3 slots by using the mapping key as the canonical `orderId` instead of storing `orderId` inside the value, storing the orderbook as a compact `bookIndex`, and rearranging the remaining fields:
 
 ```solidity
 mapping(uint128 orderId => Order order) orders;
 ```
 
 Putting `prev` and `next` in the same slot keeps the linked-list pointers together when reading or clearing an order, and leaves future paired pointer updates confined to one storage slot. Adding a version number makes the layout change backwards-compatible and gives future order layouts a clear upgrade path. The DEX also has several hot paths that read and update individual order fields (`remaining`, `prev`, and `next`) directly, so order storage is accessed through a dedicated abstraction rather than scattering version checks through matching, cancellation, and flip-order logic.
+
+The DEX already maintains an append-only `book_keys` vector. T8 assigns each orderbook its vector index and stores that `uint32` index in version `1` orders instead of repeating the full `bytes32 bookKey` in every order.
 
 ## Specification
 
@@ -44,7 +46,7 @@ slot 5: next (uint128), isFlip (bool), flipTick (int16)
 
 ### Version 1 layout
 
-T6+ orders use version `1`, stored at byte offset `31` of slot `0`.
+T8+ orders use version `1`, stored at byte offset `31` of slot `0`.
 
 ```text
 slot 0:
@@ -54,55 +56,67 @@ slot 0:
     bit 1    isFlip     bool      1 bit
   offset 21  tick       int16     2 bytes
   offset 23  flipTick   int16     2 bytes
-  offset 25  unused               6 bytes
+  offset 25  bookIndex  uint32    4 bytes
+  offset 29  unused               2 bytes
   offset 31  version    uint8     1 byte
 
 slot 1:
-  offset 0   bookKey    bytes32   32 bytes
-
-slot 2:
   offset 0   amount     uint128   16 bytes
   offset 16  remaining  uint128   16 bytes
 
-slot 3:
+slot 2:
   offset 0   prev       uint128   16 bytes
   offset 16  next       uint128   16 bytes
 ```
 
+`bookIndex` is the index into the append-only `book_keys` vector. The corresponding `bookKey` is recovered as `book_keys[bookIndex]` when decoding a version `1` order.
+
+### Orderbook indexes
+
+Starting at T8, newly created orderbooks MUST store their `book_keys` vector index on the orderbook record when `createPair` appends the key. Orderbooks created before T8 do not have a stored index. On the first T8+ lookup of a pre-T8 orderbook's index, the DEX MUST derive the index by scanning `book_keys`, store it on the orderbook record, and return it. If the `bookKey` is not initialized or cannot be found in `book_keys`, the lookup MUST fail.
+
+The DEX MUST expose:
+
+```solidity
+function bookIndexForKey(bytes32 bookKey) external returns (uint32 index);
+function bookKeyForIndex(uint32 index) external view returns (bytes32 bookKey);
+```
+
+`bookIndexForKey` is mutating because it may lazily persist the index for a pre-T8 orderbook. `bookKeyForIndex` MUST fail if the requested index is not present in `book_keys`.
+
 ### Read behavior
 
-All order reads MUST use the order storage abstraction. Before T6, reads MUST use the legacy layout directly. Starting at T6, reads MUST use the versioned dispatch below.
+All order reads MUST use the order storage abstraction. Before T8, reads MUST use the legacy layout directly. Starting at T8, reads MUST use the versioned dispatch below.
 
 1. Compute the existing mapping value base slot from `orderId`.
 2. Read slot `0`.
 3. Decode byte offset `31` as `version`.
 4. If `version == 0`, decode the legacy layout.
-5. If `version == 1`, decode the version 1 layout and synthesize `orderId` from the mapping key.
+5. If `version == 1`, decode the version 1 layout, recover `bookKey` from `bookIndex`, and synthesize `orderId` from the mapping key.
 6. Unknown versions MUST fail.
 
 `getOrder(uint128)` keeps returning the existing ABI shape for compatibility. The returned `orderId` is synthesized from the function argument for versioned layouts.
 
 ### Write behavior
 
-Before T6, new orders MUST be written using the legacy layout. Starting at T6, new orders MUST be written using the latest versioned layout. Mutations to active order fields (`remaining`, `prev`, `next`) MUST go through order storage methods rather than direct generated field accessors; before T6 those methods use legacy field access, and starting at T6 they are version-aware.
+Before T8, new orders MUST be written using the legacy layout. Starting at T8, new orders MUST be written using the latest versioned layout. Mutations to active order fields (`remaining`, `prev`, `next`) MUST go through order storage methods rather than direct generated field accessors; before T8 those methods use legacy field access, and starting at T8 they are version-aware.
 
 #### Interaction with TIP-1056 flip rewrites
 
-TIP-1056 rewrites fully filled flip orders in place under the same mapping key. After T6 activates, user placements and TIP-1056 flip rewrites MUST use the latest order storage layout; for version `1`, the rules below are authoritative and supersede the older TIP-1055-era slot-level rewrite rules in TIP-1056.
+TIP-1056 rewrites fully filled flip orders in place under the same mapping key. After T8 activates, user placements and TIP-1056 flip rewrites MUST use the latest order storage layout; for version `1`, the rules below are authoritative and supersede the older TIP-1055-era slot-level rewrite rules in TIP-1056.
 
 Concretely:
 
-- user-submitted orders created after T6, including `placeFlip` orders, MUST be written as version `1`
-- a version `0` flip order that flips after T6 activates MUST be rewritten under the same `orderId` as version `1`
+- user-submitted orders created after T8, including `placeFlip` orders, MUST be written as version `1`
+- a version `0` flip order that flips after T8 activates MUST be rewritten under the same `orderId` as version `1`
 - a version `1` flip order that flips MUST remain version `1`
 
 A version `1` flip rewrite MUST encode the post-flip order state as follows:
 
-- slot `0`: preserved `maker`, `metadata` encoding inverted `isBid` and `isFlip = true`, swapped `tick` / `flipTick`, zeroed unused bytes, and `version = 1`
-- slot `1`: preserved `bookKey`
-- slot `2`: preserved `amount` and `remaining = amount`
-- slot `3`: post-reinsertion `prev` / `next` pointers, after resetting them before insertion
-- legacy-only slots `4` and `5` MUST be cleared when upgrading from version `0`
+- slot `0`: preserved `maker`, `metadata` encoding inverted `isBid` and `isFlip = true`, swapped `tick` / `flipTick`, preserved `bookIndex`, zeroed unused bytes, and `version = 1`
+- slot `1`: preserved `amount` and `remaining = amount`
+- slot `2`: post-reinsertion `prev` / `next` pointers, after resetting them before insertion
+- legacy-only slots `3`, `4`, and `5` MUST be cleared when upgrading from version `0`
 
 These version `1` rewrite rules replace the older TIP-1056 requirements to clear slot `0`, keep slot `0` zero, and leave slots `1` and `2` untouched. The storage-version upgrade preserves TIP-1056 order identity: the mapping key remains the canonical `orderId`, and the flipped order still receives fresh queue priority at its destination tick.
 
@@ -121,6 +135,7 @@ The abstraction requirement is part of the protocol design: mixed-version linked
 - The `orders` mapping slot and mapping key type remain unchanged.
 - Existing version `0` orders decode exactly as before.
 - New version `1` orders synthesize `orderId` from the mapping key.
+- New version `1` orders recover `bookKey` from a stored `bookIndex` into the append-only `book_keys` vector.
 - Direct order storage access is not used outside the versioned order abstraction.
 - Mixed-version linked lists remain valid: `prev` and `next` updates are version-aware per target order.
 - `getOrder` remains ABI-compatible.

--- a/tips/tip-1062.md
+++ b/tips/tip-1062.md
@@ -2,7 +2,7 @@
 id: TIP-1062
 title: Versioned DEX order storage
 description: Introduce a versioned Stablecoin DEX order storage layout that keeps the existing orders mapping while allowing future order structs to be decoded by version.
-authors: Dan Robinson
+authors: Dan Robinson, Arsenii Kulikov (@klkvr)
 status: Draft
 related: TIP-1056
 ---
@@ -71,9 +71,42 @@ slot 2:
 
 `bookIndex` is the index into the append-only `book_keys` vector. The corresponding `bookKey` is recovered as `book_keys[bookIndex]` when decoding a version `1` order.
 
-### Orderbook indexes
+### Orderbook layout
 
-Starting at T8, newly created orderbooks MUST store their `book_keys` vector index on the orderbook record when `createPair` appends the key. Orderbooks created before T8 do not have a stored index. On the first T8+ lookup of a pre-T8 orderbook's index, the DEX MUST derive the index by scanning `book_keys`, store it on the orderbook record, and return it. If the `bookKey` is not initialized or cannot be found in `book_keys`, the lookup MUST fail.
+Orderbooks keep the existing logical shape and gain a persisted book index at T8:
+
+```text
+slot 0:
+  offset 0   base         address  20 bytes
+  offset 20  unused                 12 bytes
+
+slot 1:
+  offset 0   quote        address  20 bytes
+  offset 20  id           uint32    4 bytes   T8+
+  offset 24  idFlag       bool      1 byte    T8+
+  offset 25  unused                 7 bytes
+
+slot 2:
+  bids        mapping(int16 => TickLevel)
+
+slot 3:
+  asks        mapping(int16 => TickLevel)
+
+slot 4:
+  offset 0   bestBidTick  int16     2 bytes
+  offset 2   bestAskTick  int16     2 bytes
+  offset 4   unused                 28 bytes
+
+slot 5:
+  bidBitmap   mapping(int16 => uint256)
+
+slot 6:
+  askBitmap   mapping(int16 => uint256)
+```
+
+`id` is the Stablecoin DEX `book_keys` vector index for this orderbook. `idFlag` indicates whether `id` is active, distinguishing an active index `0` from the pre-T8 default value. Both fields are packed into unused bytes in existing `Orderbook` slots, so T8 does not increase the orderbook's slot count.
+
+Starting at T8, newly created orderbooks MUST store `id = book_keys.length` and `idFlag = true` on the orderbook record before appending the key to `book_keys`. Orderbooks created before T8 have `idFlag = false` and no active stored index. On the first T8+ lookup of a pre-T8 orderbook's index, the DEX MUST derive the index by scanning `book_keys`, store `id` and `idFlag = true` on the orderbook record, and return the index. If the `bookKey` is not initialized or cannot be found in `book_keys`, the lookup MUST fail.
 
 The DEX MUST expose:
 


### PR DESCRIPTION
## Summary
- update TIP-1062 to specify the #6668 book-index order storage design
- reduce the proposed V1 order layout from 4 slots to 3 by storing `bookIndex` instead of `bookKey`
- document T8 orderbook index assignment, lazy migration for pre-T8 books, and lookup helpers

## Validation
- `git diff --check`

Prompted by: @0xrusowsky