### PR TITLE
ci(bench): enable parallel builder by default in e2e benchmarks

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -31,6 +31,7 @@ const E2E_LOCAL_RETH_ARGS = [
     "--consensus.no-legacy-archive"
     "--engine.share-execution-cache-with-payload-builder"
     "--builder.enable-prewarming"
+    "--builder.parallel"
     "--rpc.max-connections" "10000"
     "--txpool.pending-max-count" "200000"
     "--txpool.basefee-max-count" "200000"


### PR DESCRIPTION
## Summary
- Enable `--builder.parallel` in the default e2e benchmark node args
- Leave replay benchmark startup args unchanged

## Tests
- `bash -n .github/scripts/bench-tempo-replay.sh`
- `nu --commands 'nu-check bench-e2e.nu'`

Prompted by: @shekhirin
