### PR TITLE
TIP-1062: move V1 order book key to last slot

### DIFF
--- a/tips/tip-1062.md
+++ b/tips/tip-1062.md
@@ -58,15 +58,15 @@ slot 0:
   offset 31  version    uint8     1 byte
 
 slot 1:
-  offset 0   bookKey    bytes32   32 bytes
-
-slot 2:
   offset 0   amount     uint128   16 bytes
   offset 16  remaining  uint128   16 bytes
 
-slot 3:
+slot 2:
   offset 0   prev       uint128   16 bytes
   offset 16  next       uint128   16 bytes
+
+slot 3:
+  offset 0   bookKey    bytes32   32 bytes
 ```
 
 ### Read behavior
@@ -99,9 +99,9 @@ Concretely:
 A version `1` flip rewrite MUST encode the post-flip order state as follows:
 
 - slot `0`: preserved `maker`, `metadata` encoding inverted `isBid` and `isFlip = true`, swapped `tick` / `flipTick`, zeroed unused bytes, and `version = 1`
-- slot `1`: preserved `bookKey`
-- slot `2`: preserved `amount` and `remaining = amount`
-- slot `3`: post-reinsertion `prev` / `next` pointers, after resetting them before insertion
+- slot `1`: preserved `amount` and `remaining = amount`
+- slot `2`: post-reinsertion `prev` / `next` pointers, after resetting them before insertion
+- slot `3`: preserved `bookKey`
 - legacy-only slots `4` and `5` MUST be cleared when upgrading from version `0`
 
 These version `1` rewrite rules replace the older TIP-1056 requirements to clear slot `0`, keep slot `0` zero, and leave slots `1` and `2` untouched. The storage-version upgrade preserves TIP-1056 order identity: the mapping key remains the canonical `orderId`, and the flipped order still receives fresh queue priority at its destination tick.


### PR DESCRIPTION
## Summary
- update the TIP-1062 V1 order storage layout so `bookKey` is slot 3
- shift `amount`/`remaining` to slot 1 and `prev`/`next` to slot 2
- align the flip rewrite slot rules with the new layout

## Testing
- Not run; documentation-only change.

Stacked on #4075.

Prompted by: @0xrusowsky