### PR TITLE
deps: update reth from main (2026-07-06)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8615,7 +8615,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9130,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9215,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9319,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9367,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9508,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "clap",
  "eyre",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9606,7 +9606,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9630,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9763,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "serde",
  "serde_json",
@@ -9787,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "bytes",
  "futures",
@@ -9833,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9850,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "bindgen",
  "cc",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "futures",
  "metrics",
@@ -9872,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9881,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9978,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10140,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10242,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10266,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10290,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "bytes",
  "eyre",
@@ -10319,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10331,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10390,7 +10390,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10481,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10540,7 +10540,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10617,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10710,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10839,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10853,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10884,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10935,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10963,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10997,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11092,7 +11092,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "clap",
  "eyre",
@@ -11122,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11184,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11209,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11255,18 +11255,15 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "crossbeam-channel",
  "crossbeam-utils",
- "derive_more",
- "itertools 0.14.0",
  "metrics",
  "rand 0.9.4",
- "rayon",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -11283,7 +11280,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
+checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1106,7 +1106,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc2cd27809c88c413e5542dbd5a8eff8c12f0086af920e881ae586d3a787d5e5"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1163,7 +1163,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1174,7 +1174,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2420,7 +2420,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3699,36 +3699,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -3747,22 +3723,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -4239,7 +4204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4287,7 +4252,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf022360bdbe9456eda5f35718a50476d5b2a0d51a97ed4eae27420737a6fba"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4742,8 +4707,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -5434,7 +5399,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5744,7 +5709,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
@@ -5830,7 +5795,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7000,7 +6965,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8615,7 +8580,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8642,7 +8607,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8675,7 +8640,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8695,7 +8660,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8708,7 +8673,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8791,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8801,7 +8766,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8854,7 +8819,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8870,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8884,7 +8849,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8862,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8922,7 +8887,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8951,7 +8916,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8977,7 +8942,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9007,7 +8972,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9022,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9047,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9071,7 +9036,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9095,7 +9060,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9130,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9187,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9215,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9263,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9319,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9349,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9367,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9383,7 +9348,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9406,7 +9371,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9417,7 +9382,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9445,7 +9410,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9467,7 +9432,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9508,7 +9473,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "clap",
  "eyre",
@@ -9531,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9547,7 +9512,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9563,7 +9528,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9576,7 +9541,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9606,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9620,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9630,7 +9595,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9655,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9675,7 +9640,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9693,7 +9658,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9706,7 +9671,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9725,7 +9690,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9763,7 +9728,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9777,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "serde",
  "serde_json",
@@ -9787,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9813,7 +9778,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "bytes",
  "futures",
@@ -9833,7 +9798,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9850,7 +9815,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "bindgen",
  "cc",
@@ -9859,7 +9824,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "futures",
  "metrics",
@@ -9872,7 +9837,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9881,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9895,7 +9860,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9953,7 +9918,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9978,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10002,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10017,7 +9982,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10031,7 +9996,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10048,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10072,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10140,7 +10105,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10195,7 +10160,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10242,7 +10207,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10266,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10290,7 +10255,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "bytes",
  "eyre",
@@ -10319,7 +10284,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10331,7 +10296,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10355,7 +10320,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10367,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10390,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10433,7 +10398,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10481,7 +10446,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10509,7 +10474,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10525,7 +10490,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10540,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10617,7 +10582,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10647,7 +10612,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10690,7 +10655,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10710,7 +10675,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10741,7 +10706,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10788,7 +10753,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10839,7 +10804,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10853,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10884,7 +10849,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10935,7 +10900,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10963,7 +10928,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10977,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10997,7 +10962,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11012,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11038,7 +11003,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11055,7 +11020,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11076,7 +11041,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11092,7 +11057,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11102,7 +11067,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "clap",
  "eyre",
@@ -11122,7 +11087,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11141,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11184,7 +11149,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11209,7 +11174,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11236,7 +11201,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11255,7 +11220,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11280,7 +11245,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4417f3#b4417f33d3c580caa948c5dcf58b274147966e1d"
+source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11813,7 +11778,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11893,7 +11858,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12305,7 +12270,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12541,7 +12506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12817,7 +12782,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14326,7 +14291,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8840ad4d852e325d3afa7fde8a50b2412f89dce47d7eb291c0cc7f87cd040f38"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14937,7 +14902,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8580,7 +8580,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8607,7 +8607,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8640,7 +8640,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8660,7 +8660,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8673,7 +8673,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8756,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8766,7 +8766,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8819,7 +8819,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8849,7 +8849,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8862,7 +8862,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8887,7 +8887,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8916,7 +8916,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8942,7 +8942,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8972,7 +8972,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8987,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9012,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9036,7 +9036,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9060,7 +9060,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9180,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9203,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9314,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9332,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9348,7 +9348,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9371,7 +9371,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9382,7 +9382,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9410,7 +9410,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9432,7 +9432,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9473,7 +9473,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "clap",
  "eyre",
@@ -9496,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9512,7 +9512,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9528,7 +9528,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9541,7 +9541,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9571,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9585,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9595,7 +9595,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9640,7 +9640,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9658,7 +9658,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9671,7 +9671,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9690,7 +9690,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9728,7 +9728,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "serde",
  "serde_json",
@@ -9752,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9778,7 +9778,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "bytes",
  "futures",
@@ -9798,7 +9798,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9815,7 +9815,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "bindgen",
  "cc",
@@ -9824,7 +9824,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "futures",
  "metrics",
@@ -9837,7 +9837,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9846,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9860,7 +9860,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9918,7 +9918,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9943,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9967,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9982,7 +9982,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9996,7 +9996,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10013,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10037,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10105,7 +10105,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10160,7 +10160,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10207,7 +10207,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10231,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10255,7 +10255,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "bytes",
  "eyre",
@@ -10284,7 +10284,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10296,7 +10296,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10320,7 +10320,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10332,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10398,7 +10398,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10446,7 +10446,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10474,7 +10474,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10490,7 +10490,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10582,7 +10582,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10612,7 +10612,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10655,7 +10655,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10675,7 +10675,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10706,7 +10706,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10753,7 +10753,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10804,7 +10804,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10849,7 +10849,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10900,7 +10900,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10928,7 +10928,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10962,7 +10962,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11003,7 +11003,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11020,7 +11020,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11041,7 +11041,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11057,7 +11057,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11067,7 +11067,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "clap",
  "eyre",
@@ -11087,7 +11087,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11106,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11149,7 +11149,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11174,7 +11174,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11201,7 +11201,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11220,7 +11220,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11245,7 +11245,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ef18429#ef184296232607b3437735d2aac7f278a74af111"
+source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,7 +224,7 @@ alloy-json-abi = { version = "1.6.0", default-features = false }
 alloy-network = { version = "2.1.0", default-features = false }
 alloy-primitives = { version = "1.6.0", default-features = false }
 alloy-provider = { version = "2.1.0", default-features = false }
-alloy-rlp = { version = "0.3.15", default-features = false }
+alloy-rlp = { version = "0.3.16", default-features = false }
 alloy-rpc-types-admin = "2.1.0"
 alloy-rpc-client = { version = "2.1.0", default-features = false }
 alloy-rpc-types-engine = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b4417f3", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "ef18429", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -239,7 +239,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
         let Some(observed) = observed_build_time_multiplier(total_work, work_at_tx_cutoff) else {
             return;
         };
-        let _ = self.build_time_multiplier.fetch_update(
+        let _ = self.build_time_multiplier.try_update(
             Ordering::Relaxed,
             Ordering::Relaxed,
             |current| Some(decay_build_time_multiplier(current, observed)),

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -370,7 +370,7 @@ where
         let BuildArguments {
             cached_reads,
             execution_cache,
-            mut trie_handle,
+            state_root_handle: mut trie_handle,
             config,
             cancel,
             best_payload,
@@ -1021,7 +1021,8 @@ where
 
         let hashed_state = if let Some(Ok(hashed_state)) = trie_handle
             .as_mut()
-            .map(|handle| handle.take_hashed_state_rx().recv())
+            .and_then(|handle| handle.try_take_hashed_state_rx())
+            .map(|rx| rx.recv())
         {
             hashed_state
         } else {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -370,7 +370,7 @@ where
         let BuildArguments {
             cached_reads,
             execution_cache,
-            state_root_handle: mut trie_handle,
+            mut state_root_handle,
             config,
             cancel,
             best_payload,
@@ -540,14 +540,14 @@ where
 
         let bal_task_handle = if self.enable_bal {
             let bal_task_handle =
-                self.spawn_bal_task(trie_handle.as_ref().map(|handle| handle.state_hook()));
+                self.spawn_bal_task(state_root_handle.as_ref().map(|handle| handle.state_hook()));
             executor
                 .evm_mut()
                 .db_mut()
                 .set_state_hook(Some(Box::new(bal_task_handle.state_hook())));
             Some(bal_task_handle)
         } else {
-            if let Some(ref handle) = trie_handle {
+            if let Some(ref handle) = state_root_handle {
                 executor
                     .evm_mut()
                     .db_mut()
@@ -1019,7 +1019,7 @@ where
         // Drop the BAL task sender to trigger finalization.
         let bal_rx = bal_task_handle.map(|handle| handle.into_bal_rx());
 
-        let hashed_state = if let Some(Ok(hashed_state)) = trie_handle
+        let hashed_state = if let Some(Ok(hashed_state)) = state_root_handle
             .as_mut()
             .and_then(|handle| handle.try_take_hashed_state_rx())
             .map(|rx| rx.recv())
@@ -1038,7 +1038,7 @@ where
                     "skipping payload state-root computation"
                 );
                 None
-            } else if let Some(mut handle) = trie_handle {
+            } else if let Some(mut handle) = state_root_handle {
                 let state_root_wait_start = Instant::now();
                 let _span = debug_span!(target: "payload_builder", "await_state_root").entered();
                 match handle.state_root() {

--- a/crates/payload/types/src/budget.rs
+++ b/crates/payload/types/src/budget.rs
@@ -45,7 +45,7 @@ pub fn observe_marshal_persist(block_size_bytes: usize, elapsed: Duration) {
     let observed = observed.min(u128::from(u64::MAX)) as u64;
 
     let _ =
-        MARSHAL_PERSIST_NS_PER_BYTE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        MARSHAL_PERSIST_NS_PER_BYTE.try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
             Some(if current == 0 || observed >= current {
                 observed
             } else {


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`8bbc5e6...011c2fd`](https://github.com/paradigmxyz/reth/compare/8bbc5e6...011c2fd)

🔗 Amp thread: https://ampcode.com/threads/T-019f35b2-670b-7608-a32a-22f6ebfdc757
**Trie**
- Removed `ParallelStateRoot` and renamed `ParallelStateRootError` to `StateRootTaskError`; refactored state root strategy ([#26121](https://github.com/paradigmxyz/reth/pull/26121), [#26132](https://github.com/paradigmxyz/reth/pull/26132), [#26085](https://github.com/paradigmxyz/reth/pull/26085))

**Perf (Net)**
- Optimized ECIES: avoid redundant zero-fill in `write_body` and skip copying decrypted message body ([#26120](https://github.com/paradigmxyz/reth/pull/26120), [#26119](https://github.com/paradigmxyz/reth/pull/26119))
- Use static wire encoding for p2p ping/pong ([#26122](https://github.com/paradigmxyz/reth/pull/26122))
- Reduce idle polling in `ActiveSession` and avoid re-polling unchanged pinger timers ([#26123](https://github.com/paradigmxyz/reth/pull/26123), [#26124](https://github.com/paradigmxyz/reth/pull/26124))
- Flush `P2PStream` once per batch instead of per message ([#26125](https://github.com/paradigmxyz/reth/pull/26125))
- Preallocate pooled hash metadata decoding ([#26145](https://github.com/paradigmxyz/reth/pull/26145))

**Prune**
- Derive receipts static file size from prune distance ([#26108](https://github.com/paradigmxyz/reth/pull/26108))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019f35b2-868f-747f-948e-4638528a8df1
- Bumped reth git dependencies from rev `8bbc5e6` to `011c2fd` across all `reth-*` crates in `Cargo.toml`
- Bumped `alloy-rlp` from `0.3.15` to `0.3.16`
- Renamed `BuildArguments` field `trie_handle` → `state_root_handle` (destructured with rebinding to `mut trie_handle`) in the payload builder
- Replaced `take_hashed_state_rx()` with the fallible `try_take_hashed_state_rx()` API, adjusting the call chain from `.map(...).recv()` to `.and_then(...).map(|rx| rx.recv())` to handle the `Option` return

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/28767774848)
