### PR TITLE
ci: trigger tip20 bench for reth updates

### DIFF
--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 env:
@@ -474,6 +475,23 @@ jobs:
               echo "::error::gh pr create failed with exit code $PR_EXIT"
               exit "$PR_EXIT"
             fi
+          fi
+
+          PR_NUMBER="${EXISTING_PR:-}"
+          if [ -z "$PR_NUMBER" ]; then
+            PR_NUMBER=$(gh pr view reth-auto-bump --json number --jq '.number')
+          fi
+
+          BENCH_COMMAND="derek bench preset=tip20"
+          EXISTING_BENCH_COMMENT=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            --jq ".[] | select(.body == \"${BENCH_COMMAND}\") | .id" \
+            | head -n1)
+          if [ -n "$EXISTING_BENCH_COMMENT" ]; then
+            echo "Benchmark command already posted on PR #${PR_NUMBER} as comment ${EXISTING_BENCH_COMMENT}"
+          else
+            echo "Posting benchmark command on PR #${PR_NUMBER}"
+            gh pr comment "$PR_NUMBER" --body "$BENCH_COMMAND"
           fi
 
       # ── wait for CI and fix failures ─────────────────────────


### PR DESCRIPTION
## Summary
- Posts `derek bench preset=tip20` on the reth auto-bump PR after the workflow creates or updates it.
- Skips posting when the exact Derek command already exists on the PR.
- Grants `issues: write` so the workflow can create PR comments.

## Testing
- `uv run python` YAML parse for `.github/workflows/update-reth.yml`
- `git diff --check`

Prompted by: @pepyakin
