### PR TITLE
fix(multisig): clear native multisig cache for RPC simulations

### DIFF
--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -386,21 +386,27 @@ fn populate_native_multisig_simulation_hints(
     request: &mut TempoTransactionRequest,
     db: &mut impl Database<Error: Into<EthApiError>>,
 ) -> Result<(), EthApiError> {
-    if request.multisig_init.is_some() || request.multisig_signature_count.is_some() {
-        return Ok(());
-    }
-
     let Some(from) = request.from else {
         return Ok(());
     };
 
-    let Some(signature_count) = load_native_multisig_simulation_hints(from, db)? else {
+    if request.multisig_init.is_none() && request.multisig_signature_count.is_none() {
+        if let Some(signature_count) = load_native_multisig_simulation_hints(from, db)? {
+            request.multisig_signature_count = Some(signature_count);
+        }
         return Ok(());
-    };
+    }
 
-    request
-        .multisig_signature_count
-        .get_or_insert(signature_count);
+    // `multisig_init` is advisory: a registered sender cannot re-init, so the
+    // stored config wins and the bootstrap hint is dropped.
+    if request.multisig_init.is_some()
+        && let Some(signature_count) = load_native_multisig_simulation_hints(from, db)?
+    {
+        request.multisig_init = None;
+        request
+            .multisig_signature_count
+            .get_or_insert(signature_count);
+    }
 
     Ok(())
 }
@@ -735,5 +741,98 @@ where
             .build();
 
         Ok(TempoEthApi::new(eth_api, self.validator_key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{Address, B256};
+    use reth_evm::revm::{bytecode::Bytecode, state::AccountInfo};
+    use std::collections::HashMap;
+    use tempo_primitives::transaction::{InitMultisig, MultisigOwner};
+
+    /// Storage-only test DB for `NATIVE_MULTISIG_ADDRESS` slots.
+    #[derive(Default)]
+    struct SlotDb(HashMap<U256, U256>);
+
+    impl SlotDb {
+        /// Packs `value` into `slot` at `offset`, mirroring `extract_from_word`.
+        fn insert_u8(&mut self, (slot, offset): (U256, Option<usize>), value: u8) {
+            *self.0.entry(slot).or_default() |=
+                U256::from(value) << (offset.unwrap_or_default() * 8);
+        }
+
+        fn registered_one_of_one(account: Address) -> Self {
+            let mut db = Self::default();
+            db.insert_u8(NativeMultisig::account_threshold_storage_slot(account), 1);
+            db.insert_u8(NativeMultisig::account_owners_len_storage_slot(account), 1);
+            db.insert_u8(
+                NativeMultisig::config_owner_weight_storage_slot(account, 0),
+                1,
+            );
+            db
+        }
+    }
+
+    impl Database for SlotDb {
+        type Error = ProviderError;
+
+        fn basic(&mut self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+            Ok(None)
+        }
+
+        fn code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
+        }
+
+        fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+            debug_assert_eq!(address, NATIVE_MULTISIG_ADDRESS);
+            Ok(self.0.get(&index).copied().unwrap_or_default())
+        }
+
+        fn block_hash(&mut self, _number: u64) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
+        }
+    }
+
+    fn init_request(from: Address) -> TempoTransactionRequest {
+        let mut request = TempoTransactionRequest::default();
+        request.from = Some(from);
+        request.multisig_init = Some(InitMultisig {
+            salt: B256::ZERO,
+            threshold: 1,
+            owners: vec![MultisigOwner {
+                owner: Address::from([0x11; 20]),
+                weight: 1,
+            }],
+        });
+        request
+    }
+
+    #[test]
+    fn populate_drops_multisig_init_for_registered_senders() {
+        let account = Address::from([0xaa; 20]);
+        let mut db = SlotDb::registered_one_of_one(account);
+        assert_eq!(
+            load_native_multisig_simulation_hints(account, &mut db).unwrap(),
+            Some(1),
+        );
+
+        let mut request = init_request(account);
+        populate_native_multisig_simulation_hints(&mut request, &mut db).unwrap();
+        assert!(request.multisig_init.is_none());
+        assert_eq!(request.multisig_signature_count, Some(1));
+    }
+
+    #[test]
+    fn populate_keeps_multisig_init_for_unregistered_senders() {
+        let account = Address::from([0xbb; 20]);
+        let mut db = SlotDb::default();
+
+        let mut request = init_request(account);
+        populate_native_multisig_simulation_hints(&mut request, &mut db).unwrap();
+        assert!(request.multisig_init.is_some());
+        assert_eq!(request.multisig_signature_count, None);
     }
 }

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -98,6 +98,7 @@ pub struct WebAuthnSignature {
     pub webauthn_data: Bytes,
 }
 
+#[expect(clippy::type_complexity)]
 fn split_p256_signature_fields(
     sig_data: &[u8; P256_SIGNATURE_LENGTH],
 ) -> Result<(&[u8; 32], &[u8; 32], &[u8; 32], &[u8; 32], bool), &'static str> {

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -1023,6 +1023,72 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_t8_rpc_simulation_bootstrap_transacts_repeatedly_on_one_evm() -> eyre::Result<()> {
+        let mut signers = [
+            PrivateKeySigner::from_bytes(&B256::from([0x11; 32]))?,
+            PrivateKeySigner::from_bytes(&B256::from([0x22; 32]))?,
+        ];
+        signers.sort_by_key(|signer| signer.address());
+
+        let config = InitMultisig {
+            salt: B256::repeat_byte(0x55),
+            threshold: 1,
+            owners: signers
+                .iter()
+                .map(|signer| MultisigOwner {
+                    owner: signer.address(),
+                    weight: 1,
+                })
+                .collect(),
+        };
+        let account = config.account().map_err(eyre::Report::msg)?;
+        let tx = TxBuilder::new()
+            .call_identity(&[])
+            .gas_limit(2_000_000)
+            .build();
+        let digest = multisig_digest(tx.signature_hash(), account);
+        let owner_signature =
+            PrimitiveSignature::Secp256k1(signers[0].sign_hash_sync(&digest)?).to_bytes();
+        let signed_tx = tx.into_signed(TempoSignature::Multisig(MultisigSignature::new(
+            account,
+            vec![owner_signature],
+            Some(config),
+        )));
+
+        let mut evm = create_funded_evm_t8(account);
+        StorageCtx::enter_ctx(&mut evm.ctx, StorageActions::disabled(), || {
+            NativeMultisig::new().initialize()
+        })?;
+
+        let mut tx_env = TempoTxEnv::from_recovered_tx(&signed_tx, account);
+        tx_env.unique_tx_identifier = Some(crate::RPC_SIMULATION_UNIQUE_TX_IDENTIFIER);
+
+        // Gas estimation transacts repeatedly on one EVM, discarding each
+        // result. The discarded bootstrap must not poison later iterations.
+        let first = evm.transact(tx_env.clone())?;
+        assert!(first.result.is_success(), "first simulation should succeed");
+
+        let second = evm.transact(tx_env)?;
+        assert!(
+            second.result.is_success(),
+            "repeat simulation should succeed: {:?}",
+            second.result
+        );
+
+        // Discarded simulations leave no registered account behind.
+        StorageCtx::enter_ctx(
+            &mut evm.ctx,
+            StorageActions::disabled(),
+            || -> eyre::Result<()> {
+                assert!(!NativeMultisig::new().is_multisig_account(account)?);
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+
     #[test_case::test_case(TempoHardfork::T1)]
     #[test_case::test_case(TempoHardfork::T1C)]
     fn test_access_millis_timestamp(spec: TempoHardfork) -> eyre::Result<()> {

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1120,6 +1120,12 @@ where
             let multisig_signature = tempo_tx_env.and_then(|aa| aa.signature.as_multisig());
             let is_rpc_simulation =
                 tx.unique_tx_identifier() == Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER);
+            // RPC simulations (e.g. `eth_estimateGas` retries) reuse one EVM and discard
+            // journal state between transacts, so markers/configs seeded by a discarded
+            // execution must not leak into this validation. Re-read from state instead.
+            if is_rpc_simulation {
+                multisig_cache.clear();
+            }
             let caller_account_info = if multisig_signature.is_some() {
                 // Native multisig validation needs code/delegation and nonce facts, but K1 and
                 // keychain transactions only need the account marker check below.
@@ -3457,6 +3463,78 @@ mod tests {
             test.evm.native_multisig_cache.get_config(&account),
             Some(&config),
             "registered multisig validation should cache the validated config"
+        );
+    }
+
+    #[test]
+    fn test_t8_rpc_simulation_bootstrap_ignores_stale_marker_cache() {
+        let config = native_multisig_config();
+        let account = config.account().unwrap();
+        let aa_env = TempoBatchCallEnv {
+            signature: TempoSignature::Multisig(MultisigSignature::new(
+                account,
+                vec![Bytes::from_static(&[0xaa; 65])],
+                Some(config.clone()),
+            )),
+            aa_calls: vec![Call {
+                to: TxKind::Call(Address::random()),
+                value: U256::ZERO,
+                input: Bytes::new(),
+            }],
+            ..Default::default()
+        };
+        let mut test = TestHandlerEvm::aa(TempoHardfork::T8, aa_env, |tx_env| {
+            tx_env.inner.caller = account;
+            tx_env.inner.kind = TxKind::Call(Address::random());
+            tx_env.unique_tx_identifier = Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER);
+        });
+        // A discarded estimate iteration executed this bootstrap and seeded the
+        // cache via `insert_config`; canonical state has no registered account.
+        test.evm
+            .native_multisig_cache
+            .insert_config(account, config.clone());
+
+        test.validate_against_state_and_deduct_caller()
+            .expect("bootstrap simulation must not trust markers from discarded executions");
+        // The stale entry is cleared on entry; this pass then re-seeds the
+        // transient bootstrapped-account guard for its own user calls.
+        assert_eq!(
+            test.evm.native_multisig_cache.get_config(&account),
+            Some(&config),
+            "bootstrap pre-execution should re-seed the guard"
+        );
+    }
+
+    #[test]
+    fn test_t8_registered_account_rejects_multisig_init_outside_simulation() {
+        let config = native_multisig_config();
+        let account = config.account().unwrap();
+        let aa_env = TempoBatchCallEnv {
+            signature: TempoSignature::Multisig(MultisigSignature::new(
+                account,
+                vec![Bytes::from_static(&[0xaa; 65])],
+                Some(config.clone()),
+            )),
+            aa_calls: vec![Call {
+                to: TxKind::Call(Address::random()),
+                value: U256::ZERO,
+                input: Bytes::new(),
+            }],
+            ..Default::default()
+        };
+        let mut test = TestHandlerEvm::aa(TempoHardfork::T8, aa_env, |tx_env| {
+            tx_env.inner.caller = account;
+            tx_env.inner.kind = TxKind::Call(Address::random());
+        });
+        store_native_multisig_account(&mut test, &config);
+
+        let err = test
+            .validate_against_state_and_deduct_caller()
+            .expect_err("registered accounts must reject multisig_init");
+        assert!(
+            err.to_string()
+                .contains("multisig_init is only allowed when bootstrapping an account"),
+            "unexpected error: {err}"
         );
     }
 


### PR DESCRIPTION
Clear the `NativeMultisigCache` per RPC-simulation transact (a discarded simulated bootstrap poisoned the marker for later estimate iterations) and drop the advisory `multisig_init` hint for registered senders, so consumers can attach it unconditionally (solves similar problem to https://github.com/tempoxyz/tempo/pull/4460).

Consumer context: https://github.com/wevm/viem/pull/4792

<details>
<summary>Repro 1: bootstrap estimation</summary>

```bash
PORT=9599
TX='{"from":"0xe27ec906a2e0727cf19530e36d906479b194429f","nonce":"0x0","type":"0x76","chainId":"0x539","calls":[{"to":"0x0000000000000000000000000000000000000001","value":"0x","data":"0x"}],"feeToken":"0x20c0000000000000000000000000000000000000","multisigInit":{"salt":"0x1111111111111111111111111111111111111111111111111111111111111111","threshold":1,"owners":[{"owner":"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266","weight":1}]}}'
rpc() { curl -s localhost:$PORT -H 'content-type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"'"$1"'","params":['"$TX"']}'; echo; }

docker run -d --rm --name tempo-repro -p $PORT:$PORT ghcr.io/tempoxyz/tempo:sha-1bb6055 \
  node --dev --http.addr 0.0.0.0 --http.port $PORT --http.api all
sleep 10

rpc eth_call         # passes: 0x
rpc eth_estimateGas  # identical request fails
docker rm -f tempo-repro
```

At `sha-1bb6055`: `eth_call` returns `0x`; `eth_estimateGas` returns `-32603 multisig_init is only allowed when bootstrapping an account`. Fixed: `0xbfa2b` (bootstrap-inclusive).

</details>

<details>
<summary>Repro 2: `multisig_init` on a registered sender</summary>

Pre-signed raws for the fresh dev chain: the dev account funds the 1-of-1 multisig, the multisig bootstraps, then the same estimate request from repro 1 (minus `nonce`) runs against the now-registered sender.

```bash
PORT=9599
FUND=0x76f8d1820539843b9aca008509502f9000830c3500f85ef85c9420c000000000000000000000000000000000000080b844a9059cbb000000000000000000000000e27ec906a2e0727cf19530e36d906479b194429f000000000000000000000000000000000000000000000000000000174876e800c0808080809420c000000000000000000000000000000000000080c0b84189ce270d6b87946d237f204e1cf06a0db85ec802689f2ad792d61bdceaf085f575121c8f802d724de5db7963a4c87e721b5fb6ee21a3d2e5b63246775a59d20b1b
BOOT=0x76f8e2820539843b9aca008509502f9000831e8480d8d79400000000000000000000000000000000000000018080c0808080809420c000000000000000000000000000000000000080c0b89905f89694e27ec906a2e0727cf19530e36d906479b194429ff843b8411af8137737bbb2852dd2ccaef9925177920a898f7e5663c5c5a80d18ce09cd086d5752b397f89b37fd4fff2cf6d67d0494b68f6a654966ec668f992b2cc3aace1cf83aa0111111111111111111111111111111111111111111111111111111111111111101d7d694f39fd6e51aad88f6f4ce6ab8827279cfffb9226601
TX='{"from":"0xe27ec906a2e0727cf19530e36d906479b194429f","type":"0x76","chainId":"0x539","calls":[{"to":"0x0000000000000000000000000000000000000001","value":"0x","data":"0x"}],"feeToken":"0x20c0000000000000000000000000000000000000","multisigInit":{"salt":"0x1111111111111111111111111111111111111111111111111111111111111111","threshold":1,"owners":[{"owner":"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266","weight":1}]}}'
rpc() { curl -s localhost:$PORT -H 'content-type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"'"$1"'","params":'"$2"'}'; echo; }

docker run -d --rm --name tempo-repro -p $PORT:$PORT ghcr.io/tempoxyz/tempo:sha-1bb6055 \
  node --dev --http.addr 0.0.0.0 --http.port $PORT --http.api all
sleep 10

rpc eth_sendRawTransactionSync '["'"$FUND"'"]'  # fund the multisig
rpc eth_sendRawTransactionSync '["'"$BOOT"'"]'  # register multisig
rpc eth_estimateGas '['"$TX"']'                 # registered multisig + multisig_init
docker rm -f tempo-repro
```

At `sha-1bb6055`: `-32603 multisig_init is only allowed when bootstrapping an account`, breaking clients that attach the hint unconditionally. Fixed: `0x674a` (hint ignored, stored config used).

</details>
