### PR TITLE
 fix(multisig): cap quorum validation work

### DIFF
--- a/.changelog/native-multisig-dos-limits.md
+++ b/.changelog/native-multisig-dos-limits.md
@@ -1,0 +1,8 @@
+---
+tempo-alloy: patch
+tempo-precompiles: patch
+tempo-primitives: patch
+tempo-revm: patch
+---
+
+Caps native multisig thresholds and submitted owner approvals at 8 while keeping configs at up to 255 owners. Registered authorization now reads the account threshold plus submitted owner weights instead of scanning the full owner list, charges owner-weight lookup gas, rejects trailing approvals after quorum, and limits nesting to one nested multisig level.

--- a/.changelog/native-multisig-dos-limits.md
+++ b/.changelog/native-multisig-dos-limits.md
@@ -1,8 +1,0 @@
----
-tempo-alloy: patch
-tempo-precompiles: patch
-tempo-primitives: patch
-tempo-revm: patch
----
-
-Caps native multisig thresholds and submitted owner approvals at 8 while keeping configs at up to 255 owners. Registered authorization now reads the account threshold plus submitted owner weights instead of scanning the full owner list, charges owner-weight lookup gas, rejects trailing approvals after quorum, and limits nesting to one nested multisig level.

--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -274,12 +274,12 @@ fn create_mock_native_multisig_owner_signatures(
     key_type: &SignatureType,
     key_data: Option<&Bytes>,
 ) -> Result<Vec<Bytes>, &'static str> {
-    use tempo_primitives::transaction::MAX_MULTISIG_OWNERS;
+    use tempo_primitives::transaction::MAX_MULTISIG_SIGNATURES;
 
     if signature_count == 0 {
         return Err("multisig mock signature requires at least one owner");
     }
-    if signature_count > MAX_MULTISIG_OWNERS {
+    if signature_count > MAX_MULTISIG_SIGNATURES {
         return Err("too many multisig signatures");
     }
 

--- a/crates/precompiles/src/native_multisig/auth.rs
+++ b/crates/precompiles/src/native_multisig/auth.rs
@@ -42,8 +42,51 @@ impl NativeMultisigAuthError {
             }
             MultisigQuorumError::EmptySignatures
             | MultisigQuorumError::TooManySignatures
+            | MultisigQuorumError::ExcessSignatures
             | MultisigQuorumError::SignersNotAscending
             | MultisigQuorumError::WeightOverflow => Self::invalid_transaction(err.as_str()),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum NativeMultisigAuthConfig<'a> {
+    Inline(&'a InitMultisig),
+    Registered { account: Address, threshold: u8 },
+}
+
+impl NativeMultisigAuthConfig<'_> {
+    fn threshold(self) -> u8 {
+        match self {
+            Self::Inline(config) => config.threshold,
+            Self::Registered { threshold, .. } => threshold,
+        }
+    }
+
+    fn owner_weight(
+        self,
+        owner: Address,
+        load_owner_weight: &mut impl FnMut(Address, Address) -> Result<u8, NativeMultisigAuthError>,
+    ) -> Result<u8, NativeMultisigAuthError> {
+        let weight = match self {
+            Self::Inline(config) => config.owner_weight(owner).unwrap_or_default(),
+            Self::Registered { account, .. } => load_owner_weight(account, owner)?,
+        };
+        if weight == 0 {
+            return Err(NativeMultisigAuthError::quorum_error(
+                MultisigQuorumError::SignerNotOwner,
+            ));
+        }
+        Ok(weight)
+    }
+
+    fn validate(self) -> Result<(), NativeMultisigAuthError> {
+        match self {
+            Self::Inline(config) => config
+                .validate()
+                .map(|_| ())
+                .map_err(|err| NativeMultisigAuthError::validation_failed(err.as_str())),
+            Self::Registered { .. } => Ok(()),
         }
     }
 }
@@ -54,8 +97,9 @@ impl NativeMultisig {
         &self,
         inner_digest: B256,
         signature: &MultisigSignature,
-        config: &InitMultisig,
-        mut load_config: impl FnMut(Address) -> Result<InitMultisig, NativeMultisigAuthError>,
+        config: NativeMultisigAuthConfig<'_>,
+        mut load_threshold: impl FnMut(Address) -> Result<u8, NativeMultisigAuthError>,
+        mut load_owner_weight: impl FnMut(Address, Address) -> Result<u8, NativeMultisigAuthError>,
     ) -> Result<(), NativeMultisigAuthError> {
         let mut account_path = vec![signature.account()];
         self.verify_authorization_inner(
@@ -63,7 +107,8 @@ impl NativeMultisig {
             signature,
             config,
             &mut account_path,
-            &mut load_config,
+            &mut load_threshold,
+            &mut load_owner_weight,
         )
         .map(|_| ())
     }
@@ -72,21 +117,20 @@ impl NativeMultisig {
         &self,
         inner_digest: B256,
         signature: &MultisigSignature,
-        config: &InitMultisig,
+        config: NativeMultisigAuthConfig<'_>,
         account_path: &mut Vec<Address>,
-        load_config: &mut impl FnMut(Address) -> Result<InitMultisig, NativeMultisigAuthError>,
+        load_threshold: &mut impl FnMut(Address) -> Result<u8, NativeMultisigAuthError>,
+        load_owner_weight: &mut impl FnMut(Address, Address) -> Result<u8, NativeMultisigAuthError>,
     ) -> Result<u8, NativeMultisigAuthError> {
         signature
             .validate_shape()
             .map_err(NativeMultisigAuthError::invalid_transaction)?;
-        config
-            .validate()
-            .map_err(|err| NativeMultisigAuthError::validation_failed(err.as_str()))?;
+        config.validate()?;
 
         let digest = signature.digest(inner_digest);
-        let mut weight_accumulator = MultisigWeightAccumulator::new(config);
+        let mut weight_accumulator = MultisigWeightAccumulator::new(config.threshold());
 
-        for signature_bytes in signature.signatures() {
+        for (signature_index, signature_bytes) in signature.signatures().iter().enumerate() {
             let owner_approval = TempoSignature::from_bytes(signature_bytes).map_err(|reason| {
                 NativeMultisigAuthError::invalid_transaction(format!(
                     "invalid multisig owner signature: {reason}"
@@ -119,8 +163,9 @@ impl NativeMultisig {
                 }
             };
 
+            let weight = config.owner_weight(owner, load_owner_weight)?;
             weight_accumulator
-                .record_owner(owner)
+                .record_owner(owner, weight)
                 .map_err(NativeMultisigAuthError::quorum_error)?;
 
             if let Some(nested_signature) = nested_signature {
@@ -135,16 +180,31 @@ impl NativeMultisig {
                     ));
                 }
 
-                let nested_config = load_config(owner)?;
+                let threshold = load_threshold(owner)?;
                 account_path.push(owner);
                 self.verify_authorization_inner(
                     digest,
                     &nested_signature,
-                    &nested_config,
+                    NativeMultisigAuthConfig::Registered {
+                        account: owner,
+                        threshold,
+                    },
                     account_path,
-                    load_config,
+                    load_threshold,
+                    load_owner_weight,
                 )?;
                 account_path.pop();
+            }
+
+            if weight_accumulator.has_quorum() {
+                if signature_index + 1 != signature.signatures().len() {
+                    return Err(NativeMultisigAuthError::quorum_error(
+                        MultisigQuorumError::ExcessSignatures,
+                    ));
+                }
+                return weight_accumulator
+                    .finish()
+                    .map_err(NativeMultisigAuthError::quorum_error);
             }
         }
 

--- a/crates/precompiles/src/native_multisig/mod.rs
+++ b/crates/precompiles/src/native_multisig/mod.rs
@@ -10,7 +10,7 @@ use tempo_contracts::precompiles::{
 };
 use tempo_precompiles_macros::{Storable, contract};
 use tempo_primitives::transaction::{
-    InitMultisig, MAX_MULTISIG_OWNERS, MultisigConfigError, MultisigOwner,
+    InitMultisig, MAX_MULTISIG_OWNERS, MAX_MULTISIG_THRESHOLD, MultisigConfigError, MultisigOwner,
     is_valid_multisig_account,
 };
 
@@ -50,6 +50,8 @@ pub struct NativeMultisig {
     accounts: Mapping<Address, StoredMultisigHeader>,
     // account -> owner index -> owner and weight.
     owners: Mapping<Address, Mapping<u32, StoredMultisigOwner>>,
+    // account -> owner address -> owner weight.
+    owner_weights: Mapping<Address, Mapping<Address, u8>>,
 
     // WARNING: transient storage slots must remain at the end.
     tx_origin: Address,
@@ -82,6 +84,15 @@ impl NativeMultisig {
         (weight.slot(), weight.offset())
     }
 
+    pub fn config_owner_lookup_weight_storage_slot(
+        account: Address,
+        owner: Address,
+    ) -> (U256, Option<usize>) {
+        let multisig = Self::new();
+        let weight = &multisig.owner_weights[account][owner];
+        (weight.slot(), weight.offset())
+    }
+
     pub fn set_tx_origin(&mut self, origin: Address) -> Result<()> {
         self.tx_origin.t_write(origin)
     }
@@ -91,11 +102,9 @@ impl NativeMultisig {
     }
 
     pub fn is_multisig_account(&self, account: Address) -> Result<bool> {
-        let header = self.accounts[account].read()?;
-        Ok(matches!(
-            parse_multisig_header(header)?,
-            ParsedMultisigHeader::Initialized { .. }
-        ))
+        Ok(self
+            .load_registered_threshold_if_present(account)?
+            .is_some())
     }
 
     pub fn get_multisig_config_id(&self, account: Address) -> Result<B256> {
@@ -114,6 +123,23 @@ impl NativeMultisig {
 
     pub fn load_registered_config(&self, account: Address) -> Result<InitMultisig> {
         self.load_stored_config(account)
+    }
+
+    pub fn load_registered_threshold(&self, account: Address) -> Result<u8> {
+        self.load_registered_threshold_if_present(account)?
+            .ok_or_else(|| NativeMultisigError::not_multisig_account().into())
+    }
+
+    pub fn load_registered_threshold_if_present(&self, account: Address) -> Result<Option<u8>> {
+        let header = self.accounts[account].read()?;
+        match parse_multisig_header(header)? {
+            ParsedMultisigHeader::Uninitialized => Ok(None),
+            ParsedMultisigHeader::Initialized { threshold, .. } => Ok(Some(threshold)),
+        }
+    }
+
+    pub fn read_owner_weight(&self, account: Address, owner: Address) -> Result<u8> {
+        self.owner_weights[account][owner].read()
     }
 
     pub fn validate_config_id(&self, account: Address, config_id: B256) -> Result<()> {
@@ -143,7 +169,7 @@ impl NativeMultisig {
             return Err(NativeMultisigError::invalid_account().into());
         }
 
-        self.write_stored_config(account, config, 0)?;
+        self.write_stored_config(account, config, &[])?;
         self.set_bootstrapped_account(account)?;
         self.emit_event(NativeMultisigEvent::multisig_initialized(account))
     }
@@ -163,11 +189,10 @@ impl NativeMultisig {
         }
 
         let stored = self.load_stored_config(msg_sender)?;
-        let previous_owner_count = stored.owners.len();
         let event_owners = owners.clone();
         let init_config = abi_config_to_init(threshold, owners)?;
 
-        self.write_stored_config(msg_sender, &init_config, previous_owner_count)?;
+        self.write_stored_config(msg_sender, &init_config, &stored.owners)?;
         self.emit_event(NativeMultisigEvent::multisig_config_updated(
             msg_sender,
             threshold,
@@ -213,7 +238,7 @@ impl NativeMultisig {
         &mut self,
         account: Address,
         config: &InitMultisig,
-        previous_owner_count: usize,
+        previous_owners: &[MultisigOwner],
     ) -> Result<()> {
         let owner_count = u8::try_from(config.owners.len())
             .map_err(|_| NativeMultisigError::too_many_owners())?;
@@ -224,8 +249,14 @@ impl NativeMultisig {
         })?;
         for (index, owner) in config.owners.iter().enumerate() {
             self.owners[account][index as u32].write(owner.into())?;
+            self.owner_weights[account][owner.owner].write(owner.weight)?;
         }
-        for index in usize::from(owner_count)..previous_owner_count {
+        for previous_owner in previous_owners {
+            if config.owner_weight(previous_owner.owner).is_none() {
+                self.owner_weights[account][previous_owner.owner].delete()?;
+            }
+        }
+        for index in usize::from(owner_count)..previous_owners.len() {
             self.owners[account][index as u32].delete()?;
         }
 
@@ -239,7 +270,7 @@ fn parse_multisig_header(header: StoredMultisigHeader) -> Result<ParsedMultisigH
         (0, _) | (_, 0) => Err(NativeMultisigError::invalid_config().into()),
         (threshold, owner_count) => {
             let owner_count = usize::from(owner_count);
-            if owner_count > MAX_MULTISIG_OWNERS {
+            if owner_count > MAX_MULTISIG_OWNERS || threshold > MAX_MULTISIG_THRESHOLD {
                 return Err(NativeMultisigError::invalid_config().into());
             }
             Ok(ParsedMultisigHeader::Initialized {
@@ -288,7 +319,9 @@ fn map_multisig_config_error(err: MultisigConfigError) -> TempoPrecompileError {
             NativeMultisigError::invalid_owner().into()
         }
         MultisigConfigError::TooManyOwners => NativeMultisigError::too_many_owners().into(),
-        MultisigConfigError::ZeroThreshold | MultisigConfigError::ThresholdExceedsWeight => {
+        MultisigConfigError::ZeroThreshold
+        | MultisigConfigError::ThresholdTooHigh
+        | MultisigConfigError::ThresholdExceedsWeight => {
             NativeMultisigError::invalid_threshold().into()
         }
         MultisigConfigError::ZeroWeight
@@ -407,7 +440,7 @@ mod tests {
 
             Ok::<_, TempoPrecompileError>(())
         })?;
-        assert_eq!(storage.counter_sstore(), 1 + config.owners.len() as u64);
+        assert_eq!(storage.counter_sstore(), 1 + 2 * config.owners.len() as u64);
 
         let (threshold_slot, threshold_offset) =
             NativeMultisig::account_threshold_storage_slot(account);
@@ -421,7 +454,12 @@ mod tests {
             let (owner_slot, _) = NativeMultisig::config_owner_weight_storage_slot(account, index);
             persistent_slots.insert(owner_slot);
         }
-        assert_eq!(persistent_slots.len(), 1 + config.owners.len());
+        for owner in &config.owners {
+            let (owner_slot, _) =
+                NativeMultisig::config_owner_lookup_weight_storage_slot(account, owner.owner);
+            persistent_slots.insert(owner_slot);
+        }
+        assert_eq!(persistent_slots.len(), 1 + 2 * config.owners.len());
 
         storage.clear_transient();
         StorageCtx::enter(&mut storage, || {
@@ -441,7 +479,7 @@ mod tests {
         let owners = max_abi_owners();
         let config = InitMultisig {
             salt: B256::ZERO,
-            threshold: u8::MAX,
+            threshold: MAX_MULTISIG_THRESHOLD,
             owners: owners
                 .iter()
                 .map(|owner| MultisigOwner {
@@ -458,8 +496,14 @@ mod tests {
             multisig.store_initial_config(account, &config)?;
 
             let stored = multisig.get_multisig_config(account)?;
-            assert_eq!(stored.threshold, u8::MAX);
+            assert_eq!(stored.threshold, MAX_MULTISIG_THRESHOLD);
             assert_eq!(stored.owners, owners);
+            for owner in &owners {
+                assert_eq!(
+                    multisig.read_owner_weight(account, owner.owner)?,
+                    owner.weight
+                );
+            }
 
             Ok::<_, TempoPrecompileError>(())
         })?;
@@ -695,7 +739,7 @@ mod tests {
                 },
             ];
             assert!(matches!(
-                multisig.update_multisig_config(account, u8::MAX, overweight_owners),
+                multisig.update_multisig_config(account, MAX_MULTISIG_THRESHOLD, overweight_owners),
                 Err(TempoPrecompileError::NativeMultisigError(
                     NativeMultisigError::InvalidWeight(_)
                 ))
@@ -767,7 +811,7 @@ mod tests {
 
             let too_many_owners = InitMultisig {
                 salt: B256::ZERO,
-                threshold: u8::MAX,
+                threshold: MAX_MULTISIG_THRESHOLD,
                 owners: (0..=MAX_MULTISIG_OWNERS as u16)
                     .map(|index| MultisigOwner {
                         owner: indexed_owner(index + 1),

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -22,8 +22,9 @@ pub use key_authorization::{
 };
 pub use multisig::{
     InitMultisig, MAX_MULTISIG_NESTING_DEPTH, MAX_MULTISIG_OWNER_SIGNATURE_BYTES,
-    MAX_MULTISIG_OWNERS, MULTISIG_SIGNATURE_DOMAIN, MultisigConfigError, MultisigOwner,
-    MultisigQuorumError, MultisigSignature, MultisigWeightAccumulator, SIGNATURE_TYPE_MULTISIG,
+    MAX_MULTISIG_OWNERS, MAX_MULTISIG_SIGNATURES, MAX_MULTISIG_THRESHOLD,
+    MULTISIG_SIGNATURE_DOMAIN, MultisigConfigError, MultisigOwner, MultisigQuorumError,
+    MultisigSignature, MultisigWeightAccumulator, SIGNATURE_TYPE_MULTISIG,
     is_valid_multisig_account, multisig_digest, multisig_signature_count_for_threshold,
     verify_ordered_owner_weights,
 };

--- a/crates/primitives/src/transaction/multisig.rs
+++ b/crates/primitives/src/transaction/multisig.rs
@@ -22,9 +22,18 @@ pub const MULTISIG_SIGNATURE_DOMAIN: &[u8] = b"tempo:multisig:signature";
 /// Maximum number of owners allowed in a native multisig config.
 pub const MAX_MULTISIG_OWNERS: usize = 255;
 
+/// Maximum threshold accepted by a native multisig config.
+///
+/// Owner weights are nonzero, so this also bounds the number of owner approvals required to
+/// satisfy one multisig authorization node.
+pub const MAX_MULTISIG_THRESHOLD: u8 = 8;
+
+/// Maximum number of owner approvals allowed in one native multisig signature.
+pub const MAX_MULTISIG_SIGNATURES: usize = MAX_MULTISIG_THRESHOLD as usize;
+
 /// Maximum number of native multisig signatures in one nested authorization path, including the
 /// top-level transaction signature.
-pub const MAX_MULTISIG_NESTING_DEPTH: usize = 3;
+pub const MAX_MULTISIG_NESTING_DEPTH: usize = 2;
 
 /// Maximum encoded byte length for one primitive owner approval.
 pub const MAX_MULTISIG_OWNER_SIGNATURE_BYTES: usize = 1 + MAX_WEBAUTHN_SIGNATURE_LENGTH;
@@ -40,6 +49,8 @@ pub enum MultisigConfigError {
     TooManyOwners,
     /// The threshold is zero.
     ZeroThreshold,
+    /// The threshold exceeds [`MAX_MULTISIG_THRESHOLD`].
+    ThresholdTooHigh,
     /// An owner address is zero.
     ZeroOwner,
     /// An owner weight is zero.
@@ -65,6 +76,7 @@ impl MultisigConfigError {
             Self::EmptyOwners => "multisig owners cannot be empty",
             Self::TooManyOwners => "too many multisig owners",
             Self::ZeroThreshold => "multisig threshold cannot be zero",
+            Self::ThresholdTooHigh => "multisig threshold exceeds max threshold",
             Self::ZeroOwner => "multisig owner cannot be zero",
             Self::ZeroWeight => "multisig owner weight cannot be zero",
             Self::DuplicateOwner => "multisig owners cannot contain duplicates",
@@ -88,8 +100,10 @@ impl core::fmt::Display for MultisigConfigError {
 pub enum MultisigQuorumError {
     /// The signature list is empty.
     EmptySignatures,
-    /// The signature list exceeds [`MAX_MULTISIG_OWNERS`].
+    /// The signature list exceeds [`MAX_MULTISIG_SIGNATURES`].
     TooManySignatures,
+    /// The signature list has entries after quorum is reached.
+    ExcessSignatures,
     /// A recovered signer is not a configured owner.
     SignerNotOwner,
     /// Recovered signers are not strictly ascending.
@@ -106,6 +120,7 @@ impl MultisigQuorumError {
         match self {
             Self::EmptySignatures => "multisig signatures cannot be empty",
             Self::TooManySignatures => "too many multisig signatures",
+            Self::ExcessSignatures => "excess multisig owner signatures",
             Self::SignerNotOwner => "multisig signer is not an owner",
             Self::SignersNotAscending => "multisig recovered owners must be strictly ascending",
             Self::WeightOverflow => "multisig recovered owner weight overflow",
@@ -133,31 +148,31 @@ impl From<MultisigQuorumError> for String {
 }
 
 /// Accumulates recovered native multisig owner weights while enforcing owner ordering.
-pub struct MultisigWeightAccumulator<'a> {
-    config: &'a InitMultisig,
+pub struct MultisigWeightAccumulator {
+    threshold: u8,
     prev_owner: Option<Address>,
     recovered_weight: u16,
     signer_count: usize,
 }
 
-impl<'a> MultisigWeightAccumulator<'a> {
-    /// Creates a new accumulator for a validated native multisig config.
-    pub const fn new(config: &'a InitMultisig) -> Self {
+impl MultisigWeightAccumulator {
+    /// Creates a new accumulator for a validated native multisig threshold.
+    pub const fn new(threshold: u8) -> Self {
         Self {
-            config,
+            threshold,
             prev_owner: None,
             recovered_weight: 0,
             signer_count: 0,
         }
     }
 
-    /// Records one recovered owner address and returns its configured weight.
-    pub fn record_owner(&mut self, owner: Address) -> Result<u8, MultisigQuorumError> {
+    /// Records one recovered owner address and its configured weight.
+    pub fn record_owner(&mut self, owner: Address, weight: u8) -> Result<u8, MultisigQuorumError> {
         self.signer_count = self
             .signer_count
             .checked_add(1)
             .ok_or(MultisigQuorumError::TooManySignatures)?;
-        if self.signer_count > MAX_MULTISIG_OWNERS {
+        if self.signer_count > MAX_MULTISIG_SIGNATURES {
             return Err(MultisigQuorumError::TooManySignatures);
         }
 
@@ -166,13 +181,6 @@ impl<'a> MultisigWeightAccumulator<'a> {
         }
         self.prev_owner = Some(owner);
 
-        let weight = self
-            .config
-            .owners
-            .binary_search_by_key(&owner, |entry| entry.owner)
-            .map(|idx| self.config.owners[idx].weight)
-            .map_err(|_| MultisigQuorumError::SignerNotOwner)?;
-
         self.recovered_weight = self
             .recovered_weight
             .checked_add(u16::from(weight))
@@ -180,12 +188,17 @@ impl<'a> MultisigWeightAccumulator<'a> {
         Ok(weight)
     }
 
+    /// Returns whether the accumulated weight satisfies the configured threshold.
+    pub fn has_quorum(&self) -> bool {
+        self.signer_count > 0 && self.recovered_weight >= u16::from(self.threshold)
+    }
+
     /// Returns the accumulated weight after enforcing the configured threshold.
     pub fn finish(self) -> Result<u8, MultisigQuorumError> {
         if self.signer_count == 0 {
             return Err(MultisigQuorumError::EmptySignatures);
         }
-        if self.recovered_weight < u16::from(self.config.threshold) {
+        if self.recovered_weight < u16::from(self.threshold) {
             return Err(MultisigQuorumError::WeightBelowThreshold);
         }
 
@@ -250,6 +263,9 @@ impl InitMultisig {
         }
         if self.threshold == 0 {
             return Err(MultisigConfigError::ZeroThreshold);
+        }
+        if self.threshold > MAX_MULTISIG_THRESHOLD {
+            return Err(MultisigConfigError::ThresholdTooHigh);
         }
 
         let mut total_weight = 0u16;
@@ -318,7 +334,7 @@ impl InitMultisig {
         if signature_count == 0 {
             return Err("multisig signatures cannot be empty");
         }
-        if signature_count > self.owners.len() {
+        if signature_count > MAX_MULTISIG_SIGNATURES || signature_count > self.owners.len() {
             return Err("too many multisig signatures");
         }
 
@@ -331,6 +347,14 @@ impl InitMultisig {
         )
         .map(|_| ())
         .map_err(MultisigQuorumError::as_str)
+    }
+
+    /// Returns the configured weight for an owner, if present.
+    pub fn owner_weight(&self, owner: Address) -> Option<u8> {
+        self.owners
+            .binary_search_by_key(&owner, |entry| entry.owner)
+            .ok()
+            .map(|idx| self.owners[idx].weight)
     }
 
     /// Decodes, verifies, and weight-accounts primitive owner approvals.
@@ -426,7 +450,7 @@ impl MultisigSignature {
         if self.signatures.is_empty() {
             return Err("multisig signatures cannot be empty");
         }
-        if self.signatures.len() > MAX_MULTISIG_OWNERS {
+        if self.signatures.len() > MAX_MULTISIG_SIGNATURES {
             return Err("too many multisig signatures");
         }
         if self.signatures.iter().any(|sig| sig.is_empty()) {
@@ -629,7 +653,7 @@ pub fn multisig_signature_count_for_threshold(
         count = count
             .checked_add(1)
             .ok_or(MultisigQuorumError::TooManySignatures)?;
-        if count > MAX_MULTISIG_OWNERS {
+        if count > MAX_MULTISIG_SIGNATURES {
             return Err(MultisigQuorumError::TooManySignatures);
         }
         signed_weight = signed_weight
@@ -651,9 +675,14 @@ pub fn verify_ordered_owner_weights(
     owners: &[Address],
     config: &InitMultisig,
 ) -> Result<u8, MultisigQuorumError> {
-    let mut accumulator = MultisigWeightAccumulator::new(config);
+    let mut accumulator = MultisigWeightAccumulator::new(config.threshold);
     for &owner in owners {
-        accumulator.record_owner(owner)?;
+        let weight = config
+            .owners
+            .binary_search_by_key(&owner, |entry| entry.owner)
+            .map(|idx| config.owners[idx].weight)
+            .map_err(|_| MultisigQuorumError::SignerNotOwner)?;
+        accumulator.record_owner(owner, weight)?;
     }
     accumulator.finish()
 }
@@ -665,7 +694,7 @@ fn recover_multisig_owner_addresses(
     if signatures.is_empty() {
         return Err("multisig signatures cannot be empty");
     }
-    if signatures.len() > MAX_MULTISIG_OWNERS {
+    if signatures.len() > MAX_MULTISIG_SIGNATURES {
         return Err("too many multisig signatures");
     }
 
@@ -695,7 +724,7 @@ fn verify_recovered_multisig_owners(
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for MultisigSignature {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let len = u.int_in_range(1..=MAX_MULTISIG_OWNERS)?;
+        let len = u.int_in_range(1..=MAX_MULTISIG_SIGNATURES)?;
         let mut signatures = Vec::new();
         for _ in 0..len {
             let mut signature = Vec::<u8>::arbitrary(u)?;
@@ -863,7 +892,7 @@ mod tests {
         let owners = (1..=MAX_MULTISIG_OWNERS as u16)
             .map(|index| (indexed_owner(index), 1))
             .collect::<Vec<_>>();
-        let config = sorted_secp_config(&owners, u8::MAX);
+        let config = sorted_secp_config(&owners, MAX_MULTISIG_THRESHOLD);
 
         assert_eq!(config.validate(), Ok(u8::MAX));
         assert!(config.account().is_ok());
@@ -874,7 +903,7 @@ mod tests {
         let owners = (1..=MAX_MULTISIG_OWNERS as u16 + 1)
             .map(|index| (indexed_owner(index), 1))
             .collect::<Vec<_>>();
-        let config = sorted_secp_config(&owners, u8::MAX);
+        let config = sorted_secp_config(&owners, MAX_MULTISIG_THRESHOLD);
 
         assert_eq!(config.validate(), Err(MultisigConfigError::TooManyOwners));
     }
@@ -883,11 +912,23 @@ mod tests {
     fn config_total_weight_is_capped_at_u8_max() {
         let owner_a = Address::from([0x11; 20]);
         let owner_b = Address::from([0x22; 20]);
-        let config = sorted_secp_config(&[(owner_a, 128), (owner_b, 128)], u8::MAX);
+        let config = sorted_secp_config(&[(owner_a, 128), (owner_b, 128)], MAX_MULTISIG_THRESHOLD);
 
         assert_eq!(
             config.validate(),
             Err(MultisigConfigError::TotalWeightExceedsMax)
+        );
+    }
+
+    #[test]
+    fn config_rejects_threshold_above_protocol_cap() {
+        let owner = Address::from([0x11; 20]);
+        let threshold = MAX_MULTISIG_THRESHOLD + 1;
+        let config = sorted_secp_config(&[(owner, threshold)], threshold);
+
+        assert_eq!(
+            config.validate(),
+            Err(MultisigConfigError::ThresholdTooHigh)
         );
     }
 
@@ -1187,7 +1228,7 @@ mod tests {
                 proptest::collection::vec(any::<u8>(), 0..256),
                 (
                     any::<Address>(),
-                    proptest::collection::vec(proptest::collection::vec(any::<u8>(), 0..128), 0..=MAX_MULTISIG_OWNERS),
+                    proptest::collection::vec(proptest::collection::vec(any::<u8>(), 0..128), 0..=MAX_MULTISIG_SIGNATURES),
                 ).prop_map(|(account, signatures)| {
                     encoded_multisig_without_init_slot(account, signatures)
                 }),

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -335,17 +335,19 @@ where
 
 /// Block-scoped native multisig lookup cache.
 ///
-/// Account markers and validated configs are cached separately so config invalidation can clear
-/// only configs while retaining marker hits. This avoids repeatedly reading marker storage after a
-/// transaction touches the native multisig precompile, while also avoiding a full marker-cache scan
-/// when configs must be invalidated.
+/// Account markers, thresholds, and validated configs are cached separately so config invalidation
+/// can clear threshold/config data while retaining marker hits. This avoids repeatedly reading
+/// marker storage after a transaction touches the native multisig precompile, while also avoiding a
+/// full marker-cache scan when configs must be invalidated.
 ///
-/// The whole cache is cleared when the EVM moves to a new block. Configs are cleared, while marker
-/// bits are retained, after transactions that call the native multisig precompile because config
-/// updates can mutate account-scoped configs but do not clear the multisig account marker.
+/// The whole cache is cleared when the EVM moves to a new block. Thresholds/configs are cleared,
+/// while marker bits are retained, after transactions that call the native multisig precompile
+/// because config updates can mutate account-scoped configs but do not clear the multisig account
+/// marker.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct NativeMultisigCache {
     markers: HashMap<Address, bool>,
+    thresholds: HashMap<Address, u8>,
     configs: HashMap<Address, InitMultisig>,
 }
 
@@ -353,17 +355,20 @@ impl NativeMultisigCache {
     /// Clears all cached markers and configs.
     pub(crate) fn clear(&mut self) {
         self.markers.clear();
+        self.thresholds.clear();
         self.configs.clear();
     }
 
     /// Clears cached configs while preserving cached account markers.
     pub(crate) fn clear_configs(&mut self) {
+        self.thresholds.clear();
         self.configs.clear();
     }
 
     /// Inserts a validated native multisig config and marks the account as multisig.
     pub(crate) fn insert_config(&mut self, account: Address, config: InitMultisig) {
         self.markers.insert(account, true);
+        self.thresholds.insert(account, config.threshold);
         self.configs.insert(account, config);
     }
 
@@ -377,8 +382,12 @@ impl NativeMultisigCache {
             return Ok(*is_multisig);
         }
 
-        let is_multisig = multisig.is_multisig_account(account)?;
+        let threshold = multisig.load_registered_threshold_if_present(account)?;
+        let is_multisig = threshold.is_some();
         self.markers.insert(account, is_multisig);
+        if let Some(threshold) = threshold {
+            self.thresholds.insert(account, threshold);
+        }
         Ok(is_multisig)
     }
 
@@ -397,6 +406,26 @@ impl NativeMultisigCache {
         Ok(config)
     }
 
+    /// Loads and caches the registered native multisig threshold for `account`.
+    pub(crate) fn load_registered_threshold(
+        &mut self,
+        multisig: &NativeMultisig,
+        account: Address,
+    ) -> Result<u8, NativeMultisigAuthError> {
+        if let Some(threshold) = self.thresholds.get(&account) {
+            return Ok(*threshold);
+        }
+        if let Some(config) = self.configs.get(&account) {
+            self.thresholds.insert(account, config.threshold);
+            return Ok(config.threshold);
+        }
+
+        let threshold = multisig.load_registered_threshold(account)?;
+        self.markers.insert(account, true);
+        self.thresholds.insert(account, threshold);
+        Ok(threshold)
+    }
+
     #[cfg(test)]
     pub(crate) fn get_config(&self, account: &Address) -> Option<&InitMultisig> {
         self.configs.get(account)
@@ -404,7 +433,7 @@ impl NativeMultisigCache {
 
     #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
-        self.markers.is_empty() && self.configs.is_empty()
+        self.markers.is_empty() && self.thresholds.is_empty() && self.configs.is_empty()
     }
 }
 

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -45,7 +45,10 @@ use tempo_precompiles::{
         SelectorRule as PrecompileSelectorRule, TokenLimit,
     },
     error::TempoPrecompileError,
-    native_multisig::{NativeMultisig, auth::NativeMultisigAuthError},
+    native_multisig::{
+        NativeMultisig,
+        auth::{NativeMultisigAuthConfig, NativeMultisigAuthError},
+    },
     nonce::{
         EXPIRING_NONCE_MAX_EXPIRY_SECS, EXPIRING_NONCE_SET_CAPACITY, INonce::getNonceCall,
         NonceManager,
@@ -82,12 +85,14 @@ const P256_VERIFY_GAS: u64 = 5_000;
 /// Additional gas for Keychain signatures (key validation overhead: COLD_SLOAD_COST + 900 processing)
 const KEYCHAIN_VALIDATION_GAS: u64 = COLD_SLOAD_COST + 900;
 
-/// Additional gas for native multisig validation.
+/// Additional gas for each native multisig config/header validation.
 ///
-/// This meters the protocol-side config/account validation as one cold storage read equivalent.
-/// Owner signature verification is charged separately, relative to the secp256k1 verification
-/// already covered by the base transaction stipend.
+/// Owner signature verification and owner-weight lookups are charged separately, relative to the
+/// secp256k1 verification already covered by the base transaction stipend.
 const NATIVE_MULTISIG_VALIDATION_GAS: u64 = COLD_SLOAD_COST;
+
+/// Additional gas for each native multisig owner-weight lookup.
+const NATIVE_MULTISIG_OWNER_WEIGHT_GAS: u64 = COLD_SLOAD_COST;
 
 /// Persistent storage rows created by native multisig bootstrap before owner rows:
 /// the packed `{ threshold, owner_count }` account header.
@@ -181,8 +186,12 @@ fn native_multisig_signature_verification_gas(
         .iter()
         .map(|sig| native_multisig_owner_approval_verification_gas(sig, depth))
         .fold(0u64, u64::saturating_add);
+    let owner_weight_gas =
+        NATIVE_MULTISIG_OWNER_WEIGHT_GAS.saturating_mul(signature.signatures().len() as u64);
 
-    let gas = NATIVE_MULTISIG_VALIDATION_GAS.saturating_add(owner_signature_gas);
+    let gas = NATIVE_MULTISIG_VALIDATION_GAS
+        .saturating_add(owner_weight_gas)
+        .saturating_add(owner_signature_gas);
     if subtract_base_secp256k1 {
         gas.saturating_sub(ECRECOVER_GAS)
     } else {
@@ -211,7 +220,7 @@ fn tempo_signature_verification_gas(signature: &TempoSignature) -> u64 {
 #[inline]
 fn native_multisig_bootstrap_storage_slots(init: &InitMultisig) -> u64 {
     let owner_slots = u64::try_from(init.owners.len()).unwrap_or(u64::MAX);
-    NATIVE_MULTISIG_BOOTSTRAP_FIXED_STORAGE_SLOTS.saturating_add(owner_slots)
+    NATIVE_MULTISIG_BOOTSTRAP_FIXED_STORAGE_SLOTS.saturating_add(owner_slots.saturating_mul(2))
 }
 
 /// Calculates persistent storage gas for native multisig bootstrap.
@@ -1274,13 +1283,22 @@ where
                     }
 
                     if caller_is_multisig {
-                        let config = multisig_cache
-                            .load_registered_config(&multisig_precompile, multisig_signature.account())
+                        let threshold = multisig_cache
+                            .load_registered_threshold(
+                                &multisig_precompile,
+                                multisig_signature.account(),
+                            )
                             .map_err(map_native_multisig_error::<DB>)?;
                         if is_rpc_simulation {
+                            let config = multisig_cache
+                                .load_registered_config(
+                                    &multisig_precompile,
+                                    multisig_signature.account(),
+                                )
+                                .map_err(map_native_multisig_error::<DB>)?;
                             config
                                 .validate_rpc_mock_signatures(multisig_signature.signature_count())
-                            .map_err(|reason| {
+                                .map_err(|reason| {
                                 TempoInvalidTransaction::NativeMultisigValidationFailed {
                                     reason: reason.to_string(),
                                 }
@@ -1290,8 +1308,19 @@ where
                                 .verify_authorization(
                                     tempo_tx_env.signature_hash,
                                     multisig_signature,
-                                    &config,
-                                    |acc| { multisig_cache.load_registered_config(&multisig_precompile, acc) },
+                                    NativeMultisigAuthConfig::Registered {
+                                        account: multisig_signature.account(),
+                                        threshold,
+                                    },
+                                    |acc| {
+                                        multisig_cache
+                                            .load_registered_threshold(&multisig_precompile, acc)
+                                    },
+                                    |account, owner| {
+                                        multisig_precompile
+                                            .read_owner_weight(account, owner)
+                                            .map_err(NativeMultisigAuthError::from)
+                                    },
                                 )
                                 .map_err(map_native_multisig_error::<DB>)?;
                         }
@@ -1343,8 +1372,16 @@ where
                                 .verify_authorization(
                                     tempo_tx_env.signature_hash,
                                     multisig_signature,
-                                    init_config,
-                                    |acc| { multisig_cache.load_registered_config(&multisig_precompile, acc) },
+                                    NativeMultisigAuthConfig::Inline(init_config),
+                                    |acc| {
+                                        multisig_cache
+                                            .load_registered_threshold(&multisig_precompile, acc)
+                                    },
+                                    |account, owner| {
+                                        multisig_precompile
+                                            .read_owner_weight(account, owner)
+                                            .map_err(NativeMultisigAuthError::from)
+                                    },
                                 )
                                 .map_err(map_native_multisig_error::<DB>)?;
                         }
@@ -3545,31 +3582,22 @@ mod tests {
         use tempo_primitives::transaction::{PrimitiveSignature, multisig_digest};
 
         let signer = PrivateKeySigner::from_bytes(&B256::from([0x11; 32])).unwrap();
-        let grandchild_config = single_owner_native_multisig_config(0x41, signer.address());
-        let grandchild_account = grandchild_config.account().unwrap();
-        let child_config = single_owner_native_multisig_config(0x42, grandchild_account);
+        let child_config = single_owner_native_multisig_config(0x42, signer.address());
         let child_account = child_config.account().unwrap();
         let parent_config = single_owner_native_multisig_config(0x43, child_account);
         let parent_account = parent_config.account().unwrap();
         let signature_hash = B256::repeat_byte(0x44);
         let parent_digest = multisig_digest(signature_hash, parent_account);
         let child_digest = multisig_digest(parent_digest, child_account);
-        let grandchild_digest = multisig_digest(child_digest, grandchild_account);
-        let grandchild_owner_signature = PrimitiveSignature::Secp256k1(
+        let child_owner_signature = PrimitiveSignature::Secp256k1(
             signer
-                .sign_hash_sync(&grandchild_digest)
+                .sign_hash_sync(&child_digest)
                 .expect("owner signing succeeds"),
         )
         .to_bytes();
-        let grandchild_signature = TempoSignature::Multisig(MultisigSignature::new(
-            grandchild_account,
-            vec![grandchild_owner_signature],
-            None,
-        ))
-        .to_bytes();
         let nested_signature = TempoSignature::Multisig(MultisigSignature::new(
             child_account,
-            vec![grandchild_signature],
+            vec![child_owner_signature],
             None,
         ))
         .to_bytes();
@@ -3593,7 +3621,6 @@ mod tests {
             tx_env.inner.caller = parent_account;
             tx_env.inner.kind = TxKind::Call(Address::random());
         });
-        store_native_multisig_account(&mut test, &grandchild_config);
         store_native_multisig_account(&mut test, &child_config);
         store_native_multisig_account(&mut test, &parent_config);
 
@@ -3608,9 +3635,7 @@ mod tests {
         use tempo_primitives::transaction::{PrimitiveSignature, multisig_digest};
 
         let signer = PrivateKeySigner::from_bytes(&B256::from([0x11; 32])).unwrap();
-        let great_grandchild_config = single_owner_native_multisig_config(0x41, signer.address());
-        let great_grandchild_account = great_grandchild_config.account().unwrap();
-        let grandchild_config = single_owner_native_multisig_config(0x42, great_grandchild_account);
+        let grandchild_config = single_owner_native_multisig_config(0x42, signer.address());
         let grandchild_account = grandchild_config.account().unwrap();
         let child_config = single_owner_native_multisig_config(0x43, grandchild_account);
         let child_account = child_config.account().unwrap();
@@ -3621,22 +3646,15 @@ mod tests {
         let parent_digest = multisig_digest(signature_hash, parent_account);
         let child_digest = multisig_digest(parent_digest, child_account);
         let grandchild_digest = multisig_digest(child_digest, grandchild_account);
-        let great_grandchild_digest = multisig_digest(grandchild_digest, great_grandchild_account);
-        let great_grandchild_owner_signature = PrimitiveSignature::Secp256k1(
+        let grandchild_owner_signature = PrimitiveSignature::Secp256k1(
             signer
-                .sign_hash_sync(&great_grandchild_digest)
+                .sign_hash_sync(&grandchild_digest)
                 .expect("owner signing succeeds"),
         )
         .to_bytes();
-        let great_grandchild_signature = TempoSignature::Multisig(MultisigSignature::new(
-            great_grandchild_account,
-            vec![great_grandchild_owner_signature],
-            None,
-        ))
-        .to_bytes();
         let grandchild_signature = TempoSignature::Multisig(MultisigSignature::new(
             grandchild_account,
-            vec![great_grandchild_signature],
+            vec![grandchild_owner_signature],
             None,
         ))
         .to_bytes();
@@ -3666,7 +3684,6 @@ mod tests {
             tx_env.inner.caller = parent_account;
             tx_env.inner.kind = TxKind::Call(Address::random());
         });
-        store_native_multisig_account(&mut test, &great_grandchild_config);
         store_native_multisig_account(&mut test, &grandchild_config);
         store_native_multisig_account(&mut test, &child_config);
         store_native_multisig_account(&mut test, &parent_config);
@@ -3819,10 +3836,13 @@ mod tests {
             signed.into_iter().map(|(_, signature)| signature).collect(),
             None,
         );
-        let result =
-            NativeMultisig::new().verify_authorization(signature_hash, &signature, &config, |_| {
-                unreachable!("primitive owner approvals should not load nested configs")
-            });
+        let result = NativeMultisig::new().verify_authorization(
+            signature_hash,
+            &signature,
+            NativeMultisigAuthConfig::Inline(&config),
+            |_| unreachable!("primitive owner approvals should not load nested configs"),
+            |_, _| unreachable!("inline owner approvals should not load owner weights"),
+        );
 
         assert!(
             matches!(
@@ -3858,10 +3878,13 @@ mod tests {
             None,
         );
 
-        let result =
-            NativeMultisig::new().verify_authorization(signature_hash, &signature, &config, |_| {
-                unreachable!("primitive owner approvals should not load nested configs")
-            });
+        let result = NativeMultisig::new().verify_authorization(
+            signature_hash,
+            &signature,
+            NativeMultisigAuthConfig::Inline(&config),
+            |_| unreachable!("primitive owner approvals should not load nested configs"),
+            |_, _| unreachable!("inline owner approvals should not load owner weights"),
+        );
 
         assert!(
             matches!(
@@ -3870,6 +3893,63 @@ mod tests {
                     if reason.contains("not an owner")
             ),
             "owner membership depends on current stored config and should remain revalidatable"
+        );
+    }
+
+    #[test]
+    fn native_multisig_authorization_rejects_trailing_owner_approvals() {
+        use alloy_signer::SignerSync;
+        use alloy_signer_local::PrivateKeySigner;
+        use tempo_primitives::transaction::{PrimitiveSignature, multisig_digest};
+
+        let mut signers = [
+            PrivateKeySigner::from_bytes(&B256::from([0x11; 32])).unwrap(),
+            PrivateKeySigner::from_bytes(&B256::from([0x22; 32])).unwrap(),
+        ];
+        signers.sort_by_key(|signer| signer.address());
+
+        let config = InitMultisig {
+            salt: B256::repeat_byte(0x42),
+            threshold: 1,
+            owners: signers
+                .iter()
+                .map(|signer| MultisigOwner {
+                    owner: signer.address(),
+                    weight: 1,
+                })
+                .collect(),
+        };
+        let account = config.account().unwrap();
+        let signature_hash = B256::repeat_byte(0x43);
+        let digest = multisig_digest(signature_hash, account);
+        let signatures = signers
+            .iter()
+            .map(|signer| {
+                PrimitiveSignature::Secp256k1(
+                    signer
+                        .sign_hash_sync(&digest)
+                        .expect("owner signing succeeds"),
+                )
+                .to_bytes()
+            })
+            .collect();
+
+        let signature = MultisigSignature::new(account, signatures, None);
+        let result = NativeMultisig::new().verify_authorization(
+            signature_hash,
+            &signature,
+            NativeMultisigAuthConfig::Inline(&config),
+            |_| unreachable!("primitive owner approvals should not load nested configs"),
+            |_, _| unreachable!("inline owner approvals should not load owner weights"),
+        );
+
+        assert!(
+            matches!(
+                result,
+                Err(NativeMultisigAuthError::InvalidTransaction(reason))
+                    if reason.contains("excess")
+            ),
+            "unused trailing approvals should make multisig signatures non-canonical"
         );
     }
 
@@ -3887,10 +3967,13 @@ mod tests {
         );
         let multisig = NativeMultisig::new();
 
-        let result =
-            multisig.verify_authorization(B256::repeat_byte(0x42), &signature, &config, |_| {
-                unreachable!("oversized owner approval should fail before nested config lookup")
-            });
+        let result = multisig.verify_authorization(
+            B256::repeat_byte(0x42),
+            &signature,
+            NativeMultisigAuthConfig::Inline(&config),
+            |_| unreachable!("oversized owner approval should fail before nested config lookup"),
+            |_, _| unreachable!("oversized owner approval should fail before owner weight lookup"),
+        );
 
         assert!(
             matches!(
@@ -4237,11 +4320,11 @@ mod tests {
         )
         .unwrap();
 
-        let expected_overhead = NATIVE_MULTISIG_VALIDATION_GAS;
+        let expected_overhead = NATIVE_MULTISIG_VALIDATION_GAS + NATIVE_MULTISIG_OWNER_WEIGHT_GAS;
         assert_eq!(
             multisig_gas.initial_regular_gas - base_gas.initial_regular_gas,
             expected_overhead,
-            "1-of-1 native multisig should add only native validation gas because base tx gas already covers one secp256k1 verification"
+            "1-of-1 native multisig should add validation plus one owner-weight lookup because base tx gas already covers one secp256k1 verification"
         );
         assert_eq!(
             multisig_gas.initial_state_gas, base_gas.initial_state_gas,
@@ -4281,7 +4364,8 @@ mod tests {
         )
         .unwrap();
 
-        let expected_overhead = NATIVE_MULTISIG_VALIDATION_GAS + ECRECOVER_GAS;
+        let expected_overhead =
+            NATIVE_MULTISIG_VALIDATION_GAS + 2 * NATIVE_MULTISIG_OWNER_WEIGHT_GAS + ECRECOVER_GAS;
         assert_eq!(
             multisig_gas.initial_regular_gas - base_gas.initial_regular_gas,
             expected_overhead,
@@ -4323,7 +4407,8 @@ mod tests {
         )
         .unwrap();
 
-        let expected_overhead = NATIVE_MULTISIG_VALIDATION_GAS + P256_VERIFY_GAS;
+        let expected_overhead =
+            NATIVE_MULTISIG_VALIDATION_GAS + NATIVE_MULTISIG_OWNER_WEIGHT_GAS + P256_VERIFY_GAS;
         assert_eq!(
             multisig_gas.initial_regular_gas - base_gas.initial_regular_gas,
             expected_overhead,
@@ -4365,7 +4450,8 @@ mod tests {
         )
         .unwrap();
 
-        let expected_overhead = NATIVE_MULTISIG_VALIDATION_GAS * 2;
+        let expected_overhead =
+            (NATIVE_MULTISIG_VALIDATION_GAS + NATIVE_MULTISIG_OWNER_WEIGHT_GAS) * 2;
         assert_eq!(
             multisig_gas.initial_regular_gas - base_gas.initial_regular_gas,
             expected_overhead,
@@ -4405,15 +4491,17 @@ mod tests {
         .unwrap();
 
         let storage_slots = native_multisig_bootstrap_storage_slots(&config);
-        assert_eq!(storage_slots, 1 + config.owners.len() as u64);
+        assert_eq!(storage_slots, 1 + 2 * config.owners.len() as u64);
 
         let expected_storage_gas =
             SSTORE_CREATE_COST * storage_slots + NATIVE_MULTISIG_BOOTSTRAP_EVENT_BUFFER;
-        let expected_overhead = NATIVE_MULTISIG_VALIDATION_GAS + expected_storage_gas;
+        let expected_overhead = NATIVE_MULTISIG_VALIDATION_GAS
+            + NATIVE_MULTISIG_OWNER_WEIGHT_GAS
+            + expected_storage_gas;
         assert_eq!(
             multisig_gas.initial_regular_gas - base_gas.initial_regular_gas,
             expected_overhead,
-            "bootstrap should charge packed account header, one owner slot per owner, and an event buffer"
+            "bootstrap should charge packed account header, indexed and lookup owner slots, and an event buffer"
         );
         assert_eq!(
             multisig_gas.initial_state_gas, base_gas.initial_state_gas,

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -891,6 +891,27 @@ The current quorum may replace the entire owner set. The protocol does not requi
 
 That matches canonical multisig authority: the current threshold controls the account. Key rotation remains an operational responsibility for owners and tooling.
 
+### Bounded Quorum Work
+
+`MAX_MULTISIG_OWNERS` is not the transaction-validation DoS bound. With direct owner-weight
+lookups, a normal multisig transaction reads only the registered threshold and the weights for
+submitted owner approvals. Configured owners that do not appear in the signature list are not loaded
+during transaction authorization.
+
+The threshold is the limiting factor for unpaid validation work because owner weights are nonzero.
+An attacker who wants to force maximum verifier work sets many submitted owners to weight `1`, so
+the verifier must process `threshold` owner approvals before quorum can be reached. Capping
+`MAX_MULTISIG_THRESHOLD` at `8` therefore caps the useful submitted approvals per multisig node,
+while still allowing a large administrative owner set of up to 255 owners. The large owner set is
+paid for when configs are created, updated, or explicitly read through the precompile; it does not
+make transaction authorization scan 255 owners.
+
+Trailing approvals after quorum are rejected rather than ignored. Once the recovered weight reaches
+the threshold, later approvals do not contribute to authorization. Accepting them would either force
+validation to keep decoding and verifying irrelevant signatures, or allow unchecked bytes to be
+relayed in otherwise valid transactions. Rejection gives each authorization a canonical minimal
+quorum proof and lets validators stop as soon as quorum is reached.
+
 ### AccountKeychain Restrictions
 
 The current AccountKeychain model is a poor fit for multisig accounts because it lets a single authorized key make calls as the parent account.

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -622,11 +622,17 @@ top-level threshold read                      = 1
 top-level submitted owner-weight reads        = 8
 8 nested owners * (threshold + 8 owner reads) = 8 * (1 + 8)
 total registered validation reads             = 81
+SLOAD gas-equivalent bound                    = 81 * 2,100 = 170,100 gas
 ```
 
 Config updates and `getMultisigConfig` can enumerate or rewrite up to `MAX_MULTISIG_OWNERS` owner
 rows, but those paths execute through the precompile/RPC surfaces where storage reads and writes are
 metered separately. Transaction authorization never needs to scan all configured owners.
+
+The `170,100` gas-equivalent bound is the maximum unpaid registered-validation storage-read work for
+the nested-owner DoS shape this TIP is designed to cap. It excludes cryptographic signature
+verification gas and calldata/data-size costs, which are already priced separately by the native
+multisig intrinsic-gas formula above.
 
 This formula only prices protocol-side native multisig authorization. `INativeMultisig` precompile
 calls are charged under the active Tempo precompile storage gas schedule, and storage-creating

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -36,9 +36,15 @@ pub const MULTISIG_SIGNATURE_DOMAIN: &[u8] = b"tempo:multisig:signature";
 /// Maximum number of owners allowed in a native multisig config.
 pub const MAX_MULTISIG_OWNERS: usize = 255;
 
+/// Maximum threshold accepted by a native multisig config.
+pub const MAX_MULTISIG_THRESHOLD: u8 = 8;
+
+/// Maximum number of owner approvals allowed in one native multisig signature.
+pub const MAX_MULTISIG_SIGNATURES: usize = MAX_MULTISIG_THRESHOLD as usize;
+
 /// Maximum number of native multisig signatures in one nested authorization path, including the
 /// top-level transaction signature.
-pub const MAX_MULTISIG_NESTING_DEPTH: usize = 3;
+pub const MAX_MULTISIG_NESTING_DEPTH: usize = 2;
 
 /// Maximum encoded byte length for one primitive owner approval.
 pub const MAX_MULTISIG_OWNER_SIGNATURE_BYTES: usize = 2049;
@@ -46,9 +52,11 @@ pub const MAX_MULTISIG_OWNER_SIGNATURE_BYTES: usize = 2049;
 
 - `SIGNATURE_TYPE_MULTISIG` is a new Tempo signature type byte in the `TempoSignature` byte-encoding namespace.
 - `MULTISIG_SIGNATURE_DOMAIN` is used only inside the owner approval digest. It is distinct from the wire signature type byte.
-- `MAX_MULTISIG_OWNERS` bounds verification cost, signature payload size, and owner storage.
-- `MAX_MULTISIG_NESTING_DEPTH` bounds recursive native multisig validation. The top-level multisig signature counts as depth `1`, so a value of `3` allows parent -> child -> grandchild authorization paths.
-- `MAX_MULTISIG_OWNER_SIGNATURE_BYTES` matches the current maximum encoded `PrimitiveSignature` length.
+- `MAX_MULTISIG_OWNERS` bounds stored config size and precompile config update/read work.
+- `MAX_MULTISIG_THRESHOLD` bounds the configured quorum a single native multisig account can require. Because owner weights are nonzero, it also bounds the number of owner approvals needed to satisfy one multisig authorization node.
+- `MAX_MULTISIG_SIGNATURES` bounds the number of owner approvals submitted in one native multisig signature.
+- `MAX_MULTISIG_NESTING_DEPTH` bounds recursive native multisig validation. The top-level multisig signature counts as depth `1`, so a value of `2` allows parent -> child authorization paths.
+- `MAX_MULTISIG_OWNER_SIGNATURE_BYTES` matches the current maximum encoded `PrimitiveSignature` length and is enforced as a raw byte cap for every submitted owner approval.
 
 ### Data Structures
 
@@ -113,18 +121,18 @@ Signature rules:
 
 - `signatures` contains encoded owner approvals. Each approval MUST decode as either `TempoSignature::Primitive` or `TempoSignature::Multisig`.
 - Implementations MUST reject any owner signature byte string that decodes as `KeychainSignature`.
-- `signatures.len()` MUST be between `1` and `MAX_MULTISIG_OWNERS`.
-- Primitive owner approval byte strings MUST be less than or equal to `MAX_MULTISIG_OWNER_SIGNATURE_BYTES`.
-- Nested multisig owner approval byte strings are bounded by the transaction's encoded-size limits, `MAX_MULTISIG_NESTING_DEPTH`, and recursive multisig validation.
+- `signatures.len()` MUST be between `1` and `MAX_MULTISIG_SIGNATURES`.
+- Each owner approval byte string MUST be less than or equal to `MAX_MULTISIG_OWNER_SIGNATURE_BYTES`.
+- Nested multisig owner approvals are additionally bounded by `MAX_MULTISIG_NESTING_DEPTH` and recursive multisig validation.
 - `init` is present only when bootstrapping a native multisig account. It carries the initial
   `InitMultisig` config and is absent on every post-bootstrap transaction.
 - When `init` is present, it MUST derive `signature.account`. That is,
   `derive_multisig_account(init) == signature.account`.
 - Nested multisig owner approvals MUST NOT carry `init`; nested multisig accounts MUST already be initialized.
 
-Flat M-of-N multisigs are represented by assigning every owner weight `1` and setting `threshold` to `M`. Because `threshold`, owner weights, and the owner count are `u8`, flat M-of-N configs can express thresholds up to 255 and owner counts up to 255.
+Flat M-of-N multisigs are represented by assigning every owner weight `1` and setting `threshold` to `M`. Because `MAX_MULTISIG_THRESHOLD` is `8`, flat M-of-N configs can express thresholds up to 8. The configured owner set can contain up to 255 owners.
 
-Weighted configs can express asymmetric authority. For example, a config with `threshold = 100`, one owner with `weight = 100`, and two owners with `weight = 50` allows the high-weight owner alone or both lower-weight owners together to authorize a transaction.
+Weighted configs can express asymmetric authority. For example, a config with `threshold = 5`, one owner with `weight = 5`, and two owners with `weight = 3` allows the high-weight owner alone or both lower-weight owners together to authorize a transaction.
 
 ### Transaction Encoding
 
@@ -195,7 +203,7 @@ The multisig signature wire encoding is:
 
 Primitive owner approval byte strings use the same encoding and size limits as existing Tempo primitive signatures.
 
-The largest primitive owner approval is a WebAuthn primitive signature. Its encoded byte length is `MAX_MULTISIG_OWNER_SIGNATURE_BYTES`. Nested multisig owner approvals are bounded by the transaction's encoded-size limits, `MAX_MULTISIG_NESTING_DEPTH`, and recursive multisig validation.
+The largest primitive owner approval is a WebAuthn primitive signature. Its encoded byte length is `MAX_MULTISIG_OWNER_SIGNATURE_BYTES`. The same raw byte cap applies to nested multisig owner approvals, and nested approvals are additionally bounded by `MAX_MULTISIG_NESTING_DEPTH` and recursive multisig validation.
 
 Decoding rules:
 
@@ -207,7 +215,8 @@ Decoding rules:
 - Nested multisig owner approvals MUST NOT include `init`.
 - Keychain owner approvals MUST be rejected.
 - Malformed or oversized primitive owner approval byte strings MUST be rejected before threshold accounting.
-- `MAX_MULTISIG_OWNERS` limits owner count, not per-signature byte size.
+- `MAX_MULTISIG_OWNERS` limits stored owner count, not per-approval byte size or submitted owner approvals.
+- `MAX_MULTISIG_SIGNATURES` limits submitted owner approvals per native multisig signature.
 
 ### Multisig Identity
 
@@ -319,6 +328,7 @@ Owner approval rules:
 - Owner membership is checked against the primitive recovered owner address or nested multisig account address.
 - Owner addresses MUST be strictly ascending.
 - Strict ordering rejects duplicates and makes weighted threshold accounting deterministic.
+- Validation MUST reject trailing owner approvals after the recovered weight first reaches the configured threshold. Extra approvals are invalid rather than ignored.
 
 ### Transaction Sender and Multisig Authorization
 
@@ -330,7 +340,7 @@ For `TempoSignature::Multisig`, sender recovery rules are:
 
 1. parsing `MultisigSignature`
 2. requiring `signature.account != address(0)`
-3. requiring `signature.signatures.len()` is between `1` and `MAX_MULTISIG_OWNERS`
+3. requiring `signature.signatures.len()` is between `1` and `MAX_MULTISIG_SIGNATURES`
 4. requiring each owner approval byte string is nonempty
 5. when `signature.init` is present, requiring `derive_multisig_account(signature.init) == signature.account`
 6. failing sender recovery if any of these checks fail
@@ -340,12 +350,14 @@ This recovered sender only identifies the account that the transaction attempts 
 
 Before stateful multisig validation succeeds, the recovered sender MUST be treated only as an attempted sender.
 
-Sender recovery MAY inspect owner approval byte string emptiness and count. It MUST NOT decode, verify, or recover owner signatures, and it MUST NOT load multisig config state.
+Sender recovery MAY inspect owner approval byte string emptiness, count, and raw byte length. It MUST NOT decode, verify, or recover owner signatures, and it MUST NOT load multisig config state.
 
 Multisig authorization is stateful. Before the transaction enters EVM execution, the protocol:
 
-1. MUST load the current multisig config or validate `signature.init` during bootstrap
-2. MUST require the recovered owner weights to meet the threshold
+1. MUST validate `signature.init` during bootstrap or load the registered account threshold for normal validation
+2. MUST verify submitted owner approvals in order
+3. MUST look up each submitted owner weight from `signature.init` during bootstrap or from stored owner-weight state during normal validation
+4. MUST require the recovered owner weights to meet the threshold with no trailing owner approvals after quorum is reached
 
 After multisig authorization succeeds, the transaction executes from `signature.account`. Top-level EVM calls observe `tx.from == signature.account`, `tx.origin == signature.account`, and `msg.sender == signature.account`.
 
@@ -364,23 +376,31 @@ Native multisig sender restriction:
 The native multisig account precompile stores the current config for each native multisig account:
 
 ```text
-multisig_accounts[account] = MultisigConfig {
+multisig_accounts[account] = MultisigAccountHeader {
   threshold,
-  owners
+  owner_count
 }
+
+multisig_owners[account][index] = MultisigOwner {
+  owner,
+  weight
+}
+
+multisig_owner_weights[account][owner] = weight
 ```
 
 Storage rules:
 
-- `owners` MUST be stored in strictly ascending `owner` address order.
+- `multisig_accounts[account]` stores the account-scoped config header and marker exposed by the native multisig account precompile for other protocol components. The marker is set when the initial config is stored and is not cleared by config updates.
+- `multisig_owners[account][index]` stores the enumerable owner list in strictly ascending `owner` address order. It is used by `getMultisigConfig` and config replacement.
+- `multisig_owner_weights[account][owner]` stores direct owner membership and weight lookup state. Transaction validation uses this mapping to read only submitted owner weights, not the full owner list.
 - Each stored owner includes a nonzero `owner` address and a nonzero `weight`.
 - The same owner address MUST NOT be stored more than once.
 - A stored config exists when the packed account header has nonzero `threshold` and nonzero `owner_count`.
 - A packed account header with `threshold == 0` and `owner_count == 0` means no native multisig config is initialized for the account.
 - A packed account header with exactly one of `threshold` or `owner_count` equal to zero is invalid and MUST NOT be created.
-- `threshold`, `owner_count`, and owner `weight` are stored as `u8` values. `MAX_MULTISIG_OWNERS` is 255 and total configured owner weight is capped at 255, leaving spare bytes in the packed account header and owner storage slots for future metadata.
-
-`multisig_accounts[account]` is the account-scoped config and marker exposed by the native multisig account precompile for other protocol components. The marker is set when the initial config is stored and is not cleared by config updates.
+- `threshold`, `owner_count`, and owner `weight` are stored as `u8` values. `MAX_MULTISIG_OWNERS` is 255, `MAX_MULTISIG_THRESHOLD` is 8, and total configured owner weight is capped at 255, leaving spare bytes in the packed account header and owner storage slots for future metadata.
+- Replacing the stored config MUST remove stale `multisig_owners[account][index]` rows and stale `multisig_owner_weights[account][owner]` entries for owners no longer present.
 
 Once `multisig_accounts[account]` exists, bootstrap for that account MUST be rejected.
 
@@ -389,6 +409,7 @@ Weight accounting rules:
 - The sum of owner weights MUST be computed using an integer type wide enough to avoid overflow.
 - The recovered owner weight sum MUST use the same overflow-safe arithmetic.
 - The total configured owner weight MUST be less than or equal to `u8::MAX`.
+- Implementations MUST reject any config where `threshold` is greater than `MAX_MULTISIG_THRESHOLD`.
 - Implementations MUST reject any config where `threshold` is greater than the total configured owner weight.
 
 ### Bootstrap
@@ -403,36 +424,38 @@ Validation rules:
 2. require `tx.key_authorization` is absent
 3. require `tx.nonce_key == 0`
 4. require `tx.nonce == 0`
-5. validate `signature.signatures.len()` is between `1` and `MAX_MULTISIG_OWNERS`
+5. validate `signature.signatures.len()` is between `1` and `MAX_MULTISIG_SIGNATURES`
 6. validate `signature.init.owners` is non-empty
 7. validate `signature.init.owners.len() <= MAX_MULTISIG_OWNERS`
 8. validate `signature.init.threshold >= 1`
-9. validate every owner address is nonzero
-10. validate every owner weight is nonzero
-11. compute `total_weight = sum(signature.init.owners.weight)`
-12. validate `total_weight <= u8::MAX`
-13. validate `signature.init.threshold <= total_weight`
-14. validate `signature.init.owners` is strictly ascending by `owner`
-15. derive `expected_account` from `signature.init`
-16. validate `expected_account` satisfies the derived account rules
-17. require `expected_account.nonce == 0`
-18. require `expected_account` code is empty
-19. require `expected_account` has no EIP-7702 delegation code
-20. require `signature.account == expected_account`
-21. require no config exists for `signature.account`
-22. recursively validate owner approvals using `tx.signature_hash()` as the top-level inner digest and `signature.account` as the top-level multisig account
-23. for primitive owner approvals, verify the primitive signature over the current `multisig_digest` and recover the owner address
-24. for nested multisig owner approvals, require `init` is absent, require the nested account is already initialized, and recursively validate the nested signature using the parent `multisig_digest` as the nested inner digest
-25. reject recursive validation if any multisig account appears twice in the same nested validation path or if the path exceeds `MAX_MULTISIG_NESTING_DEPTH`
-26. require owner addresses are strictly ascending
-27. require every owner address is in `signature.init.owners`
-28. sum the configured weights for the validated owners
-29. require the recovered owner weight sum is at least `signature.init.threshold`
-30. store `signature.init` as the current config for `signature.account`
-31. emit `MultisigInitialized(signature.account)`
-32. consume the protocol nonce for `signature.account`
-33. commit the initial config, account marker, and protocol nonce consumption as transaction-level state
-34. execute the transaction from `signature.account`
+9. validate `signature.init.threshold <= MAX_MULTISIG_THRESHOLD`
+10. validate every owner address is nonzero
+11. validate every owner weight is nonzero
+12. compute `total_weight = sum(signature.init.owners.weight)`
+13. validate `total_weight <= u8::MAX`
+14. validate `signature.init.threshold <= total_weight`
+15. validate `signature.init.owners` is strictly ascending by `owner`
+16. derive `expected_account` from `signature.init`
+17. validate `expected_account` satisfies the derived account rules
+18. require `expected_account.nonce == 0`
+19. require `expected_account` code is empty
+20. require `expected_account` has no EIP-7702 delegation code
+21. require `signature.account == expected_account`
+22. require no config exists for `signature.account`
+23. recursively validate owner approvals using `tx.signature_hash()` as the top-level inner digest and `signature.account` as the top-level multisig account
+24. for primitive owner approvals, verify the primitive signature over the current `multisig_digest` and recover the owner address
+25. for nested multisig owner approvals, require `init` is absent, require the nested account is already initialized, and recursively validate the nested signature using the parent `multisig_digest` as the nested inner digest
+26. reject recursive validation if any multisig account appears twice in the same nested validation path or if the path exceeds `MAX_MULTISIG_NESTING_DEPTH`
+27. require owner addresses are strictly ascending
+28. require every owner address is in `signature.init.owners`
+29. accumulate the configured weight for each validated owner
+30. reject trailing owner approvals after accumulated weight first reaches `signature.init.threshold`
+31. require the recovered owner weight sum is at least `signature.init.threshold`
+32. store `signature.init` as the current config for `signature.account`
+33. emit `MultisigInitialized(signature.account)`
+34. consume the protocol nonce for `signature.account`
+35. commit the initial config, account marker, and protocol nonce consumption as transaction-level state
+36. execute the transaction from `signature.account`
 
 Bootstrap state effects:
 
@@ -475,21 +498,23 @@ Validation rules:
 
 1. require `signature.init` is absent
 2. require `tx.key_authorization` is absent
-3. require `signature.signatures.len()` is between `1` and `MAX_MULTISIG_OWNERS`
+3. require `signature.signatures.len()` is between `1` and `MAX_MULTISIG_SIGNATURES`
 4. require `multisig_accounts[signature.account] == true`
 5. require `signature.account` code is empty
 6. require `signature.account` has no EIP-7702 delegation code
 7. require a config exists for `signature.account`
-8. load the stored config for `signature.account`
+8. load the stored threshold for `signature.account`
 9. recursively validate owner approvals using `tx.signature_hash()` as the top-level inner digest and `signature.account` as the top-level multisig account
 10. for primitive owner approvals, verify the primitive signature over the current `multisig_digest` and recover the owner address
 11. for nested multisig owner approvals, require `init` is absent, require the nested account is already initialized, and recursively validate the nested signature using the parent `multisig_digest` as the nested inner digest
 12. reject recursive validation if any multisig account appears twice in the same nested validation path or if the path exceeds `MAX_MULTISIG_NESTING_DEPTH`
 13. require owner addresses are strictly ascending
-14. require every owner address is in the current owner set
-15. sum the current configured weights for the validated owners
-16. require the recovered owner weight sum is at least the current threshold
-17. authorize execution from `signature.account`
+14. load the current configured weight for each validated owner address
+15. require every validated owner weight is nonzero
+16. accumulate the current configured weights for validated owners
+17. reject trailing owner approvals after accumulated weight first reaches the current threshold
+18. require the recovered owner weight sum is at least the current threshold
+19. authorize execution from `signature.account`
 
 The transaction executes with `tx.from`, `tx.origin`, and top-level `msg.sender` equal to `signature.account`.
 
@@ -517,6 +542,7 @@ Constants:
 
 ```text
 NATIVE_MULTISIG_VALIDATION_GAS = GAS_COLD_SLOAD = 2,100
+NATIVE_MULTISIG_OWNER_WEIGHT_GAS = GAS_COLD_SLOAD = 2,100
 TRADITIONAL_SECP256K1_TX_SIGNATURE_GAS = ECRECOVER_GAS = 3,000
 ```
 
@@ -533,6 +559,7 @@ For one decoded nested multisig owner approval:
 ```text
 owner_signature_full_gas(nested_multisig) =
     NATIVE_MULTISIG_VALIDATION_GAS
+  + NATIVE_MULTISIG_OWNER_WEIGHT_GAS * nested_owner_signatures.len()
   + sum(owner_signature_full_gas(signature) for signature in nested_owner_signatures)
 ```
 
@@ -541,29 +568,33 @@ The native multisig authorization surcharge is:
 ```text
 native_multisig_authorization_gas =
     NATIVE_MULTISIG_VALIDATION_GAS
+  + NATIVE_MULTISIG_OWNER_WEIGHT_GAS * owner_signatures.len()
   + sum(owner_signature_full_gas(signature) for signature in owner_signatures)
   - TRADITIONAL_SECP256K1_TX_SIGNATURE_GAS
 ```
 
 `NATIVE_MULTISIG_VALIDATION_GAS` is one cold-storage-read equivalent. It prices the
-protocol-side account/config validation needed to prove that the sender is a registered native
-multisig and to validate the current config. It intentionally does not include an additional
-rounding or processing buffer.
+protocol-side account/header validation needed to prove that the sender is a registered native
+multisig and to load the current threshold. `NATIVE_MULTISIG_OWNER_WEIGHT_GAS` is one
+cold-storage-read equivalent per submitted owner approval; it prices the direct owner-weight lookup
+used during threshold accounting. Bootstrap uses the same owner-weight charge even though its owner
+weights are supplied inline, keeping bootstrap authorization pricing conservative and symmetric with
+registered validation.
 
 The subtraction is required because the normal Tempo base transaction gas already includes one
 traditional secp256k1 transaction-signature verification. A 1-of-1 secp256k1 native multisig
-therefore pays only the validation charge:
+therefore pays the validation charge plus one owner-weight lookup:
 
 ```text
-2,100 + 3,000 - 3,000 = 2,100
+2,100 + 2,100 + 3,000 - 3,000 = 4,200
 ```
 
 Additional owner approvals are charged at their full primitive verification cost:
 
 ```text
-1 secp256k1 owner: 2,100 gas
-2 secp256k1 owners: 5,100 gas
-3 secp256k1 owners: 8,100 gas
+1 secp256k1 owner: 4,200 gas
+2 secp256k1 owners: 9,300 gas
+3 secp256k1 owners: 14,400 gas
 ```
 
 P256 and WebAuthn owner approvals use the same full verification costs used for additional
@@ -572,12 +603,28 @@ transaction signature gas model while preventing multisig owner verification fro
 unmetered as owner count grows.
 
 Nested multisig owner approvals are charged recursively. Each nested native multisig account adds
-its own `NATIVE_MULTISIG_VALIDATION_GAS`, and its primitive descendants add their full primitive
+its own `NATIVE_MULTISIG_VALIDATION_GAS`, its submitted owner approvals each add
+`NATIVE_MULTISIG_OWNER_WEIGHT_GAS`, and its primitive descendants add their full primitive
 verification gas. The `TRADITIONAL_SECP256K1_TX_SIGNATURE_GAS` subtraction is applied exactly once,
 at the top-level transaction authorization.
 
 Recursive gas accounting MUST use the same `MAX_MULTISIG_NESTING_DEPTH` bound as recursive
 validation. A transaction whose owner approvals exceed that bound is invalid.
+
+The validation storage-read bound is independent of `MAX_MULTISIG_OWNERS`. With
+`MAX_MULTISIG_SIGNATURES = 8` and `MAX_MULTISIG_NESTING_DEPTH = 2`, a normal transaction can require
+at most:
+
+```text
+top-level threshold read                      = 1
+top-level submitted owner-weight reads        = 8
+8 nested owners * (threshold + 8 owner reads) = 8 * (1 + 8)
+total registered validation reads             = 81
+```
+
+Config updates and `getMultisigConfig` can enumerate or rewrite up to `MAX_MULTISIG_OWNERS` owner
+rows, but those paths execute through the precompile/RPC surfaces where storage reads and writes are
+metered separately. Transaction authorization never needs to scan all configured owners.
 
 This formula only prices protocol-side native multisig authorization. `INativeMultisig` precompile
 calls are charged under the active Tempo precompile storage gas schedule, and storage-creating
@@ -685,8 +732,8 @@ interface INativeMultisig {
     /// @dev Reverts when invoked through nested CALL, STATICCALL, DELEGATECALL, or CALLCODE.
     /// @dev Reverts if msg.sender is not a native multisig account or its stored config header is invalid.
     /// @dev Reverts if owners is empty, too long, unsorted, duplicated, or contains a zero owner or zero weight.
-    /// @dev Reverts if threshold is zero or greater than the total owner weight.
-    /// @param threshold The new threshold. Must be between 1 and the total owner weight.
+    /// @dev Reverts if threshold is zero, greater than MAX_MULTISIG_THRESHOLD, or greater than the total owner weight.
+    /// @param threshold The new threshold. Must be between 1 and MAX_MULTISIG_THRESHOLD and not exceed the total owner weight.
     /// @param owners The new sorted owner key IDs and weights.
     function updateMultisigConfig(
         uint8 threshold,
@@ -718,7 +765,7 @@ interface INativeMultisig {
     /// @notice The initial config failed structural validation.
     error InvalidConfig();
 
-    /// @notice The threshold is zero or greater than total owner weight.
+    /// @notice The threshold is zero, greater than MAX_MULTISIG_THRESHOLD, or greater than total owner weight.
     error InvalidThreshold();
 
     /// @notice An owner key ID is the zero address.
@@ -772,7 +819,7 @@ interface INativeMultisig {
 9. validate every owner weight is nonzero (`InvalidWeight`)
 10. compute `total_weight = sum(owners.weight)`
 11. validate `total_weight <= u8::MAX` (`InvalidWeight`)
-12. validate `1 <= threshold <= total_weight` (`InvalidThreshold`)
+12. validate `1 <= threshold <= MAX_MULTISIG_THRESHOLD` and `threshold <= total_weight` (`InvalidThreshold`)
 13. validate `owners` is strictly ascending by `owner` (`DuplicateOwner` / `InvalidOwnerOrder`)
 14. replace the stored current config for `msg.sender`
 15. emit `MultisigConfigUpdated`
@@ -799,7 +846,7 @@ sequenceDiagram
 
   Owners->>Tx: Sign update transaction digest
   Tx->>Protocol: Submit MultisigSignature
-  Protocol->>MS: Load current config
+  Protocol->>MS: Load current threshold and submitted owner weights
   Protocol->>Protocol: Verify current weighted threshold signatures
   Protocol->>MS: Execute updateMultisigConfig
   MS->>MS: Validate new config
@@ -922,13 +969,15 @@ This TIP does not define any single-key path that executes with the multisig acc
 - Reject bootstrap with zero owner address.
 - Reject bootstrap with zero owner weight.
 - Reject bootstrap with threshold 0 or threshold greater than total owner weight.
+- Reject bootstrap with threshold greater than `MAX_MULTISIG_THRESHOLD`.
 - Reject bootstrap when total owner weight exceeds `u8::MAX`.
 - Reject bootstrap with zero owner signatures.
-- Reject bootstrap with more than `MAX_MULTISIG_OWNERS` owner signatures.
+- Reject bootstrap with more than `MAX_MULTISIG_SIGNATURES` owner signatures.
 - Reject bootstrap with duplicate recovered signers.
 - Reject bootstrap with unsorted recovered signers.
 - Reject bootstrap with non-owner signers.
 - Reject bootstrap with insufficient valid signature weight.
+- Reject bootstrap with trailing owner signatures after quorum is reached.
 - Reject bootstrap owner signatures that verify against the wrong inner digest or account.
 - Preserve the stored initial config, native multisig account marker, and nonce consumption when bootstrap validation succeeds but the subsequent EVM call reverts.
 - Do not write the initial config or native multisig account marker when bootstrap validation fails.
@@ -954,9 +1003,10 @@ This TIP does not define any single-key path that executes with the multisig acc
 - Reject duplicate signers through strict recovered-signer ordering.
 - Reject unsorted recovered signers.
 - Reject zero owner signatures.
-- Reject more than `MAX_MULTISIG_OWNERS` owner signatures.
+- Reject more than `MAX_MULTISIG_SIGNATURES` owner signatures.
 - Reject non-owner signers.
 - Reject below-threshold signature weight.
+- Reject trailing owner signatures after quorum is reached.
 - Reject owner signatures that verify against the wrong inner digest or account.
 - Reject owner signatures where `multisig_digest` was computed with a length-prefixed domain string.
 - Reject owner signatures where `multisig_digest` was computed with RLP or ABI encoding.
@@ -989,8 +1039,8 @@ This TIP does not define any single-key path that executes with the multisig acc
 
 ### Gas Accounting
 
-- Confirm 1-of-1 secp256k1 native multisig adds exactly `2,100` regular intrinsic gas over the same primitive secp256k1 transaction.
-- Confirm 2-of-2 secp256k1 native multisig adds exactly `5,100` regular intrinsic gas over the same primitive secp256k1 transaction.
+- Confirm 1-of-1 secp256k1 native multisig adds exactly `4,200` regular intrinsic gas over the same primitive secp256k1 transaction.
+- Confirm 2-of-2 secp256k1 native multisig adds exactly `9,300` regular intrinsic gas over the same primitive secp256k1 transaction.
 - Confirm P256 and WebAuthn owner approvals are charged using full additional owner signature costs in the multisig formula.
 - Confirm native multisig authorization gas does not add the AccountKeychain `900` processing buffer.
 - Confirm native multisig authorization gas does not add state gas.
@@ -1007,6 +1057,7 @@ This TIP does not define any single-key path that executes with the multisig acc
 - Reject updates with zero owner address.
 - Reject updates with zero owner weight.
 - Reject updates with invalid threshold.
+- Reject updates with threshold greater than `MAX_MULTISIG_THRESHOLD`.
 - Reject updates with threshold greater than total owner weight.
 - Reject updates when total owner weight exceeds `u8::MAX`.
 - Reject updates with duplicate owner addresses or unsorted owners.
@@ -1062,7 +1113,7 @@ This TIP does not define any single-key path that executes with the multisig acc
 - Accept WebAuthn owner signatures at the maximum primitive WebAuthn signature size.
 - Reject WebAuthn owner approvals whose challenge is `tx.signature_hash()` instead of `multisig_digest`.
 - Accept nested Multisig owner signatures.
-- Accept nested Multisig owner signatures up to `MAX_MULTISIG_NESTING_DEPTH`.
+- Accept a root multisig with a nested multisig owner at `MAX_MULTISIG_NESTING_DEPTH`.
 - Reject nested Multisig owner signatures that include `init`.
 - Reject nested Multisig owner signatures for accounts that are not initialized native multisig accounts.
 - Reject nested Multisig owner-signature cycles.
@@ -1099,7 +1150,7 @@ TBD.
 
 3. **Unused bootstrap account.** Bootstrap MUST be accepted only when the derived account has zero nonce, empty code, and no delegation code. A nonzero balance alone MUST NOT prevent bootstrap. This TIP does not check derived-account storage at bootstrap.
 
-4. **Config validity.** Every stored config MUST have `1 <= owners.len() <= MAX_MULTISIG_OWNERS`, strictly ascending unique nonzero owners, nonzero owner weights, `sum(owners.weight) <= u8::MAX`, and `1 <= threshold <= sum(owners.weight)`.
+4. **Config validity.** Every stored config MUST have `1 <= owners.len() <= MAX_MULTISIG_OWNERS`, strictly ascending unique nonzero owners, nonzero owner weights, `sum(owners.weight) <= u8::MAX`, and `1 <= threshold <= MAX_MULTISIG_THRESHOLD` and `threshold <= sum(owners.weight)`.
 
 5. **Marker consistency.** If `multisig_accounts[account] == true`, then an existing account-scoped stored config MUST exist for `account`.
 
@@ -1109,7 +1160,7 @@ TBD.
 
 8. **Owner set membership.** Owner addresses recovered from primitive approvals or taken from nested multisig approval accounts MUST be strictly ascending. Every owner address MUST match an entry in the current stored owner set.
 
-9. **Threshold enforcement.** A multisig transaction MUST be rejected unless the current configured weights of valid recovered owners sum to at least the current threshold.
+9. **Threshold enforcement.** A multisig transaction MUST be rejected unless the current configured weights of valid recovered owners sum to at least the current threshold. A multisig transaction MUST also be rejected if it contains owner approvals after threshold quorum has already been reached.
 
 10. **Current-state authorization.** A multisig transaction MUST be authorized against the stored config in effect at its block position.
 

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -616,6 +616,8 @@ The validation storage-read bound is independent of `MAX_MULTISIG_OWNERS`. With
 at most:
 
 ```text
+per multisig node                           = 1 threshold read + threshold owner-weight reads
+per multisig node with MAX_MULTISIG_THRESHOLD = 1 + 8 = 9
 top-level threshold read                      = 1
 top-level submitted owner-weight reads        = 8
 8 nested owners * (threshold + 8 owner reads) = 8 * (1 + 8)
@@ -902,9 +904,11 @@ The threshold is the limiting factor for unpaid validation work because owner we
 An attacker who wants to force maximum verifier work sets many submitted owners to weight `1`, so
 the verifier must process `threshold` owner approvals before quorum can be reached. Capping
 `MAX_MULTISIG_THRESHOLD` at `8` therefore caps the useful submitted approvals per multisig node,
-while still allowing a large administrative owner set of up to 255 owners. The large owner set is
-paid for when configs are created, updated, or explicitly read through the precompile; it does not
-make transaction authorization scan 255 owners.
+which bounds each multisig node to at most `1 + threshold` storage reads: one threshold read plus
+one owner-weight read per approval needed for quorum. With `MAX_MULTISIG_THRESHOLD = 8`, that is at
+most 9 storage reads per node, while still allowing a large administrative owner set of up to 255
+owners. The large owner set is paid for when configs are created, updated, or explicitly read
+through the precompile; it does not make transaction authorization scan 255 owners.
 
 Trailing approvals after quorum are rejected rather than ignored. Once the recovered weight reaches
 the threshold, later approvals do not contribute to authorization. Accepting them would either force


### PR DESCRIPTION
Caps native multisig authorization work by separating configured owner capacity from submitted quorum work. Configs can still store up to 255 owners, but protocol-accepted thresholds and submitted owner approvals are capped at 8, and recursive multisig authorization is capped at depth 2.

Registered validation now reads the account threshold plus submitted owner weights instead of loading/scanning the full owner list. It stores direct owner-weight lookup slots, charges one owner-weight SLOAD per submitted approval, and updates TIP-1061 with the per-node and worst-case registered validation bounds.

Design notes:
- Threshold, not owner count, is the DoS limiter. With direct owner-weight lookups, non-submitted configured owners are not read during tx validation. Since owner weights are nonzero, a weight-1 quorum requires at most `threshold` submitted approvals per multisig node.
- Each registered multisig node is bounded to `1 + threshold` SLOADs: one threshold/header read plus one owner-weight read per approval needed for quorum. With `MAX_MULTISIG_THRESHOLD = 8`, that is at most `9` SLOADs per node.
- With nesting depth 2 and max threshold 8, the worst-case registered validation bound is `1 + 8 + 8 * (1 + 8) = 81` SLOADs, or `81 * 2,100 = 170,100` gas-equivalent unpaid SLOAD work.
- The `170,100` number is only the storage-read component of the worst-case DoS shape; signature verification and calldata/data-size costs remain priced separately by the native multisig intrinsic-gas formula.
- Trailing owner approvals after quorum are invalid. Once threshold is reached, later approvals do not contribute to authorization; accepting them would either require decoding/verifying irrelevant signatures or allow unchecked bytes in otherwise valid txs. Rejection gives a canonical minimal quorum proof and lets validators stop at quorum.

Checks:
- `rustup run nightly cargo fmt --all`
- `cargo test -p tempo-primitives multisig`
- `cargo test -p tempo-precompiles native_multisig`
- `cargo test -p tempo-revm native_multisig`
- `cargo test -p tempo-alloy multisig`
- `cargo test -p tempo-alloy reth_compat`
