### PR TITLE
test(e2e): stabilize snapshot restart epoch check

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -33,14 +33,18 @@ failure-output = "never"
 threads-required = 8
 slow-timeout = { period = "3m", terminate-after = 1 }
 
-# Separate profile for flaky snapshot-restart tests so they fail-fast independently.
+# Separate profile for the flaky sync snapshot-restart test so it fails fast independently.
 [profile.ci-flaky]
 inherits = "ci"
 fail-fast = true
 retries = 0
 failure-output = "final"
-slow-timeout = { period = "3m", terminate-after = 1 }
-default-filter = "package(tempo-e2e) & test(can_restart_after_joining_from_snapshot)"
+slow-timeout = { period = "5m", terminate-after = 1 }
+default-filter = "package(tempo-e2e) & test(tests::sync::can_restart_after_joining_from_snapshot)"
+
+[[profile.ci-flaky.overrides]]
+filter = "package(tempo-e2e) & test(tests::sync::can_restart_after_joining_from_snapshot)"
+slow-timeout = { period = "5m", terminate-after = 3 }
 
 # Dedicated profile for live RPC matrix tests (testnet/devnet).
 # These hit rate-limited external endpoints, so we serialize them and allow

--- a/crates/consensus/src/epoch/manager/actor.rs
+++ b/crates/consensus/src/epoch/manager/actor.rs
@@ -387,8 +387,8 @@ where
         info!("started consensus engine backing the epoch");
 
         self.metrics.latest_participants.set(n_participants as i64);
-        self.metrics.active_epochs.inc();
         let _ = self.metrics.latest_epoch.try_set(epoch.get());
+        self.metrics.active_epochs.inc();
         self.metrics.how_often_signer.inc_by(u64::from(is_signer));
         self.metrics
             .how_often_verifier
@@ -402,6 +402,7 @@ where
         if let Some((engine, engine_ctx)) = self.active_epochs.remove(&epoch) {
             drop(engine_ctx);
             engine.abort();
+            self.metrics.active_epochs.dec();
             info!("stopped engine backing epoch");
         } else {
             warn!(

--- a/crates/e2e/src/metrics.rs
+++ b/crates/e2e/src/metrics.rs
@@ -7,6 +7,7 @@ use commonware_runtime::{Clock as _, deterministic::Context};
 use crate::TestingNode;
 
 const PEERS_BLOCKED: &str = "peers_blocked";
+const ACTIVE_EPOCHS: &str = "epoch_manager_active_epochs";
 const LATEST_EPOCH: &str = "epoch_manager_latest_epoch";
 const LATEST_PARTICIPANTS: &str = "epoch_manager_latest_participants";
 const PROCESSED_HEIGHT: &str = "marshal_processed_height";
@@ -140,6 +141,18 @@ impl Metrics {
 
     pub fn latest_consensus_epoch(&self) -> Option<u64> {
         self.value::<u64>(LATEST_EPOCH)
+    }
+
+    pub fn active_consensus_epochs(&self) -> Option<u64> {
+        self.value::<u64>(ACTIVE_EPOCHS)
+    }
+
+    pub fn latest_active_consensus_epoch(&self) -> Option<u64> {
+        if self.active_consensus_epochs()? == 0 {
+            return None;
+        }
+
+        self.latest_consensus_epoch()
     }
 
     pub fn latest_consensus_height(&self) -> Option<u64> {

--- a/crates/e2e/src/tests/snapshot.rs
+++ b/crates/e2e/src/tests/snapshot.rs
@@ -209,7 +209,10 @@ fn joins_from_snapshot() {
                 validator catching up; there is likely a bug",
             );
 
-            if let Some(epoch) = metrics.for_scope(&replacement).latest_consensus_epoch() {
+            if let Some(epoch) = metrics
+                .for_scope(&replacement)
+                .latest_active_consensus_epoch()
+            {
                 assert!(
                     epoch > 0,
                     "when starting from snapshot a sufficiently advanced \
@@ -399,7 +402,10 @@ fn can_restart_after_joining_from_snapshot() {
                 validator catching up; there is likely a bug",
             );
 
-            if let Some(epoch) = metrics.for_scope(&replacement).latest_consensus_epoch() {
+            if let Some(epoch) = metrics
+                .for_scope(&replacement)
+                .latest_active_consensus_epoch()
+            {
                 assert!(
                     epoch > 0,
                     "when starting from snapshot a sufficiently advanced \

--- a/crates/e2e/src/tests/sync.rs
+++ b/crates/e2e/src/tests/sync.rs
@@ -142,7 +142,7 @@ fn joins_from_snapshot() {
                 validator catching up; there is likely a bug",
             );
 
-            if let Some(epoch) = metrics.for_scope(&receiver).latest_consensus_epoch() {
+            if let Some(epoch) = metrics.for_scope(&receiver).latest_active_consensus_epoch() {
                 assert!(epoch > 0, "validator should never boot into genesis epoch");
             }
 
@@ -273,7 +273,7 @@ fn can_restart_after_joining_from_snapshot() {
                 validator catching up; there is likely a bug",
             );
 
-            if let Some(epoch) = metrics.for_scope(&receiver).latest_consensus_epoch() {
+            if let Some(epoch) = metrics.for_scope(&receiver).latest_active_consensus_epoch() {
                 assert!(epoch > 0, "validator should never boot into genesis epoch");
             }
 


### PR DESCRIPTION
Prevents snapshot restart e2e checks from treating a freshly registered `latest_epoch` metric as a real genesis epoch before the epoch manager has activated an engine. The test still fails if an active replacement validator reports epoch 0, and the flaky profile now targets the sync restart case from the failing job directly.