### PR TITLE
feat(alloy): add access key policy recipes

### DIFF
--- a/crates/alloy/src/provider/keychain.rs
+++ b/crates/alloy/src/provider/keychain.rs
@@ -140,16 +140,14 @@ pub struct AccessKeyPolicyBuilder {
 
 /// A policy tier for authorizing an access key with its own spending cap.
 ///
-/// `key_id` can be the address of a derived native multisig account. For example,
-/// one root account can authorize:
-/// - a 2-of-N multisig key with a 1,000 USD token limit
-/// - a 5-of-N multisig key with a 10,000 USD token limit
+/// For example, one shared treasury account can authorize:
+/// - an operations key with a 1,000 USD token limit
+/// - a finance key with a 10,000 USD token limit
 ///
-/// The root account remains the account that owns funds and grants access keys. The multisig
-/// accounts are the authorized key IDs, each with its own policy.
+/// The root account remains the account that owns funds and grants access keys.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AccessKeyPolicyTier {
-    /// Access-key identifier to authorize, such as a derived multisig account address.
+    /// Access-key identifier to authorize.
     pub key_id: Address,
     /// Restrictions to apply to this access key.
     pub restrictions: KeyRestrictions,
@@ -257,7 +255,7 @@ impl AccessKeyPolicyBuilder {
 ///
 /// This is the Alloy recipe for treasury-style access keys: authorize a key with a
 /// per-token spending cap, and scope it to TIP-20 transfers on that same token. The
-/// key itself can be any account address, including a multisig-derived key ID.
+/// key signs keychain transactions that spend from the account that authorized it.
 pub fn tip20_transfer_policy(
     token: Address,
     spending_limit: U256,
@@ -284,8 +282,10 @@ pub fn periodic_tip20_transfer_policy(
 
 /// Build tiered TIP-20 transfer policies keyed by access-key ID.
 ///
-/// This captures the treasury recipe where each spending band is a separate access key,
-/// and each access key can be controlled by a different multisig quorum:
+/// This captures the treasury recipe where each spending band is a separate access key
+/// spending from the same account. For native multisig accounts, the shared multisig signs
+/// the AccountKeychain authorization transaction, and the authorized access keys later
+/// spend from that shared multisig through `TempoSignature::Keychain`.
 ///
 /// ```ignore
 /// use alloy_primitives::{address, uint};
@@ -295,23 +295,21 @@ pub fn periodic_tip20_transfer_policy(
 /// use tempo_alloy::primitives::SignatureType;
 ///
 /// let path_usd = address!("0x20c0000000000000000000000000000000000001");
-/// let two_of_three_multisig = derive_multisig_account(/* threshold: 2, owners: ... */);
-/// let five_of_seven_multisig = derive_multisig_account(/* threshold: 5, owners: ... */);
+/// let ops_key = address!("0x1111111111111111111111111111111111111111");
+/// let finance_key = address!("0x2222222222222222222222222222222222222222");
 ///
 /// let tiers = tip20_transfer_policy_tiers(
 ///     path_usd,
 ///     vec![
-///         (two_of_three_multisig, uint!(1_000_U256), vec![]),
-///         (five_of_seven_multisig, uint!(10_000_U256), vec![]),
+///         (ops_key, uint!(1_000_U256), vec![]),
+///         (finance_key, uint!(10_000_U256), vec![]),
 ///     ],
 /// );
 ///
-/// // The root account authorizes each multisig account as an access key with its
-/// // corresponding policy. Native multisig key authorization requires the protocol/API
-/// // to expose a multisig key type; do not use a primitive key type for these key IDs.
+/// // The shared account authorizes each key with its corresponding policy.
 /// let calls = tiers
 ///     .into_iter()
-///     .map(|tier| authorize_key(tier.key_id, SignatureType::Multisig, tier.restrictions))
+///     .map(|tier| authorize_key(tier.key_id, SignatureType::Secp256k1, tier.restrictions))
 ///     .collect::<Vec<_>>();
 /// ```
 pub fn tip20_transfer_policy_tiers(
@@ -808,22 +806,22 @@ mod tests {
     }
 
     #[test]
-    fn test_tip20_transfer_policy_tiers_map_multisig_key_ids_to_spending_caps() {
+    fn test_tip20_transfer_policy_tiers_map_key_ids_to_spending_caps() {
         let token = address!("0x20c0000000000000000000000000000000000001");
-        let two_of_three_multisig = address!("0x2222222222222222222222222222222222222222");
-        let five_of_seven_multisig = address!("0x5555555555555555555555555555555555555555");
+        let ops_key = address!("0x2222222222222222222222222222222222222222");
+        let finance_key = address!("0x5555555555555555555555555555555555555555");
 
         let tiers = tip20_transfer_policy_tiers(
             token,
             vec![
-                (two_of_three_multisig, uint!(1_000_U256), vec![]),
-                (five_of_seven_multisig, uint!(10_000_U256), vec![]),
+                (ops_key, uint!(1_000_U256), vec![]),
+                (finance_key, uint!(10_000_U256), vec![]),
             ],
         );
 
         assert_eq!(tiers.len(), 2);
-        assert_eq!(tiers[0].key_id, two_of_three_multisig);
-        assert_eq!(tiers[1].key_id, five_of_seven_multisig);
+        assert_eq!(tiers[0].key_id, ops_key);
+        assert_eq!(tiers[1].key_id, finance_key);
 
         let lower_limits = tiers[0].restrictions.limits().expect("lower limit");
         assert_eq!(lower_limits[0].token, token);

--- a/crates/alloy/src/provider/keychain.rs
+++ b/crates/alloy/src/provider/keychain.rs
@@ -125,6 +125,208 @@ impl KeyRestrictions {
     }
 }
 
+/// Builder for access-key policy recipes.
+///
+/// This wraps [`KeyRestrictions`] with higher-level helpers for the common pattern of
+/// combining per-token spending limits with scoped TIP-20 calls.
+#[derive(Clone, Debug, Default)]
+pub struct AccessKeyPolicyBuilder {
+    restrictions: KeyRestrictions,
+    limits: Vec<TokenLimit>,
+    scopes: Vec<CallScope>,
+    enforce_limits: bool,
+    scoped_calls: bool,
+}
+
+/// A policy tier for authorizing an access key with its own spending cap.
+///
+/// `key_id` can be the address of a derived native multisig account. For example,
+/// one root account can authorize:
+/// - a 2-of-N multisig key with a 1,000 USD token limit
+/// - a 5-of-N multisig key with a 10,000 USD token limit
+///
+/// The root account remains the account that owns funds and grants access keys. The multisig
+/// accounts are the authorized key IDs, each with its own policy.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccessKeyPolicyTier {
+    /// Access-key identifier to authorize, such as a derived multisig account address.
+    pub key_id: Address,
+    /// Restrictions to apply to this access key.
+    pub restrictions: KeyRestrictions,
+}
+
+impl AccessKeyPolicyBuilder {
+    /// Create an unrestricted policy builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the access-key expiry timestamp.
+    pub fn expires_at(mut self, expiry: u64) -> Self {
+        self.restrictions = self.restrictions.with_expiry(expiry);
+        self
+    }
+
+    /// Add a one-time token spending limit.
+    pub fn token_limit(mut self, token: Address, limit: U256) -> Self {
+        self.enforce_limits = true;
+        self.limits.push(TokenLimit {
+            token,
+            limit,
+            period: 0,
+        });
+        self
+    }
+
+    /// Add a periodic token spending limit that resets every `period` seconds.
+    pub fn periodic_token_limit(mut self, token: Address, limit: U256, period: u64) -> Self {
+        self.enforce_limits = true;
+        self.limits.push(TokenLimit {
+            token,
+            limit,
+            period,
+        });
+        self
+    }
+
+    /// Deny all token spending.
+    pub fn deny_spending(mut self) -> Self {
+        self.enforce_limits = true;
+        self.limits.clear();
+        self
+    }
+
+    /// Allow TIP-20 transfers on `token`, optionally restricted to `recipients`.
+    pub fn allow_tip20_transfers(mut self, token: Address, recipients: Vec<Address>) -> Self {
+        self.scoped_calls = true;
+        self.scopes
+            .push(CallScopeBuilder::new(token).transfer(recipients).build());
+        self
+    }
+
+    /// Allow TIP-20 transfers-with-memo on `token`, optionally restricted to `recipients`.
+    pub fn allow_tip20_transfers_with_memo(
+        mut self,
+        token: Address,
+        recipients: Vec<Address>,
+    ) -> Self {
+        self.scoped_calls = true;
+        self.scopes.push(
+            CallScopeBuilder::new(token)
+                .transfer_with_memo(recipients)
+                .build(),
+        );
+        self
+    }
+
+    /// Allow TIP-20 approvals on `token`, optionally restricted to `spenders`.
+    pub fn allow_tip20_approvals(mut self, token: Address, spenders: Vec<Address>) -> Self {
+        self.scoped_calls = true;
+        self.scopes
+            .push(CallScopeBuilder::new(token).approve(spenders).build());
+        self
+    }
+
+    /// Allow any call to `target`.
+    pub fn allow_contract(mut self, target: Address) -> Self {
+        self.scoped_calls = true;
+        self.scopes.push(CallScopeBuilder::new(target).build());
+        self
+    }
+
+    /// Deny all calls.
+    pub fn deny_calls(mut self) -> Self {
+        self.scoped_calls = true;
+        self.scopes.clear();
+        self
+    }
+
+    /// Consume the builder and produce [`KeyRestrictions`].
+    pub fn build(mut self) -> KeyRestrictions {
+        if self.enforce_limits {
+            self.restrictions = self.restrictions.with_limits(self.limits);
+        }
+        if self.scoped_calls {
+            self.restrictions = self.restrictions.with_allowed_calls(self.scopes);
+        }
+        self.restrictions
+    }
+}
+
+/// Build a one-time TIP-20 transfer policy for an access key.
+///
+/// This is the Alloy recipe for treasury-style access keys: authorize a key with a
+/// per-token spending cap, and scope it to TIP-20 transfers on that same token. The
+/// key itself can be any account address, including a multisig-derived key ID.
+pub fn tip20_transfer_policy(
+    token: Address,
+    spending_limit: U256,
+    recipients: Vec<Address>,
+) -> KeyRestrictions {
+    AccessKeyPolicyBuilder::new()
+        .token_limit(token, spending_limit)
+        .allow_tip20_transfers(token, recipients)
+        .build()
+}
+
+/// Build a periodic TIP-20 transfer policy for an access key.
+pub fn periodic_tip20_transfer_policy(
+    token: Address,
+    spending_limit: U256,
+    period: u64,
+    recipients: Vec<Address>,
+) -> KeyRestrictions {
+    AccessKeyPolicyBuilder::new()
+        .periodic_token_limit(token, spending_limit, period)
+        .allow_tip20_transfers(token, recipients)
+        .build()
+}
+
+/// Build tiered TIP-20 transfer policies keyed by access-key ID.
+///
+/// This captures the treasury recipe where each spending band is a separate access key,
+/// and each access key can be controlled by a different multisig quorum:
+///
+/// ```ignore
+/// use alloy_primitives::{address, uint};
+/// use tempo_alloy::provider::keychain::{
+///     authorize_key, tip20_transfer_policy_tiers,
+/// };
+/// use tempo_alloy::primitives::SignatureType;
+///
+/// let path_usd = address!("0x20c0000000000000000000000000000000000001");
+/// let two_of_three_multisig = derive_multisig_account(/* threshold: 2, owners: ... */);
+/// let five_of_seven_multisig = derive_multisig_account(/* threshold: 5, owners: ... */);
+///
+/// let tiers = tip20_transfer_policy_tiers(
+///     path_usd,
+///     vec![
+///         (two_of_three_multisig, uint!(1_000_U256), vec![]),
+///         (five_of_seven_multisig, uint!(10_000_U256), vec![]),
+///     ],
+/// );
+///
+/// // The root account authorizes each multisig account as an access key with its
+/// // corresponding policy. Native multisig key authorization requires the protocol/API
+/// // to expose a multisig key type; do not use a primitive key type for these key IDs.
+/// let calls = tiers
+///     .into_iter()
+///     .map(|tier| authorize_key(tier.key_id, SignatureType::Multisig, tier.restrictions))
+///     .collect::<Vec<_>>();
+/// ```
+pub fn tip20_transfer_policy_tiers(
+    token: Address,
+    tiers: Vec<(Address, U256, Vec<Address>)>,
+) -> Vec<AccessKeyPolicyTier> {
+    tiers
+        .into_iter()
+        .map(|(key_id, spending_limit, recipients)| AccessKeyPolicyTier {
+            key_id,
+            restrictions: tip20_transfer_policy(token, spending_limit, recipients),
+        })
+        .collect()
+}
+
 impl From<KeyRestrictions> for AbiKeyRestrictions {
     fn from(restrictions: KeyRestrictions) -> Self {
         let KeyRestrictions {
@@ -532,6 +734,114 @@ mod tests {
             ITIP20::approveCall::SELECTOR
         );
         assert!(scope.selector_rules[1].recipients.is_empty());
+    }
+
+    #[test]
+    fn test_access_key_policy_builder_combines_limits_and_tip20_scopes() {
+        let token = address!("0x20c0000000000000000000000000000000000001");
+        let recipient = address!("0x3333333333333333333333333333333333333333");
+
+        let restrictions = AccessKeyPolicyBuilder::new()
+            .expires_at(456)
+            .periodic_token_limit(token, uint!(1000_U256), 86_400)
+            .allow_tip20_transfers(token, vec![recipient])
+            .allow_tip20_approvals(token, vec![])
+            .build();
+
+        assert_eq!(restrictions.expiry(), Some(456));
+        assert_eq!(
+            restrictions.limits(),
+            Some(
+                &[TokenLimit {
+                    token,
+                    limit: uint!(1000_U256),
+                    period: 86_400,
+                }][..]
+            )
+        );
+
+        let scopes = restrictions.allowed_calls().expect("scoped calls");
+        assert_eq!(scopes.len(), 2);
+        assert_eq!(scopes[0].target, token);
+        assert_eq!(
+            scopes[0].selector_rules[0].selector,
+            ITIP20::transferCall::SELECTOR
+        );
+        assert_eq!(scopes[0].selector_rules[0].recipients, vec![recipient]);
+        assert_eq!(
+            scopes[1].selector_rules[0].selector,
+            ITIP20::approveCall::SELECTOR
+        );
+        assert!(scopes[1].selector_rules[0].recipients.is_empty());
+    }
+
+    #[test]
+    fn test_tip20_transfer_policy_encodes_authorize_key_recipe() {
+        let key_id = address!("0x1111111111111111111111111111111111111111");
+        let token = address!("0x20c0000000000000000000000000000000000001");
+        let recipient = address!("0x3333333333333333333333333333333333333333");
+
+        let call = authorize_key(
+            key_id,
+            SignatureType::Secp256k1,
+            tip20_transfer_policy(token, uint!(1000_U256), vec![recipient]),
+        );
+
+        let decoded = authorizeKeyCall::abi_decode(&call.input).expect("decode authorizeKey");
+        assert_eq!(decoded.keyId, key_id);
+        assert!(decoded.config.enforceLimits);
+        assert_eq!(decoded.config.limits.len(), 1);
+        assert_eq!(decoded.config.limits[0].token, token);
+        assert_eq!(decoded.config.limits[0].amount, uint!(1000_U256));
+        assert_eq!(decoded.config.limits[0].period, 0);
+        assert!(!decoded.config.allowAnyCalls);
+        assert_eq!(decoded.config.allowedCalls.len(), 1);
+        assert_eq!(decoded.config.allowedCalls[0].target, token);
+        assert_eq!(
+            decoded.config.allowedCalls[0].selectorRules[0].selector,
+            ITIP20::transferCall::SELECTOR
+        );
+        assert_eq!(
+            decoded.config.allowedCalls[0].selectorRules[0].recipients,
+            vec![recipient]
+        );
+    }
+
+    #[test]
+    fn test_tip20_transfer_policy_tiers_map_multisig_key_ids_to_spending_caps() {
+        let token = address!("0x20c0000000000000000000000000000000000001");
+        let two_of_three_multisig = address!("0x2222222222222222222222222222222222222222");
+        let five_of_seven_multisig = address!("0x5555555555555555555555555555555555555555");
+
+        let tiers = tip20_transfer_policy_tiers(
+            token,
+            vec![
+                (two_of_three_multisig, uint!(1_000_U256), vec![]),
+                (five_of_seven_multisig, uint!(10_000_U256), vec![]),
+            ],
+        );
+
+        assert_eq!(tiers.len(), 2);
+        assert_eq!(tiers[0].key_id, two_of_three_multisig);
+        assert_eq!(tiers[1].key_id, five_of_seven_multisig);
+
+        let lower_limits = tiers[0].restrictions.limits().expect("lower limit");
+        assert_eq!(lower_limits[0].token, token);
+        assert_eq!(lower_limits[0].limit, uint!(1_000_U256));
+
+        let higher_limits = tiers[1].restrictions.limits().expect("higher limit");
+        assert_eq!(higher_limits[0].token, token);
+        assert_eq!(higher_limits[0].limit, uint!(10_000_U256));
+
+        for tier in tiers {
+            let scopes = tier.restrictions.allowed_calls().expect("transfer scope");
+            assert_eq!(scopes.len(), 1);
+            assert_eq!(scopes[0].target, token);
+            assert_eq!(
+                scopes[0].selector_rules[0].selector,
+                ITIP20::transferCall::SELECTOR
+            );
+        }
     }
 
     #[test]

--- a/crates/alloy/src/provider/mod.rs
+++ b/crates/alloy/src/provider/mod.rs
@@ -8,6 +8,10 @@ pub mod receive_policy;
 #[doc(inline)]
 pub use ext::{SponsoredProviderBuilder, TempoProviderBuilderExt, TempoProviderExt};
 #[doc(inline)]
-pub use keychain::{CallScopeBuilder, KeyRestrictions, KeychainBuildError};
+pub use keychain::{
+    AccessKeyPolicyBuilder, AccessKeyPolicyTier, CallScopeBuilder, KeyRestrictions,
+    KeychainBuildError, periodic_tip20_transfer_policy, tip20_transfer_policy,
+    tip20_transfer_policy_tiers,
+};
 #[doc(inline)]
 pub use receive_policy::BlockedTransfer;

--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -302,20 +302,38 @@ fn create_mock_tempo_sig(
     caller_addr: alloy_primitives::Address,
     is_t1c: bool,
 ) -> TempoSignature {
-    use tempo_primitives::transaction::tt_signature::{KeychainSignature, TempoSignature};
+    use tempo_primitives::transaction::{
+        MultisigSignature,
+        tt_signature::{KeychainSignature, TempoSignature},
+    };
 
-    let inner_sig = create_mock_primitive_signature(key_type, key_data.cloned());
+    let primitive_sig = create_mock_primitive_signature(key_type, key_data.cloned());
+    let multisig_sig = || {
+        MultisigSignature::new(
+            key_id.unwrap_or(caller_addr),
+            vec![primitive_sig.to_bytes()],
+            None,
+        )
+    };
 
     if key_id.is_some() {
         // For Keychain signatures, the root_key_address is the caller (account owner).
         let keychain_sig = if is_t1c {
-            KeychainSignature::new(caller_addr, inner_sig)
+            match key_type {
+                SignatureType::Multisig => KeychainSignature::new(caller_addr, multisig_sig()),
+                _ => KeychainSignature::new(caller_addr, primitive_sig),
+            }
         } else {
-            KeychainSignature::new_v1(caller_addr, inner_sig)
+            match key_type {
+                SignatureType::Multisig => KeychainSignature::new_v1(caller_addr, multisig_sig()),
+                _ => KeychainSignature::new_v1(caller_addr, primitive_sig),
+            }
         };
         TempoSignature::Keychain(keychain_sig)
+    } else if matches!(key_type, SignatureType::Multisig) {
+        TempoSignature::Multisig(multisig_sig())
     } else {
-        TempoSignature::Primitive(inner_sig)
+        TempoSignature::Primitive(primitive_sig)
     }
 }
 
@@ -402,6 +420,11 @@ fn create_mock_primitive_signature(
                 pub_key_y: alloy_primitives::B256::ZERO,
             })
         }
+        SignatureType::Multisig => PrimitiveSignature::Secp256k1(Signature::new(
+            alloy_primitives::U256::ZERO,
+            alloy_primitives::U256::ZERO,
+            false,
+        )),
     }
 }
 

--- a/crates/contracts/src/precompiles/account_keychain.rs
+++ b/crates/contracts/src/precompiles/account_keychain.rs
@@ -25,6 +25,7 @@ crate::sol! {
             Secp256k1,
             P256,
             WebAuthn,
+            Multisig,
         }
 
         /// Legacy token spending limit structure used before T3.

--- a/crates/node/tests/it/tempo_transaction/mod.rs
+++ b/crates/node/tests/it/tempo_transaction/mod.rs
@@ -36,6 +36,7 @@
 //! - Keychain revocation TOCTOU DoS.
 //! - Expiring nonce replay protection.
 //! - Keychain spending limit TOCTOU DoS.
+//! - Multisig access-key treasury policies.
 
 use crate::utils::{ForkSchedule, run_schedule_cases};
 use test_case::test_case;
@@ -47,6 +48,7 @@ pub(crate) mod types;
 use types::TestEnv;
 
 mod local;
+mod multisig_access_keys;
 mod rpc;
 
 /// Run all matrix tests and scenario runners against a single environment.

--- a/crates/node/tests/it/tempo_transaction/multisig_access_keys.rs
+++ b/crates/node/tests/it/tempo_transaction/multisig_access_keys.rs
@@ -1,0 +1,50 @@
+//! Acceptance tests for shared multisig accounts spending through multisig access keys.
+//!
+//! These are intentionally ignored until native multisig signatures can be used inside
+//! Keychain signatures and AccountKeychain can authorize a multisig key type. Today the
+//! transaction/keychain primitives only support primitive access-key signatures.
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "pending native multisig access-key support in KeyAuthorization and KeychainSignature"]
+async fn shared_multisig_can_spend_through_tiered_multisig_access_keys() -> eyre::Result<()> {
+    // Desired flow:
+    //
+    // 1. Create and fund a shared native multisig account, e.g. 7 owners with threshold 5.
+    // 2. Derive a 2-of-7 native multisig account to use as the low-value access key.
+    // 3. Derive a 5-of-7 native multisig account to use as the high-value access key.
+    // 4. From the shared multisig, authorize both derived multisig accounts as access keys:
+    //    - low-value key: PATH USD limit = 1_000, TIP-20 transfer scope only
+    //    - high-value key: PATH USD limit = 10_000, TIP-20 transfer scope only
+    // 5. Send a PATH USD transfer from the shared multisig using KeychainSignature {
+    //    user_address: shared_multisig,
+    //    signature: MultisigSignature(low_value_multisig, 2 owner approvals),
+    //    version: V2,
+    // }.
+    // 6. Assert the transfer succeeds, debits the shared multisig balance, credits the recipient,
+    //    and reduces only the low-value key's remaining spending limit.
+    //
+    // This cannot be expressed with the current types because KeychainSignature::signature is a
+    // PrimitiveSignature and KeyAuthorization::key_type has no Multisig variant.
+    eyre::bail!("native multisig access-key support is not implemented yet")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "pending native multisig access-key support in KeyAuthorization and KeychainSignature"]
+async fn shared_multisig_enforces_multisig_access_key_quorum_and_policy() -> eyre::Result<()> {
+    // Desired enforcement cases for the same setup as
+    // `shared_multisig_can_spend_through_tiered_multisig_access_keys`:
+    //
+    // 1. A low-value access-key spend with only 1 owner approval fails because the 2-of-7 key's
+    //    multisig threshold is not met.
+    // 2. A low-value access-key spend above 1_000 PATH USD fails with SpendingLimitExceeded.
+    // 3. A low-value access-key call outside its allowed TIP-20 transfer scope fails with the
+    //    call-scope rejection path.
+    // 4. A high-value access-key spend with only 2 owner approvals fails because the 5-of-7 key's
+    //    multisig threshold is not met.
+    // 5. A high-value access-key spend below 10_000 PATH USD with 5 owner approvals succeeds and
+    //    spends from the shared multisig account, not from the derived access-key multisig.
+    //
+    // This cannot be expressed with the current types because KeychainSignature::signature is a
+    // PrimitiveSignature and AccountKeychain rejects non-primitive signature types.
+    eyre::bail!("native multisig access-key policy enforcement is not implemented yet")
+}

--- a/crates/node/tests/it/tempo_transaction/multisig_access_keys.rs
+++ b/crates/node/tests/it/tempo_transaction/multisig_access_keys.rs
@@ -16,8 +16,8 @@ use tempo_precompiles::{ACCOUNT_KEYCHAIN_ADDRESS, tip20::ITIP20::ITIP20Instance}
 use tempo_primitives::{
     SignatureType, TempoTransaction, TempoTxEnvelope,
     transaction::{
-        InitMultisig, MultisigOwner, MultisigSignature, PrimitiveSignature, TempoSignature,
-        multisig_digest,
+        InitMultisig, KeychainSignature, MultisigOwner, MultisigSignature, PrimitiveSignature,
+        TempoSignature, multisig_digest,
     },
 };
 
@@ -28,16 +28,21 @@ const ONE_TOKEN: u64 = 1_000_000;
 const LOW_LIMIT: u64 = 1_000 * ONE_TOKEN;
 const HIGH_LIMIT: u64 = 10_000 * ONE_TOKEN;
 const SHARED_MULTISIG_FUNDING: u64 = 100_000 * ONE_TOKEN;
+const ACCESS_KEY_MULTISIG_FUNDING: u64 = 10_000 * ONE_TOKEN;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Result<()> {
     let mut env = Localnet::new().await?;
 
-    let owner_signers = multisig_owner_signers();
-    let shared_config = multisig_config(B256::repeat_byte(0x51), 2, &owner_signers);
+    let shared_signers = multisig_owner_signers(0x10);
+    let low_signers = multisig_owner_signers(0x20);
+    let high_signers = multisig_owner_signers(0x30);
+    let shared_config = multisig_config(B256::repeat_byte(0x51), 2, &shared_signers);
+    let low_key_config = multisig_config(B256::repeat_byte(0x52), 2, &low_signers);
+    let high_key_config = multisig_config(B256::repeat_byte(0x53), 3, &high_signers);
     let shared_multisig = multisig_account(&shared_config)?;
-    let low_key = PrivateKeySigner::random();
-    let high_key = PrivateKeySigner::random();
+    let low_key = multisig_account(&low_key_config)?;
+    let high_key = multisig_account(&high_key_config)?;
     let allowed_recipient = Address::random();
     let blocked_recipient = Address::random();
 
@@ -52,21 +57,24 @@ async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Res
         env.chain_id,
     )
     .await?;
+    fund_multisig_account(&mut env, low_key).await?;
+    fund_multisig_account(&mut env, high_key).await?;
 
-    bootstrap_multisig(&mut env, &shared_config, &owner_signers).await?;
+    bootstrap_multisig(&mut env, &shared_config, &shared_signers).await?;
+    bootstrap_multisig(&mut env, &low_key_config, &low_signers).await?;
+    bootstrap_multisig(&mut env, &high_key_config, &high_signers).await?;
     authorize_tiered_access_keys(
         &mut env,
         shared_multisig,
         &shared_config,
-        &owner_signers,
-        low_key.address(),
-        high_key.address(),
+        &shared_signers,
+        low_key,
+        high_key,
         allowed_recipient,
     )
     .await?;
 
-    let low_remaining_before =
-        remaining_limit(&env.provider, shared_multisig, low_key.address()).await?;
+    let low_remaining_before = remaining_limit(&env.provider, shared_multisig, low_key).await?;
     assert_eq!(low_remaining_before, U256::from(LOW_LIMIT));
 
     let low_amount = U256::from(LOW_LIMIT / 4);
@@ -74,7 +82,8 @@ async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Res
     submit_access_key_transfer(
         &mut env,
         shared_multisig,
-        &low_key,
+        &low_key_config,
+        &low_signers,
         allowed_recipient,
         low_amount,
     )
@@ -85,8 +94,7 @@ async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Res
         "low-tier access key should spend from the shared multisig within its policy"
     );
 
-    let low_remaining_after =
-        remaining_limit(&env.provider, shared_multisig, low_key.address()).await?;
+    let low_remaining_after = remaining_limit(&env.provider, shared_multisig, low_key).await?;
     assert!(
         low_remaining_after < low_remaining_before,
         "successful spend should consume the low-tier key's limit"
@@ -100,8 +108,12 @@ async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Res
         U256::from(LOW_LIMIT + ONE_TOKEN),
     )
     .await?;
-    let over_limit_sig =
-        sign_aa_tx_with_secp256k1_access_key(&over_limit_tx, &low_key, shared_multisig)?;
+    let over_limit_sig = sign_aa_tx_with_multisig_access_key(
+        &over_limit_tx,
+        shared_multisig,
+        &low_key_config,
+        &low_signers,
+    )?;
     assert_rejected(
         &mut env,
         over_limit_tx,
@@ -118,8 +130,12 @@ async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Res
         U256::from(ONE_TOKEN),
     )
     .await?;
-    let wrong_recipient_sig =
-        sign_aa_tx_with_secp256k1_access_key(&wrong_recipient_tx, &low_key, shared_multisig)?;
+    let wrong_recipient_sig = sign_aa_tx_with_multisig_access_key(
+        &wrong_recipient_tx,
+        shared_multisig,
+        &low_key_config,
+        &low_signers,
+    )?;
     assert_rejected(
         &mut env,
         wrong_recipient_tx,
@@ -128,12 +144,35 @@ async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Res
     )
     .await?;
 
+    let under_threshold_tx = transfer_tx(
+        &env.provider,
+        env.chain_id,
+        shared_multisig,
+        allowed_recipient,
+        U256::from(ONE_TOKEN),
+    )
+    .await?;
+    let under_threshold_sig = sign_aa_tx_with_multisig_access_key(
+        &under_threshold_tx,
+        shared_multisig,
+        &low_key_config,
+        &low_signers[..1],
+    )?;
+    assert_rejected(
+        &mut env,
+        under_threshold_tx,
+        under_threshold_sig,
+        "below low-tier key threshold",
+    )
+    .await?;
+
     let high_amount = U256::from(LOW_LIMIT + 500 * ONE_TOKEN);
     let high_balance_before = token_balance(&env.provider, allowed_recipient).await?;
     submit_access_key_transfer(
         &mut env,
         shared_multisig,
-        &high_key,
+        &high_key_config,
+        &high_signers,
         allowed_recipient,
         high_amount,
     )
@@ -147,11 +186,11 @@ async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Res
     Ok(())
 }
 
-fn multisig_owner_signers() -> [PrivateKeySigner; 3] {
+fn multisig_owner_signers(base: u8) -> [PrivateKeySigner; 3] {
     [
-        PrivateKeySigner::from_bytes(&B256::repeat_byte(0x11)).unwrap(),
-        PrivateKeySigner::from_bytes(&B256::repeat_byte(0x22)).unwrap(),
-        PrivateKeySigner::from_bytes(&B256::repeat_byte(0x33)).unwrap(),
+        PrivateKeySigner::from_bytes(&B256::repeat_byte(base + 1)).unwrap(),
+        PrivateKeySigner::from_bytes(&B256::repeat_byte(base + 2)).unwrap(),
+        PrivateKeySigner::from_bytes(&B256::repeat_byte(base + 3)).unwrap(),
     ]
 }
 
@@ -189,6 +228,20 @@ async fn bootstrap_multisig(
     Ok(())
 }
 
+async fn fund_multisig_account(env: &mut Localnet, account: Address) -> eyre::Result<()> {
+    fund_address_with(
+        &mut env.setup,
+        &env.provider,
+        &env.funder_signer,
+        env.funder_addr,
+        account,
+        U256::from(ACCESS_KEY_MULTISIG_FUNDING),
+        TOKEN,
+        env.chain_id,
+    )
+    .await
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn authorize_tiered_access_keys(
     env: &mut Localnet,
@@ -203,12 +256,12 @@ async fn authorize_tiered_access_keys(
     let calls = vec![
         authorize_key(
             low_key,
-            SignatureType::Secp256k1,
+            SignatureType::Multisig,
             tip20_transfer_policy(TOKEN, U256::from(LOW_LIMIT), vec![allowed_recipient]),
         ),
         authorize_key(
             high_key,
-            SignatureType::Secp256k1,
+            SignatureType::Multisig,
             tip20_transfer_policy(TOKEN, U256::from(HIGH_LIMIT), vec![allowed_recipient]),
         ),
     ];
@@ -225,7 +278,23 @@ fn sign_multisig_tx(
     include_init: bool,
 ) -> eyre::Result<TempoSignature> {
     let account = multisig_account(config)?;
-    let digest = multisig_digest(tx.signature_hash(), account);
+    Ok(TempoSignature::Multisig(sign_multisig_digest(
+        tx.signature_hash(),
+        account,
+        config,
+        owner_signers,
+        include_init,
+    )?))
+}
+
+fn sign_multisig_digest(
+    signature_hash: B256,
+    account: Address,
+    config: &InitMultisig,
+    owner_signers: &[PrivateKeySigner],
+    include_init: bool,
+) -> eyre::Result<MultisigSignature> {
+    let digest = multisig_digest(signature_hash, account);
     let mut approvals = owner_signers
         .iter()
         .map(|signer| {
@@ -244,11 +313,11 @@ fn sign_multisig_tx(
         .map(|(_, signature)| Bytes::from(signature))
         .collect();
 
-    Ok(TempoSignature::Multisig(MultisigSignature::new(
+    Ok(MultisigSignature::new(
         account,
         signatures,
         include_init.then(|| config.clone()),
-    )))
+    ))
 }
 
 fn multisig_account(config: &InitMultisig) -> eyre::Result<Address> {
@@ -260,7 +329,8 @@ fn multisig_account(config: &InitMultisig) -> eyre::Result<Address> {
 async fn submit_access_key_transfer(
     env: &mut Localnet,
     shared_multisig: Address,
-    access_key: &PrivateKeySigner,
+    access_key_config: &InitMultisig,
+    access_key_signers: &[PrivateKeySigner],
     recipient: Address,
     amount: U256,
 ) -> eyre::Result<()> {
@@ -272,9 +342,35 @@ async fn submit_access_key_transfer(
         amount,
     )
     .await?;
-    let signature = sign_aa_tx_with_secp256k1_access_key(&tx, access_key, shared_multisig)?;
+    let signature = sign_aa_tx_with_multisig_access_key(
+        &tx,
+        shared_multisig,
+        access_key_config,
+        access_key_signers,
+    )?;
     submit_and_mine_success(env, tx, signature, "access key transfer").await?;
     Ok(())
+}
+
+fn sign_aa_tx_with_multisig_access_key(
+    tx: &TempoTransaction,
+    shared_multisig: Address,
+    access_key_config: &InitMultisig,
+    access_key_signers: &[PrivateKeySigner],
+) -> eyre::Result<TempoSignature> {
+    let access_key_account = multisig_account(access_key_config)?;
+    let signing_hash = KeychainSignature::signing_hash(tx.signature_hash(), shared_multisig);
+    let inner = sign_multisig_digest(
+        signing_hash,
+        access_key_account,
+        access_key_config,
+        access_key_signers,
+        false,
+    )?;
+    Ok(TempoSignature::Keychain(KeychainSignature::new(
+        shared_multisig,
+        inner,
+    )))
 }
 
 async fn transfer_tx(

--- a/crates/node/tests/it/tempo_transaction/multisig_access_keys.rs
+++ b/crates/node/tests/it/tempo_transaction/multisig_access_keys.rs
@@ -37,6 +37,7 @@ async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Res
     let shared_signers = multisig_owner_signers(0x10);
     let low_signers = multisig_owner_signers(0x20);
     let high_signers = multisig_owner_signers(0x30);
+    let low_owner_access_keys = multisig_owner_signers(0x40);
     let shared_config = multisig_config(B256::repeat_byte(0x51), 2, &shared_signers);
     let low_key_config = multisig_config(B256::repeat_byte(0x52), 2, &low_signers);
     let high_key_config = multisig_config(B256::repeat_byte(0x53), 3, &high_signers);
@@ -59,6 +60,7 @@ async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Res
     .await?;
     fund_multisig_account(&mut env, low_key).await?;
     fund_multisig_account(&mut env, high_key).await?;
+    authorize_owner_access_keys(&mut env, &low_signers, &low_owner_access_keys).await?;
 
     bootstrap_multisig(&mut env, &shared_config, &shared_signers).await?;
     bootstrap_multisig(&mut env, &low_key_config, &low_signers).await?;
@@ -84,6 +86,7 @@ async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Res
         shared_multisig,
         &low_key_config,
         &low_signers,
+        Some(&low_owner_access_keys),
         allowed_recipient,
         low_amount,
     )
@@ -113,6 +116,7 @@ async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Res
         shared_multisig,
         &low_key_config,
         &low_signers,
+        Some(&low_owner_access_keys),
     )?;
     assert_rejected(
         &mut env,
@@ -135,6 +139,7 @@ async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Res
         shared_multisig,
         &low_key_config,
         &low_signers,
+        Some(&low_owner_access_keys),
     )?;
     assert_rejected(
         &mut env,
@@ -157,6 +162,7 @@ async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Res
         shared_multisig,
         &low_key_config,
         &low_signers[..1],
+        Some(&low_owner_access_keys[..1]),
     )?;
     assert_rejected(
         &mut env,
@@ -173,6 +179,7 @@ async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Res
         shared_multisig,
         &high_key_config,
         &high_signers,
+        None,
         allowed_recipient,
         high_amount,
     )
@@ -240,6 +247,39 @@ async fn fund_multisig_account(env: &mut Localnet, account: Address) -> eyre::Re
         env.chain_id,
     )
     .await
+}
+
+async fn authorize_owner_access_keys(
+    env: &mut Localnet,
+    owner_signers: &[PrivateKeySigner],
+    access_key_signers: &[PrivateKeySigner],
+) -> eyre::Result<()> {
+    for (owner, access_key) in owner_signers.iter().zip(access_key_signers) {
+        fund_address_with(
+            &mut env.setup,
+            &env.provider,
+            &env.funder_signer,
+            env.funder_addr,
+            owner.address(),
+            U256::from(ACCESS_KEY_MULTISIG_FUNDING),
+            TOKEN,
+            env.chain_id,
+        )
+        .await?;
+
+        authorize_access_key(
+            &mut env.setup,
+            owner,
+            owner.address(),
+            access_key.address(),
+            create_mock_secp256k1_sig(),
+            env.chain_id,
+            env.provider.get_transaction_count(owner.address()).await?,
+        )
+        .await?;
+    }
+
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -331,6 +371,7 @@ async fn submit_access_key_transfer(
     shared_multisig: Address,
     access_key_config: &InitMultisig,
     access_key_signers: &[PrivateKeySigner],
+    owner_access_key_signers: Option<&[PrivateKeySigner]>,
     recipient: Address,
     amount: U256,
 ) -> eyre::Result<()> {
@@ -347,6 +388,7 @@ async fn submit_access_key_transfer(
         shared_multisig,
         access_key_config,
         access_key_signers,
+        owner_access_key_signers,
     )?;
     submit_and_mine_success(env, tx, signature, "access key transfer").await?;
     Ok(())
@@ -357,20 +399,63 @@ fn sign_aa_tx_with_multisig_access_key(
     shared_multisig: Address,
     access_key_config: &InitMultisig,
     access_key_signers: &[PrivateKeySigner],
+    owner_access_key_signers: Option<&[PrivateKeySigner]>,
 ) -> eyre::Result<TempoSignature> {
     let access_key_account = multisig_account(access_key_config)?;
     let signing_hash = KeychainSignature::signing_hash(tx.signature_hash(), shared_multisig);
-    let inner = sign_multisig_digest(
-        signing_hash,
-        access_key_account,
-        access_key_config,
-        access_key_signers,
-        false,
-    )?;
+    let inner = if let Some(owner_access_key_signers) = owner_access_key_signers {
+        sign_multisig_digest_with_keychain_owners(
+            signing_hash,
+            access_key_account,
+            access_key_config,
+            access_key_signers,
+            owner_access_key_signers,
+        )?
+    } else {
+        sign_multisig_digest(
+            signing_hash,
+            access_key_account,
+            access_key_config,
+            access_key_signers,
+            false,
+        )?
+    };
     Ok(TempoSignature::Keychain(KeychainSignature::new(
         shared_multisig,
         inner,
     )))
+}
+
+fn sign_multisig_digest_with_keychain_owners(
+    signature_hash: B256,
+    account: Address,
+    config: &InitMultisig,
+    owner_signers: &[PrivateKeySigner],
+    owner_access_key_signers: &[PrivateKeySigner],
+) -> eyre::Result<MultisigSignature> {
+    let digest = multisig_digest(signature_hash, account);
+    let mut approvals = owner_signers
+        .iter()
+        .zip(owner_access_key_signers)
+        .map(|(owner, access_key)| {
+            let keychain_hash = KeychainSignature::signing_hash(digest, owner.address());
+            let signature = access_key.sign_hash_sync(&keychain_hash)?;
+            let inner = PrimitiveSignature::Secp256k1(signature);
+            Ok((
+                owner.address(),
+                TempoSignature::Keychain(KeychainSignature::new(owner.address(), inner)).to_bytes(),
+            ))
+        })
+        .collect::<eyre::Result<Vec<_>>>()?;
+    approvals.sort_by_key(|(owner, _)| *owner);
+
+    let signatures = approvals
+        .into_iter()
+        .take(config.threshold as usize)
+        .map(|(_, signature)| signature)
+        .collect();
+
+    Ok(MultisigSignature::new(account, signatures, None))
 }
 
 async fn transfer_tx(

--- a/crates/node/tests/it/tempo_transaction/multisig_access_keys.rs
+++ b/crates/node/tests/it/tempo_transaction/multisig_access_keys.rs
@@ -1,50 +1,372 @@
-//! Acceptance tests for shared multisig accounts spending through multisig access keys.
-//!
-//! These are intentionally ignored until native multisig signatures can be used inside
-//! Keychain signatures and AccountKeychain can authorize a multisig key type. Today the
-//! transaction/keychain primitives only support primitive access-key signatures.
+//! E2E coverage for native multisig accounts spending through scoped AccountKeychain access keys.
+
+use alloy::{
+    primitives::{Address, B256, Bytes, U256},
+    providers::Provider,
+    signers::{SignerSync, local::PrivateKeySigner},
+};
+use alloy_eips::Encodable2718;
+use reth_primitives_traits::transaction::TxHashRef;
+use tempo_alloy::provider::keychain::{authorize_key, tip20_transfer_policy};
+use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
+use tempo_contracts::precompiles::{
+    DEFAULT_FEE_TOKEN, account_keychain::IAccountKeychain::IAccountKeychainInstance,
+};
+use tempo_precompiles::{ACCOUNT_KEYCHAIN_ADDRESS, tip20::ITIP20::ITIP20Instance};
+use tempo_primitives::{
+    SignatureType, TempoTransaction, TempoTxEnvelope,
+    transaction::{
+        InitMultisig, MultisigOwner, MultisigSignature, PrimitiveSignature, TempoSignature,
+        multisig_digest,
+    },
+};
+
+use super::{helpers::*, local::Localnet};
+
+const TOKEN: Address = DEFAULT_FEE_TOKEN;
+const ONE_TOKEN: u64 = 1_000_000;
+const LOW_LIMIT: u64 = 1_000 * ONE_TOKEN;
+const HIGH_LIMIT: u64 = 10_000 * ONE_TOKEN;
+const SHARED_MULTISIG_FUNDING: u64 = 100_000 * ONE_TOKEN;
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "pending native multisig access-key support in KeyAuthorization and KeychainSignature"]
-async fn shared_multisig_can_spend_through_tiered_multisig_access_keys() -> eyre::Result<()> {
-    // Desired flow:
-    //
-    // 1. Create and fund a shared native multisig account, e.g. 7 owners with threshold 5.
-    // 2. Derive a 2-of-7 native multisig account to use as the low-value access key.
-    // 3. Derive a 5-of-7 native multisig account to use as the high-value access key.
-    // 4. From the shared multisig, authorize both derived multisig accounts as access keys:
-    //    - low-value key: PATH USD limit = 1_000, TIP-20 transfer scope only
-    //    - high-value key: PATH USD limit = 10_000, TIP-20 transfer scope only
-    // 5. Send a PATH USD transfer from the shared multisig using KeychainSignature {
-    //    user_address: shared_multisig,
-    //    signature: MultisigSignature(low_value_multisig, 2 owner approvals),
-    //    version: V2,
-    // }.
-    // 6. Assert the transfer succeeds, debits the shared multisig balance, credits the recipient,
-    //    and reduces only the low-value key's remaining spending limit.
-    //
-    // This cannot be expressed with the current types because KeychainSignature::signature is a
-    // PrimitiveSignature and KeyAuthorization::key_type has no Multisig variant.
-    eyre::bail!("native multisig access-key support is not implemented yet")
+async fn shared_multisig_spends_through_tiered_scoped_access_keys() -> eyre::Result<()> {
+    let mut env = Localnet::new().await?;
+
+    let owner_signers = multisig_owner_signers();
+    let shared_config = multisig_config(B256::repeat_byte(0x51), 2, &owner_signers);
+    let shared_multisig = multisig_account(&shared_config)?;
+    let low_key = PrivateKeySigner::random();
+    let high_key = PrivateKeySigner::random();
+    let allowed_recipient = Address::random();
+    let blocked_recipient = Address::random();
+
+    fund_address_with(
+        &mut env.setup,
+        &env.provider,
+        &env.funder_signer,
+        env.funder_addr,
+        shared_multisig,
+        U256::from(SHARED_MULTISIG_FUNDING),
+        TOKEN,
+        env.chain_id,
+    )
+    .await?;
+
+    bootstrap_multisig(&mut env, &shared_config, &owner_signers).await?;
+    authorize_tiered_access_keys(
+        &mut env,
+        shared_multisig,
+        &shared_config,
+        &owner_signers,
+        low_key.address(),
+        high_key.address(),
+        allowed_recipient,
+    )
+    .await?;
+
+    let low_remaining_before =
+        remaining_limit(&env.provider, shared_multisig, low_key.address()).await?;
+    assert_eq!(low_remaining_before, U256::from(LOW_LIMIT));
+
+    let low_amount = U256::from(LOW_LIMIT / 4);
+    let allowed_balance_before = token_balance(&env.provider, allowed_recipient).await?;
+    submit_access_key_transfer(
+        &mut env,
+        shared_multisig,
+        &low_key,
+        allowed_recipient,
+        low_amount,
+    )
+    .await?;
+    assert_eq!(
+        token_balance(&env.provider, allowed_recipient).await?,
+        allowed_balance_before + low_amount,
+        "low-tier access key should spend from the shared multisig within its policy"
+    );
+
+    let low_remaining_after =
+        remaining_limit(&env.provider, shared_multisig, low_key.address()).await?;
+    assert!(
+        low_remaining_after < low_remaining_before,
+        "successful spend should consume the low-tier key's limit"
+    );
+
+    let over_limit_tx = transfer_tx(
+        &env.provider,
+        env.chain_id,
+        shared_multisig,
+        allowed_recipient,
+        U256::from(LOW_LIMIT + ONE_TOKEN),
+    )
+    .await?;
+    let over_limit_sig =
+        sign_aa_tx_with_secp256k1_access_key(&over_limit_tx, &low_key, shared_multisig)?;
+    assert_rejected(
+        &mut env,
+        over_limit_tx,
+        over_limit_sig,
+        "over low-tier limit",
+    )
+    .await?;
+
+    let wrong_recipient_tx = transfer_tx(
+        &env.provider,
+        env.chain_id,
+        shared_multisig,
+        blocked_recipient,
+        U256::from(ONE_TOKEN),
+    )
+    .await?;
+    let wrong_recipient_sig =
+        sign_aa_tx_with_secp256k1_access_key(&wrong_recipient_tx, &low_key, shared_multisig)?;
+    assert_rejected(
+        &mut env,
+        wrong_recipient_tx,
+        wrong_recipient_sig,
+        "outside allowed recipient scope",
+    )
+    .await?;
+
+    let high_amount = U256::from(LOW_LIMIT + 500 * ONE_TOKEN);
+    let high_balance_before = token_balance(&env.provider, allowed_recipient).await?;
+    submit_access_key_transfer(
+        &mut env,
+        shared_multisig,
+        &high_key,
+        allowed_recipient,
+        high_amount,
+    )
+    .await?;
+    assert_eq!(
+        token_balance(&env.provider, allowed_recipient).await?,
+        high_balance_before + high_amount,
+        "higher-tier access key should spend above the low-tier limit"
+    );
+
+    Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
-#[ignore = "pending native multisig access-key support in KeyAuthorization and KeychainSignature"]
-async fn shared_multisig_enforces_multisig_access_key_quorum_and_policy() -> eyre::Result<()> {
-    // Desired enforcement cases for the same setup as
-    // `shared_multisig_can_spend_through_tiered_multisig_access_keys`:
-    //
-    // 1. A low-value access-key spend with only 1 owner approval fails because the 2-of-7 key's
-    //    multisig threshold is not met.
-    // 2. A low-value access-key spend above 1_000 PATH USD fails with SpendingLimitExceeded.
-    // 3. A low-value access-key call outside its allowed TIP-20 transfer scope fails with the
-    //    call-scope rejection path.
-    // 4. A high-value access-key spend with only 2 owner approvals fails because the 5-of-7 key's
-    //    multisig threshold is not met.
-    // 5. A high-value access-key spend below 10_000 PATH USD with 5 owner approvals succeeds and
-    //    spends from the shared multisig account, not from the derived access-key multisig.
-    //
-    // This cannot be expressed with the current types because KeychainSignature::signature is a
-    // PrimitiveSignature and AccountKeychain rejects non-primitive signature types.
-    eyre::bail!("native multisig access-key policy enforcement is not implemented yet")
+fn multisig_owner_signers() -> [PrivateKeySigner; 3] {
+    [
+        PrivateKeySigner::from_bytes(&B256::repeat_byte(0x11)).unwrap(),
+        PrivateKeySigner::from_bytes(&B256::repeat_byte(0x22)).unwrap(),
+        PrivateKeySigner::from_bytes(&B256::repeat_byte(0x33)).unwrap(),
+    ]
+}
+
+fn multisig_config(salt: B256, threshold: u8, signers: &[PrivateKeySigner]) -> InitMultisig {
+    let mut owners = signers
+        .iter()
+        .map(|signer| MultisigOwner {
+            owner: signer.address(),
+            weight: 1,
+        })
+        .collect::<Vec<_>>();
+    owners.sort_by_key(|owner| owner.owner);
+
+    InitMultisig {
+        salt,
+        threshold,
+        owners,
+    }
+}
+
+async fn bootstrap_multisig(
+    env: &mut Localnet,
+    config: &InitMultisig,
+    owner_signers: &[PrivateKeySigner],
+) -> eyre::Result<()> {
+    let account = multisig_account(config)?;
+    let tx = create_basic_aa_tx(
+        env.chain_id,
+        0,
+        vec![create_balance_of_call(account)],
+        3_000_000,
+    );
+    let signature = sign_multisig_tx(&tx, config, owner_signers, true)?;
+    submit_and_mine_success(env, tx, signature, "bootstrap shared multisig").await?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn authorize_tiered_access_keys(
+    env: &mut Localnet,
+    shared_multisig: Address,
+    config: &InitMultisig,
+    owner_signers: &[PrivateKeySigner],
+    low_key: Address,
+    high_key: Address,
+    allowed_recipient: Address,
+) -> eyre::Result<()> {
+    let nonce = env.provider.get_transaction_count(shared_multisig).await?;
+    let calls = vec![
+        authorize_key(
+            low_key,
+            SignatureType::Secp256k1,
+            tip20_transfer_policy(TOKEN, U256::from(LOW_LIMIT), vec![allowed_recipient]),
+        ),
+        authorize_key(
+            high_key,
+            SignatureType::Secp256k1,
+            tip20_transfer_policy(TOKEN, U256::from(HIGH_LIMIT), vec![allowed_recipient]),
+        ),
+    ];
+    let tx = create_basic_aa_tx(env.chain_id, nonce, calls, 20_000_000);
+    let signature = sign_multisig_tx(&tx, config, owner_signers, false)?;
+    submit_and_mine_success(env, tx, signature, "authorize tiered access keys").await?;
+    Ok(())
+}
+
+fn sign_multisig_tx(
+    tx: &TempoTransaction,
+    config: &InitMultisig,
+    owner_signers: &[PrivateKeySigner],
+    include_init: bool,
+) -> eyre::Result<TempoSignature> {
+    let account = multisig_account(config)?;
+    let digest = multisig_digest(tx.signature_hash(), account);
+    let mut approvals = owner_signers
+        .iter()
+        .map(|signer| {
+            let signature = signer.sign_hash_sync(&digest)?;
+            Ok((
+                signer.address(),
+                PrimitiveSignature::Secp256k1(signature).to_bytes(),
+            ))
+        })
+        .collect::<eyre::Result<Vec<_>>>()?;
+    approvals.sort_by_key(|(owner, _)| *owner);
+
+    let signatures = approvals
+        .into_iter()
+        .take(config.threshold as usize)
+        .map(|(_, signature)| Bytes::from(signature))
+        .collect();
+
+    Ok(TempoSignature::Multisig(MultisigSignature::new(
+        account,
+        signatures,
+        include_init.then(|| config.clone()),
+    )))
+}
+
+fn multisig_account(config: &InitMultisig) -> eyre::Result<Address> {
+    config
+        .account()
+        .map_err(|err| eyre::eyre!("invalid multisig config: {err:?}"))
+}
+
+async fn submit_access_key_transfer(
+    env: &mut Localnet,
+    shared_multisig: Address,
+    access_key: &PrivateKeySigner,
+    recipient: Address,
+    amount: U256,
+) -> eyre::Result<()> {
+    let tx = transfer_tx(
+        &env.provider,
+        env.chain_id,
+        shared_multisig,
+        recipient,
+        amount,
+    )
+    .await?;
+    let signature = sign_aa_tx_with_secp256k1_access_key(&tx, access_key, shared_multisig)?;
+    submit_and_mine_success(env, tx, signature, "access key transfer").await?;
+    Ok(())
+}
+
+async fn transfer_tx(
+    provider: &impl Provider,
+    chain_id: u64,
+    from: Address,
+    to: Address,
+    amount: U256,
+) -> eyre::Result<TempoTransaction> {
+    let nonce = provider.get_transaction_count(from).await?;
+    let mut tx = create_basic_aa_tx(
+        chain_id,
+        nonce,
+        vec![create_transfer_call(TOKEN, to, amount)],
+        3_000_000,
+    );
+    tx.max_priority_fee_per_gas = TEMPO_T1_BASE_FEE as u128;
+    tx.max_fee_per_gas = TEMPO_T1_BASE_FEE as u128;
+    Ok(tx)
+}
+
+async fn assert_rejected(
+    env: &mut Localnet,
+    tx: TempoTransaction,
+    signature: TempoSignature,
+    label: &str,
+) -> eyre::Result<()> {
+    let envelope: TempoTxEnvelope = tx.into_signed(signature).into();
+    let tx_hash = *envelope.tx_hash();
+    let mut encoded = Vec::new();
+    envelope.encode_2718(&mut encoded);
+
+    let result = env.setup.node.rpc.inject_tx(encoded.into()).await;
+    if result.is_err() {
+        return Ok(());
+    }
+
+    env.setup.node.advance_block().await?;
+    let receipt: Option<serde_json::Value> = env
+        .provider
+        .raw_request("eth_getTransactionReceipt".into(), [tx_hash])
+        .await?;
+    let receipt = receipt.ok_or_else(|| eyre::eyre!("{label} receipt not found for {tx_hash}"))?;
+    let status = receipt["status"]
+        .as_str()
+        .ok_or_else(|| eyre::eyre!("{label} receipt missing status for {tx_hash}"))?;
+    assert_eq!(
+        status, "0x0",
+        "{label} transaction {tx_hash} should be rejected or revert"
+    );
+    Ok(())
+}
+
+async fn submit_and_mine_success(
+    env: &mut Localnet,
+    tx: TempoTransaction,
+    signature: TempoSignature,
+    label: &str,
+) -> eyre::Result<()> {
+    let hash = submit_and_mine_aa_tx(&mut env.setup, tx, signature).await?;
+    let receipt: Option<serde_json::Value> = env
+        .provider
+        .raw_request("eth_getTransactionReceipt".into(), [hash])
+        .await?;
+    let receipt = receipt.ok_or_else(|| eyre::eyre!("{label} receipt not found for {hash}"))?;
+    let status = receipt["status"]
+        .as_str()
+        .ok_or_else(|| eyre::eyre!("{label} receipt missing status for {hash}"))?;
+    eyre::ensure!(
+        status == "0x1",
+        "{label} reverted with status {status}: {receipt}"
+    );
+    Ok(())
+}
+
+async fn token_balance(provider: &impl Provider, account: Address) -> eyre::Result<U256> {
+    Ok(ITIP20Instance::new(TOKEN, provider)
+        .balanceOf(account)
+        .call()
+        .await?)
+}
+
+async fn remaining_limit(
+    provider: &impl Provider,
+    account: Address,
+    key: Address,
+) -> eyre::Result<U256> {
+    Ok(
+        IAccountKeychainInstance::new(ACCOUNT_KEYCHAIN_ADDRESS, provider)
+            .getRemainingLimitWithPeriod(account, key, TOKEN)
+            .call()
+            .await?
+            .remaining,
+    )
 }

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -80,6 +80,7 @@ pub enum StoredSignatureType {
     Secp256k1,
     P256,
     WebAuthn,
+    Multisig,
 }
 
 impl TryFrom<SignatureType> for StoredSignatureType {
@@ -90,6 +91,7 @@ impl TryFrom<SignatureType> for StoredSignatureType {
             SignatureType::Secp256k1 => Ok(Self::Secp256k1),
             SignatureType::P256 => Ok(Self::P256),
             SignatureType::WebAuthn => Ok(Self::WebAuthn),
+            SignatureType::Multisig => Ok(Self::Multisig),
             _ => Err(AccountKeychainError::invalid_signature_type().into()),
         }
     }
@@ -101,6 +103,7 @@ impl From<StoredSignatureType> for SignatureType {
             StoredSignatureType::Secp256k1 => Self::Secp256k1,
             StoredSignatureType::P256 => Self::P256,
             StoredSignatureType::WebAuthn => Self::WebAuthn,
+            StoredSignatureType::Multisig => Self::Multisig,
         }
     }
 }

--- a/crates/precompiles/src/native_multisig/auth.rs
+++ b/crates/precompiles/src/native_multisig/auth.rs
@@ -27,11 +27,11 @@ impl From<TempoPrecompileError> for NativeMultisigAuthError {
 }
 
 impl NativeMultisigAuthError {
-    fn invalid_transaction(reason: impl Into<String>) -> Self {
+    pub fn invalid_transaction(reason: impl Into<String>) -> Self {
         Self::InvalidTransaction(reason.into())
     }
 
-    fn validation_failed(reason: impl Into<String>) -> Self {
+    pub fn validation_failed(reason: impl Into<String>) -> Self {
         Self::ValidationFailed(reason.into())
     }
 
@@ -55,7 +55,33 @@ impl NativeMultisig {
         inner_digest: B256,
         signature: &MultisigSignature,
         config: &InitMultisig,
+        load_config: impl FnMut(Address) -> Result<InitMultisig, NativeMultisigAuthError>,
+    ) -> Result<(), NativeMultisigAuthError> {
+        self.verify_authorization_with_keychains(
+            inner_digest,
+            signature,
+            config,
+            load_config,
+            |_, _| {
+                Err(NativeMultisigAuthError::invalid_transaction(
+                    "keychain signatures cannot authorize native multisig owners",
+                ))
+            },
+        )
+    }
+
+    /// Verifies a native multisig transaction authorization against current stored configs,
+    /// optionally allowing owner approvals to be keychain signatures.
+    pub fn verify_authorization_with_keychains(
+        &self,
+        inner_digest: B256,
+        signature: &MultisigSignature,
+        config: &InitMultisig,
         mut load_config: impl FnMut(Address) -> Result<InitMultisig, NativeMultisigAuthError>,
+        mut validate_keychain: impl FnMut(
+            B256,
+            &tempo_primitives::transaction::KeychainSignature,
+        ) -> Result<Address, NativeMultisigAuthError>,
     ) -> Result<(), NativeMultisigAuthError> {
         let mut account_path = vec![signature.account()];
         self.verify_authorization_inner(
@@ -64,6 +90,7 @@ impl NativeMultisig {
             config,
             &mut account_path,
             &mut load_config,
+            &mut validate_keychain,
         )
         .map(|_| ())
     }
@@ -75,6 +102,10 @@ impl NativeMultisig {
         config: &InitMultisig,
         account_path: &mut Vec<Address>,
         load_config: &mut impl FnMut(Address) -> Result<InitMultisig, NativeMultisigAuthError>,
+        validate_keychain: &mut impl FnMut(
+            B256,
+            &tempo_primitives::transaction::KeychainSignature,
+        ) -> Result<Address, NativeMultisigAuthError>,
     ) -> Result<u8, NativeMultisigAuthError> {
         signature
             .validate_shape()
@@ -102,11 +133,7 @@ impl NativeMultisig {
                     })?;
                     (owner, None)
                 }
-                TempoSignature::Keychain(_) => {
-                    return Err(NativeMultisigAuthError::invalid_transaction(
-                        "keychain signatures cannot authorize native multisig owners",
-                    ));
-                }
+                TempoSignature::Keychain(keychain) => (validate_keychain(digest, &keychain)?, None),
                 TempoSignature::Multisig(nested_signature) => {
                     nested_signature
                         .validate_registered_shape()
@@ -143,6 +170,7 @@ impl NativeMultisig {
                     &nested_config,
                     account_path,
                     load_config,
+                    validate_keychain,
                 )?;
                 account_path.pop();
             }

--- a/crates/precompiles/src/signature_verifier/mod.rs
+++ b/crates/precompiles/src/signature_verifier/mod.rs
@@ -6,7 +6,7 @@ use tempo_contracts::precompiles::SignatureVerifierError;
 use tempo_precompiles_macros::contract;
 use tempo_primitives::transaction::{
     SignatureType,
-    tt_signature::{KeychainSignature, PrimitiveSignature, TempoSignature},
+    tt_signature::{PrimitiveSignature, TempoSignature},
 };
 
 /// Gas cost for secp256k1 signature verification.
@@ -36,6 +36,7 @@ impl SignatureVerifier {
             SignatureType::Secp256k1 => SECP256K1_VERIFY_GAS,
             SignatureType::P256 => P256_VERIFY_GAS,
             SignatureType::WebAuthn => WEBAUTHN_VERIFY_GAS,
+            SignatureType::Multisig => return Err(SignatureVerifierError::invalid_format().into()),
         };
         self.storage.deduct_gas(verify_gas)?;
 
@@ -83,8 +84,9 @@ impl SignatureVerifier {
             return Err(SignatureVerifierError::invalid_format().into());
         }
 
-        let signing_hash = KeychainSignature::signing_hash(hash, keychain_sig.user_address);
-        let key_id = self.recover(signing_hash, keychain_sig.signature.to_bytes())?;
+        let key_id = keychain_sig
+            .key_id(&hash)
+            .map_err(|_| SignatureVerifierError::invalid_signature())?;
         Ok((keychain_sig.user_address, key_id))
     }
 }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -9,8 +9,8 @@ pub mod tt_signed;
 pub use tt_authorization::{MAGIC, RecoveredTempoAuthorization, TempoSignedAuthorization};
 // Re-export Authorization from alloy for convenience
 pub use tt_signature::{
-    KeychainSignature, KeychainVersion, KeychainVersionError, PrimitiveSignature, TempoSignature,
-    derive_p256_address,
+    KeychainInnerSignature, KeychainSignature, KeychainVersion, KeychainVersionError,
+    PrimitiveSignature, TempoSignature, derive_p256_address,
 };
 
 pub use crate::address::TIP20_TOKEN_PREFIX as TIP20_PAYMENT_PREFIX;

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -45,6 +45,7 @@ pub enum SignatureType {
     Secp256k1 = 0,
     P256 = 1,
     WebAuthn = 2,
+    Multisig = 3,
 }
 
 impl From<SignatureType> for u8 {
@@ -53,6 +54,7 @@ impl From<SignatureType> for u8 {
             SignatureType::Secp256k1 => 0,
             SignatureType::P256 => 1,
             SignatureType::WebAuthn => 2,
+            SignatureType::Multisig => 3,
         }
     }
 }
@@ -65,6 +67,7 @@ impl From<SignatureType> for AbiSignatureType {
             SignatureType::Secp256k1 => Self::Secp256k1,
             SignatureType::P256 => Self::P256,
             SignatureType::WebAuthn => Self::WebAuthn,
+            SignatureType::Multisig => Self::Multisig,
         }
     }
 }
@@ -77,6 +80,7 @@ impl TryFrom<AbiSignatureType> for SignatureType {
             AbiSignatureType::Secp256k1 => Ok(Self::Secp256k1),
             AbiSignatureType::P256 => Ok(Self::P256),
             AbiSignatureType::WebAuthn => Ok(Self::WebAuthn),
+            AbiSignatureType::Multisig => Ok(Self::Multisig),
             _ => Err(sig_type as u8),
         }
     }
@@ -99,6 +103,7 @@ impl alloy_rlp::Decodable for SignatureType {
             0 => Ok(Self::Secp256k1),
             1 => Ok(Self::P256),
             2 => Ok(Self::WebAuthn),
+            3 => Ok(Self::Multisig),
             _ => Err(alloy_rlp::Error::Custom("Invalid signature type")),
         }
     }

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -410,6 +410,89 @@ pub enum KeychainVersionError {
     V2BeforeActivation,
 }
 
+/// Signature variants that can authenticate a keychain access key.
+///
+/// This intentionally excludes nested keychain signatures.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged, rename_all = "camelCase"))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+pub enum KeychainInnerSignature {
+    Primitive(PrimitiveSignature),
+    Multisig(MultisigSignature),
+}
+
+impl From<PrimitiveSignature> for KeychainInnerSignature {
+    fn from(signature: PrimitiveSignature) -> Self {
+        Self::Primitive(signature)
+    }
+}
+
+impl From<MultisigSignature> for KeychainInnerSignature {
+    fn from(signature: MultisigSignature) -> Self {
+        Self::Multisig(signature)
+    }
+}
+
+impl KeychainInnerSignature {
+    fn from_bytes(data: &[u8]) -> Result<Self, &'static str> {
+        if data.len() > 1 && data[0] == SIGNATURE_TYPE_MULTISIG {
+            let mut sig_data = &data[1..];
+            return match MultisigSignature::decode(&mut sig_data) {
+                Ok(signature) if sig_data.is_empty() => Ok(Self::Multisig(signature)),
+                _ => Err("Invalid Multisig signature RLP"),
+            };
+        }
+
+        PrimitiveSignature::from_bytes(data).map(Self::Primitive)
+    }
+
+    fn to_bytes(&self) -> Bytes {
+        match self {
+            Self::Primitive(signature) => signature.to_bytes(),
+            Self::Multisig(signature) => {
+                let mut bytes = Vec::with_capacity(1 + signature.length());
+                bytes.push(SIGNATURE_TYPE_MULTISIG);
+                signature.encode(&mut bytes);
+                Bytes::from(bytes)
+            }
+        }
+    }
+
+    fn encoded_length(&self) -> usize {
+        match self {
+            Self::Primitive(signature) => signature.encoded_length(),
+            Self::Multisig(signature) => 1 + signature.length(),
+        }
+    }
+
+    pub fn signature_type(&self) -> SignatureType {
+        match self {
+            Self::Primitive(signature) => signature.signature_type(),
+            Self::Multisig(_) => SignatureType::Multisig,
+        }
+    }
+
+    fn size(&self) -> usize {
+        match self {
+            Self::Primitive(signature) => signature.size(),
+            Self::Multisig(signature) => 1 + signature.size(),
+        }
+    }
+
+    fn recover_signer(
+        &self,
+        sig_hash: &B256,
+    ) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
+        match self {
+            Self::Primitive(signature) => signature.recover_signer(sig_hash),
+            Self::Multisig(signature) => signature
+                .recover_account()
+                .map_err(|_| alloy_consensus::crypto::RecoveryError::new()),
+        }
+    }
+}
+
 /// Keychain signature wrapping another signature with a user address.
 /// This allows an access key to sign on behalf of a root account.
 ///
@@ -429,8 +512,8 @@ pub enum KeychainVersionError {
 pub struct KeychainSignature {
     /// Root account address that this transaction is being executed for
     pub user_address: Address,
-    /// The actual signature from the access key (can be Secp256k1, P256, or WebAuthn, but NOT another Keychain)
-    pub signature: PrimitiveSignature,
+    /// The actual signature from the access key (primitive or native multisig, but NOT another Keychain).
+    pub signature: KeychainInnerSignature,
     /// Keychain signature version (V1 = legacy, V2 = includes user_address in sig hash)
     #[cfg_attr(feature = "serde", serde(default))]
     pub version: KeychainVersion,
@@ -453,10 +536,10 @@ impl KeychainSignature {
     /// Create a new V2 KeychainSignature (recommended).
     ///
     /// V2 signatures include the user_address in the signature hash.
-    pub fn new(user_address: Address, signature: PrimitiveSignature) -> Self {
+    pub fn new(user_address: Address, signature: impl Into<KeychainInnerSignature>) -> Self {
         Self {
             user_address,
-            signature,
+            signature: signature.into(),
             version: KeychainVersion::V2,
             cached_key_id: OnceLock::new(),
         }
@@ -466,10 +549,10 @@ impl KeychainSignature {
     ///
     /// V1 signatures do NOT include the user_address in the signature hash
     /// and are deprecated at the T1C hardfork.
-    pub fn new_v1(user_address: Address, signature: PrimitiveSignature) -> Self {
+    pub fn new_v1(user_address: Address, signature: impl Into<KeychainInnerSignature>) -> Self {
         Self {
             user_address,
-            signature,
+            signature: signature.into(),
             version: KeychainVersion::V1,
             cached_key_id: OnceLock::new(),
         }
@@ -630,9 +713,8 @@ impl TempoSignature {
             let user_address = Address::from_slice(&sig_data[0..20]);
             let inner_sig_bytes = &sig_data[20..];
 
-            // Parse inner signature using PrimitiveSignature (which doesn't support Keychain)
-            // This automatically prevents recursive keychain signatures at compile time
-            let inner_signature = PrimitiveSignature::from_bytes(inner_sig_bytes)?;
+            // Parse inner signature without allowing recursive keychain signatures.
+            let inner_signature = KeychainInnerSignature::from_bytes(inner_sig_bytes)?;
 
             return Ok(Self::Keychain(KeychainSignature {
                 user_address,

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -190,6 +190,19 @@ fn native_multisig_signature_verification_gas(
     }
 }
 
+fn keychain_inner_signature_verification_gas(
+    signature: &tempo_primitives::transaction::KeychainInnerSignature,
+) -> u64 {
+    match signature {
+        tempo_primitives::transaction::KeychainInnerSignature::Primitive(primitive) => {
+            primitive_signature_verification_gas(primitive)
+        }
+        tempo_primitives::transaction::KeychainInnerSignature::Multisig(multisig) => {
+            native_multisig_signature_verification_gas(multisig, true, 1)
+        }
+    }
+}
+
 /// Calculates the gas cost for verifying an AA signature.
 ///
 /// For Keychain signatures, adds key validation overhead to the inner signature cost
@@ -200,7 +213,8 @@ fn tempo_signature_verification_gas(signature: &TempoSignature) -> u64 {
         TempoSignature::Primitive(prim_sig) => primitive_signature_verification_gas(prim_sig),
         TempoSignature::Keychain(keychain_sig) => {
             // Keychain = inner signature + key validation overhead (SLOAD + processing)
-            primitive_signature_verification_gas(&keychain_sig.signature) + KEYCHAIN_VALIDATION_GAS
+            keychain_inner_signature_verification_gas(&keychain_sig.signature)
+                + KEYCHAIN_VALIDATION_GAS
         }
         TempoSignature::Multisig(multisig_sig) => {
             native_multisig_signature_verification_gas(multisig_sig, true, 1)
@@ -1658,6 +1672,29 @@ where
                                 reason: format!("{e:?}"),
                             })?;
 
+                        if let tempo_primitives::transaction::KeychainInnerSignature::Multisig(
+                            multisig_signature,
+                        ) = &keychain_sig.signature
+                        {
+                            let multisig = NativeMultisig::new();
+                            let config = multisig_cache
+                                .load_registered_config(&multisig, access_key_addr)
+                                .map_err(map_native_multisig_error::<DB>)?;
+                            let signing_hash =
+                                tempo_primitives::transaction::KeychainSignature::signing_hash(
+                                    tempo_tx_env.signature_hash,
+                                    *user_address,
+                                );
+                            multisig
+                                .verify_authorization(
+                                    signing_hash,
+                                    multisig_signature,
+                                    &config,
+                                    |acc| multisig_cache.load_registered_config(&multisig, acc),
+                                )
+                                .map_err(map_native_multisig_error::<DB>)?;
+                        }
+
                         // T6 adds admin delegation: a keychain signer may authorize a different
                         // child key only if the acting transaction key is itself an active admin key.
                         if key_auth.is_some() && !key.is_admin {
@@ -1888,6 +1925,7 @@ where
                     SignatureType::Secp256k1 => PrecompileSignatureType::Secp256k1,
                     SignatureType::P256 => PrecompileSignatureType::P256,
                     SignatureType::WebAuthn => PrecompileSignatureType::WebAuthn,
+                    SignatureType::Multisig => PrecompileSignatureType::Multisig,
                 };
 
                 // Handle expiry: None means never expires (store as u64::MAX)

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -166,7 +166,10 @@ fn native_multisig_owner_approval_verification_gas(signature: &[u8], depth: usiz
         Ok(TempoSignature::Multisig(multisig_signature)) if depth < MAX_MULTISIG_NESTING_DEPTH => {
             native_multisig_signature_verification_gas(&multisig_signature, false, depth + 1)
         }
-        Ok(TempoSignature::Keychain(_)) | Err(_) => ECRECOVER_GAS + P256_VERIFY_GAS,
+        Ok(TempoSignature::Keychain(keychain)) => {
+            keychain_inner_signature_verification_gas(&keychain.signature) + KEYCHAIN_VALIDATION_GAS
+        }
+        Err(_) => ECRECOVER_GAS + P256_VERIFY_GAS,
         Ok(TempoSignature::Multisig(_)) => ECRECOVER_GAS + P256_VERIFY_GAS,
     }
 }
@@ -201,6 +204,30 @@ fn keychain_inner_signature_verification_gas(
             native_multisig_signature_verification_gas(multisig, true, 1)
         }
     }
+}
+
+fn validate_native_multisig_keychain_owner(
+    digest: alloy_primitives::B256,
+    keychain_sig: &tempo_primitives::transaction::KeychainSignature,
+    timestamp: u64,
+) -> Result<Address, NativeMultisigAuthError> {
+    if keychain_sig.is_legacy() {
+        return Err(NativeMultisigAuthError::invalid_transaction(
+            "legacy keychain signatures cannot authorize native multisig owners",
+        ));
+    }
+
+    let owner = keychain_sig.user_address;
+    let key_id = keychain_sig.key_id(&digest).map_err(|_| {
+        NativeMultisigAuthError::invalid_transaction("invalid keychain multisig owner signature")
+    })?;
+    let signature_type = Some(u8::from(keychain_sig.signature.signature_type()));
+
+    AccountKeychain::new()
+        .validate_keychain_authorization(owner, key_id, timestamp, signature_type)
+        .map_err(|err| NativeMultisigAuthError::validation_failed(format!("{err:?}")))?;
+
+    Ok(owner)
 }
 
 /// Calculates the gas cost for verifying an AA signature.
@@ -1295,11 +1322,18 @@ where
                             })?;
                         } else {
                             multisig_precompile
-                                .verify_authorization(
+                                .verify_authorization_with_keychains(
                                     tempo_tx_env.signature_hash,
                                     multisig_signature,
                                     &config,
                                     |acc| { multisig_cache.load_registered_config(&multisig_precompile, acc) },
+                                    |digest, keychain_sig| {
+                                        validate_native_multisig_keychain_owner(
+                                            digest,
+                                            keychain_sig,
+                                            block.timestamp().to::<u64>(),
+                                        )
+                                    },
                                 )
                                 .map_err(map_native_multisig_error::<DB>)?;
                         }
@@ -1348,11 +1382,18 @@ where
                             })?;
                         } else {
                             multisig_precompile
-                                .verify_authorization(
+                                .verify_authorization_with_keychains(
                                     tempo_tx_env.signature_hash,
                                     multisig_signature,
                                     init_config,
                                     |acc| { multisig_cache.load_registered_config(&multisig_precompile, acc) },
+                                    |digest, keychain_sig| {
+                                        validate_native_multisig_keychain_owner(
+                                            digest,
+                                            keychain_sig,
+                                            block.timestamp().to::<u64>(),
+                                        )
+                                    },
                                 )
                                 .map_err(map_native_multisig_error::<DB>)?;
                         }
@@ -1686,11 +1727,18 @@ where
                                     *user_address,
                                 );
                             multisig
-                                .verify_authorization(
+                                .verify_authorization_with_keychains(
                                     signing_hash,
                                     multisig_signature,
                                     &config,
                                     |acc| multisig_cache.load_registered_config(&multisig, acc),
+                                    |digest, keychain_sig| {
+                                        validate_native_multisig_keychain_owner(
+                                            digest,
+                                            keychain_sig,
+                                            block.timestamp().to::<u64>(),
+                                        )
+                                    },
                                 )
                                 .map_err(map_native_multisig_error::<DB>)?;
                         }


### PR DESCRIPTION
## Summary
- add `AccessKeyPolicyBuilder` for composing access-key restrictions from spending limits and call scopes
- add TIP-20 transfer policy recipe helpers for one-time, periodic, and tiered spending caps
- add `SignatureType::Multisig` support for AccountKeychain access keys, allowing keychain transactions to be signed by native multisig access-key accounts
- allow native multisig owner approvals to be `KeychainSignature`s after validating the owner's AccountKeychain authorization
- enforce the access-key multisig's own registered threshold before setting `transaction_key`
- cover the shared-native-multisig flow end to end: the shared multisig authorizes low/high native multisig access keys; the low-tier 2-of-3 access-key multisig is signed by two keychain-authorized owner access keys; below-threshold, over-limit, and wrong-recipient attempts are enforced; and high-tier 3-of-3 can spend above the low-tier cap

Prompted by: @0xalpharush

## Test plan
- `cargo fmt --check`
- `cargo check -p tempo-node`
- `cargo test -p tempo-alloy keychain`
- `cargo test -p tempo-primitives keychain --lib`
- `cargo test -p tempo-precompiles native_multisig --lib`
- `cargo test -p tempo-precompiles account_keychain --lib`
- `cargo test -p tempo-node --test it shared_multisig_spends_through_tiered_scoped_access_keys -- --nocapture`
